### PR TITLE
Wire Discord integration (webhooks + MCP setup docs)

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "discord": {
+      "command": "npx",
+      "args": ["-y", "@quadslab.io/discord-mcp"],
+      "env": {
+        "DISCORD_TOKEN": "REPLACE_WITH_YOUR_BOT_TOKEN",
+        "DISCORD_GUILD_ID": "1495086675523797032"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,19 @@ Key locations:
 ## Available skills
 
 - **`/current-sprint`** — surfaces the active sprint from the project board. Prefers items with Status = "In progress"; falls back to the earliest incomplete Phase.
+- **`/pr-driven-dev`** — enforces feature-branch + PR workflow; never commit directly to `master`. Includes a rescue flow if edits start on `master` by accident.
+
+## Discord integration
+
+The team coordinates in the **Tsuki Works** Discord server. Two integration paths are live:
+
+- **GitHub → Discord webhooks (passive):**
+  - `#code-review` — PR opened/reviewed/merged, PR review comments, issue comments.
+  - `#ci-alerts` — pushes, check runs, workflow runs, status events.
+  Configured on the repo via `gh api repos/tsuki-works/niko/hooks`. Don't duplicate — before adding a webhook, `gh api repos/tsuki-works/niko/hooks` to see what's already there.
+- **MCP (active, Claude-initiated):** `.mcp.json` at the repo root configures the `discord` MCP server (`@quadslab.io/discord-mcp`). File is gitignored; `.mcp.json.example` is the committed template. Use the Discord MCP tools to post to specific channels when the user asks for team updates, decisions-log entries, etc.
+
+Useful channel IDs: `#code-review` = `1495194166886400021`, `#ci-alerts` = `1495194041246285857`, `#okrs-roadmap` = `1495192531766345919`, `#decisions-log` = `1495192153947766885`, `#blockers` = `1495192657545396354`, `#general` (COMPANY) = `1495192027913130074`.
 
 ## Decisions & non-obvious context
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ This repo is set up to be worked on with [Claude Code](https://claude.com/claude
 
 Skills live under [`.claude/skills/`](.claude/skills/).
 
+### MCP setup (Discord)
+
+The Claude skills talk to Discord through an MCP server. The runtime config lives in `.mcp.json`, which is gitignored because it holds a bot token. A committed `.mcp.json.example` shows the shape.
+
+To set up locally:
+
+1. Copy the example: `cp .mcp.json.example .mcp.json`
+2. Ask an admin for the Tsuki Works Discord bot token, or generate your own at https://discord.com/developers/applications.
+3. Paste it into the `DISCORD_TOKEN` field. Leave `DISCORD_GUILD_ID` as-is.
+4. Restart Claude Code — the `discord` MCP server will start automatically.
+
+Never commit a filled-in `.mcp.json`.
+
+## Discord integration
+
+GitHub activity auto-posts to the Tsuki Works Discord server:
+
+| Event | Channel |
+|-------|---------|
+| PR opened / reviewed / merged, issue comments | `#code-review` |
+| Pushes, CI check runs, workflow results | `#ci-alerts` |
+
+Wired via GitHub → Discord channel webhooks (Discord's native GitHub integration — `/github` suffix on the webhook URL). Adjust event types in repo settings → Webhooks if the volume is wrong.
+
 ## Team
 
 Four-person founding team at Tsuki Works. Role breakdown in [`docs/05-team-roles-and-responsibilities.md`](docs/05-team-roles-and-responsibilities.md).


### PR DESCRIPTION
## Summary
Wires up the Discord integration for the Tsuki Works server.

**Live on the remote (not part of this diff):**
- Two Discord channel webhooks created: `#code-review` (GitHub PRs) and `#ci-alerts` (GitHub Pushes & CI).
- Two GitHub webhooks registered on `tsuki-works/niko` pointing at those Discord webhooks with the `/github` suffix.
  - `#code-review` ← `pull_request`, `pull_request_review`, `pull_request_review_comment`, `issue_comment`.
  - `#ci-alerts` ← `push`, `check_run`, `check_suite`, `workflow_run`, `status`.
- Both webhooks ping-tested.

**In this diff:**
- `.mcp.json.example` — committed template for the Discord MCP server config. Teammates copy to `.mcp.json` (gitignored) and fill in their own bot token.
- `README.md` — adds an MCP setup section and a Discord integration table.
- `CLAUDE.md` — documents both integration paths for future Claude sessions and caches relevant channel IDs.

## Why
- **Webhooks**: passive team awareness — no action needed, PR/CI events show up in channels the team already watches.
- **MCP**: lets Claude post directly to channels (e.g., decisions-log entries, sprint updates) on demand.
- **Committed example**: onboarding story for future teammates. The real `.mcp.json` holds a bot token and stays gitignored.

## Test plan
- [x] `gh api repos/tsuki-works/niko/hooks` lists both webhooks.
- [x] Ping sent to both webhooks (pending confirmation that the ping landed in Discord — merging this PR will also produce a `pull_request.closed` event that should hit `#code-review`).
- [ ] After merge, confirm `pull_request.closed` shows up in `#code-review`.
- [ ] Confirm `push` event shows up in `#ci-alerts`.

## Notes
- No runtime code — safe docs + example-config-only change.
- Webhooks can be revoked via `gh api -X DELETE repos/tsuki-works/niko/hooks/<id>` if noisy.
