### PR TITLE
Document master ruleset and public-repo flip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Useful channel IDs: `#code-review` = `1495194166886400021`, `#ci-alerts` = `1495
 
 - **Legal/LLC is intentionally deferred** until the product is near market-readiness (Phase 3 Beta or Phase 4 Production). Do not flag it as missing from Phase 0 exit criteria — this is a deliberate choice. The item lives under a "Deferred to Phase 3 / 4" section in issue #2.
 - **Default branch is `master`** (not `main`).
-- Branch protection on `master` is **not** enabled — GitHub requires a paid plan for this on private repos, and the org is on free. Treat `master` pushes with care.
+- **Repo is public** — flipped from private to unlock branch-protection features on the free tier until the org moves to a paid/enterprise plan.
+- **`master` is protected by a repository ruleset** (`gh api repos/tsuki-works/niko/rulesets`): PR required (1 approval, conversation resolution, stale-review dismissal), linear history enforced, force-push and deletion blocked, Copilot code review + code-quality checks on push. Repo admins can bypass — don't rely on bypass as the default path; land changes via PR.
 - **Company branding** lives in an `assets/` folder (logos by Daniel).
 
 ## Conventions


### PR DESCRIPTION
## Summary
- Replace stale CLAUDE.md note claiming branch protection isn't available (old reason: private repo on free plan — both premises no longer hold).
- Document the actual state: repo is public, and `master` is protected by a ruleset requiring PRs (1 approval, conversation resolution, stale-review dismissal), enforcing linear history, and blocking force-push and deletion. Admins retain bypass for emergencies.
- Ruleset itself (#15251875) was patched out-of-band as part of this change — it previously had `ref_name.include: []` (applied to nothing) and no `pull_request` rule. Now targets `~DEFAULT_BRANCH` with the full rule set; existing Copilot code review + code-quality rules preserved.

## Linked issue
Relates to #2 (Phase 0 — "Set up development environment and tooling").

## Test plan
- [ ] Verify ruleset shows "master" as protected in GitHub UI (Settings → Rules → Rulesets).
- [ ] Try pushing directly to `master` from a non-admin local clone and confirm it's blocked.
- [ ] Confirm this PR itself is blocked from merge without the required approval (or visibly marked as an admin bypass when merged).
- [ ] Docs read cleanly: `CLAUDE.md` no longer claims branch protection is unavailable.

## Notes
- 1-approval requirement may feel heavy for a 4-person team during Phase 0 scaffolding. If it becomes friction, drop to `required_approving_review_count: 0` (PR still required, no human approval needed) — say the word and I'll patch the ruleset.
- Out of scope: wiring a CI workflow so the `code_quality` / Copilot-review rules have something to check on push. That's the next item in the Phase 0 "CI/CD pipeline" checkbox on #2.
