### PR TITLE
Ship Superpowers plugin to the team via .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,16 @@
       "Bash(gh api repos/tsuki-works/niko/*)",
       "WebSearch"
     ]
+  },
+  "extraKnownMarketplaces": {
+    "superpowers-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers-marketplace"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "superpowers@superpowers-marketplace": true
   }
 }


### PR DESCRIPTION
## Summary
- Declares `obra/superpowers-marketplace` as an extra known marketplace in `.claude/settings.json`.
- Enables `superpowers@superpowers-marketplace` for the repo, so when a teammate trusts the folder in Claude Code they get prompted to install/enable it automatically — no per-machine `/plugin install` step.

## Why this approach
Verified against the official Claude Code docs (`code.claude.com/docs/en/plugin-marketplaces`, `code.claude.com/docs/en/discover-plugins`): repo-shared plugin distribution is the documented team pattern. Keys `extraKnownMarketplaces` + `enabledPlugins` belong in `.claude/settings.json` (team-shared) so the choice is version-controlled and auditable.

Marketplace identifier verified from the upstream repo's README — install command is `/plugin marketplace add obra/superpowers-marketplace` and the plugin resolves as `superpowers@superpowers-marketplace`.

## Linked issue
Relates to #2 (Phase 0 — development environment / tooling).

## Test plan
- [ ] After merge, pull and reopen the repo in Claude Code. Confirm the prompt to install the `superpowers-marketplace` + enable `superpowers` appears.
- [ ] Accept the prompt; verify Superpowers skills (e.g. `/brainstorm`, `/write-plan`) show up in the skill list.
- [ ] Have one other teammate (Daniel) pull, open, and confirm they get the same prompt — that verifies the mechanism actually ships, not just works on my machine.
- [ ] Anyone who wants to disable locally can add `"enabledPlugins": { "superpowers@superpowers-marketplace": false }` to their gitignored `.claude/settings.local.json`.

## Notes
- Not enabling other Superpowers-marketplace plugins here (Elements of Style, Private Journal, Developing-for-Claude-Code). If we want those later, add to `enabledPlugins` in a follow-up — the marketplace itself is already registered.
- If you ever want stricter enforcement (non-opt-out for security/compliance), the docs point to managed settings rather than `settings.json`. Not needed for our 4-person team.
