### PR TITLE
Move TTS ownership from Sandeep to Kailash

### DIFF
--- a/docs/05-team-roles-and-responsibilities.md
+++ b/docs/05-team-roles-and-responsibilities.md
@@ -37,29 +37,31 @@ Some responsibilities are **shared across the whole team** rather than assigned 
 
 > **Load note:** Meet's lane is deliberately the heaviest — it sits at the product/tech decision intersection during Phases 0–2. Phase 0 infra + CI/CD is front-loaded work that lightens by Phase 2, freeing capacity for the Toast integration in Phase 3.
 
-### Sandeep — Voice I/O & Audio Backend Lead
-**Primary:** STT + TTS pipelines, audio engineering, performance
+### Sandeep — Voice Input & Audio Backend Lead
+**Primary:** STT pipeline, audio engineering, performance
 **Secondary:** Clover POS integration (Phase 3.2)
 
 | Responsibility | Details |
 |---------------|---------|
 | STT pipeline | Deepgram Nova-2 streaming from Twilio Media Streams WebSocket |
-| TTS pipeline | ElevenLabs streaming back to Twilio |
 | Audio engineering | Barge-in detection, audio quality, interruption handling |
 | Performance | Ensure < 1 second end-to-end voice response latency |
 | Call state management | Session state, timeout/silence detection |
 | POS — Clover | Clover API integration (Phase 3.2) |
 
-### Kailash — Telephony, Security & Integrations Backend Lead
-**Primary:** Telephony, security, monitoring, Square POS integration
+### Kailash — Telephony, TTS & Security Backend Lead
+**Primary:** Telephony, TTS pipeline, security, monitoring, Square POS integration
 **Secondary:** Cross-cutting backend support
 
 | Responsibility | Details |
 |---------------|---------|
 | Telephony | Twilio setup, phone numbers, webhooks, Media Streams WebSocket plumbing |
+| TTS pipeline | ElevenLabs streaming back to Twilio (outbound audio — pairs naturally with telephony) |
 | POS — Square | Square API integration (Phase 2.3, MVP) — sets the pattern reused by Toast/Clover |
 | Security | Auth, data encryption, PCI scope minimization via tokenization |
 | Monitoring | Cloud Logging + Trace, Sentry, alerting, error tracking |
+
+> **Voice I/O split rationale:** Sandeep owns inbound audio (Twilio → STT, audio quality, interruption handling); Kailash owns outbound audio (LLM response → TTS → Twilio). Latency budget crosses both lanes — they pair on end-to-end performance.
 
 ### Daniel — Frontend & Growth Lead
 **Primary:** Dashboard (Next.js), marketing site, UX/UI
@@ -155,8 +157,9 @@ Daniel owns user-facing help content; engineering docs (API references, runbooks
 |-----------|-----------------|-----------|
 | Frontend (dashboard, marketing site) | Daniel | Meet |
 | Core backend / API | Meet | Sandeep |
-| Voice — STT / TTS / audio | Sandeep | Meet |
+| Voice — STT / audio / performance | Sandeep | Meet |
 | Voice — LLM / prompts | Meet | Sandeep |
+| Voice — TTS | Kailash | Sandeep |
 | Infrastructure (Cloud Run, CI/CD, GCP) | Meet | Kailash |
 | Telephony / Security / Monitoring | Kailash | Sandeep |
 | POS — Square | Kailash | Meet |
@@ -165,7 +168,7 @@ Daniel owns user-facing help content; engineering docs (API references, runbooks
 
 **Note on cross-pollination:** With 3 backend engineers and 1 frontend engineer, frontend PRs won't always get a cross-domain reviewer. Meet is the natural cross-domain backup for Daniel's frontend PRs (product context); where that's unavailable, Daniel self-merges after addressing automated checks.
 
-**Note on LLM/STT coupling:** LLM (Meet) and STT (Sandeep) are split but tightly coupled — conversation quality depends on both prompt design and transcription fidelity. Expect frequent pairing and mutual review; each is the other's primary secondary reviewer.
+**Note on voice-pipeline coupling:** LLM (Meet), STT (Sandeep), and TTS (Kailash) are split across three owners but tightly coupled — conversation quality and the < 1s latency budget depend on all three. Expect frequent pairing and mutual review across these three lanes; Sandeep is the secondary reviewer for both LLM and TTS since he owns the end-to-end performance contract.
 
 ---
 


### PR DESCRIPTION
## Summary
- Moves TTS pipeline ownership from Sandeep to Kailash. Reframes the voice split as **inbound audio (Sandeep)** vs **outbound audio (Kailash)** — TTS pairs naturally with Kailash's Twilio outbound telephony since both are audio flowing back to the caller.
- Sandeep keeps STT, audio engineering, interruption handling, and the end-to-end performance contract. Renames his lane to "Voice Input & Audio Backend Lead".
- Kailash's lane retitled "Telephony, TTS & Security Backend Lead" to reflect the addition.
- Review rotation (§6) now has separate rows for STT/audio (Sandeep) and TTS (Kailash). Sandeep becomes secondary reviewer for both LLM and TTS PRs because he owns the < 1s latency budget across all three voice lanes.

## Linked issue
Relates to #2 (Phase 0 — team ownership scaffolding)

## Test plan
- [ ] No runtime to test; docs-only change
- [ ] Sandeep's table no longer lists TTS; Kailash's does
- [ ] Review rotation has 3 voice-pipeline rows (STT, LLM, TTS) with distinct primary owners

## Notes
- Board update follow-up: issue #3 Phase 1 POC will be annotated with owner tags per milestone in a separate edit so the board reflects ownership without rerunning this PR.
