### PR TITLE
Scaffold Cloud Run deploy: FastAPI hello-world + WIF deploy workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.claude
+.mcp.json
+.mcp.json.example
+docs
+assets
+*.md
+__pycache__
+*.pyc
+.venv
+venv
+.env
+.env.*
+.DS_Store

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_AR_REPO }}/${{ vars.CLOUD_RUN_SERVICE }}:${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Build image
+        run: docker build -t "$IMAGE" .
+
+      - name: Push image
+        run: docker push "$IMAGE"
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ vars.CLOUD_RUN_SERVICE }}
+          region: ${{ vars.GCP_REGION }}
+          image: ${{ env.IMAGE }}
+          flags: --allow-unauthenticated --port=8080
+
+      - name: Show service URL
+        run: |
+          URL=$(gcloud run services describe ${{ vars.CLOUD_RUN_SERVICE }} \
+            --region=${{ vars.GCP_REGION }} --format='value(status.url)')
+          echo "Service deployed at: $URL"
+          echo "### Cloud Run URL: $URL" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+COPY app/ ./app/
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT}"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="niko")
+
+
+@app.get("/")
+def root():
+    return {"service": "niko", "status": "ok"}
+
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn[standard]==0.32.0


### PR DESCRIPTION
## Summary
- Minimal FastAPI app under `app/` (root + `/healthz`) with Python 3.12-slim Dockerfile
- GitHub Actions `deploy.yml` that authenticates via Workload Identity Federation (no SA JSON keys), builds the image, pushes to Artifact Registry (`us-central1-docker.pkg.dev/niko-tsuki/niko`), and deploys to Cloud Run service `niko`
- `.dockerignore` excludes docs/assets/secrets from the build context
- Node build stage intentionally omitted — added when Daniel scaffolds the Next.js dashboard under `web/`

## Linked issue
Relates to #2 (Phase 0 — wires up the CI/CD + cloud infrastructure deliverables)

## GCP setup behind this PR
- Project: `niko-tsuki` (project number `347262010229`), under Meet's `.work` Google account, no Org
- Artifact Registry: `niko` repo in `us-central1`
- Service account: `github-deploy@niko-tsuki.iam.gserviceaccount.com` with `run.admin`, `artifactregistry.writer`, `iam.serviceAccountUser`, `secretmanager.secretAccessor`
- WIF pool/provider: `github-pool` / `github-provider`, restricted to `tsuki-works/*` repos
- Repo variables wired for the workflow (`GCP_PROJECT_ID`, `GCP_REGION`, `GCP_WIF_PROVIDER`, `GCP_DEPLOY_SA`, `GCP_AR_REPO`, `CLOUD_RUN_SERVICE`)

## Test plan
- [ ] PR merges → `deploy.yml` triggers on `master`
- [ ] Image builds and pushes to Artifact Registry
- [ ] Cloud Run service `niko` is created on first run, updated on subsequent runs
- [ ] `curl <service-url>/healthz` returns `{"status":"ok"}`

## Notes
First deploy creates the Cloud Run service from the workflow — no manual `gcloud run deploy` needed. Subsequent merges to `master` redeploy automatically.