### PR TITLE
Rename /healthz to /health (GFE intercepts /healthz)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,6 @@ def root():
     return {"service": "niko", "status": "ok"}
 
 
-@app.get("/healthz")
-def healthz():
+@app.get("/health")
+def health():
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- Google Frontend intercepts `/healthz` on Cloud Run before the request reaches our container, returning a GFE HTML 404 instead of FastAPI's JSON
- All other unknown paths (`/foo`, `/health`, `/healthcheck`) pass through to FastAPI normally — only `/healthz` is special-cased at the edge
- Renaming to `/health` (also a standard convention) avoids the issue

## Linked issue
Relates to #2

## Test plan
- [ ] After merge + deploy, `curl <url>/health` returns `{"status":"ok"}`

## Notes
The interception is reproducible: hitting `/healthz` returns `Content-Type: text/html` + `Referrer-Policy: no-referrer` with no `x-cloud-trace-context` header (signature of a Google Frontend response, not Cloud Run/the container). Other paths return `application/json` + `server: Google Frontend` + a trace ID (signature of Cloud Run forwarding to our app).