### PR TITLE
Switch Anthropic plan to pay-as-you-go; mark signup done

### DIFF
--- a/docs/02-product-roadmap.md
+++ b/docs/02-product-roadmap.md
@@ -238,7 +238,7 @@ Guiding principle: **free-tier-first**. We have no outside funding, so every pic
 | Telephony | **Twilio Voice** | $15 trial credit; ~$0.0085/min inbound US after | Telnyx (~40% cheaper/min at scale) |
 | STT | **Deepgram (Nova-2 streaming)** | $200 free credit — weeks of POC testing | Stay on Deepgram |
 | TTS | **ElevenLabs** | 10k chars/mo free tier | ElevenLabs Pro ($22/mo) or Cartesia for lower latency |
-| LLM | **Anthropic Claude Haiku 4.5** | Apply to Claude for Startups for credits; cheap + fast, strong instruction-following for constrained menu flows | Claude Sonnet for harder conversations |
+| LLM | **Anthropic Claude Haiku 4.5** | Pay-as-you-go via Console (Claude for Startups requires VC backing — revisit post-raise); Haiku is cheap + fast, strong instruction-following for constrained menu flows | Claude Sonnet for harder conversations |
 | Primary POS (MVP) | **Square** | Developer sandbox + API free | — (Toast/Clover added Phase 3) |
 | Hosting | **GCP — Cloud Run + Firestore** | $300 credit (90d) + always-free Cloud Run (2M req/mo) + Firestore free tier. Scales to zero = $0 when idle. | Stay on GCP; raise tier + min-instances when funded |
 | Frontend framework | **Next.js 15 (static export)** | Built inside monolith — no separate Vercel account needed | Split to Vercel Pro if dashboard grows beyond static export |

--- a/docs/03-technical-architecture.md
+++ b/docs/03-technical-architecture.md
@@ -77,7 +77,7 @@
 |-----------|-------------|-------------|-----------|
 | **Telephony** | Twilio Voice | Telnyx / Vonage | Most mature API, best docs, programmable voice. $15 trial credit for POC; migrate to Telnyx once volume makes per-minute margin matter |
 | **STT (Speech-to-Text)** | Deepgram Nova-2 (streaming) | OpenAI Whisper API | Real-time streaming, low latency, high accuracy. $200 free credit covers POC |
-| **LLM (Conversation)** | Anthropic Claude Haiku 4.5 (POC/MVP) → Sonnet (production) | OpenAI GPT-4o | Haiku is cheap + fast with strong instruction following for constrained menu flows. Upgrade to Sonnet for harder conversations once funded. Apply to Claude for Startups for credits |
+| **LLM (Conversation)** | Anthropic Claude Haiku 4.5 (POC/MVP) → Sonnet (production) | OpenAI GPT-4o | Haiku is cheap + fast with strong instruction following for constrained menu flows. Upgrade to Sonnet for harder conversations once funded. Pay-as-you-go via Console during bootstrap; Claude for Startups is VC-gated, revisit after raising |
 | **TTS (Text-to-Speech)** | ElevenLabs | OpenAI TTS / PlayHT / Cartesia | Most natural voices, low latency streaming. 10k chars/mo free tier |
 
 ### Infrastructure

--- a/docs/06-shared-accounts.md
+++ b/docs/06-shared-accounts.md
@@ -11,7 +11,7 @@ Phase 0 exit requires shared accounts for every service in the niko stack. Each 
 | GCP | Cloud Run hosting + Firestore | Meet | ✅ Done | Live; Cloud Run auto-deploys from `master` via `.github/workflows/deploy.yml` |
 | Twilio | Voice telephony | Meet | ⬜ Todo | Free trial includes $15 credit |
 | Deepgram | STT (Nova-2 streaming) | Meet | ⬜ Todo | $200 free credit on signup |
-| Anthropic | Claude Haiku 4.5 LLM | Meet | ⬜ Todo | Apply to Claude for Startups for additional credits |
+| Anthropic | Claude Haiku 4.5 LLM | Meet | ✅ Done | Pay-as-you-go on Console; Claude for Startups is VC-gated (revisit post-raise). Key posted to `#shared-creds` |
 | ElevenLabs | TTS streaming | Meet | ⬜ Todo | Free tier: 10k chars/month |
 | Square Developer | POS sandbox + production API | Meet | ⬜ Todo | Sandbox access is free |
 


### PR DESCRIPTION
## Summary
- Dropped the "apply to Claude for Startups" suggestion from the roadmap, architecture, and shared-accounts tracker — the program is VC-gated per [claude.com/programs/startups](https://claude.com/programs/startups), so bootstrapped Tsuki Works can't apply until/unless we raise.
- Docs now reflect: pay-as-you-go via Console during bootstrap, revisit the startups program post-raise.
- Anthropic account created on the shared Gmail; API key posted to `#shared-creds`. `docs/06-shared-accounts.md` row flipped to ✅ Done.

## Test plan
- [ ] Confirm `ANTHROPIC_API_KEY` fetched from `#shared-creds` via `/shared-creds` works against `console.anthropic.com` (will be exercised naturally once Phase 1 LLM integration lands).

One down, four to go on the Phase 0 shared-accounts task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)