### PR TITLE
Flip Twilio row to done in shared-accounts tracker

### DIFF
--- a/docs/06-shared-accounts.md
+++ b/docs/06-shared-accounts.md
@@ -9,7 +9,7 @@ Phase 0 exit requires shared accounts for every service in the niko stack. Each 
 | Service | Purpose | Owner | Status | Notes |
 |---|---|---|---|---|
 | GCP | Cloud Run hosting + Firestore | Meet | ✅ Done | Live; Cloud Run auto-deploys from `master` via `.github/workflows/deploy.yml` |
-| Twilio | Voice telephony | Meet | ⬜ Todo | Free trial includes $15 credit |
+| Twilio | Voice telephony | Meet | ✅ Done | Trial account, $15 credit. Toronto (647) number — swap to US before pilot. Upgrade to paid before Phase 1 demo day to drop trial watermark. Creds in `#shared-creds` |
 | Deepgram | STT (Nova-2 streaming) | Meet | ⬜ Todo | $200 free credit on signup |
 | Anthropic | Claude Haiku 4.5 LLM | Meet | ✅ Done | Pay-as-you-go on Console; Claude for Startups is VC-gated (revisit post-raise). Key posted to `#shared-creds` |
 | ElevenLabs | TTS streaming | Meet | ⬜ Todo | Free tier: 10k chars/month |


### PR DESCRIPTION
## Summary
- Twilio trial account created on the shared Gmail.
- SID, auth token, recovery code, and Toronto (+1 647) phone number posted to `#shared-creds`.
- `docs/06-shared-accounts.md` row flipped to ✅ Done with follow-up reminders.

## Follow-ups encoded in the notes column
- Swap the Toronto 647 number for a US number before pilot launch.
- Upgrade to paid (add payment method) before Phase 1 demo day to drop the Twilio trial watermark on calls.

## Test plan
- [ ] Fetching creds via `/shared-creds` returns the Twilio block.
- [ ] Once Phase 1 Week 3 telephony work starts, verify an inbound call to `+16479058093` hits the configured webhook.

Two down, three to go on the Phase 0 shared-accounts task (Deepgram, ElevenLabs, Square).

🤖 Generated with [Claude Code](https://claude.com/claude-code)