### PR TITLE
Flip ElevenLabs row to done in shared-accounts tracker

### DIFF
--- a/docs/06-shared-accounts.md
+++ b/docs/06-shared-accounts.md
@@ -12,7 +12,7 @@ Phase 0 exit requires shared accounts for every service in the niko stack. Each 
 | Twilio | Voice telephony | Meet | ✅ Done | Trial account, $15 credit. Toronto (647) number — swap to US before pilot. Upgrade to paid before Phase 1 demo day to drop trial watermark. Creds in `#shared-creds` |
 | Deepgram | STT (Nova-2 streaming) | Meet | ✅ Done | $200 signup credit. Key `niko-poc` (member scope). Creds in `#shared-creds` |
 | Anthropic | Claude Haiku 4.5 LLM | Meet | ✅ Done | Pay-as-you-go on Console; Claude for Startups is VC-gated (revisit post-raise). Key posted to `#shared-creds` |
-| ElevenLabs | TTS streaming | Meet | ⬜ Todo | Free tier: 10k chars/month |
+| ElevenLabs | TTS streaming | Meet | ✅ Done | Free tier (10k chars/mo). Key `niko-poc`, scoped to TTS + Models + Voices-read. Upgrade to Creator ($22/mo) needed around Phase 1 demo day — team-agreement gate |
 | Square Developer | POS sandbox + production API | Meet | ⬜ Todo | Sandbox access is free |
 
 > **Owner note:** Meet is doing all Phase 0 signups in one pass to avoid parallel-coordination overhead. Domain owners (per `05-team-roles`) take over admin once the account is live and the service is used in code — e.g., Kailash inherits Twilio/Deepgram/Square admin when the telephony + STT + POS work lands; Sandeep inherits ElevenLabs admin with the TTS pipeline.


### PR DESCRIPTION
## Summary
- ElevenLabs account created on the shared Gmail, free tier (10k chars/mo).
- ElevenCreative chosen over ElevenAgents — niko builds its own voice agent pipeline; Agents would duplicate our Twilio+Deepgram+Claude+ElevenLabs stack.
- API key (`niko-poc`) posted to `#shared-creds`, scoped to Text-to-Speech + Models (Access) + Voices (Read). No admin/agent/project/workspace scopes.
- `docs/06-shared-accounts.md` row flipped to ✅ Done.

## Follow-up encoded in the notes column
- Upgrade to Creator ($22/mo) around Phase 1 demo day when TTS volume exceeds the free tier — requires team agreement per `docs/05-team-roles-and-responsibilities.md §4`.

## Test plan
- [ ] Fetching creds via `/shared-creds` returns the ElevenLabs block.
- [ ] Once Phase 1 Week 4 TTS pipeline work starts, verify streaming synthesis works with `eleven_turbo_v2_5` to Twilio.

Four down, one to go on Phase 0 shared-accounts (Square Developer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)