### PR TITLE
Flip Square row to done — Phase 0 shared-accounts complete

### DIFF
--- a/docs/06-shared-accounts.md
+++ b/docs/06-shared-accounts.md
@@ -13,7 +13,7 @@ Phase 0 exit requires shared accounts for every service in the niko stack. Each 
 | Deepgram | STT (Nova-2 streaming) | Meet | ✅ Done | $200 signup credit. Key `niko-poc` (member scope). Creds in `#shared-creds` |
 | Anthropic | Claude Haiku 4.5 LLM | Meet | ✅ Done | Pay-as-you-go on Console; Claude for Startups is VC-gated (revisit post-raise). Key posted to `#shared-creds` |
 | ElevenLabs | TTS streaming | Meet | ✅ Done | Free tier (10k chars/mo). Key `niko-poc`, scoped to TTS + Models + Voices-read. Upgrade to Creator ($22/mo) needed around Phase 1 demo day — team-agreement gate |
-| Square Developer | POS sandbox + production API | Meet | ⬜ Todo | Sandbox access is free |
+| Square Developer | POS sandbox + production API | Meet | ✅ Done | Sandbox app `niko-poc` on a CA seller account (Phase 2.3 dev only — real US restaurants use their own Square US account via OAuth). Creds in `#shared-creds` |
 
 > **Owner note:** Meet is doing all Phase 0 signups in one pass to avoid parallel-coordination overhead. Domain owners (per `05-team-roles`) take over admin once the account is live and the service is used in code — e.g., Kailash inherits Twilio/Deepgram/Square admin when the telephony + STT + POS work lands; Sandeep inherits ElevenLabs admin with the TTS pipeline.
 


### PR DESCRIPTION
## Summary
- Square Developer seller account created on the shared Gmail. Region is Canada (signup flow detected IP and redirected to Square CA); fine for sandbox dev — real US restaurants bring their own Square US account via OAuth when we onboard them in Phase 2.3.
- Sandbox app `niko-poc` created; Application ID and Access Token posted to `#shared-creds`.
- `docs/06-shared-accounts.md` row flipped to ✅ Done.

## Phase 0 shared-accounts — complete
All five remaining third-party signups are now done:
- ✅ GCP (prior)
- ✅ Anthropic (#31)
- ✅ Twilio (#32)
- ✅ Deepgram (#33)
- ✅ ElevenLabs (#34)
- ✅ Square (this PR)

Only the Phase 3/4-deferred LLC item remains on issue #2, which is intentionally out of Phase 0 exit criteria per `CLAUDE.md`.

## Test plan
- [ ] Fetching creds via `/shared-creds` returns the Square block.
- [ ] Once Phase 2.3 Square integration work starts, verify sandbox order push succeeds from the Orders API using the posted Access Token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)