### PR TITLE
Scaffold /voice TwiML endpoint + LLM prompt + demo menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@
 .mcp.json
 node_modules/
 
+# Python
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/
+venv/
+
 # Claude Code: per-developer local permissions (team-shared config lives in settings.json)
 .claude/settings.local.json
 **/.claude/settings.local.json

--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -1,0 +1,73 @@
+"""Haiku 4.5 system prompt for the POC voice agent.
+
+Built at import time from ``app.menu.MENU``. The prompt is tuned for
+voice output: short replies, natural phrasing, no markdown or lists
+(all of which sound wrong through TTS).
+"""
+
+from textwrap import dedent
+
+from app.menu import MENU
+
+_PREAMBLE = dedent("""\
+    You are niko, a friendly voice ordering agent answering the phone for {restaurant}.
+    Your words are synthesized into audio, so:
+
+    - Keep replies short — usually one or two sentences.
+    - No markdown, lists, bullet points, or emojis.
+    - Speak naturally, like a real person on the phone.
+    - Read prices as words ("twelve ninety-nine"), not digits.
+
+    Help callers with two things:
+    1. Place a pickup or delivery order from the menu below.
+    2. Answer quick questions about hours, menu items, or location.
+
+    Conversation flow:
+    - Greet the caller briefly and ask how you can help.
+    - Identify intent — ordering, question, or something else.
+    - If ordering, walk through item, size, quantity, and any modifications.
+    - Confirm the full order (items plus total) before wrapping up.
+    - If delivery, collect the address.
+
+    If a caller asks for something off-menu, politely say you don't offer it and
+    suggest a close alternative. If you're unsure what they said, ask them to
+    repeat rather than guessing.
+""")
+
+
+def _format_menu() -> str:
+    lines = [MENU["restaurant"], ""]
+
+    lines.append("Pizzas:")
+    for item in MENU["pizzas"]:
+        sizes = ", ".join(
+            f"{size} ${price:.2f}" for size, price in item["sizes"].items()
+        )
+        lines.append(f"  - {item['name']} — {item['description']} ({sizes})")
+    lines.append("")
+
+    lines.append("Sides:")
+    for item in MENU["sides"]:
+        lines.append(f"  - {item['name']} — ${item['price']:.2f}")
+    lines.append("")
+
+    lines.append("Drinks:")
+    for item in MENU["drinks"]:
+        lines.append(f"  - {item['name']} — ${item['price']:.2f}")
+    lines.append("")
+
+    lines.append(f"Hours: {MENU['hours']}")
+    lines.append(f"Address: {MENU['address']}")
+
+    return "\n".join(lines)
+
+
+def build_system_prompt() -> str:
+    return (
+        _PREAMBLE.format(restaurant=MENU["restaurant"])
+        + "\nMenu:\n"
+        + _format_menu()
+    )
+
+
+SYSTEM_PROMPT = build_system_prompt()

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
+from twilio.twiml.voice_response import VoiceResponse
 
 app = FastAPI(title="niko")
 
@@ -11,3 +12,19 @@ def root():
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+@app.post("/voice")
+def voice():
+    """Twilio Voice webhook — POC scaffold.
+
+    Returns a canned TwiML greeting so Kailash can wire the Twilio number
+    to this URL and prove the webhook round-trip. Replaced with Media
+    Streams + STT/LLM/TTS integration as the pipeline comes online.
+    """
+    twiml = VoiceResponse()
+    twiml.say(
+        "Hello, thanks for calling niko. The voice agent is coming soon.",
+        voice="alice",
+    )
+    return Response(content=str(twiml), media_type="application/xml")

--- a/app/menu.py
+++ b/app/menu.py
@@ -1,0 +1,50 @@
+"""Hardcoded demo menu used by the Phase 1 POC voice agent.
+
+Phase 2 moves restaurants + menus into Firestore; this module goes away
+then. Keep it flat and easy to read — the LLM prompt formats it directly.
+"""
+
+MENU = {
+    "restaurant": "Niko's Pizza Kitchen",
+    "phone": "+1-647-905-8093",
+    "address": "123 Main Street (demo)",
+    "hours": "Monday-Sunday, 11am to 10pm",
+    "pizzas": [
+        {
+            "name": "Margherita",
+            "description": "Tomato, fresh mozzarella, basil",
+            "sizes": {"small": 12.99, "medium": 16.99, "large": 20.99},
+        },
+        {
+            "name": "Pepperoni",
+            "description": "Tomato, mozzarella, pepperoni",
+            "sizes": {"small": 13.99, "medium": 17.99, "large": 21.99},
+        },
+        {
+            "name": "Hawaiian",
+            "description": "Tomato, mozzarella, ham, pineapple",
+            "sizes": {"small": 14.99, "medium": 18.99, "large": 22.99},
+        },
+        {
+            "name": "Veggie Supreme",
+            "description": "Tomato, mozzarella, bell peppers, onions, mushrooms, olives",
+            "sizes": {"small": 14.99, "medium": 18.99, "large": 22.99},
+        },
+        {
+            "name": "Meat Lovers",
+            "description": "Tomato, mozzarella, pepperoni, sausage, bacon, ham",
+            "sizes": {"small": 15.99, "medium": 19.99, "large": 23.99},
+        },
+    ],
+    "sides": [
+        {"name": "Garlic Knots", "price": 5.99},
+        {"name": "Caesar Salad", "price": 8.99},
+        {"name": "Buffalo Wings (6 pc)", "price": 9.99},
+    ],
+    "drinks": [
+        {"name": "Coke", "price": 2.99},
+        {"name": "Diet Coke", "price": 2.99},
+        {"name": "Sprite", "price": 2.99},
+        {"name": "Bottled Water", "price": 1.99},
+    ],
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.115.0
 uvicorn[standard]==0.32.0
+twilio>=9.0,<10.0


### PR DESCRIPTION
Meet's Week 3 prep per the Phase 1 kickoff post — landing the scaffolding that unblocks Kailash's telephony work (#36) and sets up the LLM pieces Meet picks up in #38 next week.

## What's in here

**`POST /voice` TwiML stub (`app/main.py`)**
Canned Twilio greeting response. Kailash can point the trial Twilio number at `https://<cloud-run-url>/voice` and verify the webhook round-trip before wiring Media Streams + STT. TwiML built via the `twilio` Python SDK (added to `requirements.txt`, pinned to 9.x) rather than hand-rolled XML.

**`app/menu.py`**
Hardcoded pizza-demo menu (5 pizzas, sides, drinks, hours). Intentionally flat dict — easy for the LLM prompt to format inline. Goes away in Phase 2 when restaurants/menus live in Firestore.

**`app/llm/prompts.py`**
Haiku 4.5 system prompt tuned for voice output:
- Short replies (one-to-two sentences)
- No markdown / lists / emojis (they sound wrong through TTS)
- Prices as words (\"twelve ninety-nine\"), not digits
- Conversation flow: greet → intent → order walkthrough → confirm → close
- Off-menu / misheard handling

Not yet wired to the Anthropic API — that's #38 in Week 4. Importing the module today just renders the prompt string.

**`.gitignore`**
Python bytecode caches (`__pycache__/`, `*.pyc`, etc.).

## Refs

- Unblocks #36 (Kailash + Meet)
- Prep for #38 (Meet, Week 4)
- Part of Phase 1 issue #3

## Test plan
- [x] Python syntax check all new files pass (`ast.parse`).
- [x] System prompt renders at import time with the full menu inlined (verified locally).
- [x] After merge, Cloud Run auto-deploy succeeds and `POST /voice` on the deployed URL returns 200 with `application/xml` and a `<Response>...<Say>` body.
- [ ] Kailash wires the Twilio number's Voice webhook to the Cloud Run `/voice` URL and confirms the canned greeting plays on an inbound call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
