### PR TITLE
Add Anthropic LLM client with update_order tool-use (#38)

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -1,0 +1,207 @@
+"""Anthropic Claude Haiku 4.5 client for the voice ordering agent.
+
+Takes a caller transcript plus conversation history and the current
+order state, returns the assistant's spoken reply along with any
+updates to the order (produced via the ``update_order`` tool).
+
+The tool schema mirrors ``app.orders.models.Order`` so Haiku can emit
+partial order state incrementally. The model can both speak to the
+caller and call ``update_order`` in the same turn — we process both
+and advance the conversation.
+
+Not streamed yet. #40 adds streaming to hit the <1s first-audio
+latency budget; today we just prove the synchronous round-trip works.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from anthropic import Anthropic
+
+from app.config import settings
+from app.llm.prompts import SYSTEM_PROMPT
+from app.orders.models import Order
+
+MODEL = "claude-haiku-4-5-20251001"
+MAX_TOKENS = 512
+
+UPDATE_ORDER_TOOL: dict[str, Any] = {
+    "name": "update_order",
+    "description": (
+        "Record the caller's current order state. Call this whenever "
+        "the order changes — items added, removed, or modified; order "
+        "type decided; delivery address given; or the caller confirms "
+        "or cancels. Emit the FULL current order state each time, not "
+        "a diff."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "description": "Full list of line items currently in the order.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "category": {
+                            "type": "string",
+                            "enum": ["pizza", "side", "drink"],
+                        },
+                        "size": {
+                            "type": ["string", "null"],
+                            "description": (
+                                "For pizzas: small | medium | large. "
+                                "Null for sides and drinks."
+                            ),
+                        },
+                        "quantity": {"type": "integer", "minimum": 1},
+                        "unit_price": {
+                            "type": "number",
+                            "description": "Per-unit price from the menu.",
+                        },
+                        "modifications": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Customizations like 'extra cheese' or "
+                                "'no onions'."
+                            ),
+                        },
+                    },
+                    "required": ["name", "category", "quantity", "unit_price"],
+                },
+            },
+            "order_type": {
+                "type": ["string", "null"],
+                "enum": ["pickup", "delivery", None],
+            },
+            "delivery_address": {"type": ["string", "null"]},
+            "status": {
+                "type": "string",
+                "enum": ["in_progress", "confirmed", "cancelled"],
+            },
+        },
+    },
+}
+
+
+@dataclass
+class LLMResponse:
+    reply_text: str
+    order: Order
+    history: list[dict[str, Any]]
+
+
+def _client() -> Anthropic:
+    key = settings.anthropic_api_key
+    if not key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY not set — cannot call the LLM. "
+            "Populate it in your .env (fetch via /shared-creds)."
+        )
+    return Anthropic(api_key=key)
+
+
+def _apply_update(order: Order, patch: dict[str, Any]) -> Order:
+    """Merge a tool-call payload into the current Order.
+
+    Preserves call_sid, caller_phone, restaurant_id, and created_at
+    from the existing order so the LLM cannot overwrite them. Every
+    other field the LLM provided is accepted as the new authoritative
+    value.
+    """
+
+    preserved = {
+        "call_sid": order.call_sid,
+        "caller_phone": order.caller_phone,
+        "restaurant_id": order.restaurant_id,
+        "created_at": order.created_at,
+    }
+    merged = {**order.model_dump(), **patch, **preserved}
+    return Order.model_validate(merged)
+
+
+def generate_reply(
+    *,
+    transcript: str,
+    history: list[dict[str, Any]],
+    order: Order,
+    client: Optional[Anthropic] = None,
+) -> LLMResponse:
+    """Send the caller's latest transcript to Haiku and return a reply.
+
+    ``history`` is Anthropic's Messages format: a list of
+    ``{"role": "user"|"assistant", "content": ...}`` dicts. The updated
+    history (with the new user turn and the assistant turn appended) is
+    returned in ``LLMResponse.history`` so the caller can thread it
+    into the next turn verbatim — including any tool_use blocks, which
+    Anthropic requires to stay in context.
+    """
+
+    api = client or _client()
+
+    new_history = [*history, {"role": "user", "content": transcript}]
+
+    response = api.messages.create(
+        model=MODEL,
+        max_tokens=MAX_TOKENS,
+        system=SYSTEM_PROMPT,
+        tools=[UPDATE_ORDER_TOOL],
+        messages=new_history,
+    )
+
+    reply_text_parts: list[str] = []
+    tool_uses: list[dict[str, Any]] = []
+    for block in response.content:
+        if block.type == "text":
+            reply_text_parts.append(block.text)
+        elif block.type == "tool_use" and block.name == "update_order":
+            tool_uses.append({"id": block.id, "input": block.input})
+
+    updated_order = order
+    for tu in tool_uses:
+        updated_order = _apply_update(updated_order, tu["input"])
+
+    assistant_content = [block.model_dump() for block in response.content]
+    new_history = [
+        *new_history,
+        {"role": "assistant", "content": assistant_content},
+    ]
+
+    if not reply_text_parts and tool_uses:
+        tool_results = [
+            {
+                "type": "tool_result",
+                "tool_use_id": tu["id"],
+                "content": "Order updated.",
+            }
+            for tu in tool_uses
+        ]
+        new_history = [
+            *new_history,
+            {"role": "user", "content": tool_results},
+        ]
+        followup = api.messages.create(
+            model=MODEL,
+            max_tokens=MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            tools=[UPDATE_ORDER_TOOL],
+            messages=new_history,
+        )
+        for block in followup.content:
+            if block.type == "text":
+                reply_text_parts.append(block.text)
+        followup_content = [block.model_dump() for block in followup.content]
+        new_history = [
+            *new_history,
+            {"role": "assistant", "content": followup_content},
+        ]
+
+    return LLMResponse(
+        reply_text="".join(reply_text_parts).strip(),
+        order=updated_order,
+        history=new_history,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.0
 uvicorn[standard]==0.32.0
 twilio>=9.0,<10.0
 pydantic-settings>=2.0,<3.0
+anthropic>=0.40,<1.0

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,193 @@
+"""Unit tests for the Anthropic LLM client.
+
+All tests use a fake Anthropic client so the suite runs offline with no
+API costs. The shape of ``FakeBlock`` mirrors ``anthropic.types.*Block``
+just closely enough for our consumer — ``.type``, ``.text`` / ``.id`` /
+``.name`` / ``.input``, and ``.model_dump()``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.llm import client as client_module
+from app.llm.client import _apply_update, generate_reply
+from app.orders.models import Order, OrderStatus, OrderType
+
+
+@dataclass
+class FakeBlock:
+    type: str
+    text: str = ""
+    id: str = ""
+    name: str = ""
+    input: Optional[dict[str, Any]] = field(default=None)
+
+    def model_dump(self) -> dict[str, Any]:
+        if self.type == "text":
+            return {"type": "text", "text": self.text}
+        return {
+            "type": "tool_use",
+            "id": self.id,
+            "name": self.name,
+            "input": self.input or {},
+        }
+
+
+def _fake_response(blocks: list[FakeBlock]) -> MagicMock:
+    return MagicMock(content=blocks)
+
+
+def test_plain_text_response_leaves_order_unchanged():
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [FakeBlock(type="text", text="Hi, what would you like to order?")]
+    )
+
+    result = generate_reply(
+        transcript="hello",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assert result.reply_text == "Hi, what would you like to order?"
+    assert result.order is order
+    assert fake_client.messages.create.call_count == 1
+
+
+def test_tool_use_updates_order_in_single_turn():
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [
+            FakeBlock(
+                type="tool_use",
+                id="toolu_1",
+                name="update_order",
+                input={
+                    "items": [
+                        {
+                            "name": "Pepperoni",
+                            "category": "pizza",
+                            "size": "medium",
+                            "quantity": 1,
+                            "unit_price": 17.99,
+                            "modifications": [],
+                        }
+                    ],
+                    "order_type": "pickup",
+                    "status": "in_progress",
+                },
+            ),
+            FakeBlock(
+                type="text",
+                text="One medium pepperoni for pickup. Anything else?",
+            ),
+        ]
+    )
+
+    result = generate_reply(
+        transcript="one medium pepperoni for pickup",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assert result.reply_text == "One medium pepperoni for pickup. Anything else?"
+    assert len(result.order.items) == 1
+    assert result.order.items[0].name == "Pepperoni"
+    assert result.order.order_type is OrderType.PICKUP
+    assert result.order.call_sid == "CAtest"
+    assert fake_client.messages.create.call_count == 1
+
+
+def test_tool_only_response_triggers_followup_call():
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = [
+        _fake_response(
+            [
+                FakeBlock(
+                    type="tool_use",
+                    id="toolu_1",
+                    name="update_order",
+                    input={"items": [], "status": "cancelled"},
+                ),
+            ]
+        ),
+        _fake_response(
+            [
+                FakeBlock(
+                    type="text",
+                    text="Okay, order cancelled. Have a good day.",
+                ),
+            ]
+        ),
+    ]
+
+    result = generate_reply(
+        transcript="never mind cancel",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assert result.reply_text == "Okay, order cancelled. Have a good day."
+    assert result.order.status is OrderStatus.CANCELLED
+    assert fake_client.messages.create.call_count == 2
+
+
+def test_history_threads_user_and_assistant_turns():
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [FakeBlock(type="text", text="Sure, what size?")]
+    )
+
+    result = generate_reply(
+        transcript="one pepperoni please",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assert result.history[0] == {"role": "user", "content": "one pepperoni please"}
+    assert result.history[1]["role"] == "assistant"
+    assert result.history[1]["content"] == [
+        {"type": "text", "text": "Sure, what size?"}
+    ]
+
+
+def test_apply_update_preserves_call_sid_and_created_at():
+    original = Order(call_sid="CAoriginal")
+    original_created_at = original.created_at
+
+    updated = _apply_update(
+        original,
+        {
+            "call_sid": "CAhacked",
+            "created_at": "1999-01-01T00:00:00Z",
+            "items": [
+                {
+                    "name": "Coke",
+                    "category": "drink",
+                    "quantity": 1,
+                    "unit_price": 2.99,
+                }
+            ],
+        },
+    )
+
+    assert updated.call_sid == "CAoriginal"
+    assert updated.created_at == original_created_at
+    assert len(updated.items) == 1
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.setattr(client_module.settings, "anthropic_api_key", None)
+    with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
+        client_module._client()


### PR DESCRIPTION
Second slice of Meet's Week 4 work (#38). Wires Haiku 4.5 via the Anthropic SDK so a caller transcript + conversation history + current `Order` produces a reply string and (optionally) an updated `Order` via tool-use.

Builds on the Pydantic models shipped in #45 — the tool schema mirrors them so Haiku can emit partial order state as the caller builds their order.

## What's in here

**`app/llm/client.py`**

- `generate_reply(transcript, history, order, client=None)` — main entrypoint. Calls Haiku with the system prompt from `app/llm/prompts.py`, the single `update_order` tool, and the conversation history. Returns `LLMResponse(reply_text, order, history)`.
- `UPDATE_ORDER_TOOL` — JSON Schema that mirrors `Order` + `LineItem`. Haiku emits the FULL current order state on each call (not a diff) — this keeps the merge trivial and matches how voice agents actually behave (restate the whole order after each turn).
- `_apply_update(order, patch)` — merges the tool payload over the current order, pinning `call_sid`, `caller_phone`, `restaurant_id`, `created_at` to their original values regardless of what the LLM emits. The model cannot hijack identity fields.
- Single-turn happy path: when Haiku emits text + tool_use in one response, we apply the tool and return the text — no second API call.
- Tool-only fallback: if Haiku calls the tool without speaking (rare), we send a `tool_result` and do a second call to get the spoken reply. TTS needs something to say.
- Adds `anthropic>=0.40,<1.0` to `requirements.txt`.

**`tests/test_llm_client.py`** — 6 unit tests covering:

- Plain text response leaves order unchanged, one API call.
- Tool_use + text in one response updates order + extracts reply, one API call.
- Tool-only response triggers a second call to fetch the spoken reply.
- History threading preserves Anthropic Messages format (needed for follow-up turns to retain tool_use context).
- `_apply_update` preserves `call_sid` + `created_at` even if the LLM tries to overwrite them.
- Missing `ANTHROPIC_API_KEY` raises a clean `RuntimeError`.

All tests use an injected `MagicMock` client — no network, no API cost. Suite now 20 passing.

## Out of scope for this PR

- Wiring `generate_reply` into a live endpoint. That needs STT (#37) finals, which Kailash owns this week. For now `app.main` doesn't import the module.
- Streaming (SSE / `messages.stream`). #40 introduces streaming when we're tuning for the <1s first-audio budget.
- Real-API integration test. Easy to add later as `@pytest.mark.skipif(not settings.anthropic_api_key, ...)` — omitted today to keep CI zero-cost.

## Test plan

- [x] `pytest -v` passes (20/20 — 6 new + 14 existing).
- [x] Model ID `claude-haiku-4-5-20251001` matches the env-reported Haiku 4.5 identifier.
- [x] After merge, Cloud Run auto-deploy still succeeds (new `anthropic` dep in image, no behavior change — `app.main` doesn't import the client yet).

## Refs

- Part of #38 (Meet, Week 4)
- Builds on #45 (Order/LineItem models)
- Consumed by #37 / #40 when STT finals start flowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
