### PR TITLE
Add Firestore storage module for Order persistence

### DIFF
--- a/app/storage/firestore.py
+++ b/app/storage/firestore.py
@@ -1,0 +1,88 @@
+"""Firestore persistence for orders.
+
+One collection: ``orders``. Documents are keyed by ``call_sid`` so
+writes during a single call are idempotent — the same Twilio call
+always maps to the same document.
+
+Auth resolution:
+
+- In Cloud Run, the service account attached to the service auto-auths
+  via the GCE metadata server — no setup needed.
+- Locally: ``gcloud auth application-default login`` or point
+  ``GOOGLE_APPLICATION_CREDENTIALS`` at a service-account JSON.
+
+Project is auto-detected in Cloud Run. Locally set
+``GOOGLE_CLOUD_PROJECT=niko-tsuki``.
+
+Computed fields on ``Order`` / ``LineItem`` (``subtotal``, ``line_total``)
+are written to Firestore as plain numbers for easy reads by the
+dashboard. On the way back through ``model_validate`` they are dropped
+and recomputed from the source fields, so stored values can't drift.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from google.cloud import firestore
+
+from app.orders.models import Order
+
+_COLLECTION = "orders"
+
+_client: Optional[firestore.Client] = None
+
+
+def _get_client() -> firestore.Client:
+    global _client
+    if _client is None:
+        _client = firestore.Client()
+    return _client
+
+
+def set_client(client: Optional[firestore.Client]) -> None:
+    """Override the module-level Firestore client.
+
+    Used by tests (with a ``MagicMock``) and by the Firestore emulator
+    wiring. Pass ``None`` to reset to the default client on next call.
+    """
+
+    global _client
+    _client = client
+
+
+def save_order(order: Order) -> str:
+    """Upsert an Order into Firestore, keyed by ``call_sid``.
+
+    Returns the document ID (== ``call_sid``). Idempotent across
+    retries within the same call.
+    """
+
+    client = _get_client()
+    payload = order.model_dump(mode="python")
+    client.collection(_COLLECTION).document(order.call_sid).set(payload)
+    return order.call_sid
+
+
+def get_order(call_sid: str) -> Optional[Order]:
+    """Fetch a single Order by its ``call_sid``. Returns ``None`` if
+    the document doesn't exist."""
+
+    client = _get_client()
+    snapshot = client.collection(_COLLECTION).document(call_sid).get()
+    if not snapshot.exists:
+        return None
+    return Order.model_validate(snapshot.to_dict())
+
+
+def list_recent_orders(limit: int = 50) -> list[Order]:
+    """Return orders most-recent-first, up to ``limit``. Used by the
+    dashboard read route (#41)."""
+
+    client = _get_client()
+    query = (
+        client.collection(_COLLECTION)
+        .order_by("created_at", direction=firestore.Query.DESCENDING)
+        .limit(limit)
+    )
+    return [Order.model_validate(snap.to_dict()) for snap in query.stream()]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.32.0
 twilio>=9.0,<10.0
 pydantic-settings>=2.0,<3.0
 anthropic>=0.40,<1.0
+google-cloud-firestore>=2.0,<3.0

--- a/tests/test_firestore_storage.py
+++ b/tests/test_firestore_storage.py
@@ -1,0 +1,160 @@
+"""Unit tests for the Firestore storage module.
+
+All tests use a ``MagicMock`` in place of ``firestore.Client`` so the
+suite runs offline with no GCP auth. Real Firestore behavior is
+covered separately by an integration test (follow-up) against the
+local Firestore emulator.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.orders.models import ItemCategory, LineItem, Order, OrderType
+from app.storage import firestore as storage
+
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    """Ensure every test starts with a fresh mock; module-level state
+    doesn't leak between tests."""
+
+    yield
+    storage.set_client(None)
+
+
+def _fake_client() -> MagicMock:
+    client = MagicMock()
+    storage.set_client(client)
+    return client
+
+
+def _pepperoni() -> LineItem:
+    return LineItem(
+        name="Pepperoni",
+        category=ItemCategory.PIZZA,
+        size="medium",
+        quantity=1,
+        unit_price=17.99,
+    )
+
+
+def test_save_order_upserts_by_call_sid():
+    client = _fake_client()
+    order = Order(
+        call_sid="CAsave1",
+        items=[_pepperoni()],
+        order_type=OrderType.PICKUP,
+    )
+
+    doc_id = storage.save_order(order)
+
+    assert doc_id == "CAsave1"
+    client.collection.assert_called_with("orders")
+    client.collection.return_value.document.assert_called_with("CAsave1")
+
+    set_call = client.collection.return_value.document.return_value.set
+    set_call.assert_called_once()
+    payload = set_call.call_args[0][0]
+    assert payload["call_sid"] == "CAsave1"
+    assert payload["order_type"] == "pickup"
+    assert payload["items"][0]["name"] == "Pepperoni"
+
+
+def test_get_order_returns_none_when_missing():
+    client = _fake_client()
+    client.collection.return_value.document.return_value.get.return_value.exists = False
+
+    result = storage.get_order("CAmissing")
+
+    assert result is None
+
+
+def test_get_order_hydrates_pydantic_model():
+    client = _fake_client()
+    snapshot = client.collection.return_value.document.return_value.get.return_value
+    snapshot.exists = True
+    snapshot.to_dict.return_value = {
+        "call_sid": "CAfetch",
+        "restaurant_id": "niko-pizza-kitchen",
+        "items": [
+            {
+                "name": "Coke",
+                "category": "drink",
+                "size": None,
+                "quantity": 2,
+                "unit_price": 2.99,
+                "modifications": [],
+            }
+        ],
+        "order_type": "pickup",
+        "status": "confirmed",
+    }
+
+    result = storage.get_order("CAfetch")
+
+    assert result is not None
+    assert result.call_sid == "CAfetch"
+    assert result.order_type is OrderType.PICKUP
+    assert len(result.items) == 1
+    # Computed fields re-derive from source fields on validate.
+    assert result.subtotal == pytest.approx(5.98)
+    assert result.items[0].line_total == pytest.approx(5.98)
+
+
+def test_list_recent_orders_queries_ordered_and_limited():
+    client = _fake_client()
+    snap1 = MagicMock()
+    snap1.to_dict.return_value = {"call_sid": "CA1", "items": []}
+    snap2 = MagicMock()
+    snap2.to_dict.return_value = {"call_sid": "CA2", "items": []}
+
+    query = (
+        client.collection.return_value
+        .order_by.return_value
+        .limit.return_value
+    )
+    query.stream.return_value = iter([snap1, snap2])
+
+    result = storage.list_recent_orders(limit=5)
+
+    client.collection.assert_called_with("orders")
+    client.collection.return_value.order_by.assert_called_once()
+    order_by_args = client.collection.return_value.order_by.call_args
+    assert order_by_args[0][0] == "created_at"
+
+    limit_call = client.collection.return_value.order_by.return_value.limit
+    limit_call.assert_called_with(5)
+
+    assert [o.call_sid for o in result] == ["CA1", "CA2"]
+
+
+def test_computed_fields_dropped_on_read_even_if_present():
+    """If an older stored document has stale computed fields, the
+    freshly-validated Order recomputes them — stored totals can never
+    drift from the source-of-truth."""
+
+    client = _fake_client()
+    snapshot = client.collection.return_value.document.return_value.get.return_value
+    snapshot.exists = True
+    snapshot.to_dict.return_value = {
+        "call_sid": "CAstale",
+        "items": [
+            {
+                "name": "Pepperoni",
+                "category": "pizza",
+                "size": "medium",
+                "quantity": 1,
+                "unit_price": 17.99,
+                "modifications": [],
+                "line_total": 999.99,  # stale / wrong
+            }
+        ],
+        "subtotal": 999.99,  # stale / wrong
+    }
+
+    result = storage.get_order("CAstale")
+
+    assert result is not None
+    assert result.items[0].line_total == 17.99
+    assert result.subtotal == 17.99


### PR DESCRIPTION
## Summary

- `app/storage/firestore.py` — thin wrapper over `google-cloud-firestore` with three ops: `save_order`, `get_order`, `list_recent_orders`.
- `orders` collection; documents are keyed by `call_sid` so writes during a single Twilio call are idempotent (same sid → same doc, retries are safe).
- Computed fields (`subtotal`, `line_total`) are written to Firestore as plain numbers for easy dashboard reads, then dropped + recomputed on `model_validate` — stored values can't drift from the source-of-truth fields.
- `set_client()` hook lets tests inject a `MagicMock`; no GCP auth needed in CI.

## Design notes

- Auth resolves via the GCE metadata server in Cloud Run (attached service account), or ADC locally (`gcloud auth application-default login`).
- Project auto-detects in Cloud Run; locally set `GOOGLE_CLOUD_PROJECT=niko-tsuki`.
- `google-cloud-firestore>=2.0,<3.0` added to `requirements.txt`.

## Out of scope (follow-ups)

- Provisioning the Firestore database on the `niko-tsuki` project (`gcloud firestore databases create --location=us-central1`) — one-time infra step.
- Granting `roles/datastore.user` to the Cloud Run service account before runtime calls work.
- Integration test against the Firestore emulator.
- Wiring `save_order` into `app.main` once STT (#37) lands and we have a real transcript loop.

## Test plan

- [x] `pytest -v tests/test_firestore_storage.py` — 5/5 passing (offline, MagicMock)
- [x] Full suite (excluding gated live LLM tests): 25/25 passing
- [ ] Emulator-backed integration test (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)