### PR TITLE
Add GET /orders dashboard route + /dev/seed-order

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -27,5 +27,10 @@ class Settings(BaseSettings):
     square_access_token: Optional[str] = None
     square_application_id: Optional[str] = None
 
+    # Enables dev-only routes like POST /dev/seed-order. Must stay false
+    # in production; flip to true locally or in a preview env when the
+    # dashboard needs seed data before the voice loop is wired up.
+    niko_dev_endpoints: bool = False
+
 
 settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,11 @@
-from fastapi import FastAPI, Response
+import time
+
+from fastapi import FastAPI, HTTPException, Response
 from twilio.twiml.voice_response import VoiceResponse
+
+from app.config import settings
+from app.orders.models import ItemCategory, LineItem, Order, OrderType
+from app.storage import firestore as order_storage
 
 app = FastAPI(title="niko")
 
@@ -28,3 +34,54 @@ def voice():
         voice="alice",
     )
     return Response(content=str(twiml), media_type="application/xml")
+
+
+@app.get("/orders")
+def list_orders(limit: int = 50):
+    """Return recent orders for the dashboard, most-recent-first.
+
+    Read-only view over the Firestore ``orders`` collection (#41). Hard
+    cap on ``limit`` so a misconfigured client can't exhaust the Cloud
+    Run instance.
+    """
+
+    if limit < 1 or limit > 200:
+        raise HTTPException(status_code=400, detail="limit must be 1..200")
+    orders = order_storage.list_recent_orders(limit=limit)
+    return {"orders": [o.model_dump(mode="json") for o in orders]}
+
+
+@app.post("/dev/seed-order")
+def seed_order():
+    """Insert a canned order so Daniel can build the dashboard against a
+    real Firestore read path before the voice loop is wired up.
+
+    Gated on ``NIKO_DEV_ENDPOINTS=true`` — returns 404 in production so
+    the route effectively doesn't exist there.
+    """
+
+    if not settings.niko_dev_endpoints:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    seed = Order(
+        call_sid=f"CAseed-{int(time.time())}",
+        caller_phone="+15551234567",
+        order_type=OrderType.PICKUP,
+        items=[
+            LineItem(
+                name="Pepperoni",
+                category=ItemCategory.PIZZA,
+                size="medium",
+                quantity=1,
+                unit_price=17.99,
+            ),
+            LineItem(
+                name="Coke",
+                category=ItemCategory.DRINK,
+                quantity=2,
+                unit_price=2.99,
+            ),
+        ],
+    )
+    doc_id = order_storage.save_order(seed)
+    return {"doc_id": doc_id, "order": seed.model_dump(mode="json")}

--- a/tests/test_orders_route.py
+++ b/tests/test_orders_route.py
@@ -1,0 +1,115 @@
+"""Tests for the dashboard /orders read route and /dev/seed-order.
+
+Uses the Firestore storage module's ``set_client`` injection hook with
+a ``MagicMock`` so the HTTP layer is exercised end-to-end without any
+GCP dependency.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.main import app
+from app.storage import firestore as storage
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_storage_client():
+    yield
+    storage.set_client(None)
+
+
+@pytest.fixture
+def dev_endpoints_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "niko_dev_endpoints", True)
+
+
+def _fake_firestore_with_orders(docs: list[dict]) -> MagicMock:
+    fake_client = MagicMock()
+    snapshots = []
+    for doc in docs:
+        snap = MagicMock()
+        snap.to_dict.return_value = doc
+        snapshots.append(snap)
+    (
+        fake_client.collection.return_value
+        .order_by.return_value
+        .limit.return_value
+        .stream.return_value
+    ) = iter(snapshots)
+    storage.set_client(fake_client)
+    return fake_client
+
+
+def test_list_orders_returns_recent_orders():
+    _fake_firestore_with_orders([
+        {
+            "call_sid": "CA1",
+            "items": [
+                {
+                    "name": "Pepperoni",
+                    "category": "pizza",
+                    "size": "medium",
+                    "quantity": 1,
+                    "unit_price": 17.99,
+                    "modifications": [],
+                }
+            ],
+            "order_type": "pickup",
+            "status": "confirmed",
+        },
+        {"call_sid": "CA2", "items": []},
+    ])
+
+    response = client.get("/orders")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [o["call_sid"] for o in body["orders"]] == ["CA1", "CA2"]
+    # Computed fields make it into the JSON payload for the dashboard.
+    assert body["orders"][0]["subtotal"] == 17.99
+    assert body["orders"][0]["items"][0]["line_total"] == 17.99
+
+
+def test_list_orders_respects_limit_query_param():
+    fake = _fake_firestore_with_orders([])
+
+    response = client.get("/orders?limit=10")
+
+    assert response.status_code == 200
+    fake.collection.return_value.order_by.return_value.limit.assert_called_with(10)
+
+
+def test_list_orders_rejects_out_of_range_limit():
+    _fake_firestore_with_orders([])
+
+    assert client.get("/orders?limit=0").status_code == 400
+    assert client.get("/orders?limit=500").status_code == 400
+
+
+def test_seed_order_returns_404_when_dev_flag_off(monkeypatch):
+    monkeypatch.setattr(settings, "niko_dev_endpoints", False)
+
+    response = client.post("/dev/seed-order")
+
+    assert response.status_code == 404
+
+
+def test_seed_order_persists_when_dev_flag_on(dev_endpoints_enabled):
+    fake = MagicMock()
+    storage.set_client(fake)
+
+    response = client.post("/dev/seed-order")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["doc_id"].startswith("CAseed-")
+    assert body["order"]["order_type"] == "pickup"
+    assert len(body["order"]["items"]) == 2
+
+    fake.collection.assert_called_with("orders")
+    fake.collection.return_value.document.return_value.set.assert_called_once()


### PR DESCRIPTION
## Summary

First slice of #41 — exposes the Firestore `orders` collection as a JSON read endpoint so Daniel can build the Next.js dashboard against a real API instead of fixtures.

- `GET /orders?limit=N` (1..200, default 50) — most-recent-first, uses `Order.model_dump(mode=\"json\")` so computed fields (`subtotal`, `line_total`) and datetime strings serialize cleanly for the browser.
- `POST /dev/seed-order` — inserts a canned pickup order (pepperoni + two Cokes) so the dashboard has something to render before STT + voice loop land. Gated on `NIKO_DEV_ENDPOINTS=true`; returns 404 in prod so the route effectively doesn't exist there.
- `app/config.py` gains `niko_dev_endpoints: bool = False`.

## Tests

- 5 new tests in `tests/test_orders_route.py` — MagicMock-injected Firestore client, no GCP auth needed.
- Full offline suite: 30/30 passing (excluding the gated live Anthropic tests).

## Required infra before this is usable in Cloud Run

Two one-time user-shell actions:
1. `gcloud firestore databases create --location=us-central1 --project=niko-tsuki`
2. Grant `roles/datastore.user` to the Cloud Run runtime service account.

Set `NIKO_DEV_ENDPOINTS=true` on the Cloud Run service to enable the seed endpoint temporarily for dashboard bring-up. Flip it off before we take real calls.

## Test plan

- [x] `pytest -v` — 30/30 passing
- [ ] After Cloud Run deploy: `curl https://<cloud-run-url>/orders` returns `{\"orders\": []}`
- [ ] `curl -X POST https://<cloud-run-url>/dev/seed-order` (dev flag on) → seed persists, subsequent GET returns it

🤖 Generated with [Claude Code](https://claude.com/claude-code)