### PR TITLE
Add LLM edge-case test coverage (#38)

### DIFF
--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -191,3 +191,171 @@ def test_missing_api_key_raises(monkeypatch):
     monkeypatch.setattr(client_module.settings, "anthropic_api_key", None)
     with pytest.raises(RuntimeError, match="ANTHROPIC_API_KEY"):
         client_module._client()
+
+
+def test_off_menu_request_leaves_order_empty():
+    """When the caller asks for something off-menu, the model declines
+    without calling update_order. Order state must not advance."""
+
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [
+            FakeBlock(
+                type="text",
+                text=(
+                    "Sorry, we don't offer sushi here. We have pizzas, "
+                    "sides, and drinks — would any of those work?"
+                ),
+            )
+        ]
+    )
+
+    result = generate_reply(
+        transcript="can I get some sushi",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assert "sushi" in result.reply_text.lower()
+    assert result.order.items == []
+    assert result.order.status is OrderStatus.IN_PROGRESS
+    assert fake_client.messages.create.call_count == 1
+
+
+def test_unclear_utterance_asks_for_clarification():
+    """A garbled / unclear caller utterance should produce a clarifying
+    question with no order mutation."""
+
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [
+            FakeBlock(
+                type="text",
+                text="Sorry, I didn't catch that. Could you say it again?",
+            )
+        ]
+    )
+
+    result = generate_reply(
+        transcript="mmrgh pfftbl",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assert "again" in result.reply_text.lower() or "didn't catch" in result.reply_text.lower()
+    assert result.order.items == []
+    assert fake_client.messages.create.call_count == 1
+
+
+def test_caller_changes_mind_replaces_items():
+    """When the caller switches their order mid-conversation, the model
+    emits the FULL new state via update_order — the previous item is
+    replaced, not appended to."""
+
+    order = Order(call_sid="CAtest")
+    order = _apply_update(
+        order,
+        {
+            "items": [
+                {
+                    "name": "Pepperoni",
+                    "category": "pizza",
+                    "size": "medium",
+                    "quantity": 1,
+                    "unit_price": 17.99,
+                }
+            ],
+            "order_type": "pickup",
+            "status": "in_progress",
+        },
+    )
+    assert order.items[0].name == "Pepperoni"
+
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [
+            FakeBlock(
+                type="tool_use",
+                id="toolu_change",
+                name="update_order",
+                input={
+                    "items": [
+                        {
+                            "name": "Veggie Supreme",
+                            "category": "pizza",
+                            "size": "medium",
+                            "quantity": 1,
+                            "unit_price": 18.99,
+                            "modifications": [],
+                        }
+                    ],
+                    "order_type": "pickup",
+                    "status": "in_progress",
+                },
+            ),
+            FakeBlock(
+                type="text",
+                text="Got it — one medium veggie supreme for pickup instead.",
+            ),
+        ]
+    )
+
+    result = generate_reply(
+        transcript="actually scratch that, make it a veggie supreme",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assert len(result.order.items) == 1
+    assert result.order.items[0].name == "Veggie Supreme"
+    assert result.order.items[0].unit_price == 18.99
+    assert result.order.order_type is OrderType.PICKUP
+
+
+def test_modifications_round_trip_into_line_item():
+    """Modifications like 'extra cheese' or 'no onions' must survive
+    tool-use payload → LineItem deserialization."""
+
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [
+            FakeBlock(
+                type="tool_use",
+                id="toolu_mods",
+                name="update_order",
+                input={
+                    "items": [
+                        {
+                            "name": "Margherita",
+                            "category": "pizza",
+                            "size": "large",
+                            "quantity": 1,
+                            "unit_price": 20.99,
+                            "modifications": ["extra cheese", "no basil"],
+                        }
+                    ],
+                    "order_type": "pickup",
+                    "status": "in_progress",
+                },
+            ),
+            FakeBlock(
+                type="text",
+                text="One large margherita with extra cheese and no basil.",
+            ),
+        ]
+    )
+
+    result = generate_reply(
+        transcript="large margherita extra cheese no basil",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assert result.order.items[0].modifications == ["extra cheese", "no basil"]

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -59,3 +59,57 @@ def test_greeting_does_not_mutate_order():
 
     assert len(result.reply_text) > 5, "Haiku should greet back"
     assert len(result.order.items) == 0, "No items added from a pure greeting"
+
+
+def test_off_menu_item_is_declined_without_adding():
+    """Asking for something not on the demo menu (sushi) should produce
+    a polite decline and NOT add anything to the order."""
+
+    order = Order(call_sid="CAintegration-offmenu")
+    transcript = "Hi, can I get some sushi please?"
+
+    result = generate_reply(transcript=transcript, history=[], order=order)
+
+    print(f"\n--- Caller ---\n{transcript}")
+    print(f"\n--- Haiku reply ---\n{result.reply_text}")
+    print(f"\n--- Order items ---\n{result.order.items}")
+
+    assert len(result.reply_text) > 5, "Haiku should respond"
+    assert len(result.order.items) == 0, (
+        "Off-menu requests must not be added to the order"
+    )
+
+
+def test_caller_changes_mind_replaces_pizza():
+    """A multi-turn conversation where the caller switches pizzas
+    mid-order. The final order should reflect ONLY the new pizza —
+    the model is instructed to emit full state, not diffs."""
+
+    order = Order(call_sid="CAintegration-changemind")
+
+    first = generate_reply(
+        transcript="I'd like a medium pepperoni for pickup.",
+        history=[],
+        order=order,
+    )
+    print(f"\n--- Turn 1 reply ---\n{first.reply_text}")
+    print(f"\n--- Turn 1 order ---\n{first.order.model_dump_json(indent=2)}")
+    assert any(
+        "pepperoni" in item.name.lower() for item in first.order.items
+    ), "Turn 1 should record the pepperoni"
+
+    second = generate_reply(
+        transcript="Actually, scratch that — make it a large veggie supreme instead.",
+        history=first.history,
+        order=first.order,
+    )
+    print(f"\n--- Turn 2 reply ---\n{second.reply_text}")
+    print(f"\n--- Turn 2 order ---\n{second.order.model_dump_json(indent=2)}")
+
+    pizza_names = [item.name.lower() for item in second.order.items]
+    assert any("veggie" in name for name in pizza_names), (
+        "Turn 2 should record the veggie supreme"
+    )
+    assert not any("pepperoni" in name for name in pizza_names), (
+        "Turn 2 should have replaced the pepperoni, not kept both"
+    )


### PR DESCRIPTION
## Summary
- Adds 4 mocked unit tests + 2 live integration tests covering the LLM edge cases called out in #38's done-when criterion 4: off-menu items, unclear utterances, and mid-order changes.
- Pins the contract that `update_order` carries full state (not diffs), so a caller changing their mind replaces line items instead of appending.
- No prompt edits — the existing system prompt already instructs Haiku to decline off-menu items politely and ask for clarification on unclear input.

## Linked issue
Closes #38

## Test plan
- [x] `python -m pytest tests/test_llm_client.py -v` → 10 passed (6 existing + 4 new).
- [x] Full suite (excluding modules that need `deepgram` locally): 26 passed, 4 skipped — the 4 integration tests gate cleanly without `ANTHROPIC_API_KEY`.
- [ ] Run the live integration tests once with the real key: `ANTHROPIC_API_KEY=... pytest -v -s tests/test_llm_integration.py` to confirm Haiku actually declines off-menu and replaces (not appends) on change-of-mind.

## Notes
- Streaming reply for the <1s first-audio latency budget is intentionally out of scope here — that work belongs to #40 (end-to-end call flow).
- The two new integration tests cost a small amount of API budget per run; they're gated on the key so CI / teammates without one stay silent.
