### PR TITLE
Deploy dashboard as its own Cloud Run service

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -1,0 +1,71 @@
+name: Deploy Dashboard to Cloud Run
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "dashboard/**"
+      - ".github/workflows/deploy-dashboard.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-dashboard-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      IMAGE: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GCP_AR_REPO }}/${{ vars.CLOUD_RUN_DASHBOARD_SERVICE }}:${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
+          service_account: ${{ vars.GCP_DEPLOY_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ vars.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Build image
+        # Public Firebase config is baked into the client bundle at build
+        # time. These are repo vars (not secrets) — Firebase web config is
+        # designed to be public; security rules enforce access.
+        working-directory: dashboard
+        run: |
+          docker build \
+            --build-arg NEXT_PUBLIC_FIREBASE_API_KEY="${{ vars.NEXT_PUBLIC_FIREBASE_API_KEY }}" \
+            --build-arg NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="${{ vars.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}" \
+            --build-arg NEXT_PUBLIC_FIREBASE_PROJECT_ID="${{ vars.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}" \
+            --build-arg NEXT_PUBLIC_FIREBASE_APP_ID="${{ vars.NEXT_PUBLIC_FIREBASE_APP_ID }}" \
+            -t "$IMAGE" .
+
+      - name: Push image
+        run: docker push "$IMAGE"
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ vars.CLOUD_RUN_DASHBOARD_SERVICE }}
+          region: ${{ vars.GCP_REGION }}
+          image: ${{ env.IMAGE }}
+          flags: --allow-unauthenticated --port=8080
+          env_vars: |
+            NIKO_API_BASE_URL=${{ vars.NIKO_API_BASE_URL }}
+
+      - name: Show service URL
+        run: |
+          URL=$(gcloud run services describe ${{ vars.CLOUD_RUN_DASHBOARD_SERVICE }} \
+            --region=${{ vars.GCP_REGION }} --format='value(status.url)')
+          echo "Dashboard deployed at: $URL"
+          echo "### Dashboard URL: $URL" >> $GITHUB_STEP_SUMMARY

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+.next
+.git
+.env
+.env.local
+.env.*.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+README.md
+AGENTS.md
+CLAUDE.md
+coverage
+*.log

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for the niko dashboard (Next.js 16, App Router, RSC).
+# Produces a self-contained server image via `output: "standalone"`.
+#
+# Build-time args (must be present at `next build` because Next.js inlines
+# `NEXT_PUBLIC_*` into the client bundle):
+#   - NEXT_PUBLIC_FIREBASE_API_KEY
+#   - NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+#   - NEXT_PUBLIC_FIREBASE_PROJECT_ID
+#   - NEXT_PUBLIC_FIREBASE_APP_ID
+#
+# Runtime env (passed by Cloud Run, not baked in):
+#   - NIKO_API_BASE_URL — the FastAPI Cloud Run service URL
+#   - PORT — Cloud Run sets this; Next.js standalone reads it
+
+ARG NODE_VERSION=20-alpine
+
+# ---------- deps ----------
+FROM node:${NODE_VERSION} AS deps
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml* ./
+RUN pnpm install --frozen-lockfile
+
+# ---------- build ----------
+FROM node:${NODE_VERSION} AS build
+WORKDIR /app
+RUN corepack enable
+
+ARG NEXT_PUBLIC_FIREBASE_API_KEY
+ARG NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+ARG NEXT_PUBLIC_FIREBASE_PROJECT_ID
+ARG NEXT_PUBLIC_FIREBASE_APP_ID
+ENV NEXT_PUBLIC_FIREBASE_API_KEY=${NEXT_PUBLIC_FIREBASE_API_KEY} \
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN} \
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID=${NEXT_PUBLIC_FIREBASE_PROJECT_ID} \
+    NEXT_PUBLIC_FIREBASE_APP_ID=${NEXT_PUBLIC_FIREBASE_APP_ID} \
+    NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN pnpm run build
+
+# ---------- runtime ----------
+FROM node:${NODE_VERSION} AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=8080 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup -S nextjs && adduser -S -G nextjs nextjs
+
+COPY --from=build --chown=nextjs:nextjs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nextjs /app/.next/static ./.next/static
+COPY --from=build --chown=nextjs:nextjs /app/public ./public
+
+USER nextjs
+EXPOSE 8080
+
+CMD ["node", "server.js"]

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/docs/02-product-roadmap.md
+++ b/docs/02-product-roadmap.md
@@ -241,30 +241,37 @@ Guiding principle: **free-tier-first**. We have no outside funding, so every pic
 | LLM | **Anthropic Claude Haiku 4.5** | Pay-as-you-go via Console (Claude for Startups requires VC backing — revisit post-raise); Haiku is cheap + fast, strong instruction-following for constrained menu flows | Claude Sonnet for harder conversations |
 | Primary POS (MVP) | **Square** | Developer sandbox + API free | — (Toast/Clover added Phase 3) |
 | Hosting | **GCP — Cloud Run + Firestore** | $300 credit (90d) + always-free Cloud Run (2M req/mo) + Firestore free tier. Scales to zero = $0 when idle. | Stay on GCP; raise tier + min-instances when funded |
-| Frontend framework | **Next.js 15 (static export)** | Built inside monolith — no separate Vercel account needed | Split to Vercel Pro if dashboard grows beyond static export |
+| Frontend framework | **Next.js 16 (server runtime, RSC)** | Built into its own Docker image — server-side rendering for the orders feed, plus `onSnapshot` for live updates | Vercel if we want managed Next.js infra |
 | Backend language | **Python 3.12 + FastAPI** | — | — |
-| Deployment model | **Single Docker image → Cloud Run, auto-deploy from `master`** | GitHub Actions: unlimited free minutes on public repos | — |
+| Deployment model | **Two Cloud Run services (`niko` API, `niko-dashboard` UI), auto-deploy from `master`** | GitHub Actions: unlimited free minutes on public repos | — |
 | CI/CD | **GitHub Actions** | Free forever (public repo) | — |
 
-### Deployment shape (monolith)
+### Deployment shape (two services)
 
 ```
 niko/
-├── app/                    # FastAPI: voice, dashboard API, static serving
-│   ├── voice/             # Twilio webhooks, STT/LLM/TTS orchestration
-│   ├── dashboard/         # Dashboard REST API
-│   └── main.py            # FastAPI app + static mount
-├── web/                   # Next.js (static export, built in Docker)
-├── Dockerfile             # Multi-stage: node builds web/, python serves
+├── app/                            # FastAPI: voice, dashboard REST API
+│   ├── telephony/                  # Twilio webhooks + Media Streams ingress
+│   ├── llm/                        # Claude Haiku conversation engine
+│   ├── tts/                        # ElevenLabs streaming
+│   ├── orders/                     # Pydantic models (shared schema)
+│   ├── storage/                    # Firestore reads/writes
+│   └── main.py                     # /voice, /orders, /health, /dev/seed-order
+├── Dockerfile                      # Python runtime for the API
+├── dashboard/                      # Next.js 16 (server runtime, RSC)
+│   ├── app/(dashboard)/            # Orders feed + detail pages
+│   ├── lib/firebase/client.ts      # web SDK for live onSnapshot
+│   └── Dockerfile                  # Multi-stage Node build → standalone server
 └── .github/workflows/
-    └── deploy.yml         # push master → build → Artifact Registry → Cloud Run
+    ├── deploy.yml                  # API: push master → niko on Cloud Run
+    └── deploy-dashboard.yml        # UI: dashboard/** changes → niko-dashboard on Cloud Run
 ```
 
-One service, one URL, one observability surface. Cloud Run's scale-to-zero covers the idle cost. Split into separate services only when Phase 3+ scaling demands it.
+Two Cloud Run services, one project, separate URLs. The dashboard server-renders the initial orders feed by hitting the API's `/orders` endpoint, then subscribes to Firestore directly via the web SDK for live updates — so the API stays focused on telephony + writes, and the dashboard scales independently. Cloud Run's scale-to-zero keeps idle cost near $0 for both.
 
 ### Known quirks to watch
 
 - **Cloud Run WebSocket** — 60min request timeout (fine for phone calls); long-lived connections count against concurrency. Fly.io is the escape hatch if audio streaming strains Cloud Run.
 - **Cloud Run cold starts** (~1–2s) when scaled to zero — unnoticeable for dashboard, potentially felt on first call of the day. Min-instances=1 costs ~$5/mo when we want to eliminate it.
 - **Telephony cost** — not free; budget ~$20–50 for POC testing.
-- **Vercel free tier** is not used — Next.js is built inside the Docker image and served by FastAPI, which keeps the monolith model clean and sidesteps Vercel's commercial-use restriction on Hobby.
+- **Vercel free tier** is not used — the dashboard runs on its own Cloud Run service, which sidesteps Vercel's commercial-use restriction on Hobby and keeps everything in one GCP project.

--- a/docs/03-technical-architecture.md
+++ b/docs/03-technical-architecture.md
@@ -308,71 +308,75 @@ ngrok http 8000
 
 ## 9. Deployment Model
 
-**One monolith, one Dockerfile, one Cloud Run service, auto-deployed from `master`.**
+**Two Cloud Run services in one GCP project, each auto-deployed from `master` on a paths filter.**
 
 ```
 Push to master
       │
-      ▼
-GitHub Actions (.github/workflows/deploy.yml)
+      ├── app/** changes
+      │     │
+      │     ▼
+      │   .github/workflows/deploy.yml
+      │     │
+      │     ├── Build python image from /Dockerfile
+      │     ├── Push to Artifact Registry
+      │     └── gcloud run deploy niko (region us-central1)
       │
-      ├── 1. Build Docker image (multi-stage: node builds web/, python serves)
-      ├── 2. Push to GCP Artifact Registry
-      ├── 3. gcloud run deploy (rolling, zero-downtime)
-      │
-      ▼
-Live on Cloud Run (~2-3 min after push)
+      └── dashboard/** changes
+            │
+            ▼
+          .github/workflows/deploy-dashboard.yml
+            │
+            ├── Build Next.js standalone image from /dashboard/Dockerfile
+            ├── Inject NEXT_PUBLIC_FIREBASE_* as build args (baked into client bundle)
+            ├── Push to Artifact Registry
+            └── gcloud run deploy niko-dashboard with NIKO_API_BASE_URL env
 ```
 
-**Why one service (not two):**
-- Team of 4, POC stage — one deploy target, one log stream, one URL to remember
-- FastAPI serves Twilio webhooks, WebSocket audio streams, dashboard REST, and the built Next.js static bundle from the same process
-- Splitting into separate services (voice worker + dashboard API) is a Phase 3+ concern when independent scaling matters
+**Why two services (not one):**
+- Daniel's dashboard is a real server-runtime Next.js app (RSC, Server Actions, `onSnapshot`) — it can't be statically exported, so it needs a Node runtime separate from FastAPI's Python runtime.
+- Independent rollback and scaling: a bad dashboard deploy can't take the voice pipeline offline, and the API can scale on call volume while the dashboard scales on browser sessions.
+- Separate logs and metrics per surface — easier to triage.
+- Idle cost stays near $0 because Cloud Run scales both to zero.
 
-**Dockerfile shape:**
+**API Dockerfile shape (`/Dockerfile`):**
 ```dockerfile
-# Stage 1: build Next.js static export
-FROM node:20-alpine AS web-builder
-WORKDIR /web
-COPY web/package*.json ./
-RUN npm ci
-COPY web/ ./
-RUN npm run build    # outputs to /web/out
-
-# Stage 2: python runtime
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app/ ./app/
-COPY --from=web-builder /web/out ./app/static/
 ENV PORT=8080
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
 ```
 
-**GitHub Actions workflow (outline):**
-```yaml
-name: Deploy to Cloud Run
-on:
-  push:
-    branches: [master]
+**Dashboard Dockerfile shape (`/dashboard/Dockerfile`):**
+```dockerfile
+# Multi-stage: deps → build (with NEXT_PUBLIC_* args) → runtime
+FROM node:20-alpine AS deps
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write          # Workload Identity Federation (no long-lived keys)
-    steps:
-      - uses: actions/checkout@v4
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_DEPLOY_SA }}
-      - uses: google-github-actions/setup-gcloud@v2
-      - run: gcloud builds submit --tag $REGION-docker.pkg.dev/$PROJECT/niko/app:${{ github.sha }}
-      - run: gcloud run deploy niko --image $REGION-docker.pkg.dev/$PROJECT/niko/app:${{ github.sha }} --region $REGION
+FROM node:20-alpine AS build
+ARG NEXT_PUBLIC_FIREBASE_API_KEY
+# ... other NEXT_PUBLIC_FIREBASE_* args
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm run build  # output: "standalone" → /app/.next/standalone
+
+FROM node:20-alpine AS runtime
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/public ./public
+EXPOSE 8080
+CMD ["node", "server.js"]
 ```
+
+**GitHub Actions workflows:**
+- `.github/workflows/deploy.yml` — API. Trigger: any push to `master`.
+- `.github/workflows/deploy-dashboard.yml` — UI. Trigger: push to `master` with paths in `dashboard/**` (skips deploys on backend-only changes).
+- Both use Workload Identity Federation — no long-lived service-account JSON anywhere.
 
 **Secrets / env vars:**
 - Store API keys (Twilio, Deepgram, Anthropic, ElevenLabs, Square) in **Secret Manager**

--- a/docs/05-team-roles-and-responsibilities.md
+++ b/docs/05-team-roles-and-responsibilities.md
@@ -68,7 +68,7 @@ Some responsibilities are **shared across the whole team** rather than assigned 
 
 | Responsibility | Details |
 |---------------|---------|
-| Dashboard | Next.js 15 (static export), served by FastAPI monolith; menu editor, call/order history, analytics UI |
+| Dashboard | Next.js 16 (server runtime, RSC) on its own Cloud Run service (`niko-dashboard`); reads orders via FastAPI, lives via Firestore `onSnapshot`. Menu editor, call/order history, analytics UI |
 | UX/UI design | Wireframes, user flows, design system, component library |
 | Branding | Logos, visual identity (already shipped Tsuki Works brand to `assets/`) |
 | Landing / marketing site | Public marketing pages, SEO |


### PR DESCRIPTION
## Summary
Deploys the dashboard as its own Cloud Run service (`niko-dashboard`) instead of trying to bundle it into the FastAPI monolith. Daniel's dashboard uses Server Components, Server Actions, and `onSnapshot` — none of which work in a static export — so the "single Docker image" plan from Phase 0 docs no longer matches reality. This PR realigns the pipeline + the docs.

## Linked issue
Relates to Phase 1 (#3) — unblocks demoing the dashboard at a public URL.

## What's added
- `dashboard/Dockerfile` — multi-stage Node 20 build using Next.js standalone output, runs as non-root, listens on `PORT`.
- `dashboard/next.config.ts` — `output: "standalone"`.
- `dashboard/.dockerignore` + `dashboard/public/.gitkeep`.
- `.github/workflows/deploy-dashboard.yml` — paths-filtered on `dashboard/**` so API-only pushes don't trigger it. Uses the existing WIF auth.
- Doc fixes in `docs/02-product-roadmap.md`, `docs/03-technical-architecture.md`, `docs/05-team-roles-and-responsibilities.md`.

## GCP setup needed before this workflow can deploy

Add these as **repo variables** under https://github.com/tsuki-works/niko/settings/variables/actions:

| Variable | Suggested value | Why |
|---|---|---|
| `CLOUD_RUN_DASHBOARD_SERVICE` | `niko-dashboard` | Service name on Cloud Run |
| `NIKO_API_BASE_URL` | `https://niko-ciyyvuq2pq-uc.a.run.app` | Base URL the dashboard hits server-side for `/orders`. Update if the API service URL ever changes. |
| `NEXT_PUBLIC_FIREBASE_API_KEY` | (Firebase console → Project settings → General → Your apps → web) | Baked into the client bundle at build time. |
| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | `niko-tsuki.firebaseapp.com` | Same source. |
| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | `niko-tsuki` | Same source. |
| `NEXT_PUBLIC_FIREBASE_APP_ID` | (Firebase console) | Same source. |

The Firebase web config is **public** — these are repo variables, not secrets. Security rules are what gate access, not the API key.

Also confirm the existing deploy SA (`github-deploy@niko-tsuki.iam.gserviceaccount.com`) can deploy to a **second** Cloud Run service in the same project. It already has `roles/run.admin` at the project level, so it should — but worth a 30-second sanity check before the first run.

The first deploy may need to register a Firebase Web App (Daniel called this out in `dashboard/lib/firebase/client.ts`). If `NEXT_PUBLIC_FIREBASE_*` values are blank, the dashboard still renders the orders feed via the FastAPI fetch path; live updates just stay disabled until the config lands.

## Test plan
- [ ] Add the GCP repo variables above.
- [ ] Trigger the workflow manually via `workflow_dispatch` or by merging.
- [ ] Confirm a Cloud Run URL appears in the workflow summary.
- [ ] Hit the URL, confirm the orders feed renders (call `POST /dev/seed-order` against the API first to have something to display).
- [ ] Verify backend-only PRs don't trigger the dashboard workflow (paths filter).

## Notes / out of scope
- Custom domains, CDN, edge caching: deferred. Cloud Run's default `*.run.app` URL is fine for Phase 1 demo.
- Build-time secrets: there are none here — Firebase web config is intentionally public.
- The existing `Frontend | Next.js 15 (static export, built into the monolith)` line in issue #2 (Phase 0) is left alone; that issue is the historical record of Phase 0 decisions. The active docs (`docs/`) are what's authoritative going forward, and they're now correct.
