### PR TITLE
Add streaming variant of LLM client (prep for #40)

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -9,16 +9,23 @@ partial order state incrementally. The model can both speak to the
 caller and call ``update_order`` in the same turn — we process both
 and advance the conversation.
 
-Not streamed yet. #40 adds streaming to hit the <1s first-audio
-latency budget; today we just prove the synchronous round-trip works.
+Two entry points:
+
+- ``generate_reply`` — synchronous round-trip. Used by tests and any
+  offline / batch path. Waits for Haiku to finish before returning.
+- ``stream_reply`` — async generator that yields text deltas as Haiku
+  produces them, then yields a terminal event with the final order
+  and threaded history. Used by the call-flow orchestrator (#40) to
+  start TTS before the full reply is ready and hit the <1s first-audio
+  latency budget.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, AsyncIterator, Optional
 
-from anthropic import Anthropic
+from anthropic import Anthropic, AsyncAnthropic
 
 from app.config import settings
 from app.llm.prompts import SYSTEM_PROMPT
@@ -95,14 +102,40 @@ class LLMResponse:
     history: list[dict[str, Any]]
 
 
+@dataclass
+class StreamEvent:
+    """One event yielded by ``stream_reply``.
+
+    Exactly one of ``text_delta`` or ``final`` is set on any given
+    event. Text-delta events arrive incrementally as Haiku produces
+    output; the terminal ``final`` event carries the assembled
+    ``LLMResponse`` (full reply text, updated order, threaded history)
+    so the caller can persist state and prepare for the next turn.
+    """
+
+    text_delta: Optional[str] = None
+    final: Optional[LLMResponse] = None
+
+
+def _missing_key_error() -> RuntimeError:
+    return RuntimeError(
+        "ANTHROPIC_API_KEY not set — cannot call the LLM. "
+        "Populate it in your .env (fetch via /shared-creds)."
+    )
+
+
 def _client() -> Anthropic:
     key = settings.anthropic_api_key
     if not key:
-        raise RuntimeError(
-            "ANTHROPIC_API_KEY not set — cannot call the LLM. "
-            "Populate it in your .env (fetch via /shared-creds)."
-        )
+        raise _missing_key_error()
     return Anthropic(api_key=key)
+
+
+def _async_client() -> AsyncAnthropic:
+    key = settings.anthropic_api_key
+    if not key:
+        raise _missing_key_error()
+    return AsyncAnthropic(api_key=key)
 
 
 def _apply_update(order: Order, patch: dict[str, Any]) -> Order:
@@ -204,4 +237,99 @@ def generate_reply(
         reply_text="".join(reply_text_parts).strip(),
         order=updated_order,
         history=new_history,
+    )
+
+
+async def stream_reply(
+    *,
+    transcript: str,
+    history: list[dict[str, Any]],
+    order: Order,
+    client: Optional[AsyncAnthropic] = None,
+) -> AsyncIterator[StreamEvent]:
+    """Stream Haiku's reply token-by-token for low-latency TTS handoff.
+
+    Yields ``StreamEvent(text_delta=str)`` for each incremental chunk
+    of the assistant's spoken reply, then a single terminal
+    ``StreamEvent(final=LLMResponse)`` with the full reply text,
+    updated order, and threaded history.
+
+    The contract matches ``generate_reply`` for tool-use semantics:
+    if the first turn emits only ``update_order`` blocks (no text),
+    we send a ``tool_result`` and stream a follow-up call so the
+    caller still gets a spoken reply. In practice this is the
+    "I cancelled the order" path — the model often wants to confirm
+    the side effect before talking back.
+    """
+
+    api = client or _async_client()
+
+    new_history = [*history, {"role": "user", "content": transcript}]
+
+    text_parts: list[str] = []
+    tool_uses: list[dict[str, Any]] = []
+
+    async with api.messages.stream(
+        model=MODEL,
+        max_tokens=MAX_TOKENS,
+        system=SYSTEM_PROMPT,
+        tools=[UPDATE_ORDER_TOOL],
+        messages=new_history,
+    ) as stream:
+        async for delta in stream.text_stream:
+            text_parts.append(delta)
+            yield StreamEvent(text_delta=delta)
+        first_message = await stream.get_final_message()
+
+    for block in first_message.content:
+        if block.type == "tool_use" and block.name == "update_order":
+            tool_uses.append({"id": block.id, "input": block.input})
+
+    updated_order = order
+    for tu in tool_uses:
+        updated_order = _apply_update(updated_order, tu["input"])
+
+    assistant_content = [block.model_dump() for block in first_message.content]
+    new_history = [
+        *new_history,
+        {"role": "assistant", "content": assistant_content},
+    ]
+
+    text_emitted = bool(text_parts)
+    if not text_emitted and tool_uses:
+        tool_results = [
+            {
+                "type": "tool_result",
+                "tool_use_id": tu["id"],
+                "content": "Order updated.",
+            }
+            for tu in tool_uses
+        ]
+        new_history = [
+            *new_history,
+            {"role": "user", "content": tool_results},
+        ]
+        async with api.messages.stream(
+            model=MODEL,
+            max_tokens=MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            tools=[UPDATE_ORDER_TOOL],
+            messages=new_history,
+        ) as followup_stream:
+            async for delta in followup_stream.text_stream:
+                text_parts.append(delta)
+                yield StreamEvent(text_delta=delta)
+            followup_message = await followup_stream.get_final_message()
+        followup_content = [b.model_dump() for b in followup_message.content]
+        new_history = [
+            *new_history,
+            {"role": "assistant", "content": followup_content},
+        ]
+
+    yield StreamEvent(
+        final=LLMResponse(
+            reply_text="".join(text_parts).strip(),
+            order=updated_order,
+            history=new_history,
+        )
     )

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.llm import client as client_module
-from app.llm.client import _apply_update, generate_reply
+from app.llm.client import _apply_update, generate_reply, stream_reply
 from app.orders.models import Order, OrderStatus, OrderType
 
 
@@ -315,6 +315,212 @@ def test_caller_changes_mind_replaces_items():
     assert result.order.items[0].name == "Veggie Supreme"
     assert result.order.items[0].unit_price == 18.99
     assert result.order.order_type is OrderType.PICKUP
+
+
+class _FakeAsyncStream:
+    """Mimics ``AsyncMessageStream`` just enough for ``stream_reply``.
+
+    Yields the configured text deltas through ``text_stream``, then
+    returns a fake final message via ``get_final_message`` whose
+    ``content`` blocks the consumer can iterate. ``model_dump`` is
+    required because ``stream_reply`` serializes the assistant turn
+    into history.
+    """
+
+    def __init__(self, *, deltas: list[str], blocks: list[FakeBlock]):
+        self._deltas = deltas
+        self._blocks = blocks
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    @property
+    def text_stream(self):
+        deltas = self._deltas
+
+        async def _gen():
+            for d in deltas:
+                yield d
+
+        return _gen()
+
+    async def get_final_message(self):
+        return MagicMock(content=self._blocks)
+
+
+def _stream_manager_factory(streams: list[_FakeAsyncStream]):
+    """Returns a callable that pops one stream per ``messages.stream`` call."""
+
+    iterator = iter(streams)
+
+    def _next_stream(**_kwargs):
+        return next(iterator)
+
+    return _next_stream
+
+
+async def _collect(stream_iter):
+    deltas: list[str] = []
+    final = None
+    async for event in stream_iter:
+        if event.text_delta is not None:
+            deltas.append(event.text_delta)
+        if event.final is not None:
+            final = event.final
+    return deltas, final
+
+
+async def test_stream_reply_emits_text_deltas_then_final():
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=["Hi, ", "what would you ", "like to order?"],
+                blocks=[
+                    FakeBlock(
+                        type="text", text="Hi, what would you like to order?"
+                    )
+                ],
+            )
+        ]
+    )
+
+    deltas, final = await _collect(
+        stream_reply(
+            transcript="hello",
+            history=[],
+            order=order,
+            client=fake_client,
+        )
+    )
+
+    assert deltas == ["Hi, ", "what would you ", "like to order?"]
+    assert final is not None
+    assert final.reply_text == "Hi, what would you like to order?"
+    assert final.order is order
+    assert final.history[0] == {"role": "user", "content": "hello"}
+    assert final.history[1]["role"] == "assistant"
+
+
+async def test_stream_reply_applies_tool_use_to_order_state():
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=["One medium pepperoni for pickup."],
+                blocks=[
+                    FakeBlock(
+                        type="tool_use",
+                        id="toolu_1",
+                        name="update_order",
+                        input={
+                            "items": [
+                                {
+                                    "name": "Pepperoni",
+                                    "category": "pizza",
+                                    "size": "medium",
+                                    "quantity": 1,
+                                    "unit_price": 17.99,
+                                    "modifications": [],
+                                }
+                            ],
+                            "order_type": "pickup",
+                            "status": "in_progress",
+                        },
+                    ),
+                    FakeBlock(
+                        type="text", text="One medium pepperoni for pickup."
+                    ),
+                ],
+            )
+        ]
+    )
+
+    _, final = await _collect(
+        stream_reply(
+            transcript="one medium pepperoni for pickup",
+            history=[],
+            order=order,
+            client=fake_client,
+        )
+    )
+
+    assert final.order.items[0].name == "Pepperoni"
+    assert final.order.order_type is OrderType.PICKUP
+    assert final.order.call_sid == "CAtest"
+
+
+async def test_stream_reply_runs_followup_when_first_turn_is_tool_only():
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=[],  # tool-use only, no text
+                blocks=[
+                    FakeBlock(
+                        type="tool_use",
+                        id="toolu_1",
+                        name="update_order",
+                        input={"items": [], "status": "cancelled"},
+                    )
+                ],
+            ),
+            _FakeAsyncStream(
+                deltas=["Okay, ", "order cancelled."],
+                blocks=[
+                    FakeBlock(
+                        type="text", text="Okay, order cancelled."
+                    )
+                ],
+            ),
+        ]
+    )
+
+    deltas, final = await _collect(
+        stream_reply(
+            transcript="never mind cancel",
+            history=[],
+            order=order,
+            client=fake_client,
+        )
+    )
+
+    assert deltas == ["Okay, ", "order cancelled."]
+    assert final.reply_text == "Okay, order cancelled."
+    assert final.order.status is OrderStatus.CANCELLED
+
+
+async def test_stream_reply_text_deltas_arrive_before_final():
+    """Order matters — TTS must start on the first delta, not after
+    the terminal event. This guards against accidental buffering."""
+
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=["A", "B", "C"],
+                blocks=[FakeBlock(type="text", text="ABC")],
+            )
+        ]
+    )
+
+    seen: list[str] = []
+    async for event in stream_reply(
+        transcript="x", history=[], order=order, client=fake_client
+    ):
+        if event.text_delta is not None:
+            seen.append(f"delta:{event.text_delta}")
+        if event.final is not None:
+            seen.append("final")
+
+    assert seen == ["delta:A", "delta:B", "delta:C", "final"]
 
 
 def test_modifications_round_trip_into_line_item():

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -17,7 +17,7 @@ reply transcript and the structured Order state.
 import pytest
 
 from app.config import settings
-from app.llm.client import generate_reply
+from app.llm.client import generate_reply, stream_reply
 from app.orders.models import Order
 
 pytestmark = pytest.mark.skipif(
@@ -113,3 +113,30 @@ def test_caller_changes_mind_replaces_pizza():
     assert not any("pepperoni" in name for name in pizza_names), (
         "Turn 2 should have replaced the pepperoni, not kept both"
     )
+
+
+async def test_stream_reply_yields_deltas_before_final():
+    """Real Haiku call: prove text deltas actually arrive incrementally
+    and the terminal event carries the assembled reply + order."""
+
+    order = Order(call_sid="CAintegration-stream")
+    transcript = "Hi, can I get a large pepperoni for pickup?"
+
+    delta_count = 0
+    seen_final_after_deltas = False
+    final = None
+
+    async for event in stream_reply(transcript=transcript, history=[], order=order):
+        if event.text_delta is not None:
+            delta_count += 1
+        if event.final is not None:
+            seen_final_after_deltas = True
+            final = event.final
+            break
+
+    assert delta_count >= 1, "Expected at least one text delta from Haiku"
+    assert seen_final_after_deltas, "Stream must end with a final event"
+    assert final is not None
+    assert len(final.reply_text) > 5
+    print(f"\n--- Reply ({delta_count} deltas) ---\n{final.reply_text}")
+    print(f"\n--- Order ---\n{final.order.model_dump_json(indent=2)}")


### PR DESCRIPTION
## Summary
- Adds `stream_reply`, an async generator that yields Haiku's reply incrementally. The call-flow orchestrator (#40) will hand each `text_delta` to TTS as it arrives, so first-audio can start before the full reply is ready — that's the path to the <1s perceived latency budget.
- Mirrors `generate_reply`'s tool-use semantics. If the first turn emits only `update_order` blocks (no text), it sends a `tool_result` and streams a follow-up call so callers still get a spoken reply. Cancel is the canonical example.
- `generate_reply` is unchanged. All 10 of its existing tests still pass; the new function is purely additive.

## Linked issue
Relates to #40 — primitive only. #40 closes once the WebSocket orchestrator wires this to Deepgram + ElevenLabs and the latency contract is verified end-to-end.

## Shape

```python
@dataclass
class StreamEvent:
    text_delta: Optional[str] = None
    final: Optional[LLMResponse] = None


async for event in stream_reply(transcript=t, history=h, order=o):
    if event.text_delta is not None:
        # send delta to TTS streamer
    elif event.final is not None:
        # persist order, thread history into next turn
```

Exactly one of `text_delta` / `final` is set on any given event. The terminal event always carries `final` and arrives last.

## Test plan
- [x] `pytest tests/test_llm_client.py` → 14 passed (10 existing + 4 new streaming).
- [x] `pytest tests/test_llm_integration.py` → 5 skipped cleanly without `ANTHROPIC_API_KEY`.
- [ ] Run integration tests once with the real key:
      `ANTHROPIC_API_KEY=... pytest -v -s tests/test_llm_integration.py::test_stream_reply_yields_deltas_before_final`
      to confirm Haiku actually streams (≥1 delta before the terminal event).
- [ ] Wire from `app/telephony/router.py` Media Streams handler in #40 and measure end-to-end latency.

## Notes
- Uses `AsyncAnthropic` via a new `_async_client()` helper; `_client()` (sync) is unchanged. Both share `_missing_key_error()` so the missing-key message stays consistent.
- The existing `test_tts_client.py` failures on master are pre-existing (depend on `ELEVENLABS_API_KEY` being set in the env) — not introduced by this PR.
- Follow-up handling is preserved but slower: it still requires a second `messages.stream` call. For #40, the orchestrator can start TTS the moment the second stream's first delta lands, which is the latency-critical bit.
