### PR TITLE
Add persist_on_confirm order lifecycle helper (prep for #40)

### DIFF
--- a/app/orders/lifecycle.py
+++ b/app/orders/lifecycle.py
@@ -1,0 +1,66 @@
+"""Order lifecycle transitions — the rules layer above storage.
+
+``app.storage.firestore`` handles raw Firestore reads and writes. This
+module handles the *meaning* of state transitions: when an order
+becomes confirmed it must actually be ready (items present,
+``order_type`` set, delivery has an address), the ``confirmed_at``
+timestamp is stamped at write time, and the operation is idempotent
+across retries within a single call.
+
+Today: ``persist_on_confirm`` only. Cancellation, reopen, and other
+transitions land when their callers need them — this module stays
+narrow to what the call-flow orchestrator (#40) actually needs for
+the Phase 1 demo.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.orders.models import Order, OrderStatus
+from app.storage import firestore as order_storage
+
+
+class OrderNotReadyError(ValueError):
+    """``persist_on_confirm`` was called with an order that isn't
+    complete enough to confirm. Defense in depth — the orchestrator
+    shouldn't reach this state, but the helper enforces the contract
+    regardless of caller hygiene."""
+
+
+def persist_on_confirm(order: Order) -> Order:
+    """Stamp confirmation metadata and write the order to Firestore.
+
+    Returns a new ``Order`` with ``status=CONFIRMED`` and
+    ``confirmed_at`` set. The Firestore write is a deterministic upsert
+    keyed by ``call_sid``, so re-running is safe.
+
+    Idempotent. If the order already has ``status == CONFIRMED`` and
+    ``confirmed_at`` set (e.g., a retry after a successful write whose
+    response got dropped), the original ``confirmed_at`` is preserved
+    rather than re-stamped. The Firestore write still runs — that's the
+    cheapest way to recover from a partial failure where the stamp
+    landed in memory but the network round-trip didn't.
+
+    Raises ``OrderNotReadyError`` if the order is cancelled or fails
+    ``Order.is_ready_to_confirm()``.
+    """
+
+    if order.status is OrderStatus.CANCELLED:
+        raise OrderNotReadyError(
+            f"Cannot confirm order {order.call_sid!r}: status is cancelled"
+        )
+
+    if not order.is_ready_to_confirm():
+        raise OrderNotReadyError(
+            f"Cannot confirm order {order.call_sid!r}: not ready "
+            "(missing items, order_type, or delivery_address)"
+        )
+
+    confirmed_at = order.confirmed_at or datetime.now(timezone.utc)
+    confirmed_order = order.model_copy(
+        update={"status": OrderStatus.CONFIRMED, "confirmed_at": confirmed_at}
+    )
+
+    order_storage.save_order(confirmed_order)
+    return confirmed_order

--- a/tests/test_orders_lifecycle.py
+++ b/tests/test_orders_lifecycle.py
@@ -1,0 +1,183 @@
+"""Unit tests for ``app.orders.lifecycle.persist_on_confirm``.
+
+Uses the same ``MagicMock`` pattern as ``test_firestore_storage.py`` —
+no real Firestore, no GCP auth.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderStatus,
+    OrderType,
+)
+from app.storage import firestore as storage
+
+
+@pytest.fixture(autouse=True)
+def reset_client():
+    yield
+    storage.set_client(None)
+
+
+def _fake_client() -> MagicMock:
+    client = MagicMock()
+    storage.set_client(client)
+    return client
+
+
+def _pepperoni() -> LineItem:
+    return LineItem(
+        name="Pepperoni",
+        category=ItemCategory.PIZZA,
+        size="medium",
+        quantity=1,
+        unit_price=17.99,
+    )
+
+
+def _ready_pickup_order(**overrides) -> Order:
+    base = dict(
+        call_sid="CAconfirm",
+        items=[_pepperoni()],
+        order_type=OrderType.PICKUP,
+    )
+    base.update(overrides)
+    return Order(**base)
+
+
+def _ready_delivery_order(**overrides) -> Order:
+    base = dict(
+        call_sid="CAdelivery",
+        items=[_pepperoni()],
+        order_type=OrderType.DELIVERY,
+        delivery_address="123 Main Street",
+    )
+    base.update(overrides)
+    return Order(**base)
+
+
+def test_persist_on_confirm_stamps_status_and_timestamp():
+    client = _fake_client()
+    order = _ready_pickup_order()
+    assert order.status is OrderStatus.IN_PROGRESS
+    assert order.confirmed_at is None
+
+    confirmed = persist_on_confirm(order)
+
+    assert confirmed.status is OrderStatus.CONFIRMED
+    assert confirmed.confirmed_at is not None
+    # timestamp is recent (within last few seconds — generous to avoid flakes)
+    age = datetime.now(timezone.utc) - confirmed.confirmed_at
+    assert timedelta(seconds=0) <= age < timedelta(seconds=5)
+    client.collection.return_value.document.return_value.set.assert_called_once()
+
+
+def test_persist_on_confirm_does_not_mutate_input_order():
+    """The caller's Order instance stays untouched — we return a new one."""
+
+    _fake_client()
+    order = _ready_pickup_order()
+
+    persist_on_confirm(order)
+
+    assert order.status is OrderStatus.IN_PROGRESS
+    assert order.confirmed_at is None
+
+
+def test_persist_on_confirm_writes_payload_with_confirmed_status():
+    """Whatever lands in Firestore reflects the confirmed state, not
+    the pre-confirmation snapshot."""
+
+    client = _fake_client()
+    order = _ready_pickup_order()
+
+    persist_on_confirm(order)
+
+    set_call = client.collection.return_value.document.return_value.set
+    payload = set_call.call_args[0][0]
+    assert payload["status"] == "confirmed"
+    assert payload["confirmed_at"] is not None
+    assert payload["call_sid"] == "CAconfirm"
+
+
+def test_persist_on_confirm_handles_delivery_order():
+    _fake_client()
+    order = _ready_delivery_order()
+
+    confirmed = persist_on_confirm(order)
+
+    assert confirmed.status is OrderStatus.CONFIRMED
+    assert confirmed.delivery_address == "123 Main Street"
+
+
+def test_persist_on_confirm_is_idempotent_on_already_confirmed_order():
+    """Re-running on a confirmed order keeps the original confirmed_at
+    rather than re-stamping. Save still runs (recovery from a partial
+    failure where the stamp landed but the write didn't)."""
+
+    client = _fake_client()
+    original_ts = datetime(2026, 4, 25, 12, 0, 0, tzinfo=timezone.utc)
+    order = _ready_pickup_order(
+        status=OrderStatus.CONFIRMED, confirmed_at=original_ts
+    )
+
+    confirmed = persist_on_confirm(order)
+
+    assert confirmed.confirmed_at == original_ts
+    client.collection.return_value.document.return_value.set.assert_called_once()
+
+
+def test_persist_on_confirm_refuses_empty_order():
+    _fake_client()
+    order = Order(call_sid="CAempty", order_type=OrderType.PICKUP)
+
+    with pytest.raises(OrderNotReadyError, match="not ready"):
+        persist_on_confirm(order)
+
+
+def test_persist_on_confirm_refuses_missing_order_type():
+    _fake_client()
+    order = Order(call_sid="CAtype", items=[_pepperoni()])  # no order_type
+
+    with pytest.raises(OrderNotReadyError, match="not ready"):
+        persist_on_confirm(order)
+
+
+def test_persist_on_confirm_refuses_delivery_without_address():
+    _fake_client()
+    order = Order(
+        call_sid="CAdelivery-no-addr",
+        items=[_pepperoni()],
+        order_type=OrderType.DELIVERY,
+    )
+
+    with pytest.raises(OrderNotReadyError, match="not ready"):
+        persist_on_confirm(order)
+
+
+def test_persist_on_confirm_refuses_cancelled_order():
+    _fake_client()
+    order = _ready_pickup_order(status=OrderStatus.CANCELLED)
+
+    with pytest.raises(OrderNotReadyError, match="cancelled"):
+        persist_on_confirm(order)
+
+
+def test_persist_on_confirm_does_not_save_when_refusing():
+    """Failed validation must not produce a Firestore write — it'd be
+    weird for a half-baked order to land in the dashboard."""
+
+    client = _fake_client()
+    order = Order(call_sid="CAbad", order_type=OrderType.PICKUP)
+
+    with pytest.raises(OrderNotReadyError):
+        persist_on_confirm(order)
+
+    client.collection.return_value.document.return_value.set.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `app/orders/lifecycle.py` with `persist_on_confirm(order)` — the single function the call-flow orchestrator (#40) calls when a caller confirms their order. It validates readiness, stamps `confirmed_at` once, and upserts to Firestore idempotently.
- New `OrderNotReadyError` for the refusal path (cancelled order, missing items, missing `order_type`, delivery without address).
- Splits the rules layer (this module) from the raw I/O layer (`app/storage/firestore.py`) so the orchestrator only has one entry point and the storage module stays narrow.
- 10 mocked unit tests covering happy path, idempotency, all four refusal paths, no-write-on-refusal, and the confirmed payload shape.

## Linked issue
Relates to #40 — primitive only. The orchestrator will call this on the caller's "yes confirm" turn; #40 closes once that wiring lands and the latency contract is verified end-to-end.

## API

```python
from app.orders.lifecycle import persist_on_confirm, OrderNotReadyError

try:
    confirmed = persist_on_confirm(order)  # writes to Firestore, returns new Order
    # confirmed.status == OrderStatus.CONFIRMED
    # confirmed.confirmed_at is now (UTC, tz-aware)
except OrderNotReadyError as e:
    # order was cancelled or failed is_ready_to_confirm()
    # nothing was written
```

Sync, not async — `app/storage/firestore.py` uses the sync Firestore client. The orchestrator can wrap with `asyncio.to_thread(persist_on_confirm, order)` if needed.

## Test plan
- [x] `pytest tests/test_orders_lifecycle.py -v` → 10 passed.
- [x] `pytest tests/ --ignore=...` (wider suite, excluding modules that need `deepgram`/`elevenlabs` envs locally) → 40 passed, 6 skipped (gated integration tests).
- [ ] Verified by the orchestrator integration in #40 once it lands.

## Notes / out of scope
- **`cancel_order`** is intentionally NOT in this PR. The dashboard's cancel button (`dashboard/components/orders/cancel-order-button.tsx`) currently calls a Server Action that doesn't yet have a backend write path — that's a separate piece of work, lands when the dashboard cancel flow is wired.
- **No race-condition guards** between dashboard cancel and FastAPI confirm. In Phase 1, dashboard only cancels `confirmed` orders (FastAPI is done by then), so no practical race. Flagged in `dashboard/CLAUDE.md` already.
- **No reopen / refund flows** — Phase 3+ territory.
