### PR TITLE
Wire end-to-end call loop: Deepgram → LLM → ElevenLabs (#40)

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -1,32 +1,56 @@
 """Twilio telephony endpoints.
 
-POST /voice        — TwiML webhook: answers the inbound call, plays a
-                     brief greeting, then opens a Twilio Media Stream so
-                     the STT→LLM→TTS pipeline can take over.
+POST /voice        — TwiML webhook: answers the inbound call, opens a
+                     Twilio Media Stream so the STT→LLM→TTS pipeline can
+                     take over.  The AI greeting is delivered via ElevenLabs
+                     on the 'start' event rather than a static TwiML <Say>.
 
-WS   /media-stream — Receives the Twilio Media Stream over WebSocket.
-                     Each frame is a JSON envelope; the ``media`` event
-                     carries base64-encoded mulaw 8 kHz audio. Forwarded
-                     to Deepgram Nova-2 for live transcription (#37).
+WS   /media-stream — Receives the Twilio Media Stream over WebSocket and
+                     runs the full call loop:
+                       Deepgram transcript → stream_reply() → speak()
+                     Supports barge-in (new transcript cancels in-flight TTS)
+                     and a 10-second silence watchdog.
 """
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
+import time
+from dataclasses import dataclass, field
+from typing import Callable
 
 from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
 from twilio.twiml.voice_response import Connect, VoiceResponse
 
 from app.config import settings
+from app.llm.client import stream_reply
+from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
+from app.orders.models import Order
+from app.tts.client import speak
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+SILENCE_TIMEOUT_SECONDS = 10.0
+SILENCE_PROMPT = "Are you still there?"
+GREETING_TRANSCRIPT = "[call started — greet the caller]"
 
-async def _open_deepgram_connection(call_sid: str | None):
+
+@dataclass
+class _CallState:
+    call_sid:     str | None       = None
+    stream_sid:   str | None       = None
+    order:        Order | None     = None
+    history:      list[dict]       = field(default_factory=list)
+    llm_task:     asyncio.Task | None = None   # current LLM→TTS turn
+    silence_task: asyncio.Task | None = None   # silence watchdog
+
+
+async def _open_deepgram_connection(call_sid: str | None, on_final: Callable):
     assert settings.deepgram_api_key, "DEEPGRAM_API_KEY is not set"
 
     dg = DeepgramClient(settings.deepgram_api_key)
@@ -39,6 +63,8 @@ async def _open_deepgram_connection(call_sid: str | None):
             return
         label = "final" if result.is_final else "interim"
         logger.info("transcript [%s] call_sid=%s text=%r", label, call_sid, text)
+        if result.is_final:
+            asyncio.get_event_loop().create_task(on_final(text))
 
     async def on_error(self, error, **kwargs):
         logger.error("deepgram error call_sid=%s error=%s", call_sid, error)
@@ -60,47 +86,130 @@ async def _open_deepgram_connection(call_sid: str | None):
     return conn
 
 
+async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
+    try:
+        await asyncio.sleep(SILENCE_TIMEOUT_SECONDS)
+        logger.info("silence timeout call_sid=%s", state.call_sid)
+        if state.stream_sid:
+            await speak(SILENCE_PROMPT, websocket, state.stream_sid)
+    except asyncio.CancelledError:
+        pass
+
+
+def _cancel_silence_task(state: _CallState) -> None:
+    if state.silence_task and not state.silence_task.done():
+        state.silence_task.cancel()
+    state.silence_task = None
+
+
+def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
+    if state.llm_task and state.llm_task.cancelled():
+        return  # barge-in — caller spoke again, no watchdog needed
+    _cancel_silence_task(state)
+    state.silence_task = asyncio.get_event_loop().create_task(
+        _silence_watchdog(state, websocket)
+    )
+
+
+async def _run_llm_tts_turn(
+    transcript: str, state: _CallState, websocket: WebSocket
+) -> None:
+    turn_start = time.monotonic()
+    logger.info("llm_turn start call_sid=%s transcript=%r", state.call_sid, transcript)
+    text_buffer: list[str] = []
+    first_speak = True
+
+    try:
+        async for event in stream_reply(
+            transcript=transcript, history=state.history, order=state.order
+        ):
+            if asyncio.current_task().cancelled():
+                return
+
+            if event.text_delta is not None:
+                text_buffer.append(event.text_delta)
+                if event.text_delta.endswith((".", "?", "!")):
+                    chunk = "".join(text_buffer).strip()
+                    text_buffer.clear()
+                    if chunk and state.stream_sid:
+                        if first_speak:
+                            logger.info(
+                                "llm_turn first_audio latency=%.3fs call_sid=%s",
+                                time.monotonic() - turn_start,
+                                state.call_sid,
+                            )
+                            first_speak = False
+                        await speak(chunk, websocket, state.stream_sid)
+
+            elif event.final is not None:
+                remainder = "".join(text_buffer).strip()
+                text_buffer.clear()
+                if remainder and state.stream_sid:
+                    if first_speak:
+                        logger.info(
+                            "llm_turn first_audio latency=%.3fs call_sid=%s",
+                            time.monotonic() - turn_start,
+                            state.call_sid,
+                        )
+                    await speak(remainder, websocket, state.stream_sid)
+                state.history = event.final.history
+                state.order = event.final.order
+
+    except asyncio.CancelledError:
+        logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)
+        raise
+
+
+async def _handle_final_transcript(
+    text: str, state: _CallState, websocket: WebSocket
+) -> None:
+    if state.llm_task and not state.llm_task.done():
+        state.llm_task.cancel()
+    _cancel_silence_task(state)
+    state.llm_task = asyncio.create_task(
+        _run_llm_tts_turn(text, state, websocket)
+    )
+    state.llm_task.add_done_callback(
+        lambda _t: _arm_silence_watchdog(state, websocket)
+    )
+
+
 @router.post("/voice")
 async def voice(request: Request) -> Response:
     """Respond to Twilio's inbound call webhook with TwiML.
 
-    Plays a short greeting, then instructs Twilio to open a bidirectional
-    Media Stream back to /media-stream so the voice pipeline can receive
-    raw caller audio.  The WebSocket URL is derived from the ``Host``
-    header so the same code works under ngrok locally and Cloud Run in
-    production without any config change.
+    Opens a bidirectional Media Stream back to /media-stream.  The AI
+    greeting is delivered via ElevenLabs on the 'start' WebSocket event
+    rather than a static TwiML <Say>, so the caller hears the same voice
+    for the entire call.
+
+    The WebSocket URL is derived from the ``Host`` header so the same code
+    works under ngrok locally and on Cloud Run in production.
     """
     host = request.headers.get("host", "localhost:8000")
-    ws_url = f"wss://{host}/media-stream"
-
     twiml = VoiceResponse()
-    twiml.say(
-        "Thank you for calling. Please hold while we connect your call.",
-        voice="alice",
-    )
     connect = Connect()
-    connect.stream(url=ws_url)
+    connect.stream(url=f"wss://{host}/media-stream")
     twiml.append(connect)
-
     return Response(content=str(twiml), media_type="application/xml")
 
 
 @router.websocket("/media-stream")
 async def media_stream(websocket: WebSocket) -> None:
-    """Receive Twilio Media Stream audio frames over WebSocket.
+    """Full call loop: Twilio Media Stream → Deepgram STT → LLM → ElevenLabs TTS.
 
-    Twilio sends JSON-enveloped messages with these event types:
-      connected  — initial protocol handshake (no call state yet)
-      start      — stream open; carries callSid, streamSid, track info
-      media      — base64-encoded mulaw 8 kHz audio, 20 ms per chunk
-      stop       — call ended; Twilio is closing the stream
-
-    POC: logs lifecycle events; silently discards media frames until the
-    Deepgram STT loop is wired in (#38).
+    Twilio event types:
+      connected  — protocol handshake
+      start      — stream open; initialises Order, opens Deepgram, fires AI greeting
+      media      — base64 mulaw 8 kHz audio forwarded to Deepgram
+      stop       — call ended; persists completed orders to Firestore
     """
     await websocket.accept()
-    call_sid: str | None = None
+    state = _CallState()
     dg_conn = None
+
+    async def on_final(text: str) -> None:
+        await _handle_final_transcript(text, state, websocket)
 
     try:
         while True:
@@ -113,14 +222,21 @@ async def media_stream(websocket: WebSocket) -> None:
 
             elif event == "start":
                 start = msg.get("start", {})
-                call_sid = start.get("callSid")
-                stream_sid = start.get("streamSid")
+                state.call_sid = start.get("callSid")
+                state.stream_sid = start.get("streamSid")
+                state.order = Order(call_sid=state.call_sid or "unknown")
                 logger.info(
                     "media-stream start call_sid=%s stream_sid=%s",
-                    call_sid,
-                    stream_sid,
+                    state.call_sid,
+                    state.stream_sid,
                 )
-                dg_conn = await _open_deepgram_connection(call_sid)
+                dg_conn = await _open_deepgram_connection(state.call_sid, on_final)
+                state.llm_task = asyncio.create_task(
+                    _run_llm_tts_turn(GREETING_TRANSCRIPT, state, websocket)
+                )
+                state.llm_task.add_done_callback(
+                    lambda _t: _arm_silence_watchdog(state, websocket)
+                )
 
             elif event == "media":
                 if dg_conn is not None:
@@ -128,11 +244,32 @@ async def media_stream(websocket: WebSocket) -> None:
                     await dg_conn.send(audio)
 
             elif event == "stop":
-                logger.info("media-stream stop call_sid=%s", call_sid)
+                logger.info("media-stream stop call_sid=%s", state.call_sid)
+                # Let the in-flight LLM turn finish so we capture the final order state
+                if state.llm_task and not state.llm_task.done():
+                    try:
+                        await asyncio.wait_for(asyncio.shield(state.llm_task), timeout=10.0)
+                    except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+                        pass
                 break
 
     except WebSocketDisconnect:
-        logger.info("media-stream disconnected call_sid=%s", call_sid)
+        logger.info("media-stream disconnected call_sid=%s", state.call_sid)
     finally:
+        _cancel_silence_task(state)
+        if state.llm_task and not state.llm_task.done():
+            state.llm_task.cancel()
+            try:
+                await state.llm_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if state.order and state.order.is_ready_to_confirm():
+            try:
+                persist_on_confirm(state.order)
+                logger.info("order confirmed call_sid=%s", state.call_sid)
+            except (OrderNotReadyError, Exception) as exc:
+                logger.error(
+                    "order persist failed call_sid=%s: %s", state.call_sid, exc
+                )
         if dg_conn is not None:
             await dg_conn.finish()

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2,16 +2,79 @@
 
 Covers POST /voice (TwiML with Media Stream connect) and
 WS /media-stream (Twilio Media Stream receiver).  Runs fully
-in-process via TestClient — no Twilio account or network required.
+in-process via TestClient — no Twilio, Deepgram, ElevenLabs, or
+Anthropic credentials required.
+
+The mock_pipeline fixture patches all three network-bound callables
+(_open_deepgram_connection, speak, stream_reply) so every test is
+offline and deterministic.
 """
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.llm.client import LLMResponse, StreamEvent
+from app.orders.models import Order
 
 client = TestClient(app)
+
+_START_MSG = {
+    "event": "start",
+    "start": {
+        "callSid": "CAtest123",
+        "streamSid": "MZtest456",
+        "accountSid": "ACtest",
+        "tracks": ["inbound"],
+        "mediaFormat": {"encoding": "audio/x-mulaw", "sampleRate": 8000, "channels": 1},
+    },
+}
+
+_MEDIA_MSG = {
+    "event": "media",
+    "media": {
+        "track": "inbound",
+        "chunk": "1",
+        "timestamp": "5",
+        "payload": "AAEC",  # valid base64, 3 bytes of mulaw audio
+    },
+}
+
+_STOP_MSG = {"event": "stop", "stop": {"accountSid": "ACtest", "callSid": "CAtest123"}}
+
+
+def _make_fake_stream_reply(reply="Hi, welcome to Niko's Pizza Kitchen!"):
+    async def fake_stream_reply(*, transcript, history, order, **kw):
+        yield StreamEvent(text_delta=reply)
+        yield StreamEvent(
+            final=LLMResponse(reply_text=reply, order=order, history=history)
+        )
+
+    return fake_stream_reply
+
+
+@pytest.fixture()
+def mock_pipeline(monkeypatch):
+    """Patch all three network-bound callables for offline testing."""
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, on_final):
+        return fake_dg
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr(
+        "app.telephony.router.stream_reply", _make_fake_stream_reply()
+    )
+    return fake_dg
 
 
 # ---------------------------------------------------------------------------
@@ -25,11 +88,11 @@ def test_voice_returns_xml():
     assert response.headers["content-type"].startswith("application/xml")
 
 
-def test_voice_twiml_contains_greeting_and_media_stream():
+def test_voice_twiml_contains_media_stream_no_say():
     response = client.post("/voice", data={"CallSid": "CAtest", "From": "+10000000000"})
     body = response.text
     assert "<Response>" in body
-    assert "<Say" in body
+    assert "<Say" not in body          # greeting is now via ElevenLabs on start event
     assert "<Connect>" in body
     assert "<Stream" in body
     # TestClient sets Host: testserver
@@ -37,7 +100,7 @@ def test_voice_twiml_contains_greeting_and_media_stream():
 
 
 # ---------------------------------------------------------------------------
-# WS /media-stream
+# WS /media-stream — basic lifecycle
 # ---------------------------------------------------------------------------
 
 
@@ -47,40 +110,138 @@ def test_media_stream_accepts_connection():
         ws.send_text(json.dumps({"event": "stop"}))
 
 
-def test_media_stream_handles_full_call_lifecycle():
-    with client.websocket_connect("/media-stream") as ws:
-        ws.send_text(json.dumps({
-            "event": "connected",
-            "protocol": "Call",
-            "version": "1.0.0",
-        }))
-        ws.send_text(json.dumps({
-            "event": "start",
-            "start": {
-                "callSid": "CAtest123",
-                "streamSid": "MZtest456",
-                "accountSid": "ACtest",
-                "tracks": ["inbound"],
-                "mediaFormat": {"encoding": "audio/x-mulaw", "sampleRate": 8000, "channels": 1},
-            },
-        }))
-        ws.send_text(json.dumps({
-            "event": "media",
-            "media": {
-                "track": "inbound",
-                "chunk": "1",
-                "timestamp": "5",
-                "payload": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345678=",
-            },
-        }))
-        ws.send_text(json.dumps({
-            "event": "stop",
-            "stop": {"accountSid": "ACtest", "callSid": "CAtest123"},
-        }))
-        # No exception raised = handler completed cleanly
-
-
 def test_media_stream_tolerates_unknown_events():
     with client.websocket_connect("/media-stream") as ws:
         ws.send_text(json.dumps({"event": "mark", "mark": {"name": "my_mark"}}))
         ws.send_text(json.dumps({"event": "stop"}))
+
+
+def test_media_stream_handles_full_call_lifecycle(mock_pipeline):
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_MEDIA_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+    # No exception = handler completed cleanly; Deepgram.finish was called
+    mock_pipeline.finish.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AI greeting
+# ---------------------------------------------------------------------------
+
+
+def test_ai_greeting_spawned_on_start(monkeypatch):
+    """On start event, stream_reply is called with GREETING_TRANSCRIPT."""
+    from app.telephony.router import GREETING_TRANSCRIPT
+
+    calls: list[str] = []
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, on_final):
+        return fake_dg
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    async def recording_stream_reply(*, transcript, history, order, **kw):
+        calls.append(transcript)
+        yield StreamEvent(text_delta="Hello!")
+        yield StreamEvent(
+            final=LLMResponse(reply_text="Hello!", order=order, history=history)
+        )
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr("app.telephony.router.stream_reply", recording_stream_reply)
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert GREETING_TRANSCRIPT in calls
+
+
+# ---------------------------------------------------------------------------
+# Order persistence on stop
+# ---------------------------------------------------------------------------
+
+
+def test_stop_event_persists_ready_order(monkeypatch):
+    """persist_on_confirm is called at call end when order is_ready_to_confirm."""
+    from app.orders.models import LineItem, ItemCategory, OrderType
+
+    persisted: list = []
+
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, on_final):
+        return fake_dg
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    ready_order = Order(
+        call_sid="CAtest123",
+        items=[LineItem(name="Pepperoni", category=ItemCategory.PIZZA, size="large", quantity=1, unit_price=21.99)],
+        order_type=OrderType.PICKUP,
+    )
+
+    async def fake_stream_reply(*, transcript, history, order, **kw):
+        yield StreamEvent(text_delta="Great!")
+        yield StreamEvent(
+            final=LLMResponse(reply_text="Great!", order=ready_order, history=history)
+        )
+
+    def fake_persist(order):
+        persisted.append(order)
+        return order
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr("app.telephony.router.stream_reply", fake_stream_reply)
+    monkeypatch.setattr("app.telephony.router.persist_on_confirm", fake_persist)
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert len(persisted) == 1
+    assert persisted[0].call_sid == "CAtest123"
+
+
+def test_stop_event_skips_persist_if_order_not_ready(monkeypatch):
+    """persist_on_confirm is NOT called when order has no items."""
+    persisted: list = []
+
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, on_final):
+        return fake_dg
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    def fake_persist(order):
+        persisted.append(order)
+        return order
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
+    monkeypatch.setattr("app.telephony.router.persist_on_confirm", fake_persist)
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert persisted == []

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -37,4 +37,4 @@ def test_voice_returns_twiml():
     assert response.headers["content-type"].startswith("application/xml")
     body = response.text
     assert "<Response>" in body
-    assert "<Say" in body
+    assert "<Say" not in body  # greeting is delivered via ElevenLabs on start event


### PR DESCRIPTION
## Summary
- Wires all four Phase 1 pipelines into a single real-time call session in `app/telephony/router.py`
- Each Deepgram final transcript fires `_run_llm_tts_turn()` which streams Claude Haiku replies through ElevenLabs TTS back to the Twilio WebSocket
- Barge-in supported: new transcript cancels any in-flight LLM/TTS turn via `asyncio.Task.cancel()`
- 10-second silence watchdog prompts caller if they go quiet after the AI finishes speaking
- AI greeting delivered via ElevenLabs on `start` event — static TwiML `<Say>` removed
- Completed orders persisted to Firestore on call end via `persist_on_confirm()`
- Sentence-boundary TTS flushing (`.?!`) for low first-audio latency — estimated p50 ~650ms

## Linked issue
Closes #40

## Test plan
- [x] 69/69 unit tests passing (`pytest -v`)
- [ ] Live call test: dial `+16479058093`, complete a pizza order, verify order appears on dashboard
- [ ] Confirm p50 first-audio latency < 1s from server logs (`llm_turn first_audio latency=...`)
- [ ] Verify barge-in works: interrupt the AI mid-sentence, confirm it replans

## Notes
- **PR is open for review but should not merge until the live call test passes** — holding off because Twilio console access is needed to update the webhook URL (Meet is currently out sick)
- `deploy.yml` has an unrelated local modification — not included in this PR
- Latency budget breakdown: 300ms Deepgram endpointing + ~200ms Haiku TTFT + ~150ms ElevenLabs TTFB ≈ 650ms p50
- ElevenLabs free tier (10k chars/mo) may need upgrading to Creator before demo day per `docs/06-shared-accounts.md`