### PR TITLE
Swap TTS from ElevenLabs to Deepgram Aura (#62)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,9 @@
 # Anthropic — Claude Haiku 4.5
 ANTHROPIC_API_KEY=
 
-# Deepgram — streaming STT
+# Deepgram — streaming STT (Nova-2) and TTS (Aura)
 DEEPGRAM_API_KEY=
-
-# ElevenLabs — streaming TTS
-ELEVENLABS_API_KEY=
-ELEVENLABS_MODEL_ID=eleven_turbo_v2_5
-ELEVENLABS_VOICE_ID=pNInz6obpgDQGcFmaJgB
+DEEPGRAM_TTS_MODEL=aura-2-thalia-en
 
 # Twilio — Voice webhook + trial number
 TWILIO_ACCOUNT_SID=

--- a/app/config.py
+++ b/app/config.py
@@ -20,18 +20,11 @@ class Settings(BaseSettings):
 
     deepgram_api_key: Optional[str] = None
 
-    elevenlabs_api_key: Optional[str] = None
-
-    # Available ElevenLabs models (ordered by latency, fastest first):
-    # eleven_turbo_v2_5      — lowest latency, recommended for real-time voice (default)
-    # eleven_turbo_v2        — slightly higher quality, ~20ms slower
-    # eleven_multilingual_v2 — best quality, multi-language, highest latency
-    # eleven_monolingual_v1  — legacy English-only
-    elevenlabs_model_id: str = "eleven_turbo_v2_5"
-
-    # Adam voice — free-tier premade voice. Rachel (21m00Tcm4TlvDq8ikWAM) requires a paid plan.
-    # Browse voices at https://elevenlabs.io/voice-library and override via ELEVENLABS_VOICE_ID.
-    elevenlabs_voice_id: str = "pNInz6obpgDQGcFmaJgB"
+    # Deepgram Aura TTS voice/model. The model name encodes both the model
+    # generation (aura-2) and the voice (thalia — warm, conversational female).
+    # Browse voices at https://developers.deepgram.com/docs/tts-models and
+    # override via DEEPGRAM_TTS_MODEL.
+    deepgram_tts_model: str = "aura-2-thalia-en"
 
     twilio_account_sid: Optional[str] = None
     twilio_auth_token: Optional[str] = None

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -2,8 +2,9 @@
 
 POST /voice        — TwiML webhook: answers the inbound call, opens a
                      Twilio Media Stream so the STT→LLM→TTS pipeline can
-                     take over.  The AI greeting is delivered via ElevenLabs
-                     on the 'start' event rather than a static TwiML <Say>.
+                     take over.  The AI greeting is delivered via Deepgram
+                     Aura on the 'start' event rather than a static TwiML
+                     <Say>.
 
 WS   /media-stream — Receives the Twilio Media Stream over WebSocket and
                      runs the full call loop:
@@ -179,7 +180,7 @@ async def voice(request: Request) -> Response:
     """Respond to Twilio's inbound call webhook with TwiML.
 
     Opens a bidirectional Media Stream back to /media-stream.  The AI
-    greeting is delivered via ElevenLabs on the 'start' WebSocket event
+    greeting is delivered via Deepgram Aura on the 'start' WebSocket event
     rather than a static TwiML <Say>, so the caller hears the same voice
     for the entire call.
 
@@ -196,7 +197,7 @@ async def voice(request: Request) -> Response:
 
 @router.websocket("/media-stream")
 async def media_stream(websocket: WebSocket) -> None:
-    """Full call loop: Twilio Media Stream → Deepgram STT → LLM → ElevenLabs TTS.
+    """Full call loop: Twilio Media Stream → Deepgram STT → LLM → Deepgram Aura TTS.
 
     Twilio event types:
       connected  — protocol handshake

--- a/app/tts/client.py
+++ b/app/tts/client.py
@@ -1,11 +1,12 @@
-"""ElevenLabs TTS client for the niko voice agent.
+"""Deepgram Aura TTS client for the niko voice agent.
 
-Streams LLM reply text through ElevenLabs and pipes mulaw 8 kHz audio
+Streams LLM reply text through Deepgram Aura and pipes mulaw 8 kHz audio
 back to the caller via the active Twilio Media Streams WebSocket.
 
-Upgrade path: this module uses the ElevenLabs HTTP streaming API (Option A).
-When #40 adds LLM token streaming, upgrade to the ElevenLabs WebSocket API
-(Option B) for lower first-audio latency — the speak() signature stays the same.
+Why Deepgram Aura (over ElevenLabs):
+  - Server-to-server design — no abuse detector that blocks Cloud Run egress.
+  - Native ``mulaw`` 8 kHz output — drop-in for Twilio Media Streams.
+  - Reuses the Deepgram API key already in use for STT.
 """
 
 from __future__ import annotations
@@ -22,14 +23,14 @@ from app.config import settings
 
 logger = logging.getLogger(__name__)
 
-_ELEVENLABS_BASE = "https://api.elevenlabs.io/v1"
+_DEEPGRAM_BASE = "https://api.deepgram.com/v1"
 
 
 def _api_key() -> str:
-    key = settings.elevenlabs_api_key
+    key = settings.deepgram_api_key
     if not key:
         raise RuntimeError(
-            "ELEVENLABS_API_KEY not set — cannot call TTS. "
+            "DEEPGRAM_API_KEY not set — cannot call TTS. "
             "Fetch credentials via /shared-creds."
         )
     return key
@@ -42,11 +43,12 @@ async def speak(
     *,
     client: Optional[httpx.AsyncClient] = None,
 ) -> None:
-    """Stream ElevenLabs TTS audio back into the Twilio call.
+    """Stream Deepgram Aura TTS audio back into the Twilio call.
 
-    Requests ulaw_8000 output from ElevenLabs (native mulaw 8 kHz — no
-    transcoding needed). Each binary chunk is base64-encoded and sent as
-    a Twilio ``media`` WebSocket event immediately, keeping latency low.
+    Requests ``encoding=mulaw`` at 8 kHz with no container — raw mulaw
+    bytes that Twilio's Media Streams accepts directly. Each binary chunk
+    is base64-encoded and sent as a Twilio ``media`` WebSocket event
+    immediately, keeping latency low.
 
     Args:
         text:       LLM reply text to synthesize.
@@ -58,19 +60,20 @@ async def speak(
         return
 
     key = _api_key()
-    voice_id = settings.elevenlabs_voice_id
-    model_id = settings.elevenlabs_model_id
-    url = f"{_ELEVENLABS_BASE}/text-to-speech/{voice_id}/stream"
+    model = settings.deepgram_tts_model
+    url = f"{_DEEPGRAM_BASE}/speak"
+    params = {
+        "model": model,
+        "encoding": "mulaw",
+        "sample_rate": "8000",
+        "container": "none",
+    }
 
     headers = {
-        "xi-api-key": key,
+        "Authorization": f"Token {key}",
         "Content-Type": "application/json",
     }
-    body = {
-        "text": text,
-        "model_id": model_id,
-        "output_format": "ulaw_8000",
-    }
+    body = {"text": text}
 
     created_client = client is None
     _client = client or httpx.AsyncClient(
@@ -78,17 +81,19 @@ async def speak(
     )
 
     try:
-        async with _client.stream("POST", url, headers=headers, json=body) as response:
+        async with _client.stream(
+            "POST", url, headers=headers, params=params, json=body
+        ) as response:
             if response.status_code != 200:
                 error_body = await response.aread()
                 logger.error(
-                    "tts: ElevenLabs returned %d stream_sid=%s body=%s",
+                    "tts: Deepgram returned %d stream_sid=%s body=%s",
                     response.status_code,
                     stream_sid,
                     error_body.decode(errors="replace")[:200],
                 )
                 raise RuntimeError(
-                    f"ElevenLabs returned {response.status_code}: "
+                    f"Deepgram returned {response.status_code}: "
                     f"{error_body.decode(errors='replace')}"
                 )
 

--- a/docs/02-product-roadmap.md
+++ b/docs/02-product-roadmap.md
@@ -237,7 +237,7 @@ Guiding principle: **free-tier-first**. We have no outside funding, so every pic
 | Company name | **Tsuki Works** | — | — |
 | Telephony | **Twilio Voice** | $15 trial credit; ~$0.0085/min inbound US after | Telnyx (~40% cheaper/min at scale) |
 | STT | **Deepgram (Nova-2 streaming)** | $200 free credit — weeks of POC testing | Stay on Deepgram |
-| TTS | **ElevenLabs** | 10k chars/mo free tier | ElevenLabs Pro ($22/mo) or Cartesia for lower latency |
+| TTS | **Deepgram Aura** | $200 signup credit (shared with STT) | ElevenLabs (richer voices) or Cartesia (lower latency) if Aura quality becomes a blocker |
 | LLM | **Anthropic Claude Haiku 4.5** | Pay-as-you-go via Console (Claude for Startups requires VC backing — revisit post-raise); Haiku is cheap + fast, strong instruction-following for constrained menu flows | Claude Sonnet for harder conversations |
 | Primary POS (MVP) | **Square** | Developer sandbox + API free | — (Toast/Clover added Phase 3) |
 | Hosting | **GCP — Cloud Run + Firestore** | $300 credit (90d) + always-free Cloud Run (2M req/mo) + Firestore free tier. Scales to zero = $0 when idle. | Stay on GCP; raise tier + min-instances when funded |
@@ -253,7 +253,7 @@ niko/
 ├── app/                            # FastAPI: voice, dashboard REST API
 │   ├── telephony/                  # Twilio webhooks + Media Streams ingress
 │   ├── llm/                        # Claude Haiku conversation engine
-│   ├── tts/                        # ElevenLabs streaming
+│   ├── tts/                        # Deepgram Aura streaming
 │   ├── orders/                     # Pydantic models (shared schema)
 │   ├── storage/                    # Firestore reads/writes
 │   └── main.py                     # /voice, /orders, /health, /dev/seed-order

--- a/docs/03-technical-architecture.md
+++ b/docs/03-technical-architecture.md
@@ -38,7 +38,7 @@
                              │  └────────┬────────┘  │
                              │           ▼           │
                              │  ┌─────────────────┐  │
-                             │  │  TTS Engine      │  │  ElevenLabs / PlayHT
+                             │  │  TTS Engine      │  │  Deepgram Aura
                              │  │  (Text→Speech)   │  │
                              │  └─────────────────┘  │
                              └──────────┬─────────────┘
@@ -78,7 +78,7 @@
 | **Telephony** | Twilio Voice | Telnyx / Vonage | Most mature API, best docs, programmable voice. $15 trial credit for POC; migrate to Telnyx once volume makes per-minute margin matter |
 | **STT (Speech-to-Text)** | Deepgram Nova-2 (streaming) | OpenAI Whisper API | Real-time streaming, low latency, high accuracy. $200 free credit covers POC |
 | **LLM (Conversation)** | Anthropic Claude Haiku 4.5 (POC/MVP) → Sonnet (production) | OpenAI GPT-4o | Haiku is cheap + fast with strong instruction following for constrained menu flows. Upgrade to Sonnet for harder conversations once funded. Pay-as-you-go via Console during bootstrap; Claude for Startups is VC-gated, revisit after raising |
-| **TTS (Text-to-Speech)** | ElevenLabs | OpenAI TTS / PlayHT / Cartesia | Most natural voices, low latency streaming. 10k chars/mo free tier |
+| **TTS (Text-to-Speech)** | Deepgram Aura | ElevenLabs / Cartesia / OpenAI TTS | Native mulaw 8 kHz output (drop-in for Twilio); reuses the Deepgram key already used for STT; server-to-server design (no abuse-detector blocks on Cloud Run) |
 
 ### Infrastructure
 
@@ -122,7 +122,7 @@ Inbound Call (Twilio)
 │                                                   │
 │  1. Audio In → STT (Deepgram streaming)           │
 │  2. Text → LLM (Claude/GPT with restaurant context)│
-│  3. LLM Response → TTS (ElevenLabs streaming)     │
+│  3. LLM Response → TTS (Deepgram Aura streaming)  │
 │  4. Audio Out → Caller                            │
 │                                                   │
 │  State: conversation history, order-in-progress,  │
@@ -298,9 +298,8 @@ ngrok http 8000
 
 ### Required API Keys for Development
 - Twilio (Account SID, Auth Token, Phone Number)
-- Deepgram (API Key)
+- Deepgram (API Key — used for both STT and TTS)
 - Anthropic (API Key)
-- ElevenLabs (API Key)
 - Square (Sandbox Application ID, Access Token)
 - GCP service account JSON (for Firestore + Secret Manager)
 
@@ -379,7 +378,7 @@ CMD ["node", "server.js"]
 - Both use Workload Identity Federation — no long-lived service-account JSON anywhere.
 
 **Secrets / env vars:**
-- Store API keys (Twilio, Deepgram, Anthropic, ElevenLabs, Square) in **Secret Manager**
+- Store API keys (Twilio, Deepgram, Anthropic, Square) in **Secret Manager**
 - Reference them from Cloud Run via `--set-secrets` at deploy time — never bake secrets into the image
 
 **Escape hatches:**

--- a/docs/05-team-roles-and-responsibilities.md
+++ b/docs/05-team-roles-and-responsibilities.md
@@ -42,7 +42,7 @@ Some responsibilities are **shared across the whole team** rather than assigned 
 
 | Responsibility | Details |
 |---------------|---------|
-| TTS pipeline | ElevenLabs streaming back to Twilio |
+| TTS pipeline | Deepgram Aura streaming back to Twilio |
 | Audio engineering | Barge-in detection, audio quality, interruption handling |
 | Performance | Ensure < 1 second end-to-end voice response latency |
 | Call state management | Session state, timeout/silence detection |

--- a/docs/06-shared-accounts.md
+++ b/docs/06-shared-accounts.md
@@ -10,12 +10,12 @@ Phase 0 exit requires shared accounts for every service in the niko stack. Each 
 |---|---|---|---|---|
 | GCP | Cloud Run hosting + Firestore | Meet | ✅ Done | Live; Cloud Run auto-deploys from `master` via `.github/workflows/deploy.yml` |
 | Twilio | Voice telephony | Meet | ✅ Done | Trial account, $15 credit. Toronto (647) number — swap to US before pilot. Upgrade to paid before Phase 1 demo day to drop trial watermark. Creds in `#shared-creds` |
-| Deepgram | STT (Nova-2 streaming) | Meet | ✅ Done | $200 signup credit. Key `niko-poc` (member scope). Creds in `#shared-creds` |
+| Deepgram | STT (Nova-2 streaming) + TTS (Aura) | Meet | ✅ Done | $200 signup credit covers both STT and TTS. Single key `niko-poc` (member scope) used for both. Creds in `#shared-creds` |
 | Anthropic | Claude Haiku 4.5 LLM | Meet | ✅ Done | Pay-as-you-go on Console; Claude for Startups is VC-gated (revisit post-raise). Key posted to `#shared-creds` |
-| ElevenLabs | TTS streaming | Meet | ✅ Done | Free tier (10k chars/mo). Key `niko-poc`, scoped to TTS + Models + Voices-read. Upgrade to Creator ($22/mo) needed around Phase 1 demo day — team-agreement gate |
+| ~~ElevenLabs~~ | ~~TTS streaming~~ | — | Retired (#62) | Replaced by Deepgram Aura on 2026-04-25. Free tier blocked Cloud Run egress IPs (`detected_unusual_activity` 401). Account/key archived |
 | Square Developer | POS sandbox + production API | Meet | ✅ Done | Sandbox app `niko-poc` on a CA seller account (Phase 2.3 dev only — real US restaurants use their own Square US account via OAuth). Creds in `#shared-creds` |
 
-> **Owner note:** Meet is doing all Phase 0 signups in one pass to avoid parallel-coordination overhead. Domain owners (per `05-team-roles`) take over admin once the account is live and the service is used in code — e.g., Kailash inherits Twilio/Deepgram/Square admin when the telephony + STT + POS work lands; Sandeep inherits ElevenLabs admin with the TTS pipeline.
+> **Owner note:** Meet is doing all Phase 0 signups in one pass to avoid parallel-coordination overhead. Domain owners (per `05-team-roles`) take over admin once the account is live and the service is used in code — e.g., Kailash inherits Twilio/Deepgram/Square admin when the telephony + STT + POS work lands. With ElevenLabs retired, Deepgram now covers both STT (Kailash's lane) and TTS (Sandeep's lane); the two pair on the single Deepgram key.
 
 ## How to complete a signup
 

--- a/tests/test_tts_client.py
+++ b/tests/test_tts_client.py
@@ -38,7 +38,7 @@ def make_mock_client(chunks: list[bytes], status_code: int = 200) -> MagicMock:
     mock_response = MagicMock()
     mock_response.status_code = status_code
     mock_response.aiter_bytes = lambda: _chunk_gen(chunks)
-    mock_response.aread = AsyncMock(return_value=b"bad request from elevenlabs")
+    mock_response.aread = AsyncMock(return_value=b"bad request from deepgram")
 
     mock_client = MagicMock()
     mock_client.stream.return_value = _AsyncStreamCtx(mock_response)
@@ -49,6 +49,15 @@ def make_mock_websocket() -> AsyncMock:
     ws = AsyncMock()
     ws.send_json = AsyncMock()
     return ws
+
+
+@pytest.fixture(autouse=True)
+def _patch_settings():
+    """Default settings for every test — keeps the suite independent of local .env."""
+    with patch("app.tts.client.settings") as mock_settings:
+        mock_settings.deepgram_api_key = "test-key"
+        mock_settings.deepgram_tts_model = "aura-2-thalia-en"
+        yield mock_settings
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +84,7 @@ async def test_speak_sends_media_events():
 
 @pytest.mark.asyncio
 async def test_speak_empty_text_sends_nothing():
-    """Empty text returns immediately without hitting ElevenLabs."""
+    """Empty text returns immediately without hitting Deepgram."""
     client = make_mock_client([b"\x00"])
     ws = make_mock_websocket()
 
@@ -87,7 +96,7 @@ async def test_speak_empty_text_sends_nothing():
 
 @pytest.mark.asyncio
 async def test_speak_whitespace_only_sends_nothing():
-    """Whitespace-only text is treated as empty — ElevenLabs not called."""
+    """Whitespace-only text is treated as empty — Deepgram not called."""
     client = make_mock_client([b"\x00"])
     ws = make_mock_websocket()
 
@@ -98,19 +107,18 @@ async def test_speak_whitespace_only_sends_nothing():
 
 
 @pytest.mark.asyncio
-async def test_speak_missing_api_key_raises():
-    """RuntimeError raised when ELEVENLABS_API_KEY is not set."""
+async def test_speak_missing_api_key_raises(_patch_settings):
+    """RuntimeError raised when DEEPGRAM_API_KEY is not set."""
     ws = make_mock_websocket()
+    _patch_settings.deepgram_api_key = None
 
-    with patch("app.tts.client.settings") as mock_settings:
-        mock_settings.elevenlabs_api_key = None
-        with pytest.raises(RuntimeError, match="ELEVENLABS_API_KEY"):
-            await speak("Hello", ws, stream_sid="MZ123")
+    with pytest.raises(RuntimeError, match="DEEPGRAM_API_KEY"):
+        await speak("Hello", ws, stream_sid="MZ123")
 
 
 @pytest.mark.asyncio
 async def test_speak_non_200_raises():
-    """RuntimeError raised when ElevenLabs returns a non-200 status."""
+    """RuntimeError raised when Deepgram returns a non-200 status."""
     client = make_mock_client([], status_code=401)
     ws = make_mock_websocket()
 
@@ -133,21 +141,20 @@ async def test_speak_websocket_disconnect_is_handled():
 
 
 @pytest.mark.asyncio
-async def test_speak_uses_configured_voice_and_model():
-    """ElevenLabs is called with the voice_id and model_id from settings."""
+async def test_speak_uses_configured_model_and_mulaw_format():
+    """Deepgram is called with the configured model, mulaw 8 kHz, no container."""
     client = make_mock_client([b"\x00"])
     ws = make_mock_websocket()
 
-    with patch("app.tts.client.settings") as mock_settings:
-        mock_settings.elevenlabs_api_key = "test-key"
-        mock_settings.elevenlabs_voice_id = "test-voice-id"
-        mock_settings.elevenlabs_model_id = "eleven_turbo_v2_5"
-
-        await speak("Hello", ws, stream_sid="MZ123", client=client)
+    await speak("Hello", ws, stream_sid="MZ123", client=client)
 
     assert client.stream.call_args.args[0] == "POST"
-    assert "test-voice-id" in client.stream.call_args.args[1]
+    assert client.stream.call_args.args[1].endswith("/speak")
+
     kwargs = client.stream.call_args.kwargs
-    body = kwargs["json"]
-    assert body["model_id"] == "eleven_turbo_v2_5"
-    assert body["output_format"] == "ulaw_8000"
+    assert kwargs["params"]["model"] == "aura-2-thalia-en"
+    assert kwargs["params"]["encoding"] == "mulaw"
+    assert kwargs["params"]["sample_rate"] == "8000"
+    assert kwargs["params"]["container"] == "none"
+    assert kwargs["headers"]["Authorization"] == "Token test-key"
+    assert kwargs["json"] == {"text": "Hello"}

--- a/tests/test_tts_integration.py
+++ b/tests/test_tts_integration.py
@@ -1,13 +1,13 @@
-"""Live ElevenLabs integration test for speak().
+"""Live Deepgram Aura integration test for speak().
 
-Skipped when ELEVENLABS_API_KEY is absent so CI never calls the real API.
+Skipped when DEEPGRAM_API_KEY is absent so CI never calls the real API.
 Run locally with your key in .env to verify the full round-trip.
 
 Usage:
     pytest tests/test_tts_integration.py -v -s
     pytest tests/test_tts_integration.py -v -s --phrase "Hi, welcome to Niko's Pizza!"
 
-Audio is saved to tts_test_output.wav (mulaw) or tts_test_output.mp3 (free tier).
+Audio is saved to tts_test_output.wav (mulaw 8 kHz, decoded to PCM16).
 """
 import base64
 import struct
@@ -20,8 +20,8 @@ from app.config import settings
 from app.tts.client import speak
 
 pytestmark = pytest.mark.skipif(
-    not settings.elevenlabs_api_key,
-    reason="ELEVENLABS_API_KEY not set — skipping live ElevenLabs test",
+    not settings.deepgram_api_key,
+    reason="DEEPGRAM_API_KEY not set — skipping live Deepgram TTS test",
 )
 
 # G.711 mu-law decode table (ITU-T, matches CPython audioop implementation).
@@ -43,13 +43,7 @@ def _mulaw_to_pcm16(mulaw_data: bytes) -> bytes:
 
 
 def _save_audio(audio_bytes: bytes) -> Path:
-    """Save audio to the right format based on what ElevenLabs actually returned."""
-    if audio_bytes[:3] == b"ID3" or audio_bytes[:2] == b"\xff\xfb":
-        # Free tier returns MP3 regardless of requested ulaw_8000 format
-        path = Path("tts_test_output.mp3")
-        path.write_bytes(audio_bytes)
-        return path
-
+    """Save audio as a WAV by decoding the raw mulaw stream to PCM16."""
     import wave
     path = Path("tts_test_output.wav")
     pcm = _mulaw_to_pcm16(audio_bytes)
@@ -62,7 +56,7 @@ def _save_audio(audio_bytes: bytes) -> Path:
 
 
 async def test_speak_returns_audio_chunks(tts_phrase):
-    """Real ElevenLabs call — audio saved to tts_test_output.wav or .mp3."""
+    """Real Deepgram Aura call — audio saved to tts_test_output.wav."""
     received: list[dict] = []
 
     ws = AsyncMock()
@@ -72,7 +66,7 @@ async def test_speak_returns_audio_chunks(tts_phrase):
 
     await speak(tts_phrase, ws, stream_sid="TEST-STREAM-SID")
 
-    assert len(received) > 0, "Expected at least one media event from ElevenLabs"
+    assert len(received) > 0, "Expected at least one media event from Deepgram"
 
     for event in received:
         assert event["event"] == "media"

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -37,4 +37,4 @@ def test_voice_returns_twiml():
     assert response.headers["content-type"].startswith("application/xml")
     body = response.text
     assert "<Response>" in body
-    assert "<Say" not in body  # greeting is delivered via ElevenLabs on start event
+    assert "<Say" not in body  # greeting is delivered via Deepgram Aura on start event


### PR DESCRIPTION
## Summary
- Replaces the ElevenLabs HTTP streaming call in `app/tts/client.py` with Deepgram Aura (`POST /v1/speak`, `encoding=mulaw`, `sample_rate=8000`, `container=none`). Same `speak()` signature, no caller-side changes.
- Drops `elevenlabs_*` settings; adds `deepgram_tts_model` (default `aura-2-thalia-en`). Reuses the existing `DEEPGRAM_API_KEY` for both STT and TTS.
- Updates docs (`02-product-roadmap`, `03-technical-architecture`, `05-team-roles`, `06-shared-accounts`) + `.env.example` to reflect the swap; ElevenLabs row in `06` marked retired with the reason.

## Why
ElevenLabs free tier blocks Cloud Run egress IPs — every TTS request returned **HTTP 401 `detected_unusual_activity`**, leaving the entire 2026-04-25 22:24 UTC test call in dead air. Deepgram Aura is built for server-to-server use, outputs mulaw 8 kHz natively for Twilio, and consolidates the voice stack under one vendor (Kailash already owns Deepgram admin per `docs/06-shared-accounts.md`). The $200 Deepgram signup credit covers POC + demo-day volume effectively for free.

## Linked issue
Closes #62 (created in this conversation; supersedes the ElevenLabs upgrade path mentioned in #40 retro notes).

## Test plan
- [x] `pytest -v` — 63/63 unit tests passing locally; the new `test_speak_uses_configured_model_and_mulaw_format` asserts the Deepgram URL/headers/params/body shape.
- [x] Test suite is now independent of local `.env` (autouse fixture patches `settings`).
- [ ] Live call to `+16479058093` produces audible AI replies and completes a pizza order; order persists to Firestore + appears on the dashboard.
- [ ] p50 first-audio latency stays <1s (Phase 1 contract from #40); confirm via `llm_turn first_audio latency=...` log line.

## Notes
- Voice quality tradeoff: ElevenLabs is more expressive than Aura-2; for order-taking dialogue the gap is small. Override `DEEPGRAM_TTS_MODEL` to try other Aura voices (full list: https://developers.deepgram.com/docs/tts-models).
- Follow-up worth a separate PR (out of scope here): `_run_llm_tts_turn` and `_silence_watchdog` currently log "Task exception was never retrieved" when `speak()` raises — caller hears silence. Catch the `RuntimeError` and play a TwiML `<Say>` fallback or end the call cleanly so future TTS outages aren't dead air.