### PR TITLE
Fix LLM 400 on multi-turn calls: strip SDK-only fields from history (#64)

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -138,6 +138,26 @@ def _async_client() -> AsyncAnthropic:
     return AsyncAnthropic(api_key=key)
 
 
+def _serialize_block(block: Any) -> dict[str, Any]:
+    """Convert an SDK content block to the dict shape the Messages API accepts.
+
+    The Anthropic SDK's streaming blocks carry extra attributes like
+    ``parsed_output`` that ``model_dump()`` faithfully serializes — but the
+    Messages API rejects unknown fields, so any subsequent turn that threads
+    that history 400s. We rebuild the API-valid shape by hand instead.
+    """
+    if block.type == "text":
+        return {"type": "text", "text": block.text}
+    if block.type == "tool_use":
+        return {
+            "type": "tool_use",
+            "id": block.id,
+            "name": block.name,
+            "input": block.input,
+        }
+    raise ValueError(f"Unsupported content block type: {block.type!r}")
+
+
 def _apply_update(order: Order, patch: dict[str, Any]) -> Order:
     """Merge a tool-call payload into the current Order.
 
@@ -198,7 +218,7 @@ def generate_reply(
     for tu in tool_uses:
         updated_order = _apply_update(updated_order, tu["input"])
 
-    assistant_content = [block.model_dump() for block in response.content]
+    assistant_content = [_serialize_block(block) for block in response.content]
     new_history = [
         *new_history,
         {"role": "assistant", "content": assistant_content},
@@ -227,7 +247,7 @@ def generate_reply(
         for block in followup.content:
             if block.type == "text":
                 reply_text_parts.append(block.text)
-        followup_content = [block.model_dump() for block in followup.content]
+        followup_content = [_serialize_block(block) for block in followup.content]
         new_history = [
             *new_history,
             {"role": "assistant", "content": followup_content},
@@ -289,7 +309,7 @@ async def stream_reply(
     for tu in tool_uses:
         updated_order = _apply_update(updated_order, tu["input"])
 
-    assistant_content = [block.model_dump() for block in first_message.content]
+    assistant_content = [_serialize_block(block) for block in first_message.content]
     new_history = [
         *new_history,
         {"role": "assistant", "content": assistant_content},
@@ -320,7 +340,7 @@ async def stream_reply(
                 text_parts.append(delta)
                 yield StreamEvent(text_delta=delta)
             followup_message = await followup_stream.get_final_message()
-        followup_content = [b.model_dump() for b in followup_message.content]
+        followup_content = [_serialize_block(b) for b in followup_message.content]
         new_history = [
             *new_history,
             {"role": "assistant", "content": followup_content},

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -162,6 +162,39 @@ def test_history_threads_user_and_assistant_turns():
     ]
 
 
+def test_history_strips_sdk_only_fields_from_assistant_blocks():
+    """Regression for #64: the real Anthropic SDK's streaming TextBlock
+    carries a ``parsed_output`` attribute (and others). If we ``model_dump``
+    those into history, the next turn 400s with
+    ``messages.N.content.0.text.parsed_output: Extra inputs are not permitted``.
+    The serializer must emit only the API-valid shape regardless of what
+    extra attributes the block carries."""
+
+    class SdkLikeBlock:
+        type = "text"
+        text = "Sure, what size?"
+        parsed_output = {"some": "sdk-internal-thing"}
+        citations = None
+        index = 0
+
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = MagicMock(content=[SdkLikeBlock()])
+
+    result = generate_reply(
+        transcript="one pepperoni please",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    assistant_block = result.history[1]["content"][0]
+    assert assistant_block == {"type": "text", "text": "Sure, what size?"}
+    assert "parsed_output" not in assistant_block
+    assert "citations" not in assistant_block
+    assert "index" not in assistant_block
+
+
 def test_apply_update_preserves_call_sid_and_created_at():
     original = Order(call_sid="CAoriginal")
     original_created_at = original.created_at


### PR DESCRIPTION
## Summary
- Replace `block.model_dump()` with a hand-built `_serialize_block()` at the four sites in `app/llm/client.py` (`generate_reply` + `stream_reply`, both first-turn and tool-use follow-up).
- New helper emits **only** the API-valid content-block shape: `{type, text}` for text and `{type, id, name, input}` for tool_use.
- Add `test_history_strips_sdk_only_fields_from_assistant_blocks` regression test using a fake SDK-like block carrying `parsed_output`, `citations`, and `index` attributes.

## Root cause
Production logs from call_sid `CAf7fcf6d3402ed55e8259aa2522d31a87` (2026-04-25 22:02 UTC):

```
anthropic.BadRequestError: 400 - messages.1.content.0.text.parsed_output:
                                  Extra inputs are not permitted
```

Anthropic's streaming SDK enriches text content blocks with extra attributes (notably `parsed_output`). `model_dump()` faithfully serializes them. The Messages API rejects unknown fields on content blocks, so every turn after the greeting 400d before the first token — caller heard dead air.

The unit suite missed it because `tests/test_llm_client.py::FakeBlock.model_dump()` is hand-rolled to return only the API-valid keys; it did not reproduce the real-SDK behavior. The new regression test closes that gap.

## Linked issue
Closes #64.

## Test plan
- [x] `pytest -v` — 64/64 unit tests passing locally (was 63 + 1 new regression).
- [ ] Live call to `+16479058093` — caller's first reply gets a Haiku response back; conversation continues for several turns; order persists to Firestore on hangup.

## Notes
- No behavior change for any block type currently produced by Haiku (text, tool_use). If a future model emits a new block type the serializer will raise `ValueError` rather than silently corrupt history — preferable to a hard-to-diagnose 400.
- Independent of #62/#63 (the TTS swap). With both landed, the call loop should be end-to-end functional.