### PR TITLE
Fix LLM dead-air mid-call: always emit tool_result after tool_use (#66)

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -158,6 +158,40 @@ def _serialize_block(block: Any) -> dict[str, Any]:
     raise ValueError(f"Unsupported content block type: {block.type!r}")
 
 
+def _tool_result_block(tool_use_id: str, content: str = "Order updated.") -> dict[str, Any]:
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": content,
+    }
+
+
+def _append_user_transcript(
+    history: list[dict[str, Any]], transcript: str
+) -> list[dict[str, Any]]:
+    """Append the caller's transcript to history with valid alternation.
+
+    Anthropic requires strict user/assistant alternation. After a turn
+    that produced both text and a ``tool_use``, history ends in a synthetic
+    ``user: [tool_result]`` message. Appending another ``user`` message
+    would error, so we merge the new transcript into that pending
+    ``tool_result`` message instead.
+    """
+    if (
+        history
+        and history[-1]["role"] == "user"
+        and isinstance(history[-1]["content"], list)
+        and history[-1]["content"]
+        and history[-1]["content"][0].get("type") == "tool_result"
+    ):
+        merged = [
+            *history[-1]["content"],
+            {"type": "text", "text": transcript},
+        ]
+        return [*history[:-1], {"role": "user", "content": merged}]
+    return [*history, {"role": "user", "content": transcript}]
+
+
 def _apply_update(order: Order, patch: dict[str, Any]) -> Order:
     """Merge a tool-call payload into the current Order.
 
@@ -196,7 +230,7 @@ def generate_reply(
 
     api = client or _client()
 
-    new_history = [*history, {"role": "user", "content": transcript}]
+    new_history = _append_user_transcript(history, transcript)
 
     response = api.messages.create(
         model=MODEL,
@@ -224,19 +258,16 @@ def generate_reply(
         {"role": "assistant", "content": assistant_content},
     ]
 
-    if not reply_text_parts and tool_uses:
-        tool_results = [
-            {
-                "type": "tool_result",
-                "tool_use_id": tu["id"],
-                "content": "Order updated.",
-            }
-            for tu in tool_uses
-        ]
+    if tool_uses:
         new_history = [
             *new_history,
-            {"role": "user", "content": tool_results},
+            {
+                "role": "user",
+                "content": [_tool_result_block(tu["id"]) for tu in tool_uses],
+            },
         ]
+
+    if not reply_text_parts and tool_uses:
         followup = api.messages.create(
             model=MODEL,
             max_tokens=MAX_TOKENS,
@@ -284,7 +315,7 @@ async def stream_reply(
 
     api = client or _async_client()
 
-    new_history = [*history, {"role": "user", "content": transcript}]
+    new_history = _append_user_transcript(history, transcript)
 
     text_parts: list[str] = []
     tool_uses: list[dict[str, Any]] = []
@@ -315,20 +346,17 @@ async def stream_reply(
         {"role": "assistant", "content": assistant_content},
     ]
 
-    text_emitted = bool(text_parts)
-    if not text_emitted and tool_uses:
-        tool_results = [
-            {
-                "type": "tool_result",
-                "tool_use_id": tu["id"],
-                "content": "Order updated.",
-            }
-            for tu in tool_uses
-        ]
+    if tool_uses:
         new_history = [
             *new_history,
-            {"role": "user", "content": tool_results},
+            {
+                "role": "user",
+                "content": [_tool_result_block(tu["id"]) for tu in tool_uses],
+            },
         ]
+
+    text_emitted = bool(text_parts)
+    if not text_emitted and tool_uses:
         async with api.messages.stream(
             model=MODEL,
             max_tokens=MAX_TOKENS,

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -162,6 +162,119 @@ def test_history_threads_user_and_assistant_turns():
     ]
 
 
+def test_text_plus_tool_use_appends_tool_result_to_history():
+    """Regression for #66: when Haiku emits BOTH text and tool_use in a
+    single turn, the assistant message ends with a dangling tool_use.
+    Anthropic requires every tool_use to be followed by a tool_result,
+    so we must append a synthetic ``user: [tool_result]`` message —
+    otherwise the next turn 400s with ``tool_use ids were found without
+    tool_result blocks``. Confirmed in production logs for
+    call_sid=CA8e3be2e91a7471221f87ba1aab63d1cd."""
+
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [
+            FakeBlock(
+                type="text",
+                text="Got it, one large margarita for pickup. Anything else?",
+            ),
+            FakeBlock(
+                type="tool_use",
+                id="toolu_committed",
+                name="update_order",
+                input={
+                    "items": [
+                        {
+                            "name": "Margarita",
+                            "category": "pizza",
+                            "size": "large",
+                            "quantity": 1,
+                            "unit_price": 19.99,
+                        }
+                    ],
+                    "order_type": "pickup",
+                    "status": "in_progress",
+                },
+            ),
+        ]
+    )
+
+    result = generate_reply(
+        transcript="i'll take a large margarita for pickup",
+        history=[],
+        order=order,
+        client=fake_client,
+    )
+
+    # No follow-up call — text was emitted.
+    assert fake_client.messages.create.call_count == 1
+    # History ends with a synthetic tool_result so the next turn is valid.
+    assert result.history[-1] == {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_committed",
+                "content": "Order updated.",
+            }
+        ],
+    }
+
+
+def test_next_transcript_merges_into_pending_tool_result():
+    """When the prior turn ended with ``user: [tool_result]`` (text+tool_use
+    case), the *next* turn must merge the new transcript into that user
+    message rather than appending a second consecutive user message —
+    Anthropic requires strict role alternation."""
+
+    order = Order(call_sid="CAtest")
+    history_with_pending_tool_result = [
+        {"role": "user", "content": "i'll take a large margarita for pickup"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Got it, anything else?"},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_committed",
+                    "name": "update_order",
+                    "input": {"items": [], "status": "in_progress"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_committed",
+                    "content": "Order updated.",
+                }
+            ],
+        },
+    ]
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [FakeBlock(type="text", text="Sure thing.")]
+    )
+
+    result = generate_reply(
+        transcript="extra olives please",
+        history=history_with_pending_tool_result,
+        order=order,
+        client=fake_client,
+    )
+
+    # Find the last user message; assert the new transcript was merged
+    # into the pending tool_result message rather than appended separately.
+    user_messages = [m for m in result.history if m["role"] == "user"]
+    last_user = user_messages[-1]
+    assert isinstance(last_user["content"], list)
+    assert last_user["content"][0]["type"] == "tool_result"
+    assert last_user["content"][1] == {"type": "text", "text": "extra olives please"}
+
+
 def test_history_strips_sdk_only_fields_from_assistant_blocks():
     """Regression for #64: the real Anthropic SDK's streaming TextBlock
     carries a ``parsed_output`` attribute (and others). If we ``model_dump``


### PR DESCRIPTION
## Summary
- Always append a synthetic `user: [tool_result]` message after any assistant `tool_use`, regardless of whether text was emitted.
- Keep the followup-call only for the *no-text* tool_use case (caller still needs a verbal reply).
- New `_append_user_transcript()` helper merges the next-turn transcript into a trailing `tool_result` user message to preserve user/assistant alternation (Anthropic requires it).
- Apply the same fix to both `generate_reply` and `stream_reply`.

## Why
Live calls (call_sids `CA1fa31451294f94252d2bfa99dc455ce1`, `CA8e3be2e91a7471221f87ba1aab63d1cd`) stalled silently the moment Haiku committed an item to the order. The Anthropic API was returning:

```
400 - messages.N: tool_use ids were found without tool_result blocks
                  immediately after: toolu_01XH7qJknRPYquSmtP6QY37M
```

`stream_reply` only emitted `tool_result` in the *no-text* branch (the followup-call path used when Haiku tool-called without speaking). But Haiku's natural pattern is to **both speak and tool-call in the same turn** ("Got it, one large margarita for pickup. Anything else?" + `update_order(...)`). In that case the assistant message ended with a dangling `tool_use`, and the next turn 400d before the first token. Caller heard dead air; the silence watchdog kicked in but its prompt also tried to LLM-call and failed the same way.

## Test plan
- [x] `pytest -v` — 66/66 unit tests, including:
  - `test_text_plus_tool_use_appends_tool_result_to_history` — asserts the synthetic `user: [tool_result]` lands at the end of history after a text+tool_use turn.
  - `test_next_transcript_merges_into_pending_tool_result` — asserts the next-turn transcript merges into the pending tool_result message rather than appending a second user message.
- [ ] Live call: dial `+16479058093`, place an order with multiple modifications and a confirmation. No dead-air stall after Haiku commits items.

## Linked issue
Closes #66.

## Notes
- Independent of #62 (TTS swap) and #64 (parsed_output strip). With all three landed, the call loop should be production-ready for the POC demo.
- Follow-up worth opening as a separate issue: the `_silence_watchdog` `speak()` call should be wrapped in a try/except so a sustained LLM outage doesn't compound into watchdog 401/400 spam in the logs.