### PR TITLE
Dev call-logs view — backend /dev/calls + dashboard Calls page (#68)

### DIFF
--- a/app/dev/calls.py
+++ b/app/dev/calls.py
@@ -1,0 +1,231 @@
+"""Dev-only call-log surface backed by Cloud Logging.
+
+Reads structured telephony log lines from Cloud Logging, groups them by
+``call_sid``, and exposes:
+
+- ``list_recent_calls`` — summary per call_sid (start/end, transcript
+  count, error flag, terminal status).
+- ``get_call_timeline`` — full ordered event timeline for one call_sid.
+
+Authoritative event source is the same Cloud Run service that generated
+the logs. The Cloud Run service account needs ``roles/logging.viewer``.
+
+This module is consumed by the ``/dev/calls`` and ``/dev/calls/{call_sid}``
+routes, both gated on ``NIKO_DEV_ENDPOINTS=true``. It is **not** a Phase 2
+product feature — it's a debug surface for the team.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Optional
+
+# google-cloud-logging is an optional runtime dependency; importing lazily
+# keeps unit tests independent of the SDK and lets the routes raise a clear
+# error if the deploy environment is missing the package.
+try:
+    from google.cloud import logging as gcp_logging
+except ImportError:  # pragma: no cover - exercised only when SDK absent
+    gcp_logging = None  # type: ignore[assignment]
+
+
+_CALL_SID_RE = re.compile(r"call_sid=(CA\w+)")
+_TEXT_RE = re.compile(r"text='([^']*)'")
+_TRANSCRIPT_RE = re.compile(r"transcript=('([^']*)'|\"([^\"]*)\")")
+_LATENCY_RE = re.compile(r"latency=([0-9.]+)s")
+
+_SERVICE_NAME = os.environ.get("K_SERVICE") or "niko"
+
+
+@dataclass
+class CallEvent:
+    timestamp: datetime
+    kind: str  # "start" | "transcript_final" | "transcript_interim" | "llm_turn_start" | "first_audio" | "barge_in" | "silence_timeout" | "stop" | "order_confirmed" | "error" | "log"
+    text: str  # original log payload (or extracted detail)
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CallSummary:
+    call_sid: str
+    started_at: datetime
+    ended_at: datetime
+    transcript_count: int
+    has_error: bool
+    status: str  # "confirmed" | "ended" | "in_progress"
+
+
+def _classify(payload: str) -> tuple[str, dict[str, Any]]:
+    """Map a raw log payload into an event kind + extracted details.
+
+    Recognises the lines emitted by ``app.telephony.router`` and falls back
+    to ``log`` for everything else (so the timeline still shows context like
+    Anthropic / Deepgram HTTP responses or asyncio errors).
+    """
+    detail: dict[str, Any] = {}
+    if "transcript [final]" in payload:
+        match = _TEXT_RE.search(payload)
+        if match:
+            detail["text"] = match.group(1)
+        return "transcript_final", detail
+    if "transcript [interim]" in payload:
+        match = _TEXT_RE.search(payload)
+        if match:
+            detail["text"] = match.group(1)
+        return "transcript_interim", detail
+    if "media-stream start" in payload:
+        return "start", detail
+    if "media-stream stop" in payload:
+        return "stop", detail
+    if "order confirmed" in payload:
+        return "order_confirmed", detail
+    if "first_audio" in payload:
+        match = _LATENCY_RE.search(payload)
+        if match:
+            detail["latency_seconds"] = float(match.group(1))
+        return "first_audio", detail
+    if "llm_turn cancelled (barge-in)" in payload:
+        return "barge_in", detail
+    if "llm_turn start" in payload:
+        match = _TRANSCRIPT_RE.search(payload)
+        if match:
+            detail["transcript"] = match.group(2) or match.group(3) or ""
+        return "llm_turn_start", detail
+    if "silence timeout" in payload:
+        return "silence_timeout", detail
+    if "ERROR" in payload or "Task exception" in payload or "Traceback" in payload:
+        return "error", detail
+    return "log", detail
+
+
+def _extract_call_sid(payload: str) -> Optional[str]:
+    match = _CALL_SID_RE.search(payload)
+    return match.group(1) if match else None
+
+
+def _entry_payload(entry: Any) -> str:
+    """Pull the textual payload out of a Cloud Logging entry.
+
+    Cloud Logging exposes either ``payload`` (text logs) or
+    ``json_payload`` (structured). Cloud Run forwards stdout as text by
+    default, so most entries land in ``payload``. Be defensive against
+    structured payloads that contain a ``message`` field.
+    """
+    payload = getattr(entry, "payload", None)
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, dict):
+        return str(payload.get("message") or payload)
+    return str(payload or "")
+
+
+def _entry_timestamp(entry: Any) -> datetime:
+    ts = getattr(entry, "timestamp", None)
+    if isinstance(ts, datetime):
+        return ts.astimezone(timezone.utc) if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+    return datetime.now(tz=timezone.utc)
+
+
+def parse_events(entries: Iterable[Any]) -> dict[str, list[CallEvent]]:
+    """Group raw log entries by call_sid and turn each into a CallEvent.
+
+    Entries without a recognisable call_sid are skipped — they're not
+    associated with any call. Output is ordered chronologically per call.
+    """
+    grouped: dict[str, list[CallEvent]] = {}
+    for entry in entries:
+        payload = _entry_payload(entry)
+        call_sid = _extract_call_sid(payload)
+        if not call_sid:
+            continue
+        kind, detail = _classify(payload)
+        event = CallEvent(
+            timestamp=_entry_timestamp(entry),
+            kind=kind,
+            text=payload,
+            detail=detail,
+        )
+        grouped.setdefault(call_sid, []).append(event)
+    for events in grouped.values():
+        events.sort(key=lambda e: e.timestamp)
+    return grouped
+
+
+def summarize(call_sid: str, events: list[CallEvent]) -> CallSummary:
+    started = events[0].timestamp
+    ended = events[-1].timestamp
+    transcript_count = sum(1 for e in events if e.kind == "transcript_final")
+    has_error = any(e.kind == "error" for e in events)
+    if any(e.kind == "order_confirmed" for e in events):
+        status = "confirmed"
+    elif any(e.kind == "stop" for e in events):
+        status = "ended"
+    else:
+        status = "in_progress"
+    return CallSummary(
+        call_sid=call_sid,
+        started_at=started,
+        ended_at=ended,
+        transcript_count=transcript_count,
+        has_error=has_error,
+        status=status,
+    )
+
+
+def _logging_client():
+    if gcp_logging is None:
+        raise RuntimeError(
+            "google-cloud-logging is not installed. "
+            "Add it to requirements.txt and redeploy."
+        )
+    return gcp_logging.Client()
+
+
+def _build_filter(hours: int) -> str:
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=hours)
+    return (
+        f'resource.type="cloud_run_revision" '
+        f'resource.labels.service_name="{_SERVICE_NAME}" '
+        f'timestamp>="{cutoff.isoformat()}" '
+        f'textPayload:"call_sid=CA"'
+    )
+
+
+def fetch_entries(
+    *, hours: int, page_size: int = 1000, client: Any = None
+) -> Iterable[Any]:
+    """Pull recent niko service log entries that mention a call_sid.
+
+    ``client`` is injectable for tests — pass any object with a
+    ``list_entries`` method that yields entry-like objects.
+    """
+    log_client = client or _logging_client()
+    filter_str = _build_filter(hours)
+    descending = (
+        gcp_logging.DESCENDING if gcp_logging is not None else "timestamp desc"
+    )
+    return log_client.list_entries(
+        filter_=filter_str,
+        order_by=descending,
+        page_size=page_size,
+    )
+
+
+def list_recent_calls(*, hours: int = 24, client: Any = None) -> list[CallSummary]:
+    """Return one summary per call_sid seen in the last ``hours``, newest first."""
+    grouped = parse_events(fetch_entries(hours=hours, client=client))
+    summaries = [summarize(sid, events) for sid, events in grouped.items()]
+    summaries.sort(key=lambda s: s.started_at, reverse=True)
+    return summaries
+
+
+def get_call_timeline(
+    call_sid: str, *, hours: int = 168, client: Any = None
+) -> Optional[list[CallEvent]]:
+    """Return the ordered event timeline for a single call_sid, or ``None``
+    if no logs exist for it within the lookback window."""
+    grouped = parse_events(fetch_entries(hours=hours, client=client))
+    return grouped.get(call_sid)

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, HTTPException
 logging.basicConfig(level=logging.INFO)
 
 from app.config import settings
+from app.dev import calls as dev_calls
 from app.orders.models import ItemCategory, LineItem, Order, OrderType
 from app.storage import firestore as order_storage
 from app.telephony.router import router as telephony_router
@@ -37,6 +38,62 @@ def list_orders(limit: int = 50):
         raise HTTPException(status_code=400, detail="limit must be 1..200")
     orders = order_storage.list_recent_orders(limit=limit)
     return {"orders": [o.model_dump(mode="json") for o in orders]}
+
+
+def _require_dev_endpoints() -> None:
+    if not settings.niko_dev_endpoints:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+@app.get("/dev/calls")
+def dev_list_calls(hours: int = 24):
+    """List recent call sessions extracted from Cloud Logging.
+
+    Gated on ``NIKO_DEV_ENDPOINTS=true``. Returns one entry per call_sid
+    seen in the last ``hours`` window, newest-first. Used by the
+    dashboard's dev-only Calls page (#68).
+    """
+    _require_dev_endpoints()
+    if hours < 1 or hours > 24 * 7:
+        raise HTTPException(status_code=400, detail="hours must be 1..168")
+    summaries = dev_calls.list_recent_calls(hours=hours)
+    return {
+        "calls": [
+            {
+                "call_sid": s.call_sid,
+                "started_at": s.started_at.isoformat(),
+                "ended_at": s.ended_at.isoformat(),
+                "transcript_count": s.transcript_count,
+                "has_error": s.has_error,
+                "status": s.status,
+            }
+            for s in summaries
+        ]
+    }
+
+
+@app.get("/dev/calls/{call_sid}")
+def dev_call_timeline(call_sid: str, hours: int = 168):
+    """Full event timeline for one call_sid (transcripts, LLM turns,
+    barge-ins, silence timeouts, errors). Gated on dev endpoints (#68)."""
+    _require_dev_endpoints()
+    if hours < 1 or hours > 24 * 7:
+        raise HTTPException(status_code=400, detail="hours must be 1..168")
+    events = dev_calls.get_call_timeline(call_sid, hours=hours)
+    if events is None:
+        raise HTTPException(status_code=404, detail="call_sid not found in logs")
+    return {
+        "call_sid": call_sid,
+        "events": [
+            {
+                "timestamp": e.timestamp.isoformat(),
+                "kind": e.kind,
+                "text": e.text,
+                "detail": e.detail,
+            }
+            for e in events
+        ],
+    }
 
 
 @app.post("/dev/seed-order")

--- a/dashboard/app/(dashboard)/calls/[call_sid]/loading.tsx
+++ b/dashboard/app/(dashboard)/calls/[call_sid]/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function Loading() {
+  return (
+    <section className="flex flex-1 flex-col gap-4 p-6">
+      <Skeleton className="h-4 w-24" />
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-3 w-72" />
+      <div className="flex flex-col gap-2 rounded-xl border bg-card p-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-full" />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/(dashboard)/calls/[call_sid]/not-found.tsx
+++ b/dashboard/app/(dashboard)/calls/[call_sid]/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { PhoneOff } from 'lucide-react';
+
+export default function CallNotFound() {
+  return (
+    <section className="flex flex-1 items-center justify-center p-6">
+      <div className="flex max-w-md flex-col items-center gap-3 rounded-xl border bg-card p-10 text-center">
+        <PhoneOff className="h-8 w-8 text-muted-foreground" aria-hidden />
+        <h2 className="text-lg font-medium">Call not found</h2>
+        <p className="text-sm text-muted-foreground">
+          No log events for this call_sid in the last 7 days. Older calls have
+          rolled off Cloud Logging.
+        </p>
+        <Link
+          href="/calls"
+          className="text-sm font-medium text-primary hover:underline"
+        >
+          ← Back to all calls
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/(dashboard)/calls/[call_sid]/page.tsx
+++ b/dashboard/app/(dashboard)/calls/[call_sid]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from 'next/navigation';
+
+import { CallTimelineView } from '@/components/calls/call-timeline';
+import { ComingSoon } from '@/components/shared/coming-soon';
+import { getCallTimeline } from '@/lib/api/calls';
+
+export const dynamic = 'force-dynamic';
+
+export default async function CallDetailPage({
+  params,
+}: {
+  params: Promise<{ call_sid: string }>;
+}) {
+  const { call_sid } = await params;
+  const result = await getCallTimeline(call_sid);
+
+  if (!result.available) {
+    return (
+      <ComingSoon
+        title="Calls"
+        description="Call history, transcripts, and recording playback land in Phase 2."
+      />
+    );
+  }
+
+  if ('notFound' in result) notFound();
+
+  return <CallTimelineView timeline={result.timeline} />;
+}

--- a/dashboard/app/(dashboard)/calls/page.tsx
+++ b/dashboard/app/(dashboard)/calls/page.tsx
@@ -1,10 +1,37 @@
 import { ComingSoon } from '@/components/shared/coming-soon';
+import { CallsTable } from '@/components/calls/calls-table';
+import { listRecentCalls } from '@/lib/api/calls';
 
-export default function CallsPage() {
+export const dynamic = 'force-dynamic';
+
+export default async function CallsPage() {
+  const result = await listRecentCalls(24);
+
+  if (!result.available) {
+    return (
+      <ComingSoon
+        title="Calls"
+        description="Call history, transcripts, and recording playback land in Phase 2."
+      />
+    );
+  }
+
   return (
-    <ComingSoon
-      title="Calls"
-      description="Call history, transcripts, and recording playback land in Phase 2."
-    />
+    <section className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex items-baseline justify-between">
+        <div>
+          <h1 className="text-lg font-medium">Calls (dev)</h1>
+          <p className="text-sm text-muted-foreground">
+            Last 24h · {result.calls.length} session
+            {result.calls.length === 1 ? '' : 's'}
+          </p>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Backed by Cloud Logging · gated on{' '}
+          <code className="font-mono">NIKO_DEV_ENDPOINTS</code>
+        </p>
+      </header>
+      <CallsTable calls={result.calls} />
+    </section>
   );
 }

--- a/dashboard/components/calls/call-timeline.tsx
+++ b/dashboard/components/calls/call-timeline.tsx
@@ -1,0 +1,175 @@
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  Mic,
+  PhoneCall,
+  PhoneOff,
+  Sparkles,
+  Volume2,
+  Zap,
+} from 'lucide-react';
+import Link from 'next/link';
+
+import { LocalTime } from '@/components/shared/local-time';
+import type { CallEvent, CallTimeline } from '@/lib/api/calls';
+import { cn } from '@/lib/utils';
+
+export function CallTimelineView({ timeline }: { timeline: CallTimeline }) {
+  return (
+    <section className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex items-center gap-3">
+        <Link
+          href="/calls"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          All calls
+        </Link>
+      </header>
+
+      <div className="flex flex-col gap-1">
+        <h1 className="text-lg font-medium">Call timeline</h1>
+        <p className="font-mono text-xs text-muted-foreground">
+          {timeline.call_sid}
+        </p>
+      </div>
+
+      <ol className="flex flex-col gap-2 rounded-xl border bg-card p-4">
+        {timeline.events.map((event, i) => (
+          <TimelineRow key={i} event={event} />
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function TimelineRow({ event }: { event: CallEvent }) {
+  const ts = new Date(event.timestamp);
+  const { Icon, accent, label, body } = renderEvent(event);
+
+  return (
+    <li className="flex items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-muted/40">
+      <div
+        className={cn(
+          'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full',
+          accent,
+        )}
+      >
+        <Icon className="h-3.5 w-3.5" aria-hidden />
+      </div>
+      <div className="flex min-w-[5rem] shrink-0 flex-col text-xs text-muted-foreground tabular-nums">
+        <LocalTime date={ts} mode="absolute" />
+      </div>
+      <div className="flex flex-1 flex-col gap-0.5">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </p>
+        <p className="text-sm">{body}</p>
+      </div>
+    </li>
+  );
+}
+
+type RenderedEvent = {
+  Icon: typeof Mic;
+  accent: string;
+  label: string;
+  body: React.ReactNode;
+};
+
+function renderEvent(event: CallEvent): RenderedEvent {
+  switch (event.kind) {
+    case 'start':
+      return {
+        Icon: PhoneCall,
+        accent: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+        label: 'call started',
+        body: 'Twilio media stream opened',
+      };
+    case 'stop':
+      return {
+        Icon: PhoneOff,
+        accent: 'bg-muted text-muted-foreground',
+        label: 'call ended',
+        body: 'Caller hung up',
+      };
+    case 'order_confirmed':
+      return {
+        Icon: CheckCircle2,
+        accent: 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+        label: 'order confirmed',
+        body: 'Order persisted to Firestore',
+      };
+    case 'transcript_final': {
+      const text = (event.detail.text as string) || '(empty)';
+      return {
+        Icon: Mic,
+        accent: 'bg-foreground/10 text-foreground',
+        label: 'caller',
+        body: <span className="italic">“{text}”</span>,
+      };
+    }
+    case 'transcript_interim': {
+      const text = (event.detail.text as string) || '';
+      return {
+        Icon: Mic,
+        accent: 'bg-muted text-muted-foreground',
+        label: 'interim transcript',
+        body: <span className="text-muted-foreground italic">“{text}”</span>,
+      };
+    }
+    case 'llm_turn_start': {
+      const transcript = (event.detail.transcript as string) ?? '';
+      return {
+        Icon: Sparkles,
+        accent: 'bg-violet-500/15 text-violet-600 dark:text-violet-400',
+        label: 'LLM turn start',
+        body: transcript ? `→ "${transcript}"` : 'turn opened',
+      };
+    }
+    case 'first_audio': {
+      const latency = event.detail.latency_seconds as number | undefined;
+      const overBudget = typeof latency === 'number' && latency >= 1;
+      return {
+        Icon: Volume2,
+        accent: overBudget
+          ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+          : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
+        label: 'first audio',
+        body:
+          typeof latency === 'number'
+            ? `${(latency * 1000).toFixed(0)}ms${overBudget ? ' (over <1s budget)' : ''}`
+            : 'first audio bytes sent',
+      };
+    }
+    case 'barge_in':
+      return {
+        Icon: Zap,
+        accent: 'bg-orange-500/15 text-orange-700 dark:text-orange-400',
+        label: 'barge-in',
+        body: 'caller spoke over the AI; in-flight reply cancelled',
+      };
+    case 'silence_timeout':
+      return {
+        Icon: AlertTriangle,
+        accent: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+        label: 'silence timeout',
+        body: 'no caller activity for 10s — bot prompted',
+      };
+    case 'error':
+      return {
+        Icon: AlertTriangle,
+        accent: 'bg-destructive/15 text-destructive',
+        label: 'error',
+        body: <pre className="whitespace-pre-wrap font-mono text-xs">{event.text}</pre>,
+      };
+    default:
+      return {
+        Icon: Sparkles,
+        accent: 'bg-muted text-muted-foreground',
+        label: 'log',
+        body: <span className="font-mono text-xs">{event.text}</span>,
+      };
+  }
+}

--- a/dashboard/components/calls/calls-table.tsx
+++ b/dashboard/components/calls/calls-table.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link';
+import { AlertTriangle, CheckCircle2, PhoneIncoming, Radio } from 'lucide-react';
+
+import { LocalTime } from '@/components/shared/local-time';
+import type { CallStatus, CallSummary } from '@/lib/api/calls';
+import { cn } from '@/lib/utils';
+
+export function CallsTable({ calls }: { calls: CallSummary[] }) {
+  if (calls.length === 0) return <EmptyState />;
+
+  return (
+    <div className="overflow-hidden rounded-xl border">
+      <table className="w-full text-left text-sm">
+        <thead className="bg-muted/40 text-muted-foreground">
+          <tr>
+            <Th className="w-32">Call ID</Th>
+            <Th className="w-32">Started</Th>
+            <Th className="w-24 text-right">Duration</Th>
+            <Th className="w-24 text-right">Turns</Th>
+            <Th className="w-32">Status</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {calls.map((call) => (
+            <CallRow key={call.call_sid} call={call} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CallRow({ call }: { call: CallSummary }) {
+  const startedAt = new Date(call.started_at);
+  const endedAt = new Date(call.ended_at);
+  const durationSec = Math.max(
+    0,
+    Math.round((endedAt.getTime() - startedAt.getTime()) / 1000),
+  );
+
+  return (
+    <tr className="border-t transition-colors hover:bg-muted/40">
+      <Td className="py-3">
+        <Link
+          href={`/calls/${encodeURIComponent(call.call_sid)}`}
+          className="flex items-center gap-2 font-medium"
+        >
+          <PhoneIncoming className="h-4 w-4 text-muted-foreground" aria-hidden />
+          <span className="font-mono text-xs">
+            {call.call_sid.slice(0, 8)}…
+          </span>
+        </Link>
+      </Td>
+      <Td>
+        <LocalTime date={startedAt} mode="datetime" />
+      </Td>
+      <Td className="text-right tabular-nums">{formatDuration(durationSec)}</Td>
+      <Td className="text-right tabular-nums">{call.transcript_count}</Td>
+      <Td>
+        <CallStatusBadge status={call.status} hasError={call.has_error} />
+      </Td>
+    </tr>
+  );
+}
+
+function CallStatusBadge({
+  status,
+  hasError,
+}: {
+  status: CallStatus;
+  hasError: boolean;
+}) {
+  if (hasError) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md bg-destructive/15 px-2 py-1 text-xs font-medium text-destructive">
+        <AlertTriangle className="h-3 w-3" aria-hidden /> errored
+      </span>
+    );
+  }
+  if (status === 'confirmed') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md bg-emerald-500/15 px-2 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+        <CheckCircle2 className="h-3 w-3" aria-hidden /> confirmed
+      </span>
+    );
+  }
+  if (status === 'in_progress') {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md bg-amber-500/15 px-2 py-1 text-xs font-medium text-amber-700 dark:text-amber-400">
+        <Radio className="h-3 w-3" aria-hidden /> live
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs font-medium text-muted-foreground">
+      ended
+    </span>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}m ${s.toString().padStart(2, '0')}s`;
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-2 rounded-xl border bg-card p-10 text-center">
+      <PhoneIncoming className="h-6 w-6 text-muted-foreground" aria-hidden />
+      <p className="text-sm font-medium">No calls in the selected window</p>
+      <p className="text-xs text-muted-foreground">
+        Dial +1 647-905-8093 — the call will appear here once it ends.
+      </p>
+    </div>
+  );
+}
+
+function Th({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <th className={cn('px-4 py-2 text-xs font-medium uppercase tracking-wide', className)}>
+      {children}
+    </th>
+  );
+}
+
+function Td({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <td className={cn('px-4 py-3 align-middle', className)}>{children}</td>;
+}

--- a/dashboard/lib/api/calls.ts
+++ b/dashboard/lib/api/calls.ts
@@ -1,0 +1,106 @@
+/**
+ * HTTP client for the FastAPI dev call-logs endpoints.
+ *
+ * These routes are gated on `NIKO_DEV_ENDPOINTS=true` in the backend
+ * service. When the flag is off they return 404 — we surface that to the
+ * dashboard so it can fall back to the "Coming Soon" treatment.
+ *
+ * Endpoints:
+ *   GET /dev/calls                  ← list of recent call sessions
+ *   GET /dev/calls/{call_sid}       ← full event timeline for one call
+ *
+ * Server-only — same as `lib/api/orders.ts`. No browser-side fetches.
+ */
+import 'server-only';
+
+export type CallStatus = 'confirmed' | 'ended' | 'in_progress';
+
+export type CallEventKind =
+  | 'start'
+  | 'transcript_final'
+  | 'transcript_interim'
+  | 'llm_turn_start'
+  | 'first_audio'
+  | 'barge_in'
+  | 'silence_timeout'
+  | 'stop'
+  | 'order_confirmed'
+  | 'error'
+  | 'log';
+
+export type CallSummary = {
+  call_sid: string;
+  started_at: string;
+  ended_at: string;
+  transcript_count: number;
+  has_error: boolean;
+  status: CallStatus;
+};
+
+export type CallEvent = {
+  timestamp: string;
+  kind: CallEventKind;
+  text: string;
+  detail: Record<string, unknown>;
+};
+
+export type CallTimeline = {
+  call_sid: string;
+  events: CallEvent[];
+};
+
+export type CallsListResult =
+  | { available: true; calls: CallSummary[] }
+  | { available: false };
+
+export type CallTimelineResult =
+  | { available: true; timeline: CallTimeline }
+  | { available: false }
+  | { available: true; notFound: true };
+
+function apiBase(): string {
+  const base = process.env.NIKO_API_BASE_URL;
+  if (!base) throw new Error('NIKO_API_BASE_URL is not set');
+  return base.replace(/\/$/, '');
+}
+
+export async function listRecentCalls(hours = 24): Promise<CallsListResult> {
+  const url = new URL(`${apiBase()}/dev/calls`);
+  url.searchParams.set('hours', String(hours));
+
+  const res = await fetch(url, { cache: 'no-store' });
+  if (res.status === 404) return { available: false };
+  if (!res.ok) {
+    throw new Error(`GET /dev/calls failed: ${res.status} ${res.statusText}`);
+  }
+
+  const body = (await res.json()) as { calls: CallSummary[] };
+  return { available: true, calls: body.calls };
+}
+
+export async function getCallTimeline(
+  callSid: string,
+): Promise<CallTimelineResult> {
+  const url = `${apiBase()}/dev/calls/${encodeURIComponent(callSid)}`;
+  const res = await fetch(url, { cache: 'no-store' });
+
+  if (res.status === 404) {
+    // The backend returns 404 for both "dev disabled" and "call not found".
+    // Probe the list endpoint to disambiguate — if it 404s the feature is
+    // disabled; otherwise the specific call_sid wasn't in the log window.
+    const probe = await fetch(`${apiBase()}/dev/calls?hours=1`, {
+      cache: 'no-store',
+    });
+    if (probe.status === 404) return { available: false };
+    return { available: true, notFound: true };
+  }
+
+  if (!res.ok) {
+    throw new Error(
+      `GET /dev/calls/${callSid} failed: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const body = (await res.json()) as CallTimeline;
+  return { available: true, timeline: body };
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ twilio>=9.0,<10.0
 pydantic-settings>=2.0,<3.0
 anthropic>=0.40,<1.0
 google-cloud-firestore>=2.0,<3.0
+google-cloud-logging>=3.0,<4.0
 deepgram-sdk>=3.0,<4.0
 httpx>=0.27,<1.0

--- a/tests/test_dev_calls.py
+++ b/tests/test_dev_calls.py
@@ -1,0 +1,213 @@
+"""Unit tests for app.dev.calls.
+
+Hand-rolls a tiny fake matching the shape of google.cloud.logging entries —
+``payload`` (str) + ``timestamp`` (datetime). The module is hermetic; we
+never touch the real Cloud Logging API in tests.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from app.dev import calls as dev_calls
+
+
+@dataclass
+class FakeEntry:
+    payload: str
+    timestamp: datetime
+
+
+class FakeLoggingClient:
+    def __init__(self, entries: list[FakeEntry]):
+        self._entries = entries
+        self.last_filter: str | None = None
+
+    def list_entries(self, *, filter_, order_by, page_size):
+        self.last_filter = filter_
+        return list(self._entries)
+
+
+def _ts(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc)
+
+
+def _full_call_entries(call_sid: str, base_minute: int) -> list[FakeEntry]:
+    """Build a synthetic happy-path call: start, greeting, two transcript
+    finals each with a Haiku turn, then stop + order_confirmed."""
+    return [
+        FakeEntry(
+            payload=f"INFO:app.telephony.router:media-stream start call_sid={call_sid} stream_sid=MZ123",
+            timestamp=_ts(f"2026-04-25T22:{base_minute:02d}:00"),
+        ),
+        FakeEntry(
+            payload=f"INFO:app.telephony.router:llm_turn start call_sid={call_sid} transcript='[call started — greet the caller]'",
+            timestamp=_ts(f"2026-04-25T22:{base_minute:02d}:01"),
+        ),
+        FakeEntry(
+            payload=f"INFO:app.telephony.router:llm_turn first_audio latency=0.704s call_sid={call_sid}",
+            timestamp=_ts(f"2026-04-25T22:{base_minute:02d}:02"),
+        ),
+        FakeEntry(
+            payload=f"INFO:app.telephony.router:transcript [final] call_sid={call_sid} text='one large pepperoni'",
+            timestamp=_ts(f"2026-04-25T22:{base_minute:02d}:09"),
+        ),
+        FakeEntry(
+            payload=f"INFO:app.telephony.router:llm_turn start call_sid={call_sid} transcript='one large pepperoni'",
+            timestamp=_ts(f"2026-04-25T22:{base_minute:02d}:09"),
+        ),
+        FakeEntry(
+            payload=f"INFO:app.telephony.router:transcript [final] call_sid={call_sid} text='confirm'",
+            timestamp=_ts(f"2026-04-25T22:{base_minute:02d}:18"),
+        ),
+        FakeEntry(
+            payload=f"INFO:app.telephony.router:media-stream stop call_sid={call_sid}",
+            timestamp=_ts(f"2026-04-25T22:{base_minute:02d}:25"),
+        ),
+        FakeEntry(
+            payload=f"INFO:app.telephony.router:order confirmed call_sid={call_sid}",
+            timestamp=_ts(f"2026-04-25T22:{base_minute:02d}:25"),
+        ),
+    ]
+
+
+def test_parse_events_groups_by_call_sid():
+    entries = (
+        _full_call_entries("CAfirst", base_minute=10)
+        + _full_call_entries("CAsecond", base_minute=30)
+    )
+    grouped = dev_calls.parse_events(entries)
+
+    assert set(grouped.keys()) == {"CAfirst", "CAsecond"}
+    assert len(grouped["CAfirst"]) == 8
+    assert len(grouped["CAsecond"]) == 8
+
+
+def test_parse_events_skips_lines_without_call_sid():
+    entries = [
+        FakeEntry(
+            payload="INFO:uvicorn.error:Application startup complete.",
+            timestamp=_ts("2026-04-25T22:09:59"),
+        ),
+        FakeEntry(
+            payload="INFO:app.telephony.router:media-stream start call_sid=CAtest stream_sid=MZ123",
+            timestamp=_ts("2026-04-25T22:10:00"),
+        ),
+    ]
+    grouped = dev_calls.parse_events(entries)
+
+    assert list(grouped.keys()) == ["CAtest"]
+
+
+def test_classify_transcript_final_extracts_text():
+    payload = "INFO:app.telephony.router:transcript [final] call_sid=CA123 text='extra olives please'"
+    kind, detail = dev_calls._classify(payload)
+
+    assert kind == "transcript_final"
+    assert detail == {"text": "extra olives please"}
+
+
+def test_classify_first_audio_extracts_latency():
+    payload = "INFO:app.telephony.router:llm_turn first_audio latency=0.912s call_sid=CA123"
+    kind, detail = dev_calls._classify(payload)
+
+    assert kind == "first_audio"
+    assert detail == {"latency_seconds": 0.912}
+
+
+def test_classify_error_lines():
+    payload = "ERROR:asyncio:Task exception was never retrieved (call_sid=CA123)"
+    kind, _ = dev_calls._classify(payload)
+    assert kind == "error"
+
+
+def test_classify_barge_in_before_llm_turn_start():
+    """Barge-in lines literally contain 'llm_turn cancelled (barge-in)' —
+    must not be mis-classified as a vanilla llm_turn_start."""
+    payload = "INFO:app.telephony.router:llm_turn cancelled (barge-in) call_sid=CA123"
+    kind, _ = dev_calls._classify(payload)
+    assert kind == "barge_in"
+
+
+def test_summarize_confirmed_call():
+    events = dev_calls.parse_events(_full_call_entries("CAconfirmed", base_minute=10))[
+        "CAconfirmed"
+    ]
+    summary = dev_calls.summarize("CAconfirmed", events)
+
+    assert summary.call_sid == "CAconfirmed"
+    assert summary.transcript_count == 2
+    assert summary.has_error is False
+    assert summary.status == "confirmed"
+    assert summary.started_at < summary.ended_at
+
+
+def test_summarize_call_with_error_flags_has_error():
+    base = _full_call_entries("CAerror", base_minute=10)
+    base.append(
+        FakeEntry(
+            payload="ERROR:asyncio:Task exception was never retrieved call_sid=CAerror",
+            timestamp=_ts("2026-04-25T22:10:15"),
+        )
+    )
+    events = dev_calls.parse_events(base)["CAerror"]
+    summary = dev_calls.summarize("CAerror", events)
+
+    assert summary.has_error is True
+    assert summary.status == "confirmed"  # order_confirmed still present
+
+
+def test_summarize_call_without_stop_is_in_progress():
+    entries = [
+        FakeEntry(
+            payload="INFO:app.telephony.router:media-stream start call_sid=CAlive stream_sid=MZ",
+            timestamp=_ts("2026-04-25T22:50:00"),
+        ),
+        FakeEntry(
+            payload="INFO:app.telephony.router:transcript [final] call_sid=CAlive text='hello'",
+            timestamp=_ts("2026-04-25T22:50:05"),
+        ),
+    ]
+    events = dev_calls.parse_events(entries)["CAlive"]
+    summary = dev_calls.summarize("CAlive", events)
+
+    assert summary.status == "in_progress"
+
+
+def test_list_recent_calls_orders_newest_first():
+    fake = FakeLoggingClient(
+        _full_call_entries("CAearly", base_minute=10)
+        + _full_call_entries("CAlate", base_minute=30)
+    )
+    summaries = dev_calls.list_recent_calls(hours=24, client=fake)
+
+    assert [s.call_sid for s in summaries] == ["CAlate", "CAearly"]
+
+
+def test_list_recent_calls_filter_includes_service_and_call_sid_substring():
+    fake = FakeLoggingClient([])
+    dev_calls.list_recent_calls(hours=6, client=fake)
+
+    assert fake.last_filter is not None
+    assert 'resource.type="cloud_run_revision"' in fake.last_filter
+    assert "service_name=" in fake.last_filter
+    assert 'textPayload:"call_sid=CA"' in fake.last_filter
+
+
+def test_get_call_timeline_returns_events_for_known_call():
+    fake = FakeLoggingClient(_full_call_entries("CAknown", base_minute=10))
+    events = dev_calls.get_call_timeline("CAknown", client=fake)
+
+    assert events is not None
+    kinds = [e.kind for e in events]
+    assert kinds[0] == "start"
+    assert "first_audio" in kinds
+    assert "transcript_final" in kinds
+    assert kinds[-1] in {"order_confirmed", "stop"}
+
+
+def test_get_call_timeline_returns_none_for_unknown_call():
+    fake = FakeLoggingClient(_full_call_entries("CAknown", base_minute=10))
+    events = dev_calls.get_call_timeline("CAmissing", client=fake)
+
+    assert events is None


### PR DESCRIPTION
## Summary
- **Backend** (`app/dev/calls.py` + two routes): `GET /dev/calls` lists recent call sessions reconstructed from Cloud Logging; `GET /dev/calls/{call_sid}` returns the full per-call event timeline. Both gated on `niko_dev_endpoints` — 404 when disabled.
- **Dashboard**: `/calls` page now renders a real call list when the backend feature is on; falls back to the existing `ComingSoon` treatment when it's not. `/calls/[call_sid]` is a new detail page that timelines the call with per-event icons and highlights any first-audio latency over the 1s budget.
- **Tests**: 13 new backend unit tests covering the log parser, event classifier, status summarization, ordering, and filter-string composition. Dashboard `typecheck` + `vitest` + `next build` all green.
- **New dep**: `google-cloud-logging>=3.0,<4.0`.

## Why
While shaking out #64 and #66 we kept dropping into `gcloud run services logs read niko | grep call_sid=...`. That works for me, but it doesn't surface to Daniel/Sandeep when they're testing the demo, and it loses time. The `/calls` page in the sidebar already existed as a `ComingSoon` stub from #54 — perfect slot for a debug view that goes live when `NIKO_DEV_ENDPOINTS=true` and stays "Coming Soon" otherwise. Cloud Logging is the data source today; the proper Phase 2 version (Firestore-backed `call_sessions` collection with analytics) is explicitly out of scope here.

## Linked issue
Closes #68.

## ⚠️ Deploy step (one-time IAM grant)
The backend Cloud Run service account currently has `logging.logWriter` (write) but not `logging.viewer` (read). After this lands, before the `/dev/calls` route returns data:

\`\`\`bash
SA=\$(gcloud run services describe niko --region=us-central1 \
       --format='value(spec.template.spec.serviceAccountName)')
gcloud projects add-iam-policy-binding niko-tsuki \
       --member="serviceAccount:\${SA}" \
       --role="roles/logging.viewer"
\`\`\`

Without this the route will 500 with a permission error rather than returning data — easy to spot in the dashboard.

## Test plan
- [x] `pytest -v` — 79/79 backend tests passing (66 prior + 13 new).
- [x] Dashboard: `tsc --noEmit` clean, `vitest` 9/9 pass, `next build` succeeds. Both `/calls` and `/calls/[call_sid]` show as dynamic server-rendered routes.
- [ ] Deploy + IAM grant, then visit `/calls` on the live dashboard and confirm:
  - List shows recent call sessions with duration, turn count, and status badges (confirmed / errored / live).
  - Click a row → detail page renders the event timeline; transcripts marked with mic icon, LLM turns with sparkles, first_audio with green/amber latency.
  - Errors render in red with the original log payload preserved.

## Notes
- The detail-route 404 disambiguation is a small wart: backend returns 404 for both *dev disabled* and *call_sid not in window*. The dashboard probes the list endpoint to tell them apart. Could be replaced by a single dedicated capability check (e.g., `GET /dev/health`) in a future PR — not worth doing now.
- No `"use client"` introduced; everything is server-rendered. Sidebar nav is unchanged.
- `app/dev/__init__.py` is empty (package marker only), matching the pattern in `app/orders/`, `app/storage/`, etc.