### PR TITLE
Live call event stream: Firestore-backed onSnapshot in dashboard (#70)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,10 +5,12 @@ from fastapi import FastAPI, HTTPException
 
 logging.basicConfig(level=logging.INFO)
 
+from datetime import datetime
+from typing import Any
+
 from app.config import settings
-from app.dev import calls as dev_calls
 from app.orders.models import ItemCategory, LineItem, Order, OrderType
-from app.storage import firestore as order_storage
+from app.storage import call_sessions, firestore as order_storage
 from app.telephony.router import router as telephony_router
 
 app = FastAPI(title="niko")
@@ -45,51 +47,65 @@ def _require_dev_endpoints() -> None:
         raise HTTPException(status_code=404, detail="Not Found")
 
 
-@app.get("/dev/calls")
-def dev_list_calls(hours: int = 24):
-    """List recent call sessions extracted from Cloud Logging.
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
 
-    Gated on ``NIKO_DEV_ENDPOINTS=true``. Returns one entry per call_sid
-    seen in the last ``hours`` window, newest-first. Used by the
-    dashboard's dev-only Calls page (#68).
+
+@app.get("/dev/calls")
+def dev_list_calls(limit: int = 50):
+    """List recent call sessions from Firestore, newest-first.
+
+    Gated on ``NIKO_DEV_ENDPOINTS=true``. Used by the dashboard's
+    dev-only Calls page for the initial server-side render; live
+    updates come from a direct ``onSnapshot`` subscription against
+    the same ``call_sessions`` collection (#70).
     """
     _require_dev_endpoints()
-    if hours < 1 or hours > 24 * 7:
-        raise HTTPException(status_code=400, detail="hours must be 1..168")
-    summaries = dev_calls.list_recent_calls(hours=hours)
+    if limit < 1 or limit > 200:
+        raise HTTPException(status_code=400, detail="limit must be 1..200")
+    sessions = call_sessions.list_recent_sessions(limit=limit)
     return {
         "calls": [
             {
-                "call_sid": s.call_sid,
-                "started_at": s.started_at.isoformat(),
-                "ended_at": s.ended_at.isoformat(),
-                "transcript_count": s.transcript_count,
-                "has_error": s.has_error,
-                "status": s.status,
+                "call_sid": s.get("call_sid"),
+                "started_at": _iso(s.get("started_at")),
+                "ended_at": _iso(s.get("ended_at"))
+                or _iso(s.get("last_event_at")),
+                "transcript_count": s.get("transcript_count", 0),
+                "has_error": s.get("has_error", False),
+                "status": s.get("status", "in_progress"),
             }
-            for s in summaries
+            for s in sessions
         ]
     }
 
 
 @app.get("/dev/calls/{call_sid}")
-def dev_call_timeline(call_sid: str, hours: int = 168):
-    """Full event timeline for one call_sid (transcripts, LLM turns,
-    barge-ins, silence timeouts, errors). Gated on dev endpoints (#68)."""
+def dev_call_timeline(call_sid: str):
+    """Full event timeline for one call_sid (#70).
+
+    Reads from the ``call_sessions/{call_sid}/events`` subcollection.
+    The dashboard uses this for the initial server render; live updates
+    arrive via direct Firestore ``onSnapshot``.
+    """
     _require_dev_endpoints()
-    if hours < 1 or hours > 24 * 7:
-        raise HTTPException(status_code=400, detail="hours must be 1..168")
-    events = dev_calls.get_call_timeline(call_sid, hours=hours)
+    events = call_sessions.get_session_events(call_sid)
     if events is None:
-        raise HTTPException(status_code=404, detail="call_sid not found in logs")
+        raise HTTPException(status_code=404, detail="call_sid not found")
     return {
         "call_sid": call_sid,
         "events": [
             {
-                "timestamp": e.timestamp.isoformat(),
-                "kind": e.kind,
-                "text": e.text,
-                "detail": e.detail,
+                "timestamp": _iso(e.get("timestamp")),
+                "kind": e.get("kind", "log"),
+                "text": e.get("text", ""),
+                "detail": e.get("detail", {}),
             }
             for e in events
         ],

--- a/app/storage/call_sessions.py
+++ b/app/storage/call_sessions.py
@@ -1,0 +1,173 @@
+"""Firestore persistence for live call sessions.
+
+Two collections:
+
+  call_sessions/{call_sid}                — parent doc with summary fields
+  call_sessions/{call_sid}/events/{auto}  — one doc per timeline event
+
+The dashboard subscribes to both via ``onSnapshot`` so transcripts appear
+in real time as the caller speaks. The Cloud-Logging-backed surface from
+#68 is kept around as a pure parser library for backfill but the live
+read path is here.
+
+Field names are snake_case to mirror the Pydantic models on the Python
+side and the Zod schemas on the dashboard side. Timestamps are written
+as Firestore native ``Timestamp`` (via ``datetime``) — the dashboard
+converter unwraps them to ``Date``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from google.cloud import firestore
+
+logger = logging.getLogger(__name__)
+
+_COLLECTION = "call_sessions"
+_EVENTS_SUBCOLLECTION = "events"
+
+_client: Optional[firestore.Client] = None
+
+
+def _get_client() -> firestore.Client:
+    global _client
+    if _client is None:
+        _client = firestore.Client()
+    return _client
+
+
+def set_client(client: Optional[firestore.Client]) -> None:
+    """Override the module-level Firestore client (for tests + emulator)."""
+    global _client
+    _client = client
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def init_call_session(call_sid: str, *, started_at: Optional[datetime] = None) -> None:
+    """Create or update the parent doc for a fresh call.
+
+    Idempotent: re-calling for the same call_sid resets ``started_at``
+    and ``status`` to a fresh in-progress state. Called from
+    ``media-stream start``.
+    """
+    started = started_at or _now()
+    doc = {
+        "call_sid": call_sid,
+        "started_at": started,
+        "ended_at": None,
+        "status": "in_progress",
+        "transcript_count": 0,
+        "has_error": False,
+        "last_event_at": started,
+    }
+    try:
+        _get_client().collection(_COLLECTION).document(call_sid).set(doc)
+    except Exception:
+        logger.exception("call_sessions: init failed call_sid=%s", call_sid)
+
+
+def record_event(
+    call_sid: str,
+    *,
+    kind: str,
+    text: str = "",
+    detail: Optional[dict[str, Any]] = None,
+    timestamp: Optional[datetime] = None,
+) -> None:
+    """Append one event to the call's events subcollection.
+
+    All known kinds (mirror ``app/dev/calls.py``):
+      start | transcript_final | transcript_interim | llm_turn_start |
+      first_audio | barge_in | silence_timeout | stop | order_confirmed |
+      error | log
+
+    The parent doc's ``transcript_count``, ``has_error``, and
+    ``last_event_at`` are kept in sync so the list view doesn't need to
+    aggregate per-event subcollections to render badges.
+    """
+    ts = timestamp or _now()
+    payload = {
+        "timestamp": ts,
+        "kind": kind,
+        "text": text,
+        "detail": detail or {},
+    }
+    try:
+        client = _get_client()
+        parent = client.collection(_COLLECTION).document(call_sid)
+        parent.collection(_EVENTS_SUBCOLLECTION).add(payload)
+
+        update: dict[str, Any] = {"last_event_at": ts}
+        if kind == "transcript_final":
+            update["transcript_count"] = firestore.Increment(1)
+        if kind == "error":
+            update["has_error"] = True
+        parent.update(update)
+    except Exception:
+        logger.exception(
+            "call_sessions: record_event failed call_sid=%s kind=%s",
+            call_sid,
+            kind,
+        )
+
+
+def list_recent_sessions(limit: int = 50) -> list[dict[str, Any]]:
+    """Return parent docs ordered by ``started_at`` desc, newest-first."""
+    client = _get_client()
+    query = (
+        client.collection(_COLLECTION)
+        .order_by("started_at", direction=firestore.Query.DESCENDING)
+        .limit(limit)
+    )
+    return [snap.to_dict() for snap in query.stream()]
+
+
+def get_session_events(call_sid: str) -> Optional[list[dict[str, Any]]]:
+    """Return the timeline of events for one call_sid, oldest-first.
+
+    ``None`` when the parent doc doesn't exist (call_sid never tracked).
+    Empty list when the parent exists but no events were written yet.
+    """
+    client = _get_client()
+    parent = client.collection(_COLLECTION).document(call_sid).get()
+    if not parent.exists:
+        return None
+    events_query = (
+        client.collection(_COLLECTION)
+        .document(call_sid)
+        .collection(_EVENTS_SUBCOLLECTION)
+        .order_by("timestamp")
+    )
+    return [snap.to_dict() for snap in events_query.stream()]
+
+
+def mark_call_ended(
+    call_sid: str,
+    *,
+    confirmed: bool,
+    ended_at: Optional[datetime] = None,
+) -> None:
+    """Stamp the parent doc with the terminal state.
+
+    ``status`` flips to ``confirmed`` if the order persisted, otherwise
+    ``ended``. Called from the ``finally`` block of ``/media-stream``.
+    """
+    end = ended_at or _now()
+    try:
+        _get_client().collection(_COLLECTION).document(call_sid).update(
+            {
+                "ended_at": end,
+                "last_event_at": end,
+                "status": "confirmed" if confirmed else "ended",
+            }
+        )
+    except Exception:
+        logger.exception(
+            "call_sessions: mark_call_ended failed call_sid=%s", call_sid
+        )

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -31,6 +31,7 @@ from app.config import settings
 from app.llm.client import stream_reply
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
 from app.orders.models import Order
+from app.storage import call_sessions
 from app.tts.client import speak
 
 router = APIRouter()
@@ -39,6 +40,21 @@ logger = logging.getLogger(__name__)
 SILENCE_TIMEOUT_SECONDS = 10.0
 SILENCE_PROMPT = "Are you still there?"
 GREETING_TRANSCRIPT = "[call started — greet the caller]"
+
+
+def _bg_call_event(call_sid: str | None, **kwargs) -> None:
+    """Fire-and-forget Firestore write so the audio loop never blocks on it.
+
+    The storage module catches its own exceptions, so failures here just
+    drop the event from the live dashboard — the call continues normally.
+    """
+    if not call_sid:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    loop.create_task(asyncio.to_thread(call_sessions.record_event, call_sid, **kwargs))
 
 
 @dataclass
@@ -65,6 +81,9 @@ async def _open_deepgram_connection(call_sid: str | None, on_final: Callable):
         label = "final" if result.is_final else "interim"
         logger.info("transcript [%s] call_sid=%s text=%r", label, call_sid, text)
         if result.is_final:
+            _bg_call_event(
+                call_sid, kind="transcript_final", text=text, detail={"text": text}
+            )
             asyncio.get_event_loop().create_task(on_final(text))
 
     async def on_error(self, error, **kwargs):
@@ -91,6 +110,7 @@ async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
     try:
         await asyncio.sleep(SILENCE_TIMEOUT_SECONDS)
         logger.info("silence timeout call_sid=%s", state.call_sid)
+        _bg_call_event(state.call_sid, kind="silence_timeout")
         if state.stream_sid:
             await speak(SILENCE_PROMPT, websocket, state.stream_sid)
     except asyncio.CancelledError:
@@ -117,8 +137,28 @@ async def _run_llm_tts_turn(
 ) -> None:
     turn_start = time.monotonic()
     logger.info("llm_turn start call_sid=%s transcript=%r", state.call_sid, transcript)
+    _bg_call_event(
+        state.call_sid,
+        kind="llm_turn_start",
+        text=transcript,
+        detail={"transcript": transcript},
+    )
     text_buffer: list[str] = []
     first_speak = True
+    full_reply_parts: list[str] = []
+
+    def _record_first_audio() -> None:
+        latency = time.monotonic() - turn_start
+        logger.info(
+            "llm_turn first_audio latency=%.3fs call_sid=%s",
+            latency,
+            state.call_sid,
+        )
+        _bg_call_event(
+            state.call_sid,
+            kind="first_audio",
+            detail={"latency_seconds": round(latency, 3)},
+        )
 
     try:
         async for event in stream_reply(
@@ -129,16 +169,13 @@ async def _run_llm_tts_turn(
 
             if event.text_delta is not None:
                 text_buffer.append(event.text_delta)
+                full_reply_parts.append(event.text_delta)
                 if event.text_delta.endswith((".", "?", "!")):
                     chunk = "".join(text_buffer).strip()
                     text_buffer.clear()
                     if chunk and state.stream_sid:
                         if first_speak:
-                            logger.info(
-                                "llm_turn first_audio latency=%.3fs call_sid=%s",
-                                time.monotonic() - turn_start,
-                                state.call_sid,
-                            )
+                            _record_first_audio()
                             first_speak = False
                         await speak(chunk, websocket, state.stream_sid)
 
@@ -147,17 +184,31 @@ async def _run_llm_tts_turn(
                 text_buffer.clear()
                 if remainder and state.stream_sid:
                     if first_speak:
-                        logger.info(
-                            "llm_turn first_audio latency=%.3fs call_sid=%s",
-                            time.monotonic() - turn_start,
-                            state.call_sid,
-                        )
+                        _record_first_audio()
                     await speak(remainder, websocket, state.stream_sid)
                 state.history = event.final.history
                 state.order = event.final.order
+                full_reply = "".join(full_reply_parts).strip()
+                if full_reply:
+                    _bg_call_event(
+                        state.call_sid,
+                        kind="agent_reply",
+                        text=full_reply,
+                        detail={"text": full_reply},
+                    )
 
     except asyncio.CancelledError:
         logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)
+        _bg_call_event(state.call_sid, kind="barge_in")
+        raise
+    except Exception as exc:
+        logger.exception("llm_turn errored call_sid=%s", state.call_sid)
+        _bg_call_event(
+            state.call_sid,
+            kind="error",
+            text=str(exc)[:500],
+            detail={"exception": type(exc).__name__},
+        )
         raise
 
 
@@ -231,6 +282,17 @@ async def media_stream(websocket: WebSocket) -> None:
                     state.call_sid,
                     state.stream_sid,
                 )
+                if state.call_sid:
+                    asyncio.get_running_loop().create_task(
+                        asyncio.to_thread(
+                            call_sessions.init_call_session, state.call_sid
+                        )
+                    )
+                    _bg_call_event(
+                        state.call_sid,
+                        kind="start",
+                        detail={"stream_sid": state.stream_sid or ""},
+                    )
                 dg_conn = await _open_deepgram_connection(state.call_sid, on_final)
                 state.llm_task = asyncio.create_task(
                     _run_llm_tts_turn(GREETING_TRANSCRIPT, state, websocket)
@@ -246,6 +308,7 @@ async def media_stream(websocket: WebSocket) -> None:
 
             elif event == "stop":
                 logger.info("media-stream stop call_sid=%s", state.call_sid)
+                _bg_call_event(state.call_sid, kind="stop")
                 # Let the in-flight LLM turn finish so we capture the final order state
                 if state.llm_task and not state.llm_task.done():
                     try:
@@ -264,13 +327,28 @@ async def media_stream(websocket: WebSocket) -> None:
                 await state.llm_task
             except (asyncio.CancelledError, Exception):
                 pass
+        order_confirmed = False
         if state.order and state.order.is_ready_to_confirm():
             try:
                 persist_on_confirm(state.order)
                 logger.info("order confirmed call_sid=%s", state.call_sid)
+                _bg_call_event(state.call_sid, kind="order_confirmed")
+                order_confirmed = True
             except (OrderNotReadyError, Exception) as exc:
                 logger.error(
                     "order persist failed call_sid=%s: %s", state.call_sid, exc
+                )
+        if state.call_sid:
+            try:
+                await asyncio.to_thread(
+                    call_sessions.mark_call_ended,
+                    state.call_sid,
+                    confirmed=order_confirmed,
+                )
+            except Exception:
+                logger.exception(
+                    "call_sessions: mark_call_ended scheduling failed call_sid=%s",
+                    state.call_sid,
                 )
         if dg_conn is not None:
             await dg_conn.finish()

--- a/dashboard/app/(dashboard)/calls/[call_sid]/page.tsx
+++ b/dashboard/app/(dashboard)/calls/[call_sid]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 
-import { CallTimelineView } from '@/components/calls/call-timeline';
+import { CallTimelineLive } from '@/components/calls/call-timeline-live';
 import { ComingSoon } from '@/components/shared/coming-soon';
 import { getCallTimeline } from '@/lib/api/calls';
 
@@ -25,5 +25,5 @@ export default async function CallDetailPage({
 
   if ('notFound' in result) notFound();
 
-  return <CallTimelineView timeline={result.timeline} />;
+  return <CallTimelineLive callSid={call_sid} initial={result.timeline} />;
 }

--- a/dashboard/app/(dashboard)/calls/page.tsx
+++ b/dashboard/app/(dashboard)/calls/page.tsx
@@ -1,6 +1,8 @@
+import { CallsFeed } from '@/components/calls/calls-feed';
 import { ComingSoon } from '@/components/shared/coming-soon';
-import { CallsTable } from '@/components/calls/calls-table';
 import { listRecentCalls } from '@/lib/api/calls';
+import { parseCallSessionFromJson } from '@/lib/firebase/call-converters';
+import type { CallSession } from '@/lib/schemas/call';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,22 +18,16 @@ export default async function CallsPage() {
     );
   }
 
-  return (
-    <section className="flex flex-1 flex-col gap-4 p-6">
-      <header className="flex items-baseline justify-between">
-        <div>
-          <h1 className="text-lg font-medium">Calls (dev)</h1>
-          <p className="text-sm text-muted-foreground">
-            Last 24h · {result.calls.length} session
-            {result.calls.length === 1 ? '' : 's'}
-          </p>
-        </div>
-        <p className="text-xs text-muted-foreground">
-          Backed by Cloud Logging · gated on{' '}
-          <code className="font-mono">NIKO_DEV_ENDPOINTS</code>
-        </p>
-      </header>
-      <CallsTable calls={result.calls} />
-    </section>
+  const initial: CallSession[] = result.calls.map((c) =>
+    parseCallSessionFromJson({
+      call_sid: c.call_sid,
+      started_at: c.started_at,
+      ended_at: c.ended_at,
+      status: c.status,
+      transcript_count: c.transcript_count,
+      has_error: c.has_error,
+    }),
   );
+
+  return <CallsFeed initial={initial} />;
 }

--- a/dashboard/components/calls/call-timeline-live.tsx
+++ b/dashboard/components/calls/call-timeline-live.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  collection,
+  onSnapshot,
+  orderBy,
+  query,
+} from 'firebase/firestore';
+
+import { CallTimelineView } from '@/components/calls/call-timeline';
+import { db } from '@/lib/firebase/client';
+import { callEventConverter } from '@/lib/firebase/call-converters';
+import type { CallEvent, CallTimeline } from '@/lib/api/calls';
+import type { CallEvent as ZodCallEvent } from '@/lib/schemas/call';
+
+type Props = {
+  callSid: string;
+  initial: CallTimeline;
+};
+
+export function CallTimelineLive({ callSid, initial }: Props) {
+  const [events, setEvents] = useState<CallEvent[]>(initial.events);
+
+  useEffect(() => {
+    if (!db) return;
+
+    const q = query(
+      collection(db, 'call_sessions', callSid, 'events').withConverter(
+        callEventConverter,
+      ),
+      orderBy('timestamp'),
+    );
+
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        const next = snap.docs.map((d) => toApiEvent(d.data()));
+        setEvents(next);
+      },
+      (err) => console.error('Call timeline subscription error', err),
+    );
+    return unsub;
+  }, [callSid]);
+
+  return <CallTimelineView timeline={{ call_sid: callSid, events }} />;
+}
+
+function toApiEvent(e: ZodCallEvent): CallEvent {
+  return {
+    timestamp: e.timestamp.toISOString(),
+    kind: e.kind,
+    text: e.text,
+    detail: e.detail,
+  };
+}

--- a/dashboard/components/calls/call-timeline.tsx
+++ b/dashboard/components/calls/call-timeline.tsx
@@ -128,6 +128,15 @@ function renderEvent(event: CallEvent): RenderedEvent {
         body: transcript ? `→ "${transcript}"` : 'turn opened',
       };
     }
+    case 'agent_reply': {
+      const reply = (event.detail.text as string) || event.text || '';
+      return {
+        Icon: Sparkles,
+        accent: 'bg-violet-500/15 text-violet-600 dark:text-violet-400',
+        label: 'agent',
+        body: <span className="italic">“{reply}”</span>,
+      };
+    }
     case 'first_audio': {
       const latency = event.detail.latency_seconds as number | undefined;
       const overBudget = typeof latency === 'number' && latency >= 1;

--- a/dashboard/components/calls/calls-feed.tsx
+++ b/dashboard/components/calls/calls-feed.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  collection,
+  limit as fsLimit,
+  onSnapshot,
+  orderBy,
+  query,
+} from 'firebase/firestore';
+
+import { CallsTable } from '@/components/calls/calls-table';
+import { LiveIndicator } from '@/components/orders/live-indicator';
+import { db } from '@/lib/firebase/client';
+import { callSessionConverter } from '@/lib/firebase/call-converters';
+import type { CallSession } from '@/lib/schemas/call';
+
+type Props = {
+  initial: CallSession[];
+};
+
+const ANNOUNCE_THROTTLE_MS = 2000;
+
+export function CallsFeed({ initial }: Props) {
+  const [calls, setCalls] = useState<CallSession[]>(initial);
+  const [announcement, setAnnouncement] = useState('');
+
+  const seenSids = useRef(new Set(initial.map((c) => c.call_sid)));
+  const lastAnnouncedAt = useRef(0);
+
+  useEffect(() => {
+    if (!db) return;
+
+    const q = query(
+      collection(db, 'call_sessions').withConverter(callSessionConverter),
+      orderBy('started_at', 'desc'),
+      fsLimit(50),
+    );
+
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        const next = snap.docs.map((d) => d.data());
+        setCalls(next);
+
+        const fresh = next.filter((c) => !seenSids.current.has(c.call_sid));
+        fresh.forEach((c) => seenSids.current.add(c.call_sid));
+        if (fresh.length > 0) {
+          const now = Date.now();
+          if (now - lastAnnouncedAt.current >= ANNOUNCE_THROTTLE_MS) {
+            lastAnnouncedAt.current = now;
+            setAnnouncement(`New call ${fresh[0].call_sid.slice(0, 8)}…`);
+          }
+        }
+      },
+      (err) => console.error('Calls subscription error', err),
+    );
+    return unsub;
+  }, []);
+
+  return (
+    <section className="flex flex-1 flex-col gap-4 p-6">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <h1 className="text-lg font-medium">Calls</h1>
+          <p className="text-sm text-muted-foreground">
+            {calls.length} session{calls.length === 1 ? '' : 's'} · live
+          </p>
+        </div>
+        <LiveIndicator />
+      </header>
+      <CallsTable calls={calls.map(toRow)} />
+      <div role="status" aria-live="polite" className="sr-only">
+        {announcement}
+      </div>
+    </section>
+  );
+}
+
+function toRow(c: CallSession) {
+  return {
+    call_sid: c.call_sid,
+    started_at: c.started_at.toISOString(),
+    ended_at: (c.ended_at ?? c.last_event_at ?? c.started_at).toISOString(),
+    transcript_count: c.transcript_count,
+    has_error: c.has_error,
+    status: c.status,
+  };
+}

--- a/dashboard/lib/api/calls.ts
+++ b/dashboard/lib/api/calls.ts
@@ -20,6 +20,7 @@ export type CallEventKind =
   | 'transcript_final'
   | 'transcript_interim'
   | 'llm_turn_start'
+  | 'agent_reply'
   | 'first_audio'
   | 'barge_in'
   | 'silence_timeout'

--- a/dashboard/lib/firebase/call-converters.ts
+++ b/dashboard/lib/firebase/call-converters.ts
@@ -1,0 +1,149 @@
+/**
+ * Firestore converters for the live `call_sessions` collection.
+ *
+ * Mirrors `lib/firebase/converters.ts` for orders. Every Firestore read
+ * goes through Zod validation — on parse failure we log and throw rather
+ * than silently coercing, so a backend-side schema drift becomes
+ * immediately obvious.
+ */
+import {
+  type FirestoreDataConverter,
+  type QueryDocumentSnapshot,
+  type SnapshotOptions,
+  Timestamp,
+} from 'firebase/firestore';
+import { z } from 'zod';
+
+import {
+  type CallEvent,
+  CallEventSchema,
+  type CallSession,
+  CallSessionSchema,
+} from '@/lib/schemas/call';
+
+export class CallValidationError extends Error {
+  constructor(
+    readonly docId: string,
+    readonly issues: z.ZodIssue[],
+  ) {
+    super(
+      `Call document ${docId} failed schema validation: ${issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ')}`,
+    );
+    this.name = 'CallValidationError';
+  }
+}
+
+function unwrapTimestamp(v: unknown): unknown {
+  if (v == null) return v;
+  if (v instanceof Timestamp) return v.toDate();
+  if (
+    v &&
+    typeof v === 'object' &&
+    'toDate' in v &&
+    typeof (v as { toDate: unknown }).toDate === 'function'
+  ) {
+    return (v as { toDate: () => Date }).toDate();
+  }
+  return v;
+}
+
+function normalizeSession(raw: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...raw,
+    started_at: unwrapTimestamp(raw.started_at),
+    ended_at: unwrapTimestamp(raw.ended_at),
+    last_event_at: unwrapTimestamp(raw.last_event_at),
+  };
+}
+
+function normalizeEvent(raw: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...raw,
+    timestamp: unwrapTimestamp(raw.timestamp),
+  };
+}
+
+export const callSessionConverter: FirestoreDataConverter<CallSession> = {
+  toFirestore(session) {
+    return session as Record<string, unknown>;
+  },
+  fromFirestore(snap: QueryDocumentSnapshot, options?: SnapshotOptions): CallSession {
+    const raw = snap.data(options) as Record<string, unknown>;
+    const parsed = CallSessionSchema.safeParse(normalizeSession(raw));
+    if (!parsed.success) {
+      console.error(
+        '[callSessionConverter] schema validation failed',
+        snap.id,
+        parsed.error.issues,
+      );
+      throw new CallValidationError(snap.id, parsed.error.issues);
+    }
+    return parsed.data;
+  },
+};
+
+export const callEventConverter: FirestoreDataConverter<CallEvent> = {
+  toFirestore(event) {
+    return event as Record<string, unknown>;
+  },
+  fromFirestore(snap: QueryDocumentSnapshot, options?: SnapshotOptions): CallEvent {
+    const raw = snap.data(options) as Record<string, unknown>;
+    const parsed = CallEventSchema.safeParse(normalizeEvent(raw));
+    if (!parsed.success) {
+      console.error(
+        '[callEventConverter] schema validation failed',
+        snap.id,
+        parsed.error.issues,
+      );
+      throw new CallValidationError(snap.id, parsed.error.issues);
+    }
+    return parsed.data;
+  },
+};
+
+/**
+ * Parse a CallSession-shaped object that came back as JSON from the
+ * FastAPI dev route. Used by the RSC fetch path that seeds the initial
+ * render before onSnapshot takes over.
+ */
+export function parseCallSessionFromJson(raw: unknown): CallSession {
+  const withDates =
+    raw && typeof raw === 'object'
+      ? {
+          ...(raw as Record<string, unknown>),
+          started_at: toDate((raw as Record<string, unknown>).started_at),
+          ended_at: toDate((raw as Record<string, unknown>).ended_at),
+        }
+      : raw;
+  const parsed = CallSessionSchema.safeParse(withDates);
+  if (!parsed.success) {
+    console.error('[parseCallSessionFromJson] failed', parsed.error.issues);
+    throw new CallValidationError('api', parsed.error.issues);
+  }
+  return parsed.data;
+}
+
+export function parseCallEventFromJson(raw: unknown): CallEvent {
+  const withDates =
+    raw && typeof raw === 'object'
+      ? {
+          ...(raw as Record<string, unknown>),
+          timestamp: toDate((raw as Record<string, unknown>).timestamp),
+        }
+      : raw;
+  const parsed = CallEventSchema.safeParse(withDates);
+  if (!parsed.success) {
+    console.error('[parseCallEventFromJson] failed', parsed.error.issues);
+    throw new CallValidationError('api', parsed.error.issues);
+  }
+  return parsed.data;
+}
+
+function toDate(v: unknown): unknown {
+  if (v == null) return v;
+  if (v instanceof Date) return v;
+  if (typeof v === 'string' || typeof v === 'number') return new Date(v);
+  return v;
+}

--- a/dashboard/lib/schemas/call.ts
+++ b/dashboard/lib/schemas/call.ts
@@ -1,0 +1,55 @@
+/**
+ * Call session schemas — mirror the Firestore documents written by
+ * `app/storage/call_sessions.py` (collection: `call_sessions`,
+ * subcollection: `call_sessions/{call_sid}/events`).
+ *
+ * Field names are snake_case to match the backend writes — do not
+ * rename to camelCase on read.
+ */
+import { z } from 'zod';
+
+export const CallStatusSchema = z.enum([
+  'in_progress',
+  'ended',
+  'confirmed',
+]);
+export type CallStatus = z.infer<typeof CallStatusSchema>;
+
+export const CallEventKindSchema = z.enum([
+  'start',
+  'transcript_final',
+  'transcript_interim',
+  'llm_turn_start',
+  'agent_reply',
+  'first_audio',
+  'barge_in',
+  'silence_timeout',
+  'stop',
+  'order_confirmed',
+  'error',
+  'log',
+]);
+export type CallEventKind = z.infer<typeof CallEventKindSchema>;
+
+export const CallSessionSchema = z.object({
+  call_sid: z.string().min(1),
+  started_at: z.coerce.date(),
+  ended_at: z.coerce.date().nullable(),
+  status: CallStatusSchema,
+  transcript_count: z.number().int().min(0).default(0),
+  has_error: z.boolean().default(false),
+  last_event_at: z.coerce.date().nullish(),
+});
+export type CallSession = z.infer<typeof CallSessionSchema>;
+
+export const CallEventSchema = z.object({
+  timestamp: z.coerce.date(),
+  kind: CallEventKindSchema.catch('log'),
+  text: z.string().default(''),
+  detail: z.record(z.string(), z.unknown()).default({}),
+});
+export type CallEvent = z.infer<typeof CallEventSchema>;
+
+export function callShortId(session: { call_sid: string }): string {
+  return session.call_sid.slice(0, 8) + '…';
+}

--- a/tests/test_call_sessions_storage.py
+++ b/tests/test_call_sessions_storage.py
@@ -1,0 +1,268 @@
+"""Unit tests for app.storage.call_sessions.
+
+Uses a tiny in-memory Firestore fake — just enough surface to exercise
+the storage module's reads and writes. No emulator, no network.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.storage import call_sessions
+
+
+# ---------------------------------------------------------------------------
+# Fake Firestore — just the surface we use
+# ---------------------------------------------------------------------------
+
+
+class _Snap:
+    def __init__(self, data: dict | None):
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self) -> dict:
+        return dict(self._data or {})
+
+
+class _IncrementSentinel:
+    def __init__(self, amount: int):
+        self.amount = amount
+
+
+class _FakeFirestoreModule:
+    """Stand-in for the symbols the storage module imports from
+    ``google.cloud.firestore``."""
+
+    Increment = _IncrementSentinel
+
+    class Query:
+        DESCENDING = "DESCENDING"
+
+
+class _Query:
+    def __init__(self, rows: list[dict]):
+        self._rows = list(rows)
+        self._order_field: str | None = None
+        self._reverse = False
+        self._limit: int | None = None
+
+    def order_by(self, field, direction=None):
+        q = _Query(self._rows)
+        q._order_field = field
+        q._reverse = direction == "DESCENDING"
+        q._limit = self._limit
+        return q
+
+    def limit(self, n: int):
+        q = _Query(self._rows)
+        q._order_field = self._order_field
+        q._reverse = self._reverse
+        q._limit = n
+        return q
+
+    def stream(self):
+        rows = list(self._rows)
+        if self._order_field:
+            rows.sort(
+                key=lambda r: r.get(self._order_field) or datetime.min.replace(tzinfo=timezone.utc),
+                reverse=self._reverse,
+            )
+        if self._limit is not None:
+            rows = rows[: self._limit]
+        for r in rows:
+            yield _Snap(r)
+
+
+class _DocRef:
+    def __init__(self, client: "FakeClient", call_sid: str):
+        self._client = client
+        self._call_sid = call_sid
+
+    def set(self, payload: dict) -> None:
+        self._client.parents[self._call_sid] = dict(payload)
+        self._client.events.setdefault(self._call_sid, [])
+
+    def update(self, patch: dict) -> None:
+        existing = self._client.parents.setdefault(self._call_sid, {})
+        for key, val in patch.items():
+            if isinstance(val, _IncrementSentinel):
+                existing[key] = existing.get(key, 0) + val.amount
+            else:
+                existing[key] = val
+
+    def get(self) -> _Snap:
+        return _Snap(self._client.parents.get(self._call_sid))
+
+    def collection(self, name: str) -> "_EventsCollectionRef":
+        assert name == "events"
+        return _EventsCollectionRef(self._client, self._call_sid)
+
+
+class _EventsCollectionRef:
+    def __init__(self, client: "FakeClient", call_sid: str):
+        self._client = client
+        self._call_sid = call_sid
+
+    def add(self, payload: dict):
+        self._client.events.setdefault(self._call_sid, []).append(dict(payload))
+        return (0.0, None)
+
+    def order_by(self, field, direction=None):
+        rows = list(self._client.events.get(self._call_sid, []))
+        return _Query(rows).order_by(field, direction)
+
+
+class _ParentCollectionRef:
+    def __init__(self, client: "FakeClient"):
+        self._client = client
+
+    def document(self, call_sid: str) -> _DocRef:
+        return _DocRef(self._client, call_sid)
+
+    def order_by(self, field, direction=None):
+        rows = [
+            {**doc, "_id": sid} for sid, doc in self._client.parents.items()
+        ]
+        return _Query(rows).order_by(field, direction)
+
+
+class FakeClient:
+    def __init__(self):
+        self.parents: dict[str, dict] = {}
+        self.events: dict[str, list[dict]] = {}
+
+    def collection(self, name: str) -> _ParentCollectionRef:
+        assert name == "call_sessions"
+        return _ParentCollectionRef(self)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_firestore(monkeypatch):
+    """Swap the firestore module symbols used by the storage module."""
+    monkeypatch.setattr(call_sessions, "firestore", _FakeFirestoreModule)
+
+
+@pytest.fixture()
+def fake_client():
+    client = FakeClient()
+    call_sessions.set_client(client)
+    yield client
+    call_sessions.set_client(None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_init_creates_parent_doc_in_progress(fake_client):
+    started = datetime(2026, 4, 25, 22, 0, tzinfo=timezone.utc)
+    call_sessions.init_call_session("CAtest", started_at=started)
+
+    snap = fake_client.collection("call_sessions").document("CAtest").get()
+    assert snap.exists
+    doc = snap.to_dict()
+    assert doc["call_sid"] == "CAtest"
+    assert doc["status"] == "in_progress"
+    assert doc["started_at"] == started
+    assert doc["ended_at"] is None
+    assert doc["transcript_count"] == 0
+    assert doc["has_error"] is False
+
+
+def test_record_event_appends_to_subcollection_and_stamps_parent(fake_client):
+    call_sessions.init_call_session("CAtest")
+    call_sessions.record_event(
+        "CAtest", kind="transcript_final", text="hello", detail={"text": "hello"}
+    )
+    call_sessions.record_event(
+        "CAtest", kind="transcript_final", text="goodbye", detail={"text": "goodbye"}
+    )
+
+    snap = fake_client.collection("call_sessions").document("CAtest").get()
+    assert snap.to_dict()["transcript_count"] == 2
+
+    rows = list(
+        fake_client.collection("call_sessions")
+        .document("CAtest")
+        .collection("events")
+        .order_by("timestamp")
+        .stream()
+    )
+    events = [s.to_dict() for s in rows]
+    assert [e["kind"] for e in events] == ["transcript_final", "transcript_final"]
+    assert events[0]["text"] == "hello"
+
+
+def test_record_event_error_kind_flips_has_error(fake_client):
+    call_sessions.init_call_session("CAtest")
+    call_sessions.record_event("CAtest", kind="error", text="500 from anthropic")
+
+    snap = fake_client.collection("call_sessions").document("CAtest").get()
+    assert snap.to_dict()["has_error"] is True
+
+
+def test_mark_call_ended_confirmed_status(fake_client):
+    call_sessions.init_call_session("CAconfirmed")
+    end = datetime(2026, 4, 25, 22, 5, tzinfo=timezone.utc)
+    call_sessions.mark_call_ended("CAconfirmed", confirmed=True, ended_at=end)
+
+    doc = fake_client.collection("call_sessions").document("CAconfirmed").get().to_dict()
+    assert doc["status"] == "confirmed"
+    assert doc["ended_at"] == end
+
+
+def test_mark_call_ended_unconfirmed_becomes_ended(fake_client):
+    call_sessions.init_call_session("CAdrop")
+    call_sessions.mark_call_ended("CAdrop", confirmed=False)
+
+    doc = fake_client.collection("call_sessions").document("CAdrop").get().to_dict()
+    assert doc["status"] == "ended"
+
+
+def test_list_recent_sessions_orders_by_started_at_desc(fake_client):
+    early = datetime(2026, 4, 25, 22, 0, tzinfo=timezone.utc)
+    late = early + timedelta(minutes=15)
+    call_sessions.init_call_session("CAearly", started_at=early)
+    call_sessions.init_call_session("CAlate", started_at=late)
+
+    sessions = call_sessions.list_recent_sessions(limit=10)
+    sids = [s["call_sid"] for s in sessions]
+    assert sids == ["CAlate", "CAearly"]
+
+
+def test_get_session_events_returns_events_for_known_call(fake_client):
+    call_sessions.init_call_session("CAknown")
+    call_sessions.record_event("CAknown", kind="start")
+    call_sessions.record_event(
+        "CAknown", kind="transcript_final", text="hi", detail={"text": "hi"}
+    )
+
+    events = call_sessions.get_session_events("CAknown")
+    assert events is not None
+    assert [e["kind"] for e in events] == ["start", "transcript_final"]
+
+
+def test_get_session_events_returns_none_for_unknown_call(fake_client):
+    assert call_sessions.get_session_events("CAmissing") is None
+
+
+def test_record_event_swallows_firestore_exceptions(fake_client):
+    """Critical contract: a Firestore failure mid-call must NOT propagate
+    out of record_event(). The audio loop is more important than the
+    dev dashboard."""
+
+    class BoomClient:
+        def collection(self, *_a, **_k):
+            raise RuntimeError("firestore exploded")
+
+    call_sessions.set_client(BoomClient())
+    # No exception escaping is the assertion.
+    call_sessions.record_event("CAtest", kind="transcript_final", text="hi")

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -58,7 +58,7 @@ def _make_fake_stream_reply(reply="Hi, welcome to Niko's Pizza Kitchen!"):
 
 @pytest.fixture()
 def mock_pipeline(monkeypatch):
-    """Patch all three network-bound callables for offline testing."""
+    """Patch all four network-bound callables for offline testing."""
     fake_dg = AsyncMock()
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
@@ -69,11 +69,18 @@ def mock_pipeline(monkeypatch):
     async def fake_speak(text, websocket, stream_sid, **kw):
         pass
 
+    # Stub out Firestore writes for the live call_sessions stream so the
+    # router never tries to auth to GCP from a unit test (#70).
+    from app.storage import call_sessions
+
     monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
     monkeypatch.setattr("app.telephony.router.speak", fake_speak)
     monkeypatch.setattr(
         "app.telephony.router.stream_reply", _make_fake_stream_reply()
     )
+    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
     return fake_dg
 
 


### PR DESCRIPTION
## Summary
- Backend writes a live event stream to Firestore (`call_sessions/{call_sid}` parent + `events` subcollection) at every lifecycle point. All writes are fire-and-forget via `asyncio.to_thread` so the audio loop never blocks.
- `/dev/calls` and `/dev/calls/{call_sid}` switch from Cloud Logging to Firestore. Same JSON contract — the dashboard's `lib/api/calls.ts` keeps working untouched. The Cloud Logging parser in `app/dev/calls.py` stays as a library for future backfill.
- Dashboard adds `lib/schemas/call.ts` + `lib/firebase/call-converters.ts` (snake_case Zod, mirrors the orders pattern).
- New client components `<CallsFeed>` and `<CallTimelineLive>` subscribe via `onSnapshot` — calls appear in the list within ~1s of the greeting, transcripts populate the timeline as the caller speaks.
- 9 new backend tests (88/88 passing). Dashboard typecheck + vitest + `next build` all green.

## Why
The Cloud-Logging-backed view from #68 was post-mortem only: 5–30s ingestion delay, no live subscription. For demo-day-style "watch the AI take an order in real time" we needed the orders-feed treatment — Firestore + `onSnapshot`. This is the build.

## Linked issue
Closes #70.

## Architecture notes
- Parent doc per call_sid carries summary fields (`status`, `transcript_count`, `has_error`, `last_event_at`) so the list view never aggregates the subcollection.
- `transcript_count` uses `firestore.Increment` for race-free per-event updates.
- `transcript_interim` events are NOT written to Firestore — they fire 3–10/sec and would burn writes for no UX win. Only `transcript_final` is persisted.
- A new `agent_reply` event kind captures the LLM's full assembled reply at end-of-turn, so the timeline reads as a real conversation (caller bubble → agent bubble) rather than a sequence of internal LLM events.
- Storage module catches its own exceptions. A Firestore outage drops events from the dashboard but does not break the call.

## Test plan
- [x] `pytest -v` — 88/88 (was 79 + 9 new in test_call_sessions_storage.py).
- [x] Dashboard `tsc --noEmit` clean, `vitest run` 9/9 pass, `next build` succeeds.
- [ ] Live test: open `/calls` in one tab, dial `+1 647-905-8093` from another phone. The new call should appear in the list within ~1s of the greeting; clicking through to the detail page should show transcripts being added in real time as the caller speaks.

## Phase 2 graduation
This effectively starts moving Calls from a deferred-Phase-2 feature to a real surface. \`dashboard/CLAUDE.md\` says \"call records themselves aren't surfaced in Phase 1\" — that line will need a follow-up update once we decide whether to drop the \`NIKO_DEV_ENDPOINTS\` gate. For now the page still falls back to ComingSoon when the backend gate is off.

## Notes
- No new dependencies. All imports already present in the repo.
- No IAM changes required for the new Firestore writes — the Cloud Run SA already has `roles/datastore.user` from the orders pipeline.
- `app/dev/calls.py` (the Cloud Logging parser) is no longer wired to a route but is intentionally retained — it's useful for any future backfill from old logs into Firestore.