### PR TITLE
Add Copy / Download buttons to the call timeline (#72)

### DIFF
--- a/dashboard/components/calls/call-timeline.tsx
+++ b/dashboard/components/calls/call-timeline.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 
+import { TimelineExport } from '@/components/calls/timeline-export';
 import { LocalTime } from '@/components/shared/local-time';
 import type { CallEvent, CallTimeline } from '@/lib/api/calls';
 import { cn } from '@/lib/utils';
@@ -28,11 +29,14 @@ export function CallTimelineView({ timeline }: { timeline: CallTimeline }) {
         </Link>
       </header>
 
-      <div className="flex flex-col gap-1">
-        <h1 className="text-lg font-medium">Call timeline</h1>
-        <p className="font-mono text-xs text-muted-foreground">
-          {timeline.call_sid}
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-lg font-medium">Call timeline</h1>
+          <p className="font-mono text-xs text-muted-foreground">
+            {timeline.call_sid}
+          </p>
+        </div>
+        <TimelineExport timeline={timeline} />
       </div>
 
       <ol className="flex flex-col gap-2 rounded-xl border bg-card p-4">

--- a/dashboard/components/calls/timeline-export.tsx
+++ b/dashboard/components/calls/timeline-export.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Copy, Download } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import type { CallTimeline } from '@/lib/api/calls';
+import {
+  formatTimelineAsText,
+  timelineFilename,
+} from '@/lib/formatters/call-timeline';
+
+export function TimelineExport({ timeline }: { timeline: CallTimeline }) {
+  const handleCopy = async () => {
+    const text = formatTimelineAsText(timeline);
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success('Timeline copied to clipboard');
+    } catch (err) {
+      console.error('Clipboard write failed', err);
+      toast.error("Couldn't copy — clipboard permission denied?");
+    }
+  };
+
+  const handleDownload = () => {
+    const text = formatTimelineAsText(timeline);
+    const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = timelineFilename(timeline);
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleCopy}
+        aria-label="Copy timeline as text"
+      >
+        <Copy aria-hidden /> Copy
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleDownload}
+        aria-label="Download timeline as text file"
+      >
+        <Download aria-hidden /> Download
+      </Button>
+    </div>
+  );
+}

--- a/dashboard/lib/formatters/call-timeline.ts
+++ b/dashboard/lib/formatters/call-timeline.ts
@@ -1,0 +1,115 @@
+/**
+ * Plain-text formatter for call timelines (#72).
+ *
+ * Produces a fixed-width one-line-per-event log suitable for pasting
+ * into Slack threads, GitHub issues, or PR comments. Pure function so
+ * it's easy to unit-test independent of the React surface.
+ */
+import type { CallEvent, CallTimeline } from '@/lib/api/calls';
+
+const KIND_LABEL: Record<string, string> = {
+  start: 'CALL_START',
+  stop: 'CALL_END',
+  order_confirmed: 'ORDER_CONFIRMED',
+  transcript_final: 'CALLER',
+  transcript_interim: 'CALLER_INTERIM',
+  llm_turn_start: 'LLM_TURN',
+  agent_reply: 'AGENT',
+  first_audio: 'FIRST_AUDIO',
+  barge_in: 'BARGE_IN',
+  silence_timeout: 'SILENCE_TIMEOUT',
+  error: 'ERROR',
+  log: 'LOG',
+};
+
+const KIND_COL_WIDTH = 17;
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + ' '.repeat(width - s.length);
+}
+
+function hms(d: Date): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZone: 'UTC',
+  }).format(d);
+}
+
+function isoUtc(d: Date): string {
+  return d.toISOString().replace('T', ' ').replace(/\..+$/, '') + ' UTC';
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}m ${s.toString().padStart(2, '0')}s`;
+}
+
+function eventBody(event: CallEvent): string {
+  switch (event.kind) {
+    case 'transcript_final':
+    case 'transcript_interim':
+      return (event.detail.text as string) ?? '';
+    case 'llm_turn_start':
+      return (event.detail.transcript as string) ?? '';
+    case 'agent_reply':
+      return (event.detail.text as string) || event.text || '';
+    case 'first_audio': {
+      const latency = event.detail.latency_seconds as number | undefined;
+      if (typeof latency !== 'number') return '';
+      const ms = Math.round(latency * 1000);
+      return ms >= 1000 ? `${ms}ms (over budget)` : `${ms}ms`;
+    }
+    case 'error':
+      return event.text;
+    default:
+      return '';
+  }
+}
+
+export function formatTimelineAsText(timeline: CallTimeline): string {
+  const events = timeline.events;
+  if (events.length === 0) {
+    return `Call ${timeline.call_sid}\n(no events)`;
+  }
+
+  const startedAt = new Date(events[0].timestamp);
+  const endedAt = new Date(events[events.length - 1].timestamp);
+  const durationSec = Math.max(
+    0,
+    Math.round((endedAt.getTime() - startedAt.getTime()) / 1000),
+  );
+
+  const header = [
+    `Call ${timeline.call_sid}`,
+    `Started: ${isoUtc(startedAt)}`,
+    `Duration: ${formatDuration(durationSec)}`,
+    '',
+  ].join('\n');
+
+  const rows = events.map((event) => {
+    const ts = hms(new Date(event.timestamp));
+    const label = pad(KIND_LABEL[event.kind] ?? event.kind.toUpperCase(), KIND_COL_WIDTH);
+    const body = eventBody(event);
+    return body ? `${ts}  ${label}${body}` : `${ts}  ${label.trimEnd()}`;
+  });
+
+  return header + rows.join('\n') + '\n';
+}
+
+export function timelineFilename(timeline: CallTimeline, now: Date = new Date()): string {
+  const date = new Intl.DateTimeFormat('en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    timeZone: 'UTC',
+  })
+    .format(now)
+    .replaceAll('-', '');
+  const shortSid = timeline.call_sid.slice(0, 10);
+  return `niko-call-${shortSid}-${date}.txt`;
+}

--- a/dashboard/tests/call-timeline-formatter.test.ts
+++ b/dashboard/tests/call-timeline-formatter.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CallTimeline } from '@/lib/api/calls';
+import {
+  formatTimelineAsText,
+  timelineFilename,
+} from '@/lib/formatters/call-timeline';
+
+const TIMELINE: CallTimeline = {
+  call_sid: 'CA1fa31451294f94252d2bfa99dc455ce1',
+  events: [
+    {
+      timestamp: '2026-04-25T23:11:08.000Z',
+      kind: 'start',
+      text: '',
+      detail: {},
+    },
+    {
+      timestamp: '2026-04-25T23:11:08.700Z',
+      kind: 'first_audio',
+      text: '',
+      detail: { latency_seconds: 0.749 },
+    },
+    {
+      timestamp: '2026-04-25T23:11:17.000Z',
+      kind: 'transcript_final',
+      text: '',
+      detail: { text: 'can i get a barbecue pizza' },
+    },
+    {
+      timestamp: '2026-04-25T23:11:18.246Z',
+      kind: 'first_audio',
+      text: '',
+      detail: { latency_seconds: 1.246 },
+    },
+    {
+      timestamp: '2026-04-25T23:11:34.000Z',
+      kind: 'agent_reply',
+      text: 'One barbecue pizza coming up. Anything else?',
+      detail: { text: 'One barbecue pizza coming up. Anything else?' },
+    },
+    {
+      timestamp: '2026-04-25T23:13:58.000Z',
+      kind: 'order_confirmed',
+      text: '',
+      detail: {},
+    },
+  ],
+};
+
+describe('formatTimelineAsText', () => {
+  it('emits a header with call_sid and start time', () => {
+    const text = formatTimelineAsText(TIMELINE);
+    expect(text).toContain('Call CA1fa31451294f94252d2bfa99dc455ce1');
+    expect(text).toContain('Started: 2026-04-25 23:11:08 UTC');
+  });
+
+  it('renders caller transcripts with the CALLER label and the spoken text', () => {
+    const text = formatTimelineAsText(TIMELINE);
+    expect(text).toMatch(/23:11:17\s+CALLER\s+can i get a barbecue pizza/);
+  });
+
+  it('annotates first_audio events that breach the 1s budget', () => {
+    const text = formatTimelineAsText(TIMELINE);
+    expect(text).toContain('FIRST_AUDIO');
+    expect(text).toContain('749ms');
+    expect(text).toContain('1246ms (over budget)');
+  });
+
+  it('renders agent_reply events with the AGENT label', () => {
+    const text = formatTimelineAsText(TIMELINE);
+    expect(text).toMatch(
+      /23:11:34\s+AGENT\s+One barbecue pizza coming up\. Anything else\?/,
+    );
+  });
+
+  it('orders rows in arrival order (matches the events array)', () => {
+    const text = formatTimelineAsText(TIMELINE);
+    const startIdx = text.indexOf('CALL_START');
+    const orderConfirmedIdx = text.indexOf('ORDER_CONFIRMED');
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(orderConfirmedIdx).toBeGreaterThan(startIdx);
+  });
+
+  it('falls back to a no-events placeholder when the timeline is empty', () => {
+    const text = formatTimelineAsText({ call_sid: 'CAempty', events: [] });
+    expect(text).toBe('Call CAempty\n(no events)');
+  });
+});
+
+describe('timelineFilename', () => {
+  it('builds a sortable filename with the short call_sid and the date', () => {
+    const filename = timelineFilename(TIMELINE, new Date('2026-04-25T23:50:00Z'));
+    expect(filename).toBe('niko-call-CA1fa31451-20260425.txt');
+  });
+});


### PR DESCRIPTION
## Summary
- Two icon buttons (Copy + Download) in the header of \`/calls/[call_sid]\`.
- Plaintext format with header + one fixed-width row per event — caller speech, agent replies, first-audio latencies (with over-budget annotation), errors, etc.
- Formatter extracted to \`lib/formatters/call-timeline.ts\` as a pure function so it's testable independent of React. 7 new vitest cases (16/16 total passing).
- Toast on copy success; clipboard-permission failures show an error toast instead of silently dropping.

## Sample output
\`\`\`
Call CA1fa31451294f94252d2bfa99dc455ce1
Started: 2026-04-25 23:11:08 UTC
Duration: 2m 50s

23:11:08  CALL_START
23:11:09  FIRST_AUDIO      749ms
23:11:17  CALLER           can i get a barbecue pizza
23:11:18  FIRST_AUDIO      1246ms (over budget)
23:11:34  AGENT            One barbecue pizza coming up. Anything else?
…
23:13:58  ORDER_CONFIRMED
\`\`\`

## Linked issue
Closes #72.

## Test plan
- [x] \`vitest run\` — 16/16 (was 9 + 7 new in \`call-timeline-formatter.test.ts\`).
- [x] \`tsc --noEmit\` clean, \`next build\` succeeds.
- [ ] Open any call detail page on the deployed dashboard, click Copy → paste into Slack and confirm formatting; click Download → confirm a \`.txt\` file lands.

## Notes
- JSON export was considered but is out of scope here — easy to add behind the same buttons later if anyone asks.
- No backend changes; the formatter consumes the same \`CallTimeline\` shape the dashboard already renders.
- Filename: \`niko-call-{first 10 of call_sid}-{YYYYMMDD}.txt\` so \`ls\` sorts cleanly.