### PR TITLE
Barge-in: clear Twilio's audio buffer when caller interrupts (#74)

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -57,6 +57,28 @@ def _bg_call_event(call_sid: str | None, **kwargs) -> None:
     loop.create_task(asyncio.to_thread(call_sessions.record_event, call_sid, **kwargs))
 
 
+async def clear_twilio_audio(websocket: WebSocket, stream_sid: str | None) -> None:
+    """Tell Twilio to flush its audio buffer and stop playback.
+
+    Cancelling the LLM task only stops *generation* of new audio — bytes
+    already in Twilio's buffer keep playing for another 1–3 seconds, which
+    is exactly what callers experience as "the bot doesn't pause when I
+    interrupt." Twilio's Media Streams API has a dedicated ``clear`` event
+    that drops the buffer in ~80ms; we fire it whenever we cancel an
+    in-flight reply (#74).
+    """
+    if not stream_sid:
+        return
+    try:
+        await websocket.send_json({"event": "clear", "streamSid": stream_sid})
+    except WebSocketDisconnect:
+        # Caller already hung up — nothing to clear.
+        return
+    except Exception:
+        # Don't let a transient send failure break the call loop.
+        logger.exception("clear: failed to send Twilio clear event stream_sid=%s", stream_sid)
+
+
 @dataclass
 class _CallState:
     call_sid:     str | None       = None
@@ -215,9 +237,17 @@ async def _run_llm_tts_turn(
 async def _handle_final_transcript(
     text: str, state: _CallState, websocket: WebSocket
 ) -> None:
+    interrupted = bool(state.llm_task and not state.llm_task.done())
     if state.llm_task and not state.llm_task.done():
         state.llm_task.cancel()
+    silence_was_active = bool(
+        state.silence_task and not state.silence_task.done()
+    )
     _cancel_silence_task(state)
+    if interrupted or silence_was_active:
+        # Drop Twilio's pending audio buffer so the caller actually hears
+        # us pause instead of getting talked over (#74).
+        await clear_twilio_audio(websocket, state.stream_sid)
     state.llm_task = asyncio.create_task(
         _run_llm_tts_turn(text, state, websocket)
     )

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -252,3 +252,51 @@ def test_stop_event_skips_persist_if_order_not_ready(monkeypatch):
         ws.send_text(json.dumps(_STOP_MSG))
 
     assert persisted == []
+
+
+# ---------------------------------------------------------------------------
+# Barge-in: clear Twilio's audio buffer (#74)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
+    """The helper emits the documented Twilio clear payload."""
+    from app.telephony.router import clear_twilio_audio
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await clear_twilio_audio(ws, "MZtest456")
+
+    ws.send_json.assert_awaited_once_with(
+        {"event": "clear", "streamSid": "MZtest456"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_twilio_audio_skips_when_stream_sid_missing():
+    """No stream means we never opened the start frame — nothing to clear."""
+    from app.telephony.router import clear_twilio_audio
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await clear_twilio_audio(ws, None)
+
+    ws.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clear_twilio_audio_swallows_websocket_disconnect():
+    """If the caller already hung up, the clear send raises — but we
+    must not let that exception escape into the call loop."""
+    from starlette.websockets import WebSocketDisconnect
+
+    from app.telephony.router import clear_twilio_audio
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock(side_effect=WebSocketDisconnect())
+
+    # No exception escaping is the assertion.
+    await clear_twilio_audio(ws, "MZtest456")


### PR DESCRIPTION
## Summary
- New \`clear_twilio_audio(websocket, stream_sid)\` helper that sends Twilio's \`{\"event\": \"clear\", \"streamSid\": ...}\` message and flushes the queued audio in ~80ms.
- \`_handle_final_transcript\` calls it after cancelling the in-flight LLM task (and after cancelling a silence-watchdog speak), but only when there was actually a running task — so it's a no-op for the normal "caller speaks while bot is silent" path.
- WebSocketDisconnect tolerated cleanly; other failures log and continue rather than escaping into the call loop.
- 3 new unit tests on the helper. Total 91/91 backend tests passing.

## Why
Recent live calls (\`CAc7664866…\`, \`CAac9961f5…\`, \`CAc5a8f164…\`) consistently show: caller starts talking, the LLM task is cancelled — but the caller still hears the AI for another 1–3 seconds because Twilio plays through whatever bytes we already sent. Cancellation stopped *generation*; it didn't drain Twilio's buffer. \`clear\` is the documented way to drain it.

## Linked issue
Closes #74.

## Test plan
- [x] \`pytest -v\` — 91/91 (88 prior + 3 new on \`clear_twilio_audio\`).
- [ ] Live test: dial in, let the AI start a long sentence, talk over it. AI audio should cut off within ~100ms instead of finishing the original sentence. Should also feel right when the caller interrupts the silence-prompt ("Are you still there?").

## Out of scope
- Earlier barge-in trigger via Deepgram's \`SpeechStarted\` VAD event (currently fires on \`is_final\` ≈ 300ms after caller stops speaking). Holding off — want to see how this clear-only fix feels first.
- Filler-word / cough false-positive guard.

## Notes
- The clear is gated on \`interrupted or silence_was_active\` so we don't fire it on every final transcript when nothing was playing.
- No backend or dashboard schema changes; nothing for #71's onSnapshot subscriber to update. The barge-in event still fires the same Firestore write as before.