### PR TITLE
Prompt: don't recite placeholder address on pickup wrap-up; speak before tool_use (#76)

### DIFF
--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -27,7 +27,20 @@ _PREAMBLE = dedent("""\
     - Identify intent — ordering, question, or something else.
     - If ordering, walk through item, size, quantity, and any modifications.
     - Confirm the full order (items plus total) before wrapping up.
-    - If delivery, collect the address.
+    - If delivery, collect the caller's delivery address.
+
+    Restaurant address handling:
+    - The "Address:" line in the menu is the restaurant's location. It's only
+      for answering direct questions like "where are you?" or "what's your
+      address?". Do NOT recite it during pickup wrap-ups — the caller knows
+      which restaurant they called. End pickup confirmations with something
+      generic like "we'll have it ready for you soon" instead.
+
+    When you call the update_order tool:
+    - Say a brief acknowledgement to the caller in plain text FIRST, then
+      call the tool. For example: "One large Margherita coming up." then
+      update_order(...). Never emit update_order before any spoken words —
+      it delays audio and the caller thinks you stopped listening.
 
     If a caller asks for something off-menu, politely say you don't offer it and
     suggest a close alternative. If you're unsure what they said, ask them to

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,49 @@
+"""Tests for the system prompt builder.
+
+These guard the two behavioural directives we tuned in #76:
+
+1. The address from app/menu.py must NOT be recited during pickup
+   wrap-ups — only used for direct location questions.
+2. The agent must speak before calling update_order, never the other
+   way around (latency).
+
+Both rules live in `app/llm/prompts.py`. If a future edit accidentally
+deletes them the tests fail loudly rather than degrading the live
+caller experience silently.
+"""
+from app.llm.prompts import SYSTEM_PROMPT, build_system_prompt
+from app.menu import MENU
+
+
+def test_prompt_includes_restaurant_name_and_menu_items():
+    prompt = build_system_prompt()
+    assert MENU["restaurant"] in prompt
+    for pizza in MENU["pizzas"]:
+        assert pizza["name"] in prompt
+
+
+def test_prompt_warns_against_reciting_address_on_pickup_wrapup():
+    """Regression for #76 — the placeholder address (or any address) must
+    not be volunteered in pickup confirmations."""
+    prompt = build_system_prompt()
+    lower = prompt.lower()
+    assert "restaurant address handling" in lower
+    assert "do not recite it during pickup wrap-ups" in lower or "do not recite" in lower
+    assert "where are you" in lower  # the only time the address should come up
+
+
+def test_prompt_requires_text_before_tool_use():
+    """Regression for #76 — Haiku must speak first then call update_order,
+    so audio starts streaming within the <1s budget on commit turns."""
+    prompt = build_system_prompt()
+    lower = prompt.lower()
+    assert "when you call the update_order tool" in lower
+    assert "first" in lower
+    assert "never emit update_order before any spoken words" in lower
+
+
+def test_module_level_system_prompt_matches_builder():
+    """The cached SYSTEM_PROMPT must equal a fresh build — catches the
+    case where someone edits build_system_prompt() but forgets that
+    SYSTEM_PROMPT is computed at import time."""
+    assert SYSTEM_PROMPT == build_system_prompt()


### PR DESCRIPTION
## Summary
Two surgical \`app/llm/prompts.py\` edits, both motivated by the 01:12 UTC test call (\`CAc9de847f1a785c874bb75c055ed90a5f\`):

1. **Restaurant address handling** — instruct the agent to use \`MENU['address']\` only when the caller asks where the restaurant is, and to end pickup confirms with a generic \"we'll have it ready for you\" instead of the placeholder street.
2. **Tool-call ordering** — speak a brief acknowledgement first, then call \`update_order\`. Cuts first-audio latency on commit turns.

4 new prompt-builder tests (\`tests/test_prompts.py\`) lock both directives in so future prompt edits can't quietly delete them. 95/95 backend tests pass.

## Why
**On the address:** Haiku ended a pickup with *\"we'll have that ready for you soon at 123 Main Street.\"* That's not a hallucination — \`app/menu.py\` literally has \`\"address\": \"123 Main Street (demo)\"\` and the prompt builder injects it as \`Address: …\`. Haiku correctly parroted it (and stripped the \"(demo)\"). For a real demo or pilot caller, this sounds authoritative when it's a placeholder. The fix is in the prompt, not the data — the address still needs to be available for direct \"where are you?\" questions.

**On tool ordering:** four turns in that same call hit >1s first-audio, including a 3.8s outlier when Haiku emitted \`update_order\` before any text. Asking the model to speak first then call the tool means TTS starts streaming on the first text delta, not after the tool_use payload completes.

## Linked issue
Closes #76.

## Test plan
- [x] \`pytest -v\` — 95/95 (91 prior + 4 new in \`test_prompts.py\`).
- [ ] Live test: place a pickup order. Goodbye should sound like *\"perfect, we'll have it ready for you soon — see you in a bit\"* (no street address). Tool-use turns should hit first audio in <800ms.
- [ ] Live test: ask the bot *\"where are you located?\"* — should still answer with the menu address, since that's the one case it's allowed to.

## Notes
- No code change beyond \`prompts.py\`. The \`SYSTEM_PROMPT\` constant is rebuilt at import; deploy picks up the new wording on the next Cloud Run revision.
- Prompt remains forwards-compatible with Phase 2's per-tenant menus — when restaurants live in Firestore, the same address-handling rule applies; only the data source changes.