### PR TITLE
Auto-hangup after order confirmation (Twilio mark + grace window) (#78)

### DIFF
--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -29,6 +29,15 @@ _PREAMBLE = dedent("""\
     - Confirm the full order (items plus total) before wrapping up.
     - If delivery, collect the caller's delivery address.
 
+    Closing the call:
+    - Once the caller has confirmed the summary (e.g. "yes that's right",
+      "yep", "no that's it"), set the order's status to "confirmed" via
+      update_order and say a brief, terminal goodbye like "Great, your
+      order is in — see you soon!" or "Perfect, we'll have it ready —
+      thanks for calling!"
+    - Do NOT ask another follow-up question after confirming. The call
+      ends shortly after your goodbye.
+
     Restaurant address handling:
     - The "Address:" line in the menu is the restaurant's location. It's only
       for answering direct questions like "where are you?" or "what's your

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -30,7 +30,7 @@ from twilio.twiml.voice_response import Connect, VoiceResponse
 from app.config import settings
 from app.llm.client import stream_reply
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
-from app.orders.models import Order
+from app.orders.models import Order, OrderStatus
 from app.storage import call_sessions
 from app.tts.client import speak
 
@@ -40,6 +40,13 @@ logger = logging.getLogger(__name__)
 SILENCE_TIMEOUT_SECONDS = 10.0
 SILENCE_PROMPT = "Are you still there?"
 GREETING_TRANSCRIPT = "[call started — greet the caller]"
+
+# Auto-hangup after order confirmation (#78). Twilio echoes back this
+# named mark when its audio buffer drains, signalling the caller has
+# heard the goodbye; we then hold for the grace window in case they
+# squeeze in a late question before terminating the call.
+END_OF_CALL_MARK = "end_of_call"
+HANGUP_GRACE_SECONDS = 3.0
 
 
 def _bg_call_event(call_sid: str | None, **kwargs) -> None:
@@ -55,6 +62,83 @@ def _bg_call_event(call_sid: str | None, **kwargs) -> None:
     except RuntimeError:
         return
     loop.create_task(asyncio.to_thread(call_sessions.record_event, call_sid, **kwargs))
+
+
+def _twilio_end_call_sync(call_sid: str) -> None:
+    """End a Twilio call via the REST API. Runs in a worker thread so the
+    audio loop never blocks on network I/O."""
+    sid = settings.twilio_account_sid
+    token = settings.twilio_auth_token
+    if not sid or not token:
+        logger.warning(
+            "twilio creds missing; cannot end call_sid=%s", call_sid
+        )
+        return
+    from twilio.rest import Client as TwilioRestClient
+
+    TwilioRestClient(sid, token).calls(call_sid).update(status="completed")
+
+
+async def send_end_of_call_mark(
+    websocket: WebSocket, stream_sid: str | None
+) -> bool:
+    """Append a named ``mark`` event to Twilio's outgoing media stream.
+
+    Twilio echoes the same mark back over the WebSocket once its audio
+    buffer drains past it — i.e. once the caller has heard everything
+    we sent. We use that as the precise trigger for auto-hangup (#78).
+    Returns True if the send succeeded.
+    """
+    if not stream_sid:
+        return False
+    try:
+        await websocket.send_json(
+            {
+                "event": "mark",
+                "streamSid": stream_sid,
+                "mark": {"name": END_OF_CALL_MARK},
+            }
+        )
+        return True
+    except WebSocketDisconnect:
+        return False
+    except Exception:
+        logger.exception(
+            "mark: failed to send end_of_call mark stream_sid=%s", stream_sid
+        )
+        return False
+
+
+async def _hang_up_after_grace(state: _CallState) -> None:
+    """Wait HANGUP_GRACE_SECONDS, then end the call IFF the caller
+    didn't speak in the meantime.
+
+    The grace window lets a caller squeeze in a late follow-up like
+    *"how long does that take?"* — a final transcript clears
+    ``state.pending_hangup`` and we abort.
+    """
+    try:
+        await asyncio.sleep(HANGUP_GRACE_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.pending_hangup or not state.call_sid:
+        return
+    try:
+        await asyncio.to_thread(_twilio_end_call_sync, state.call_sid)
+        logger.info("call ended by server call_sid=%s", state.call_sid)
+    except Exception:
+        logger.exception(
+            "auto-hangup: REST end_call failed call_sid=%s", state.call_sid
+        )
+
+
+def _abort_pending_hangup(state: _CallState) -> None:
+    """Cancel a pending auto-hangup because the caller spoke during
+    the grace window. Safe to call when no hangup is pending."""
+    state.pending_hangup = False
+    if state.hangup_task and not state.hangup_task.done():
+        state.hangup_task.cancel()
+    state.hangup_task = None
 
 
 async def clear_twilio_audio(websocket: WebSocket, stream_sid: str | None) -> None:
@@ -87,6 +171,8 @@ class _CallState:
     history:      list[dict]       = field(default_factory=list)
     llm_task:     asyncio.Task | None = None   # current LLM→TTS turn
     silence_task: asyncio.Task | None = None   # silence watchdog
+    hangup_task:  asyncio.Task | None = None   # pending auto-hangup (#78)
+    pending_hangup: bool           = False     # set when goodbye mark sent (#78)
 
 
 async def _open_deepgram_connection(call_sid: str | None, on_final: Callable):
@@ -218,6 +304,16 @@ async def _run_llm_tts_turn(
                         text=full_reply,
                         detail={"text": full_reply},
                     )
+                # Order just got confirmed — queue a Twilio mark behind the
+                # goodbye audio so we know precisely when to hang up (#78).
+                if (
+                    state.order is not None
+                    and state.order.status == OrderStatus.CONFIRMED
+                    and state.stream_sid
+                ):
+                    sent = await send_end_of_call_mark(websocket, state.stream_sid)
+                    if sent:
+                        state.pending_hangup = True
 
     except asyncio.CancelledError:
         logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)
@@ -244,6 +340,10 @@ async def _handle_final_transcript(
         state.silence_task and not state.silence_task.done()
     )
     _cancel_silence_task(state)
+    # Caller spoke — abort any pending auto-hangup (#78). Even if they
+    # spoke during the grace window after a confirmation, we want to
+    # keep the call alive and process this transcript.
+    _abort_pending_hangup(state)
     if interrupted or silence_was_active:
         # Drop Twilio's pending audio buffer so the caller actually hears
         # us pause instead of getting talked over (#74).
@@ -336,6 +436,22 @@ async def media_stream(websocket: WebSocket) -> None:
                     audio = base64.b64decode(msg["media"]["payload"])
                     await dg_conn.send(audio)
 
+            elif event == "mark":
+                # Twilio echoes our outgoing marks once the audio queued
+                # before them has finished playing. We use it to drive
+                # auto-hangup after order confirmation (#78).
+                mark_name = msg.get("mark", {}).get("name")
+                if mark_name == END_OF_CALL_MARK and state.pending_hangup:
+                    logger.info(
+                        "auto-hangup: end_of_call mark received call_sid=%s",
+                        state.call_sid,
+                    )
+                    if state.hangup_task and not state.hangup_task.done():
+                        state.hangup_task.cancel()
+                    state.hangup_task = asyncio.create_task(
+                        _hang_up_after_grace(state)
+                    )
+
             elif event == "stop":
                 logger.info("media-stream stop call_sid=%s", state.call_sid)
                 _bg_call_event(state.call_sid, kind="stop")
@@ -351,6 +467,9 @@ async def media_stream(websocket: WebSocket) -> None:
         logger.info("media-stream disconnected call_sid=%s", state.call_sid)
     finally:
         _cancel_silence_task(state)
+        # Auto-hangup: stop any pending grace-window timer; the call is
+        # already ending so we don't need to fire the REST close (#78).
+        _abort_pending_hangup(state)
         if state.llm_task and not state.llm_task.done():
             state.llm_task.cancel()
             try:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -42,6 +42,18 @@ def test_prompt_requires_text_before_tool_use():
     assert "never emit update_order before any spoken words" in lower
 
 
+def test_prompt_makes_confirmation_goodbyes_terminal():
+    """Regression for #78 — once the caller confirms, the agent should
+    say a brief terminal goodbye and NOT ask another question. Otherwise
+    the auto-hangup would cut off whatever the bot asked next."""
+    prompt = build_system_prompt()
+    lower = prompt.lower()
+    assert "closing the call" in lower
+    assert "do not ask another follow-up question after confirming" in lower
+    # Spot-check that the directive references the confirmed status flow.
+    assert 'set the order\'s status to "confirmed"' in lower or "status to confirmed" in lower
+
+
 def test_module_level_system_prompt_matches_builder():
     """The cached SYSTEM_PROMPT must equal a fresh build — catches the
     case where someone edits build_system_prompt() but forgets that

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -288,6 +288,83 @@ async def test_clear_twilio_audio_skips_when_stream_sid_missing():
 
 
 @pytest.mark.asyncio
+async def test_send_end_of_call_mark_emits_mark_payload():
+    from app.telephony.router import END_OF_CALL_MARK, send_end_of_call_mark
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    sent = await send_end_of_call_mark(ws, "MZtest456")
+
+    assert sent is True
+    ws.send_json.assert_awaited_once_with(
+        {
+            "event": "mark",
+            "streamSid": "MZtest456",
+            "mark": {"name": END_OF_CALL_MARK},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_end_of_call_mark_returns_false_when_stream_sid_missing():
+    from app.telephony.router import send_end_of_call_mark
+
+    ws = AsyncMock()
+    sent = await send_end_of_call_mark(ws, None)
+    assert sent is False
+    ws.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hang_up_after_grace_calls_twilio_when_pending(monkeypatch):
+    """The grace timer fires the REST hangup when no transcript arrived."""
+    from app.telephony.router import (
+        HANGUP_GRACE_SECONDS,
+        _CallState,
+        _hang_up_after_grace,
+    )
+
+    ended: list[str] = []
+    monkeypatch.setattr(
+        "app.telephony.router._twilio_end_call_sync",
+        lambda call_sid: ended.append(call_sid),
+    )
+    # Speed the grace timer up so the test runs fast.
+    monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
+
+    state = _CallState(call_sid="CAtest", pending_hangup=True)
+    await _hang_up_after_grace(state)
+
+    assert ended == ["CAtest"]
+    # Sanity: original constant unchanged.
+    assert HANGUP_GRACE_SECONDS == 3.0
+
+
+@pytest.mark.asyncio
+async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
+    """If pending_hangup gets cleared during the grace window (caller
+    spoke), the REST hangup MUST NOT fire."""
+    from app.telephony.router import _CallState, _hang_up_after_grace
+
+    ended: list[str] = []
+    monkeypatch.setattr(
+        "app.telephony.router._twilio_end_call_sync",
+        lambda call_sid: ended.append(call_sid),
+    )
+    monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
+
+    state = _CallState(call_sid="CAtest", pending_hangup=True)
+    # Simulate: caller spoke during the grace window — _handle_final_transcript
+    # cleared the flag before the timer fired.
+    state.pending_hangup = False
+
+    await _hang_up_after_grace(state)
+
+    assert ended == []
+
+
+@pytest.mark.asyncio
 async def test_clear_twilio_audio_swallows_websocket_disconnect():
     """If the caller already hung up, the clear send raises — but we
     must not let that exception escape into the call loop."""


### PR DESCRIPTION
## Summary
- After \`state.order.status\` flips to \`confirmed\`, the server queues a Twilio \`mark {name: \"end_of_call\"}\` event behind the goodbye audio.
- Twilio echoes the mark back once its buffer drains; the WebSocket handler then arms a **3s grace timer**.
- A final transcript during the grace window clears \`pending_hangup\` and cancels the timer — late questions keep the call alive.
- If the timer expires with the flag still set, we end the call via the Twilio REST API (\`calls(sid).update(status=\"completed\")\`) in a worker thread so the audio loop never blocks.
- Prompt nudge: tells Haiku to make confirmation goodbyes terminal (no follow-up \"anything else?\" question after the order is confirmed).
- 5 new unit tests. 100/100 backend tests pass.

## Why
Live call \`CA271fd715206f49756ab540446b5344fc\` (01:30 UTC, 1m 12s, Coke pickup): bot confirmed the order at 01:30:56 with *\"we'll have it ready for you soon!\"* and \`status → confirmed\`. **Caller stayed on for 17 more seconds** before they hung up themselves — they squeezed in a *\"how long does that take?\"* mid-silence. The agent should drive the close.

## Linked issue
Closes #78.

## Test plan
- [x] \`pytest -v\` — 100/100 (95 prior + 5 new).
- [ ] Live test: place a pickup order, confirm. After the goodbye audio finishes, ~3s of silence, then call ends.
- [ ] Live test: place a pickup order, confirm, then immediately ask *\"actually, can you make it large?\"*. Call should NOT hang up; conversation continues normally.
- [ ] Live test: barge in DURING the goodbye. Existing #75 \`clear\` flushes the audio; the mark in Twilio's queue should fire eventually but \`pending_hangup\` is already cleared, so no rogue REST close.

## Notes
- Uses \`twilio.rest.Client\` (twilio package already a backend dep). Pulls credentials from existing \`settings.twilio_account_sid\` / \`settings.twilio_auth_token\`.
- The 3s grace is a guess; if it feels too short or too long, single constant to tune.
- Will not auto-hang on errors / cancellations / non-confirmed exits — only the explicit \"order is confirmed\" path. Still works fine if the caller hangs up first; the existing teardown handles that path.