### PR TITLE
Auto-hangup: heuristic fallback when Haiku forgets status=confirmed (#84)

### DIFF
--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -35,6 +35,10 @@ _PREAMBLE = dedent("""\
       update_order and say a brief, terminal goodbye like "Great, your
       order is in — see you soon!" or "Perfect, we'll have it ready —
       thanks for calling!"
+    - CRITICAL: any time you say a wrap-up phrase like "your order is in",
+      "we'll have it ready", "see you soon", or "thanks for calling", you
+      MUST call update_order in the same turn with status="confirmed".
+      Saying the goodbye without flipping status leaves the call hanging.
     - Do NOT ask another follow-up question after confirming. The call
       ends shortly after your goodbye.
 

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -48,6 +48,36 @@ GREETING_TRANSCRIPT = "[call started — greet the caller]"
 END_OF_CALL_MARK = "end_of_call"
 HANGUP_GRACE_SECONDS = 3.0
 
+# Phrases the model uses when wrapping up. Used as a fallback signal
+# for auto-hangup when Haiku says a goodbye but forgets to mark the
+# order status as confirmed via update_order (#79). Matched
+# case-insensitive against the full assembled reply.
+_GOODBYE_PATTERNS = (
+    "your order is in",
+    "have it ready",
+    "see you soon",
+    "see you in a",
+    "thanks for calling",
+    "thanks for ordering",
+    "have a great day",
+    "have a good day",
+    "enjoy your",
+    "coming right up",
+)
+
+
+def _looks_like_goodbye(reply: str) -> bool:
+    """True if ``reply`` reads as a terminal wrap-up rather than another
+    follow-up question. Combined with ``Order.is_ready_to_confirm`` this
+    is the fallback trigger for auto-hangup."""
+    if not reply:
+        return False
+    stripped = reply.strip()
+    if stripped.endswith("?"):
+        return False
+    lower = stripped.lower()
+    return any(pat in lower for pat in _GOODBYE_PATTERNS)
+
 
 def _bg_call_event(call_sid: str | None, **kwargs) -> None:
     """Fire-and-forget Firestore write so the audio loop never blocks on it.
@@ -304,16 +334,40 @@ async def _run_llm_tts_turn(
                         text=full_reply,
                         detail={"text": full_reply},
                     )
-                # Order just got confirmed — queue a Twilio mark behind the
-                # goodbye audio so we know precisely when to hang up (#78).
-                if (
-                    state.order is not None
-                    and state.order.status == OrderStatus.CONFIRMED
-                    and state.stream_sid
-                ):
-                    sent = await send_end_of_call_mark(websocket, state.stream_sid)
-                    if sent:
-                        state.pending_hangup = True
+                # Decide whether this turn is the wrap-up. Two signals:
+                #  1. Haiku set status=confirmed via update_order (the
+                #     primary path the prompt asks for).
+                #  2. Fallback (#79) — Haiku emitted a goodbye-shaped
+                #     reply ("your order is in", "see you soon", etc.)
+                #     AND the order has the data to actually confirm.
+                #     The model sometimes says the right closing line
+                #     without remembering to flip status.
+                if state.order is not None and state.stream_sid:
+                    explicitly_confirmed = (
+                        state.order.status == OrderStatus.CONFIRMED
+                    )
+                    fallback_confirmed = (
+                        state.order.is_ready_to_confirm()
+                        and state.order.status != OrderStatus.CANCELLED
+                        and _looks_like_goodbye(full_reply)
+                    )
+                    if explicitly_confirmed or fallback_confirmed:
+                        if fallback_confirmed and not explicitly_confirmed:
+                            logger.info(
+                                "auto-hangup: heuristic wrap-up detected "
+                                "(LLM didn't set status=confirmed) call_sid=%s",
+                                state.call_sid,
+                            )
+                            # Mirror the explicit-confirmation path locally
+                            # so the finally-block persist sees it too.
+                            state.order = state.order.model_copy(
+                                update={"status": OrderStatus.CONFIRMED}
+                            )
+                        sent = await send_end_of_call_mark(
+                            websocket, state.stream_sid
+                        )
+                        if sent:
+                            state.pending_hangup = True
 
     except asyncio.CancelledError:
         logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -54,6 +54,17 @@ def test_prompt_makes_confirmation_goodbyes_terminal():
     assert 'set the order\'s status to "confirmed"' in lower or "status to confirmed" in lower
 
 
+def test_prompt_couples_goodbye_phrases_with_status_flip():
+    """Regression for #79 — Haiku was saying 'your order is in' without
+    calling update_order(status='confirmed'), which left the auto-hangup
+    inert. The prompt now insists on the status flip in the same turn."""
+    prompt = build_system_prompt()
+    lower = prompt.lower()
+    assert "critical" in lower
+    assert "your order is in" in lower
+    assert 'status="confirmed"' in lower
+
+
 def test_module_level_system_prompt_matches_builder():
     """The cached SYSTEM_PROMPT must equal a fresh build — catches the
     case where someone edits build_system_prompt() but forgets that

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -287,6 +287,41 @@ async def test_clear_twilio_audio_skips_when_stream_sid_missing():
     ws.send_json.assert_not_called()
 
 
+def test_looks_like_goodbye_matches_terminal_phrases():
+    from app.telephony.router import _looks_like_goodbye
+
+    assert _looks_like_goodbye(
+        "Great, your order is in — we'll have it ready for you soon!"
+    )
+    assert _looks_like_goodbye("Perfect, see you soon!")
+    assert _looks_like_goodbye("Thanks for calling!")
+    assert _looks_like_goodbye("Have a great day.")
+
+
+def test_looks_like_goodbye_rejects_questions():
+    """A reply that ends with '?' is still asking the caller something."""
+    from app.telephony.router import _looks_like_goodbye
+
+    assert not _looks_like_goodbye(
+        "Got that. Anything else, or are you all set?"
+    )
+    # Even with goodbye-shaped phrasing earlier, trailing '?' = still asking.
+    assert not _looks_like_goodbye(
+        "Your order is in — does that all sound right?"
+    )
+
+
+def test_looks_like_goodbye_rejects_simple_acknowledgements():
+    """Bot acknowledging an item mid-conversation must NOT trigger the
+    auto-hangup fallback."""
+    from app.telephony.router import _looks_like_goodbye
+
+    assert not _looks_like_goodbye("One large margarita, got it.")
+    assert not _looks_like_goodbye("Sure, what size would you like?")
+    assert not _looks_like_goodbye("")
+    assert not _looks_like_goodbye("   ")
+
+
 @pytest.mark.asyncio
 async def test_send_end_of_call_mark_emits_mark_payload():
     from app.telephony.router import END_OF_CALL_MARK, send_end_of_call_mark


### PR DESCRIPTION
## Summary
- New `_looks_like_goodbye(reply)` helper recognises wrap-up phrases ("your order is in", "have it ready", "see you soon", "thanks for calling", etc.) and rejects replies still ending with `?`.
- Auto-hangup mark now fires when EITHER:
  - `state.order.status == CONFIRMED` (the explicit prompt path from #78), OR
  - `is_ready_to_confirm()` AND `status != CANCELLED` AND `_looks_like_goodbye(full_reply)` — the safety net.
- When the fallback fires, the status flip is mirrored locally so the `finally`-block `persist_on_confirm` sees it.
- Prompt nudge: adds a CRITICAL directive coupling goodbye phrases with the `status="confirmed"` tool call.
- 4 new tests. 104/104 backend tests pass.

## Why
Live call `CA9c2679ab4e619d5ea50fbe599f9eb501` (2026-04-26 01:46): Haiku said *"Great, your order is in — we'll have it ready for you soon!"* but didn't call `update_order(status="confirmed")`. `state.order.status` stayed `IN_PROGRESS`, the auto-hangup mark never fired, and the call hung for 16 seconds until the caller manually disconnected. Order was confirmed only by the `finally`-block persist on WebSocket close.

## Linked issue
Closes #84.

(Branch is named `fix/79-…` from a numbering mistake when I created the fix before the issue. Issue #79 is a different Sprint 2.1 epic — ignore the branch number.)

## Test plan
- [x] `pytest -v` — 104/104 (100 prior + 4 new on the heuristic + prompt directive).
- [ ] Live test 1: place a pickup order and confirm. After bot says "your order is in", ~3s of silence, call ends.
- [ ] Live test 2: confirm the order, then immediately ask a follow-up. Call should NOT drop; conversation continues.
- [ ] Live test 3: bot mid-conversation says "One large margarita, got it. What size?" — must NOT trigger fallback (ends with `?`).

## Notes
- Heuristic is intentionally conservative — phrase list + `is_ready_to_confirm()` + no trailing `?`. If Haiku regularly bypasses the prompt, we tighten further; if false positives appear, drop the looser phrases.
- The prompt's CRITICAL framing is the long-term reliable path — the fallback exists so a single missed tool call doesn't degrade the caller experience for 30 seconds.