### PR TITLE
Restaurants schema + dynamic system prompt (PR A of #79)

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -28,7 +28,6 @@ from typing import Any, AsyncIterator, Optional
 from anthropic import Anthropic, AsyncAnthropic
 
 from app.config import settings
-from app.llm.prompts import SYSTEM_PROMPT
 from app.orders.models import Order
 
 MODEL = "claude-haiku-4-5-20251001"
@@ -216,9 +215,13 @@ def generate_reply(
     transcript: str,
     history: list[dict[str, Any]],
     order: Order,
+    system_prompt: str,
     client: Optional[Anthropic] = None,
 ) -> LLMResponse:
     """Send the caller's latest transcript to Haiku and return a reply.
+
+    ``system_prompt`` is rendered per call from the inbound restaurant's
+    config (#79); the previously-cached module-level prompt is gone.
 
     ``history`` is Anthropic's Messages format: a list of
     ``{"role": "user"|"assistant", "content": ...}`` dicts. The updated
@@ -235,7 +238,7 @@ def generate_reply(
     response = api.messages.create(
         model=MODEL,
         max_tokens=MAX_TOKENS,
-        system=SYSTEM_PROMPT,
+        system=system_prompt,
         tools=[UPDATE_ORDER_TOOL],
         messages=new_history,
     )
@@ -271,7 +274,7 @@ def generate_reply(
         followup = api.messages.create(
             model=MODEL,
             max_tokens=MAX_TOKENS,
-            system=SYSTEM_PROMPT,
+            system=system_prompt,
             tools=[UPDATE_ORDER_TOOL],
             messages=new_history,
         )
@@ -296,6 +299,7 @@ async def stream_reply(
     transcript: str,
     history: list[dict[str, Any]],
     order: Order,
+    system_prompt: str,
     client: Optional[AsyncAnthropic] = None,
 ) -> AsyncIterator[StreamEvent]:
     """Stream Haiku's reply token-by-token for low-latency TTS handoff.
@@ -323,7 +327,7 @@ async def stream_reply(
     async with api.messages.stream(
         model=MODEL,
         max_tokens=MAX_TOKENS,
-        system=SYSTEM_PROMPT,
+        system=system_prompt,
         tools=[UPDATE_ORDER_TOOL],
         messages=new_history,
     ) as stream:
@@ -360,7 +364,7 @@ async def stream_reply(
         async with api.messages.stream(
             model=MODEL,
             max_tokens=MAX_TOKENS,
-            system=SYSTEM_PROMPT,
+            system=system_prompt,
             tools=[UPDATE_ORDER_TOOL],
             messages=new_history,
         ) as followup_stream:

--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -1,13 +1,21 @@
-"""Haiku 4.5 system prompt for the POC voice agent.
+"""Haiku 4.5 system prompt builder for the voice agent.
 
-Built at import time from ``app.menu.MENU``. The prompt is tuned for
-voice output: short replies, natural phrasing, no markdown or lists
-(all of which sound wrong through TTS).
+Built per call from a ``Restaurant`` object (loaded by the call-flow
+orchestrator in ``app/telephony/router.py``). Pre-#79 this module was
+a singleton — ``SYSTEM_PROMPT`` baked from ``app.menu.MENU`` at import
+time. Multi-tenancy means the prompt has to vary per call, so the
+singleton is gone; build fresh on each ``media-stream start``.
+
+The prompt is tuned for voice output: short replies, natural phrasing,
+no markdown or lists (all of which sound wrong through TTS).
 """
 
-from textwrap import dedent
+from __future__ import annotations
 
-from app.menu import MENU
+from textwrap import dedent
+from typing import Any
+
+from app.restaurants.models import Restaurant
 
 _PREAMBLE = dedent("""\
     You are niko, a friendly voice ordering agent answering the phone for {restaurant}.
@@ -61,39 +69,56 @@ _PREAMBLE = dedent("""\
 """)
 
 
-def _format_menu() -> str:
-    lines = [MENU["restaurant"], ""]
+def _format_menu(restaurant: Restaurant) -> str:
+    menu = restaurant.menu
+    lines: list[str] = [restaurant.name, ""]
 
-    lines.append("Pizzas:")
-    for item in MENU["pizzas"]:
-        sizes = ", ".join(
-            f"{size} ${price:.2f}" for size, price in item["sizes"].items()
-        )
-        lines.append(f"  - {item['name']} — {item['description']} ({sizes})")
-    lines.append("")
+    pizzas: list[dict[str, Any]] = menu.get("pizzas", []) or []
+    if pizzas:
+        lines.append("Pizzas:")
+        for item in pizzas:
+            sizes = ", ".join(
+                f"{size} ${price:.2f}"
+                for size, price in (item.get("sizes") or {}).items()
+            )
+            desc = item.get("description", "")
+            lines.append(f"  - {item['name']} — {desc} ({sizes})")
+        lines.append("")
 
-    lines.append("Sides:")
-    for item in MENU["sides"]:
-        lines.append(f"  - {item['name']} — ${item['price']:.2f}")
-    lines.append("")
+    sides: list[dict[str, Any]] = menu.get("sides", []) or []
+    if sides:
+        lines.append("Sides:")
+        for item in sides:
+            lines.append(f"  - {item['name']} — ${item['price']:.2f}")
+        lines.append("")
 
-    lines.append("Drinks:")
-    for item in MENU["drinks"]:
-        lines.append(f"  - {item['name']} — ${item['price']:.2f}")
-    lines.append("")
+    drinks: list[dict[str, Any]] = menu.get("drinks", []) or []
+    if drinks:
+        lines.append("Drinks:")
+        for item in drinks:
+            lines.append(f"  - {item['name']} — ${item['price']:.2f}")
+        lines.append("")
 
-    lines.append(f"Hours: {MENU['hours']}")
-    lines.append(f"Address: {MENU['address']}")
+    lines.append(f"Hours: {restaurant.hours}")
+    lines.append(f"Address: {restaurant.address}")
 
     return "\n".join(lines)
 
 
-def build_system_prompt() -> str:
-    return (
-        _PREAMBLE.format(restaurant=MENU["restaurant"])
+def build_system_prompt(restaurant: Restaurant) -> str:
+    """Render the system prompt for one tenant.
+
+    A ``greeting_addendum`` entry in ``restaurant.prompt_overrides`` is
+    appended after the menu — used to inject restaurant-specific tone
+    or quirks ("we're family-run since 1972", "ask about today's
+    special") without forking the whole prompt.
+    """
+    body = (
+        _PREAMBLE.format(restaurant=restaurant.name)
         + "\nMenu:\n"
-        + _format_menu()
+        + _format_menu(restaurant)
     )
-
-
-SYSTEM_PROMPT = build_system_prompt()
+    addendum = restaurant.prompt_overrides.get("greeting_addendum")
+    if addendum:
+        body = f"{body}\n\n{addendum.strip()}"
+    return body

--- a/app/restaurants/__init__.py
+++ b/app/restaurants/__init__.py
@@ -1,0 +1,11 @@
+"""Per-restaurant configuration: identity, menu, prompt overrides.
+
+PR A of Sprint 2.1 (#79). Until #4 (the parent sprint) closes, the only
+consumer is the demo restaurant ``niko-pizza-kitchen``. The Twilio
+inbound-routing path lands in PR B; see ``app/storage/restaurants.py``
+for how restaurants are loaded and the fallback semantics.
+"""
+
+from app.restaurants.models import Restaurant
+
+__all__ = ["Restaurant"]

--- a/app/restaurants/models.py
+++ b/app/restaurants/models.py
@@ -1,0 +1,56 @@
+"""Restaurant Pydantic model for multi-tenancy (#79).
+
+One ``Restaurant`` doc per tenant in Firestore at ``restaurants/{id}``.
+The ``id`` is the Firestore document key (e.g. ``niko-pizza-kitchen``).
+Every field that drives runtime behavior — menu, address, prompt
+overrides — is read fresh per call rather than baked at module import,
+so an update in Firestore takes effect on the next call without a
+redeploy.
+
+Two phone fields, intentionally split:
+
+- ``display_phone`` — what customers dial; on Google Maps, menus,
+  signage. Never used for routing.
+- ``twilio_phone`` — the number we provisioned for this restaurant.
+  Twilio's ``To`` field on inbound calls equals this. PR B keys the
+  routing lookup off it.
+
+The customer's existing line is configured (carrier-side) to forward
+inbound calls to ``twilio_phone``. Restaurant keeps their published
+number; we sit behind it.
+
+``menu`` stays a free-form dict to match the existing
+``app.menu.MENU`` shape during the migration. A stricter
+``MenuItem`` / ``Menu`` schema is a follow-up — Sprint 2.4 owns the
+menu CRUD UI and is the right time to tighten validation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class Restaurant(BaseModel):
+    id: str
+    name: str
+    display_phone: str
+    twilio_phone: str
+    address: str
+    hours: str
+    menu: dict[str, Any] = Field(default_factory=dict)
+    # Free-form per-restaurant prompt nudges (e.g. ``greeting_addendum``,
+    # ``tone``). Consumed by ``app.llm.prompts.build_system_prompt``.
+    prompt_overrides: dict[str, str] = Field(default_factory=dict)
+    # Informational only — we don't enforce it. Tracks how the restaurant
+    # configured their carrier-level forwarding so onboarding/support can
+    # answer "why are calls landing here?".
+    forwarding_mode: str = "always"
+    created_at: datetime = Field(default_factory=_now_utc)
+    updated_at: datetime = Field(default_factory=_now_utc)

--- a/app/storage/restaurants.py
+++ b/app/storage/restaurants.py
@@ -1,0 +1,176 @@
+"""Firestore persistence for the ``restaurants`` collection (#79).
+
+PR A wiring:
+
+- ``get_restaurant(rid)`` — load by document id.
+- ``get_restaurant_by_twilio_phone(e164)`` — load by Twilio number;
+  used by PR B to route inbound calls to the right tenant.
+- ``demo_restaurant_from_menu()`` — build a ``Restaurant`` from
+  ``app.menu.MENU``. Lets the demo call flow keep working before
+  ``scripts/seed_demo_restaurant.py`` has been run.
+
+Reads are cached in-process for ``CACHE_TTL_SECONDS`` so we don't hit
+Firestore on every LLM turn. The cache is keyed by both id and
+twilio_phone — looking a restaurant up by either resolves to the same
+cached object. Cloud Run instances are short-lived (~15 minutes idle),
+so a stale cache self-corrects without an explicit invalidation.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Optional
+
+from google.cloud import firestore
+
+from app.restaurants.models import Restaurant
+
+logger = logging.getLogger(__name__)
+
+_COLLECTION = "restaurants"
+
+# Demo restaurant id — must match ``Order.restaurant_id`` default in
+# ``app/orders/models.py`` so existing flat-collection orders still
+# attribute back to this tenant after the PR C migration.
+DEMO_RID = "niko-pizza-kitchen"
+
+CACHE_TTL_SECONDS = 60.0
+
+_client: Optional[firestore.Client] = None
+_cache: dict[str, tuple[float, Restaurant]] = {}
+
+
+def _get_client() -> firestore.Client:
+    global _client
+    if _client is None:
+        _client = firestore.Client()
+    return _client
+
+
+def set_client(client: Optional[firestore.Client]) -> None:
+    """Override the module-level Firestore client (tests + emulator)."""
+    global _client
+    _client = client
+
+
+def clear_cache() -> None:
+    """Drop all cached restaurants. Used by tests; rarely needed in prod."""
+    _cache.clear()
+
+
+def _cache_get(key: str) -> Optional[Restaurant]:
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    expires_at, restaurant = entry
+    if time.monotonic() > expires_at:
+        _cache.pop(key, None)
+        return None
+    return restaurant
+
+
+def _cache_put(restaurant: Restaurant) -> None:
+    expires_at = time.monotonic() + CACHE_TTL_SECONDS
+    _cache[f"id:{restaurant.id}"] = (expires_at, restaurant)
+    _cache[f"twilio:{restaurant.twilio_phone}"] = (expires_at, restaurant)
+
+
+def get_restaurant(rid: str) -> Optional[Restaurant]:
+    """Load a restaurant by its Firestore document id.
+
+    Returns ``None`` when the doc doesn't exist (caller decides
+    whether to fall back, 404, or raise).
+    """
+    cached = _cache_get(f"id:{rid}")
+    if cached is not None:
+        return cached
+    try:
+        snap = _get_client().collection(_COLLECTION).document(rid).get()
+    except Exception:
+        logger.exception("restaurants: load failed rid=%s", rid)
+        return None
+    if not snap.exists:
+        return None
+    restaurant = Restaurant.model_validate(snap.to_dict())
+    _cache_put(restaurant)
+    return restaurant
+
+
+def get_restaurant_by_twilio_phone(e164: str) -> Optional[Restaurant]:
+    """Load a restaurant by the Twilio number it answers on.
+
+    Used by the inbound-call routing path in PR B — Twilio passes the
+    dialed number as ``To`` on every webhook. ``e164`` is the E.164
+    string (e.g. ``+16479058093``).
+    """
+    cached = _cache_get(f"twilio:{e164}")
+    if cached is not None:
+        return cached
+    try:
+        query = (
+            _get_client()
+            .collection(_COLLECTION)
+            .where("twilio_phone", "==", e164)
+            .limit(1)
+        )
+        docs = list(query.stream())
+    except Exception:
+        logger.exception("restaurants: phone lookup failed phone=%s", e164)
+        return None
+    if not docs:
+        return None
+    restaurant = Restaurant.model_validate(docs[0].to_dict())
+    _cache_put(restaurant)
+    return restaurant
+
+
+def save_restaurant(restaurant: Restaurant) -> str:
+    """Upsert a restaurant doc keyed by ``restaurant.id``. Used by
+    ``scripts/seed_demo_restaurant.py`` and ``scripts/provision_restaurant.py``."""
+    payload = restaurant.model_dump(mode="python")
+    _get_client().collection(_COLLECTION).document(restaurant.id).set(payload)
+    _cache_put(restaurant)
+    return restaurant.id
+
+
+def demo_restaurant_from_menu() -> Restaurant:
+    """Build a ``Restaurant`` from the legacy ``app.menu.MENU`` dict.
+
+    Bridges the gap between PR A (this PR) and the seeding step. The
+    router prefers a Firestore lookup; if that returns ``None`` because
+    the seed hasn't run yet, this fallback keeps the demo call flow
+    working. Removed in PR F when ``app/menu.py`` itself goes away.
+    """
+    from app.menu import MENU
+
+    return Restaurant(
+        id=DEMO_RID,
+        name=MENU["restaurant"],
+        display_phone=MENU["phone"],
+        twilio_phone="+16479058093",
+        address=MENU["address"],
+        hours=MENU["hours"],
+        menu={
+            "pizzas": MENU["pizzas"],
+            "sides": MENU["sides"],
+            "drinks": MENU["drinks"],
+        },
+    )
+
+
+def load_or_fallback_demo(rid: str = DEMO_RID) -> Restaurant:
+    """Load ``rid`` from Firestore, or fall back to the menu-based demo.
+
+    The single chokepoint the call-flow code uses during PR A. Logs a
+    one-line warning when falling back so misconfigured tenants are
+    visible in Cloud Run logs.
+    """
+    restaurant = get_restaurant(rid)
+    if restaurant is not None:
+        return restaurant
+    logger.warning(
+        "restaurants: %s not in Firestore — falling back to app.menu (demo)",
+        rid,
+    )
+    return demo_restaurant_from_menu()

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -29,9 +29,11 @@ from twilio.twiml.voice_response import Connect, VoiceResponse
 
 from app.config import settings
 from app.llm.client import stream_reply
+from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
 from app.orders.models import Order, OrderStatus
-from app.storage import call_sessions
+from app.restaurants.models import Restaurant
+from app.storage import call_sessions, restaurants as restaurants_storage
 from app.tts.client import speak
 
 router = APIRouter()
@@ -199,6 +201,8 @@ class _CallState:
     stream_sid:   str | None       = None
     order:        Order | None     = None
     history:      list[dict]       = field(default_factory=list)
+    restaurant:   Restaurant | None = None     # tenant for this call (#79)
+    system_prompt: str             = ""        # built from restaurant on start
     llm_task:     asyncio.Task | None = None   # current LLM→TTS turn
     silence_task: asyncio.Task | None = None   # silence watchdog
     hangup_task:  asyncio.Task | None = None   # pending auto-hangup (#78)
@@ -300,7 +304,10 @@ async def _run_llm_tts_turn(
 
     try:
         async for event in stream_reply(
-            transcript=transcript, history=state.history, order=state.order
+            transcript=transcript,
+            history=state.history,
+            order=state.order,
+            system_prompt=state.system_prompt,
         ):
             if asyncio.current_task().cancelled():
                 return
@@ -460,11 +467,20 @@ async def media_stream(websocket: WebSocket) -> None:
                 start = msg.get("start", {})
                 state.call_sid = start.get("callSid")
                 state.stream_sid = start.get("streamSid")
-                state.order = Order(call_sid=state.call_sid or "unknown")
+                # PR A: every call uses the demo tenant. PR B reads
+                # Twilio's ``To`` field and routes to the matching
+                # restaurant doc.
+                state.restaurant = restaurants_storage.load_or_fallback_demo()
+                state.system_prompt = build_system_prompt(state.restaurant)
+                state.order = Order(
+                    call_sid=state.call_sid or "unknown",
+                    restaurant_id=state.restaurant.id,
+                )
                 logger.info(
-                    "media-stream start call_sid=%s stream_sid=%s",
+                    "media-stream start call_sid=%s stream_sid=%s restaurant=%s",
                     state.call_sid,
                     state.stream_sid,
+                    state.restaurant.id,
                 )
                 if state.call_sid:
                     asyncio.get_running_loop().create_task(

--- a/scripts/provision_restaurant.py
+++ b/scripts/provision_restaurant.py
@@ -1,0 +1,166 @@
+"""Provision a new restaurant tenant end-to-end (PR A of #79).
+
+What it does, in order:
+
+1. Buy a Twilio phone number in the requested area code.
+2. Configure that number's voice webhook to point at our Cloud Run
+   service (``{BACKEND_URL}/voice``).
+3. Write a ``restaurants/{rid}`` doc to Firestore with name, address,
+   hours, menu, and the new ``twilio_phone``.
+
+After this script runs, the restaurant just needs to set up
+forwarding from their existing line to the new Twilio number. See
+``docs/onboarding-forwarding.md`` (TODO, PR B).
+
+Usage:
+    python -m scripts.provision_restaurant \\
+        --rid pizza-palace \\
+        --name "Pizza Palace" \\
+        --display-phone +14165551234 \\
+        --address "456 Queen St W, Toronto" \\
+        --hours "Mon-Sun, 11am-11pm" \\
+        --area-code 416 \\
+        --menu-file restaurants/pizza-palace.json
+
+``--menu-file`` is a JSON file in the shape ``{"pizzas":[...],
+"sides":[...], "drinks":[...]}`` — same as ``app.menu.MENU`` minus
+the top-level metadata fields.
+
+Required env:
+    TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN — buys + configures number
+    BACKEND_URL — e.g. https://niko-ciyyvuq2pq-uc.a.run.app
+                  Must be stable; if Cloud Run URL changes, re-run
+                  this script's update step.
+    GOOGLE_CLOUD_PROJECT, GOOGLE_APPLICATION_CREDENTIALS — Firestore
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+from twilio.rest import Client as TwilioClient
+
+from app.config import settings
+from app.restaurants.models import Restaurant
+from app.storage import restaurants as restaurants_storage
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rid", required=True, help="Firestore document id (slug)")
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--display-phone", required=True, help="E.164 customer-facing number")
+    parser.add_argument("--address", required=True)
+    parser.add_argument("--hours", required=True)
+    parser.add_argument("--area-code", required=True, help="3-digit area code for Twilio search")
+    parser.add_argument("--menu-file", required=True, help="Path to JSON menu file")
+    parser.add_argument(
+        "--forwarding-mode",
+        default="always",
+        choices=["always", "busy", "noanswer"],
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip Twilio purchase + Firestore write; just log what would happen",
+    )
+    return parser.parse_args()
+
+
+def _twilio_client() -> TwilioClient:
+    sid = settings.twilio_account_sid or os.environ.get("TWILIO_ACCOUNT_SID")
+    token = settings.twilio_auth_token or os.environ.get("TWILIO_AUTH_TOKEN")
+    if not sid or not token:
+        raise SystemExit("TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN are required")
+    return TwilioClient(sid, token)
+
+
+def _backend_url() -> str:
+    url = os.environ.get("BACKEND_URL", "").rstrip("/")
+    if not url:
+        raise SystemExit("BACKEND_URL env var is required (e.g. https://niko-xyz.run.app)")
+    return url
+
+
+def _purchase_number(twilio: TwilioClient, area_code: str) -> str:
+    """Buy a US/CA local number in ``area_code``. Returns the E.164 string."""
+    available = twilio.available_phone_numbers("CA").local.list(
+        area_code=area_code, limit=1
+    )
+    if not available:
+        # Fall back to US if the area code has no Canadian inventory.
+        available = twilio.available_phone_numbers("US").local.list(
+            area_code=area_code, limit=1
+        )
+    if not available:
+        raise SystemExit(f"No numbers available in area code {area_code}")
+    candidate = available[0].phone_number
+    logger.info("twilio: purchasing %s (area code %s)", candidate, area_code)
+    purchased = twilio.incoming_phone_numbers.create(phone_number=candidate)
+    return purchased.phone_number
+
+
+def _configure_voice_webhook(twilio: TwilioClient, e164: str, backend_url: str) -> None:
+    voice_url = f"{backend_url}/voice"
+    numbers = twilio.incoming_phone_numbers.list(phone_number=e164, limit=1)
+    if not numbers:
+        raise SystemExit(f"twilio: number {e164} not found on this account")
+    twilio.incoming_phone_numbers(numbers[0].sid).update(
+        voice_url=voice_url, voice_method="POST"
+    )
+    logger.info("twilio: %s voice webhook → %s", e164, voice_url)
+
+
+def main() -> int:
+    args = _parse_args()
+
+    with open(args.menu_file, encoding="utf-8") as fh:
+        menu = json.load(fh)
+
+    if args.dry_run:
+        twilio_phone = "+10000000000"
+        logger.info("[dry-run] would purchase a number in area code %s", args.area_code)
+    else:
+        twilio = _twilio_client()
+        backend_url = _backend_url()
+        twilio_phone = _purchase_number(twilio, args.area_code)
+        _configure_voice_webhook(twilio, twilio_phone, backend_url)
+
+    restaurant = Restaurant(
+        id=args.rid,
+        name=args.name,
+        display_phone=args.display_phone,
+        twilio_phone=twilio_phone,
+        address=args.address,
+        hours=args.hours,
+        menu=menu,
+        forwarding_mode=args.forwarding_mode,
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    if args.dry_run:
+        logger.info("[dry-run] would write restaurants/%s", args.rid)
+        logger.info(restaurant.model_dump_json(indent=2))
+        return 0
+
+    rid = restaurants_storage.save_restaurant(restaurant)
+    logger.info("firestore: wrote restaurants/%s", rid)
+    logger.info("✔ provisioned %s — twilio_phone=%s", args.name, twilio_phone)
+    logger.info(
+        "next: configure %s to forward inbound calls to %s",
+        args.display_phone,
+        twilio_phone,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_demo_restaurant.py
+++ b/scripts/seed_demo_restaurant.py
@@ -1,0 +1,47 @@
+"""Seed the demo restaurant doc into Firestore (PR A of #79).
+
+Idempotent: re-running upserts the same id (``niko-pizza-kitchen``).
+Reads menu + business info from ``app.menu.MENU`` so the seed always
+matches the current hardcoded source of truth, and bumps
+``updated_at`` to ``now``.
+
+Usage:
+    python -m scripts.seed_demo_restaurant
+
+Auth: same as the rest of the backend — Cloud Run service account in
+prod, ``gcloud auth application-default login`` locally. Set
+``GOOGLE_CLOUD_PROJECT=niko-tsuki`` if running outside GCP.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import datetime, timezone
+
+from app.storage import restaurants as restaurants_storage
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    restaurant = restaurants_storage.demo_restaurant_from_menu()
+    restaurant.updated_at = datetime.now(timezone.utc)
+
+    rid = restaurants_storage.save_restaurant(restaurant)
+    logger.info("seeded restaurants/%s", rid)
+    logger.info("  name           = %s", restaurant.name)
+    logger.info("  display_phone  = %s", restaurant.display_phone)
+    logger.info("  twilio_phone   = %s", restaurant.twilio_phone)
+    logger.info(
+        "  menu items     = %d pizzas, %d sides, %d drinks",
+        len(restaurant.menu.get("pizzas", [])),
+        len(restaurant.menu.get("sides", [])),
+        len(restaurant.menu.get("drinks", [])),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -16,6 +16,8 @@ from app.llm import client as client_module
 from app.llm.client import _apply_update, generate_reply, stream_reply
 from app.orders.models import Order, OrderStatus, OrderType
 
+_TEST_SYSTEM_PROMPT = "you are a test agent"
+
 
 @dataclass
 class FakeBlock:
@@ -51,6 +53,7 @@ def test_plain_text_response_leaves_order_unchanged():
         transcript="hello",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -94,6 +97,7 @@ def test_tool_use_updates_order_in_single_turn():
         transcript="one medium pepperoni for pickup",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -133,6 +137,7 @@ def test_tool_only_response_triggers_followup_call():
         transcript="never mind cancel",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -152,6 +157,7 @@ def test_history_threads_user_and_assistant_turns():
         transcript="one pepperoni please",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -204,6 +210,7 @@ def test_text_plus_tool_use_appends_tool_result_to_history():
         transcript="i'll take a large margarita for pickup",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -263,6 +270,7 @@ def test_next_transcript_merges_into_pending_tool_result():
         transcript="extra olives please",
         history=history_with_pending_tool_result,
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -298,6 +306,7 @@ def test_history_strips_sdk_only_fields_from_assistant_blocks():
         transcript="one pepperoni please",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -361,6 +370,7 @@ def test_off_menu_request_leaves_order_empty():
         transcript="can I get some sushi",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -389,6 +399,7 @@ def test_unclear_utterance_asks_for_clarification():
         transcript="mmrgh pfftbl",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -454,6 +465,7 @@ def test_caller_changes_mind_replaces_items():
         transcript="actually scratch that, make it a veggie supreme",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 
@@ -540,6 +552,7 @@ async def test_stream_reply_emits_text_deltas_then_final():
             transcript="hello",
             history=[],
             order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
             client=fake_client,
         )
     )
@@ -592,6 +605,7 @@ async def test_stream_reply_applies_tool_use_to_order_state():
             transcript="one medium pepperoni for pickup",
             history=[],
             order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
             client=fake_client,
         )
     )
@@ -633,6 +647,7 @@ async def test_stream_reply_runs_followup_when_first_turn_is_tool_only():
             transcript="never mind cancel",
             history=[],
             order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
             client=fake_client,
         )
     )
@@ -659,7 +674,11 @@ async def test_stream_reply_text_deltas_arrive_before_final():
 
     seen: list[str] = []
     async for event in stream_reply(
-        transcript="x", history=[], order=order, client=fake_client
+        transcript="x",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
     ):
         if event.text_delta is not None:
             seen.append(f"delta:{event.text_delta}")
@@ -707,6 +726,7 @@ def test_modifications_round_trip_into_line_item():
         transcript="large margherita extra cheese no basil",
         history=[],
         order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
         client=fake_client,
     )
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,31 +1,36 @@
 """Tests for the system prompt builder.
 
-These guard the two behavioural directives we tuned in #76:
+These guard the behavioural directives we tuned across #76, #78, and
+#79: address handling, speak-before-tool-use, terminal goodbyes,
+and the goodbye/status-flip coupling. Plus the multi-tenancy plumbing
+from #79 — the builder accepts a ``Restaurant`` and reads from it
+rather than a global menu.
 
-1. The address from app/menu.py must NOT be recited during pickup
-   wrap-ups — only used for direct location questions.
-2. The agent must speak before calling update_order, never the other
-   way around (latency).
-
-Both rules live in `app/llm/prompts.py`. If a future edit accidentally
-deletes them the tests fail loudly rather than degrading the live
-caller experience silently.
+If a future edit accidentally deletes any of these the tests fail
+loudly rather than degrading the live caller experience silently.
 """
-from app.llm.prompts import SYSTEM_PROMPT, build_system_prompt
-from app.menu import MENU
+
+from app.llm.prompts import build_system_prompt
+from app.restaurants.models import Restaurant
+from app.storage.restaurants import demo_restaurant_from_menu
+
+
+def _demo() -> Restaurant:
+    return demo_restaurant_from_menu()
 
 
 def test_prompt_includes_restaurant_name_and_menu_items():
-    prompt = build_system_prompt()
-    assert MENU["restaurant"] in prompt
-    for pizza in MENU["pizzas"]:
+    restaurant = _demo()
+    prompt = build_system_prompt(restaurant)
+    assert restaurant.name in prompt
+    for pizza in restaurant.menu["pizzas"]:
         assert pizza["name"] in prompt
 
 
 def test_prompt_warns_against_reciting_address_on_pickup_wrapup():
     """Regression for #76 — the placeholder address (or any address) must
     not be volunteered in pickup confirmations."""
-    prompt = build_system_prompt()
+    prompt = build_system_prompt(_demo())
     lower = prompt.lower()
     assert "restaurant address handling" in lower
     assert "do not recite it during pickup wrap-ups" in lower or "do not recite" in lower
@@ -35,7 +40,7 @@ def test_prompt_warns_against_reciting_address_on_pickup_wrapup():
 def test_prompt_requires_text_before_tool_use():
     """Regression for #76 — Haiku must speak first then call update_order,
     so audio starts streaming within the <1s budget on commit turns."""
-    prompt = build_system_prompt()
+    prompt = build_system_prompt(_demo())
     lower = prompt.lower()
     assert "when you call the update_order tool" in lower
     assert "first" in lower
@@ -46,7 +51,7 @@ def test_prompt_makes_confirmation_goodbyes_terminal():
     """Regression for #78 — once the caller confirms, the agent should
     say a brief terminal goodbye and NOT ask another question. Otherwise
     the auto-hangup would cut off whatever the bot asked next."""
-    prompt = build_system_prompt()
+    prompt = build_system_prompt(_demo())
     lower = prompt.lower()
     assert "closing the call" in lower
     assert "do not ask another follow-up question after confirming" in lower
@@ -58,15 +63,37 @@ def test_prompt_couples_goodbye_phrases_with_status_flip():
     """Regression for #79 — Haiku was saying 'your order is in' without
     calling update_order(status='confirmed'), which left the auto-hangup
     inert. The prompt now insists on the status flip in the same turn."""
-    prompt = build_system_prompt()
+    prompt = build_system_prompt(_demo())
     lower = prompt.lower()
     assert "critical" in lower
     assert "your order is in" in lower
     assert 'status="confirmed"' in lower
 
 
-def test_module_level_system_prompt_matches_builder():
-    """The cached SYSTEM_PROMPT must equal a fresh build — catches the
-    case where someone edits build_system_prompt() but forgets that
-    SYSTEM_PROMPT is computed at import time."""
-    assert SYSTEM_PROMPT == build_system_prompt()
+def test_prompt_renders_per_tenant_name():
+    """Multi-tenancy (#79): the same builder run against a different
+    Restaurant produces a prompt with that restaurant's name — proves
+    the prompt is no longer baked from a module-level singleton."""
+    other = Restaurant(
+        id="other-shop",
+        name="Sandeep's Sandwich Hut",
+        display_phone="+14160000000",
+        twilio_phone="+14160000001",
+        address="1 Spadina Ave",
+        hours="11am-9pm",
+        menu={"pizzas": [], "sides": [], "drinks": []},
+    )
+    prompt = build_system_prompt(other)
+    assert "Sandeep's Sandwich Hut" in prompt
+    assert "Niko's Pizza Kitchen" not in prompt
+
+
+def test_prompt_appends_greeting_addendum_when_provided():
+    """``prompt_overrides.greeting_addendum`` lets a tenant inject a
+    short tone/quirk note without forking the whole prompt."""
+    restaurant = _demo()
+    restaurant.prompt_overrides = {
+        "greeting_addendum": "We're family-run since 1972 — feel free to ask about today's special."
+    }
+    prompt = build_system_prompt(restaurant)
+    assert "family-run since 1972" in prompt

--- a/tests/test_restaurants_storage.py
+++ b/tests/test_restaurants_storage.py
@@ -1,0 +1,186 @@
+"""Unit tests for the restaurants storage module (#79).
+
+Mocks the Firestore client so the suite stays offline. Covers:
+
+- ``get_restaurant`` happy path + missing doc + cache hit
+- ``get_restaurant_by_twilio_phone`` happy path + no match
+- ``demo_restaurant_from_menu`` mirrors the legacy ``app.menu.MENU`` shape
+- ``load_or_fallback_demo`` falls back to the menu when Firestore is empty
+- ``save_restaurant`` populates the cache so a same-process read after
+  write doesn't go back to Firestore
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.restaurants.models import Restaurant
+from app.storage import restaurants as storage
+
+
+@pytest.fixture(autouse=True)
+def _reset_module():
+    """Each test starts with a fresh client + empty cache."""
+    yield
+    storage.set_client(None)
+    storage.clear_cache()
+
+
+def _fake_client() -> MagicMock:
+    client = MagicMock()
+    storage.set_client(client)
+    return client
+
+
+def _fake_doc(data: dict) -> MagicMock:
+    snap = MagicMock()
+    snap.exists = True
+    snap.to_dict.return_value = data
+    return snap
+
+
+def _restaurant_payload(rid: str = "niko-pizza-kitchen") -> dict:
+    return {
+        "id": rid,
+        "name": "Niko's Pizza Kitchen",
+        "display_phone": "+16475550100",
+        "twilio_phone": "+16479058093",
+        "address": "123 Main Street",
+        "hours": "11am-10pm",
+        "menu": {"pizzas": [], "sides": [], "drinks": []},
+        "prompt_overrides": {},
+        "forwarding_mode": "always",
+    }
+
+
+def test_get_restaurant_returns_none_when_doc_missing():
+    client = _fake_client()
+    client.collection.return_value.document.return_value.get.return_value.exists = False
+
+    assert storage.get_restaurant("niko-pizza-kitchen") is None
+
+
+def test_get_restaurant_hydrates_pydantic_model():
+    client = _fake_client()
+    snap = _fake_doc(_restaurant_payload())
+    client.collection.return_value.document.return_value.get.return_value = snap
+
+    result = storage.get_restaurant("niko-pizza-kitchen")
+
+    assert result is not None
+    assert isinstance(result, Restaurant)
+    assert result.id == "niko-pizza-kitchen"
+    assert result.twilio_phone == "+16479058093"
+
+
+def test_get_restaurant_caches_within_ttl():
+    """Second lookup with the same id must not hit Firestore again."""
+    client = _fake_client()
+    snap = _fake_doc(_restaurant_payload())
+    client.collection.return_value.document.return_value.get.return_value = snap
+
+    storage.get_restaurant("niko-pizza-kitchen")
+    storage.get_restaurant("niko-pizza-kitchen")
+
+    # ``.get()`` should only have been called once across the two reads.
+    get_calls = client.collection.return_value.document.return_value.get.call_count
+    assert get_calls == 1
+
+
+def test_get_restaurant_by_twilio_phone_returns_doc():
+    client = _fake_client()
+    snap = _fake_doc(_restaurant_payload())
+    query = (
+        client.collection.return_value
+        .where.return_value
+        .limit.return_value
+    )
+    query.stream.return_value = iter([snap])
+
+    result = storage.get_restaurant_by_twilio_phone("+16479058093")
+
+    assert result is not None
+    assert result.id == "niko-pizza-kitchen"
+    client.collection.return_value.where.assert_called_with(
+        "twilio_phone", "==", "+16479058093"
+    )
+
+
+def test_get_restaurant_by_twilio_phone_returns_none_when_no_match():
+    client = _fake_client()
+    query = (
+        client.collection.return_value
+        .where.return_value
+        .limit.return_value
+    )
+    query.stream.return_value = iter([])
+
+    assert storage.get_restaurant_by_twilio_phone("+19990000000") is None
+
+
+def test_save_restaurant_populates_cache():
+    """Caches by both id and twilio_phone — a save followed by either
+    lookup avoids a Firestore round-trip."""
+    client = _fake_client()
+    restaurant = Restaurant.model_validate(_restaurant_payload())
+
+    storage.save_restaurant(restaurant)
+
+    # Reset get-calls so we can assert no Firestore reads happen below.
+    client.collection.return_value.document.return_value.get.reset_mock()
+
+    by_id = storage.get_restaurant("niko-pizza-kitchen")
+    by_phone = storage.get_restaurant_by_twilio_phone("+16479058093")
+
+    assert by_id is not None and by_id.id == "niko-pizza-kitchen"
+    assert by_phone is not None and by_phone.id == "niko-pizza-kitchen"
+    client.collection.return_value.document.return_value.get.assert_not_called()
+    client.collection.return_value.where.assert_not_called()
+
+
+def test_demo_restaurant_from_menu_mirrors_legacy_menu():
+    from app.menu import MENU
+
+    restaurant = storage.demo_restaurant_from_menu()
+
+    assert restaurant.id == "niko-pizza-kitchen"
+    assert restaurant.name == MENU["restaurant"]
+    assert restaurant.address == MENU["address"]
+    assert restaurant.hours == MENU["hours"]
+    assert restaurant.menu["pizzas"] == MENU["pizzas"]
+    assert restaurant.menu["sides"] == MENU["sides"]
+    assert restaurant.menu["drinks"] == MENU["drinks"]
+
+
+def test_load_or_fallback_demo_uses_firestore_when_present():
+    client = _fake_client()
+    snap = _fake_doc(_restaurant_payload())
+    client.collection.return_value.document.return_value.get.return_value = snap
+
+    result = storage.load_or_fallback_demo()
+    assert result.name == "Niko's Pizza Kitchen"
+
+
+def test_load_or_fallback_demo_falls_back_when_doc_missing(caplog):
+    client = _fake_client()
+    client.collection.return_value.document.return_value.get.return_value.exists = False
+
+    with caplog.at_level("WARNING"):
+        result = storage.load_or_fallback_demo()
+
+    assert result.id == "niko-pizza-kitchen"
+    assert any("falling back" in rec.message for rec in caplog.records)
+
+
+def test_get_restaurant_returns_none_when_firestore_raises(caplog):
+    """A transient Firestore error must not crash the call flow — the
+    router treats ``None`` as a fallback signal."""
+    client = _fake_client()
+    client.collection.return_value.document.return_value.get.side_effect = (
+        RuntimeError("firestore unavailable")
+    )
+
+    with caplog.at_level("ERROR"):
+        result = storage.get_restaurant("niko-pizza-kitchen")
+
+    assert result is None


### PR DESCRIPTION
## Summary

First of three backend PRs landing multi-tenancy (Sprint 2.1 #4). Pure-additive schema + read path: introduces the `restaurants/{rid}` data model, the storage module, and a dynamic per-call system prompt — but the demo call flow keeps working unchanged through a fallback path.

- New `Restaurant` Pydantic model: `id`, `name`, `display_phone`, `twilio_phone`, `address`, `hours`, `menu`, `prompt_overrides`, `forwarding_mode`. The two phone fields are intentional: `display_phone` is what customers dial (on Google/menus); `twilio_phone` is what we provisioned and what Twilio's `To` field will key the routing lookup off in PR B.
- New `app/storage/restaurants.py` — `get_restaurant`, `get_restaurant_by_twilio_phone`, `save_restaurant`, plus `load_or_fallback_demo()` which the router uses to bridge the gap until the seed has been written.
- `app/llm/prompts.py` is no longer a module-level singleton baked from `app.menu.MENU`. `build_system_prompt(restaurant)` now renders per-call from a `Restaurant` object. `prompt_overrides.greeting_addendum` is honored as an optional tenant-specific tone nudge.
- `app/llm/client.py` — `generate_reply` and `stream_reply` take `system_prompt` as a kwarg.
- `app/telephony/router.py` — on `media-stream start`, loads the demo restaurant (Firestore or fallback), builds the system prompt, and threads it through to every `stream_reply` call. `_CallState` gains `restaurant` and `system_prompt`.
- `scripts/seed_demo_restaurant.py` — one-shot, idempotent: writes `restaurants/niko-pizza-kitchen` from `app.menu.MENU`.
- `scripts/provision_restaurant.py` — Tsuki admin tool: buys a Twilio number, configures its voice webhook to our Cloud Run URL, writes the Firestore seed. Restaurant then sets up carrier-side forwarding from their existing line.

## Linked issue

Relates to #79 (closes after PRs B + C land). Sub-task of #4.

## Test plan

- [x] `pytest -v` green: 115 passed (gated integration tests skipped)
- [x] New `tests/test_restaurants_storage.py` covers cache, fallback, twilio-phone lookup, save+cache populate, and Firestore-error → `None` graceful path
- [x] `tests/test_prompts.py` asserts the prompt renders per-tenant (different `Restaurant` produces a different prompt) and honors `prompt_overrides.greeting_addendum`
- [x] All 15 call sites in `tests/test_llm_client.py` thread `system_prompt` through
- [ ] Live test deferred to PR C (after the seed script runs against prod Firestore)

## Notes

**Demo restaurant unchanged through this PR.** The router calls `load_or_fallback_demo()`, which prefers Firestore but falls back to constructing a `Restaurant` from `app.menu.MENU` if the seed hasn't run yet. So merging this PR before running `scripts/seed_demo_restaurant.py` is safe — fallback keeps the call flow alive.

**No data migration here.** Orders and call_sessions still write to flat collections (`orders/{call_sid}`, `call_sessions/{call_sid}`). PR C does the move to `restaurants/{rid}/orders/{call_sid}` with a backfill script. Until then, every order's `restaurant_id` field continues to be `"niko-pizza-kitchen"`.

**`scripts/provision_restaurant.py`** isn't exercised in CI — it touches Twilio's API and Firestore. We'll dry-run it (`--dry-run`) once the demo seed lands and a stable `BACKEND_URL` is decided. Open question per the design doc: do we want a custom domain (e.g. `voice.tsuki.works`) before locking restaurants' Twilio webhooks against `niko-xyz.run.app`?

**Out of scope, deferred per design doc:** menu CRUD UI (Sprint 2.4), multi-user-per-restaurant (Phase 3), self-serve signup + billing (Phase 4), number porting flow (Phase 3 upsell).