### PR TITLE
Twilio inbound routing by To field (PR B of #79)

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -417,22 +417,69 @@ async def _handle_final_transcript(
     )
 
 
+_UNCONFIGURED_TWIML_MESSAGE = (
+    "Sorry, this number is not currently configured. Goodbye."
+)
+
+
+def _resolve_restaurant_for_voice(
+    to_e164: str,
+) -> Restaurant | None:
+    """Find the tenant for an inbound Twilio call (PR B of #79).
+
+    Looks up by the ``To`` field — Twilio's name for the dialed number,
+    which equals the per-restaurant ``twilio_phone`` we provisioned. If
+    Firestore returns nothing AND the dialed number matches the
+    demo's hardcoded ``twilio_phone``, falls back to building the demo
+    restaurant from ``app.menu.MENU``. The fallback is removed in PR F
+    once the seed is canonical.
+    """
+    restaurant = restaurants_storage.get_restaurant_by_twilio_phone(to_e164)
+    if restaurant is not None:
+        return restaurant
+    demo = restaurants_storage.demo_restaurant_from_menu()
+    if to_e164 == demo.twilio_phone:
+        logger.warning(
+            "voice: demo Twilio number %s not in Firestore — falling back to MENU",
+            to_e164,
+        )
+        return demo
+    return None
+
+
 @router.post("/voice")
 async def voice(request: Request) -> Response:
     """Respond to Twilio's inbound call webhook with TwiML.
 
-    Opens a bidirectional Media Stream back to /media-stream.  The AI
-    greeting is delivered via Deepgram Aura on the 'start' WebSocket event
-    rather than a static TwiML <Say>, so the caller hears the same voice
-    for the entire call.
+    Looks up the tenant by Twilio's ``To`` field, opens a bidirectional
+    Media Stream back to /media-stream, and forwards the resolved
+    restaurant id to the WebSocket handler via a ``<Parameter>`` on the
+    stream — Twilio echoes it back on the ``start`` event so the WS
+    can load the right restaurant without re-querying.
 
-    The WebSocket URL is derived from the ``Host`` header so the same code
-    works under ngrok locally and on Cloud Run in production.
+    If the dialed number isn't mapped to any tenant, returns a brief
+    TwiML hangup so callers don't sit through dead air.
+
+    The WebSocket URL is derived from the ``Host`` header so the same
+    code works under ngrok locally and on Cloud Run in production.
     """
-    host = request.headers.get("host", "localhost:8000")
+    form = await request.form()
+    to_e164 = (form.get("To") or "").strip()
+    restaurant = _resolve_restaurant_for_voice(to_e164)
+
     twiml = VoiceResponse()
+    if restaurant is None:
+        logger.warning(
+            "voice: no restaurant for To=%s — rejecting call", to_e164 or "(missing)"
+        )
+        twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
+        twiml.hangup()
+        return Response(content=str(twiml), media_type="application/xml")
+
+    host = request.headers.get("host", "localhost:8000")
     connect = Connect()
-    connect.stream(url=f"wss://{host}/media-stream")
+    stream = connect.stream(url=f"wss://{host}/media-stream")
+    stream.parameter(name="restaurant_id", value=restaurant.id)
     twiml.append(connect)
     return Response(content=str(twiml), media_type="application/xml")
 
@@ -467,10 +514,19 @@ async def media_stream(websocket: WebSocket) -> None:
                 start = msg.get("start", {})
                 state.call_sid = start.get("callSid")
                 state.stream_sid = start.get("streamSid")
-                # PR A: every call uses the demo tenant. PR B reads
-                # Twilio's ``To`` field and routes to the matching
-                # restaurant doc.
-                state.restaurant = restaurants_storage.load_or_fallback_demo()
+                # PR B: /voice looks up the restaurant by ``To`` and
+                # forwards the id via Stream <Parameter>; Twilio echoes
+                # it back on the start event under customParameters.
+                # When the parameter is missing (older clients, manual
+                # WS connects in tests), fall back to the demo path.
+                custom_params = start.get("customParameters", {}) or {}
+                rid = custom_params.get("restaurant_id")
+                if rid:
+                    state.restaurant = restaurants_storage.get_restaurant(rid)
+                if state.restaurant is None:
+                    state.restaurant = restaurants_storage.load_or_fallback_demo(
+                        rid or restaurants_storage.DEMO_RID
+                    )
                 state.system_prompt = build_system_prompt(state.restaurant)
                 state.order = Order(
                     call_sid=state.call_sid or "unknown",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.115.0
 uvicorn[standard]==0.32.0
+python-multipart>=0.0.9,<1.0
 twilio>=9.0,<10.0
 pydantic-settings>=2.0,<3.0
 anthropic>=0.40,<1.0

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -19,8 +19,25 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.llm.client import LLMResponse, StreamEvent
 from app.orders.models import Order
+from app.storage import restaurants as restaurants_storage
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_restaurants_cache():
+    """Each /voice request hits the restaurants storage; clear between
+    tests so cache state doesn't leak."""
+    yield
+    restaurants_storage.clear_cache()
+
+
+# Inbound test number — matches ``demo_restaurant_from_menu().twilio_phone``
+# so /voice resolves to the demo via the MENU fallback (Firestore returns
+# None under TestClient because GCP isn't reachable).
+_DEMO_TO = "+16479058093"
+
+_VOICE_FORM = {"CallSid": "CAtest", "From": "+10000000000", "To": _DEMO_TO}
 
 _START_MSG = {
     "event": "start",
@@ -30,6 +47,7 @@ _START_MSG = {
         "accountSid": "ACtest",
         "tracks": ["inbound"],
         "mediaFormat": {"encoding": "audio/x-mulaw", "sampleRate": 8000, "channels": 1},
+        "customParameters": {"restaurant_id": "niko-pizza-kitchen"},
     },
 }
 
@@ -89,14 +107,20 @@ def mock_pipeline(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_voice_returns_xml():
-    response = client.post("/voice", data={"CallSid": "CAtest", "From": "+10000000000"})
+def test_voice_returns_xml(monkeypatch):
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
+    response = client.post("/voice", data=_VOICE_FORM)
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/xml")
 
 
-def test_voice_twiml_contains_media_stream_no_say():
-    response = client.post("/voice", data={"CallSid": "CAtest", "From": "+10000000000"})
+def test_voice_twiml_contains_media_stream_no_say(monkeypatch):
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
+    response = client.post("/voice", data=_VOICE_FORM)
     body = response.text
     assert "<Response>" in body
     assert "<Say" not in body          # greeting is now via ElevenLabs on start event
@@ -104,6 +128,66 @@ def test_voice_twiml_contains_media_stream_no_say():
     assert "<Stream" in body
     # TestClient sets Host: testserver
     assert "wss://testserver/media-stream" in body
+
+
+def test_voice_passes_restaurant_id_as_stream_parameter(monkeypatch):
+    """PR B (#79): /voice resolves the tenant by ``To`` and forwards the
+    id to /media-stream via a Stream <Parameter>. Twilio echoes it back
+    on the start event under ``customParameters.restaurant_id``."""
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
+    response = client.post("/voice", data=_VOICE_FORM)
+    body = response.text
+    assert "<Parameter" in body
+    assert 'name="restaurant_id"' in body
+    assert 'value="niko-pizza-kitchen"' in body
+
+
+def test_voice_uses_firestore_lookup_when_present(monkeypatch):
+    """When Firestore has a doc for the dialed number, ``/voice`` uses
+    it directly without touching the MENU fallback."""
+    from app.restaurants.models import Restaurant
+
+    seeded = Restaurant(
+        id="pizza-palace",
+        name="Pizza Palace",
+        display_phone="+14165550100",
+        twilio_phone="+14165550101",
+        address="456 Queen St W",
+        hours="11am-11pm",
+        menu={"pizzas": [], "sides": [], "drinks": []},
+    )
+    monkeypatch.setattr(
+        restaurants_storage,
+        "get_restaurant_by_twilio_phone",
+        lambda e164: seeded if e164 == "+14165550101" else None,
+    )
+    response = client.post(
+        "/voice",
+        data={"CallSid": "CAtest", "From": "+10000000000", "To": "+14165550101"},
+    )
+    body = response.text
+    assert 'value="pizza-palace"' in body
+
+
+def test_voice_rejects_unmapped_number(monkeypatch):
+    """Inbound to a number with no tenant mapping plays a brief hangup
+    message instead of dead air."""
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
+    response = client.post(
+        "/voice",
+        data={"CallSid": "CAtest", "From": "+10000000000", "To": "+19999999999"},
+    )
+    assert response.status_code == 200
+    body = response.text
+    assert "<Say" in body
+    assert "not currently configured" in body
+    assert "<Hangup" in body
+    # Crucially: no Connect/Stream — we never opened the media pipeline.
+    assert "<Connect" not in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -5,11 +5,21 @@ liveness probe, and the Twilio Voice webhook. Runs fully in-process via
 ``TestClient`` — no network, no Cloud Run.
 """
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.storage import restaurants as restaurants_storage
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_restaurants_cache():
+    """The /voice tests resolve the demo via the MENU fallback. Clearing
+    the cache between tests keeps each test self-contained."""
+    yield
+    restaurants_storage.clear_cache()
 
 
 def test_root_returns_service_banner():
@@ -24,7 +34,12 @@ def test_health_returns_ok():
     assert response.json() == {"status": "ok"}
 
 
-def test_voice_returns_twiml():
+def test_voice_returns_twiml(monkeypatch):
+    """Inbound to the demo Twilio number resolves via the MENU fallback
+    (Firestore returns None in unit tests) and opens a Media Stream."""
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
     response = client.post(
         "/voice",
         data={


### PR DESCRIPTION
## Summary

Second of three backend PRs landing multi-tenancy. Wires inbound Twilio calls to the right tenant by reading the dialed number off the webhook and looking it up in the new `restaurants/` collection.

- `POST /voice` now reads `To` from the Twilio form body, calls `get_restaurant_by_twilio_phone()`, and forwards the resolved id to `/media-stream` via a Stream `<Parameter name=\"restaurant_id\" value=\"...\"/>`. Twilio echoes it back on the WebSocket `start` event under `customParameters.restaurant_id`.
- The WS handler in `media-stream` reads the parameter and loads the restaurant from cache (PR A's storage layer) instead of always calling `load_or_fallback_demo()`. If the parameter is missing — older clients, manual WS connects in tests — it falls back to the demo path so existing tests keep working.
- Unmapped numbers (no Firestore doc, not the demo) get a brief TwiML `<Say>` + `<Hangup>` instead of dead air. Logged at WARN so we can spot misconfigured tenants.
- Demo number gets a transitional fallback: if Firestore returns `None` but `To` matches the demo's hardcoded `twilio_phone` (`+16479058093`), we synthesize the Restaurant from `app.menu.MENU`. Removed in PR F.
- `requirements.txt` adds `python-multipart>=0.0.9,<1.0` — FastAPI needs it for `request.form()` on the webhook.

## Linked issue

Relates to #79 (closes after PR C). Sub-task of #4.

## Test plan

- [x] `pytest -q` — 118 passed (was 115 in PR A; +3 new tests)
- [x] New: Stream `<Parameter>` carries `restaurant_id=niko-pizza-kitchen`
- [x] New: Firestore-hit path resolves a non-demo Restaurant (e.g. `pizza-palace`)
- [x] New: rejection TwiML for unmapped `To` (no Connect/Stream emitted)
- [x] Existing `/voice` tests updated to pass `To` and mock the storage lookup
- [ ] Live test deferred until PR C lands and the demo seed is written to prod Firestore — at that point dialing the existing Twilio number should still work end-to-end

## Notes

**Webhook contract is unchanged for Twilio.** Customers still POST to `/voice`; we just consume more of the body now. No Twilio Console reconfiguration needed for the demo number.

**Demo fallback is intentional.** PR A's `load_or_fallback_demo()` plus this PR's `_resolve_restaurant_for_voice()` together mean the demo keeps answering even before the seed script has run against Firestore. Both fallbacks die together in PR F.

**Why a Stream `<Parameter>` instead of a query string on the WS URL?** Stream parameters are Twilio's documented mechanism for handing context across the HTTP→WS boundary; query strings would work but are ignored by Twilio's signed-request validation we may add later. The parameter shows up as `start.customParameters` on the existing WS event.

**No data writes change in this PR.** Orders + call_sessions still go to flat collections. PR C migrates those to nested subcollections under `restaurants/{rid}/`.