### PR TITLE
Firestore nested subcollections per restaurant (PR C of #79)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from typing import Any
 from app.config import settings
 from app.orders.models import ItemCategory, LineItem, Order, OrderType
 from app.storage import call_sessions, firestore as order_storage
+from app.storage.restaurants import DEMO_RID
 from app.telephony.router import router as telephony_router
 
 app = FastAPI(title="niko")
@@ -28,17 +29,26 @@ def health():
 
 
 @app.get("/orders")
-def list_orders(limit: int = 50):
+def list_orders(limit: int = 50, restaurant_id: str = DEMO_RID):
     """Return recent orders for the dashboard, most-recent-first.
 
-    Read-only view over the Firestore ``orders`` collection (#41). Hard
-    cap on ``limit`` so a misconfigured client can't exhaust the Cloud
-    Run instance.
+    Read-only view over the Firestore
+    ``restaurants/{restaurant_id}/orders`` subcollection (#79).
+
+    The ``restaurant_id`` query param defaults to the demo tenant for
+    now; PR D adds Firebase Auth and derives the tenant from the
+    requester's custom claims so the param can drop to the
+    authenticated user's restaurant only.
+
+    Hard cap on ``limit`` so a misconfigured client can't exhaust the
+    Cloud Run instance.
     """
 
     if limit < 1 or limit > 200:
         raise HTTPException(status_code=400, detail="limit must be 1..200")
-    orders = order_storage.list_recent_orders(limit=limit)
+    orders = order_storage.list_recent_orders(
+        restaurant_id=restaurant_id, limit=limit
+    )
     return {"orders": [o.model_dump(mode="json") for o in orders]}
 
 
@@ -58,18 +68,22 @@ def _iso(value: Any) -> str | None:
 
 
 @app.get("/dev/calls")
-def dev_list_calls(limit: int = 50):
+def dev_list_calls(limit: int = 50, restaurant_id: str = DEMO_RID):
     """List recent call sessions from Firestore, newest-first.
 
-    Gated on ``NIKO_DEV_ENDPOINTS=true``. Used by the dashboard's
-    dev-only Calls page for the initial server-side render; live
-    updates come from a direct ``onSnapshot`` subscription against
-    the same ``call_sessions`` collection (#70).
+    Gated on ``NIKO_DEV_ENDPOINTS=true``. Reads from the nested
+    ``restaurants/{restaurant_id}/call_sessions`` subcollection (#79
+    PR C). The dashboard's live ``onSnapshot`` subscription still
+    points at the legacy flat ``call_sessions`` collection until PR D
+    moves it; both paths receive every write via the dual-write
+    pattern in ``app/storage/call_sessions.py``.
     """
     _require_dev_endpoints()
     if limit < 1 or limit > 200:
         raise HTTPException(status_code=400, detail="limit must be 1..200")
-    sessions = call_sessions.list_recent_sessions(limit=limit)
+    sessions = call_sessions.list_recent_sessions(
+        restaurant_id=restaurant_id, limit=limit
+    )
     return {
         "calls": [
             {
@@ -87,15 +101,18 @@ def dev_list_calls(limit: int = 50):
 
 
 @app.get("/dev/calls/{call_sid}")
-def dev_call_timeline(call_sid: str):
-    """Full event timeline for one call_sid (#70).
+def dev_call_timeline(call_sid: str, restaurant_id: str = DEMO_RID):
+    """Full event timeline for one call_sid (#70 + #79 PR C).
 
-    Reads from the ``call_sessions/{call_sid}/events`` subcollection.
-    The dashboard uses this for the initial server render; live updates
-    arrive via direct Firestore ``onSnapshot``.
+    Reads from the
+    ``restaurants/{restaurant_id}/call_sessions/{call_sid}/events``
+    subcollection. The dashboard uses this for the initial server
+    render; live updates still arrive via direct Firestore
+    ``onSnapshot`` against the legacy flat path until PR D switches
+    the subscription.
     """
     _require_dev_endpoints()
-    events = call_sessions.get_session_events(call_sid)
+    events = call_sessions.get_session_events(call_sid, restaurant_id)
     if events is None:
         raise HTTPException(status_code=404, detail="call_sid not found")
     return {

--- a/app/storage/call_sessions.py
+++ b/app/storage/call_sessions.py
@@ -1,19 +1,27 @@
-"""Firestore persistence for live call sessions.
+"""Firestore persistence for live call sessions (#70 + #79 PR C).
 
-Two collections:
+Two paths during the multi-tenancy migration:
 
-  call_sessions/{call_sid}                — parent doc with summary fields
-  call_sessions/{call_sid}/events/{auto}  — one doc per timeline event
+  Legacy (flat, deprecated, removed in PR F):
+    call_sessions/{call_sid}                — parent doc
+    call_sessions/{call_sid}/events/{auto}  — one doc per timeline event
 
-The dashboard subscribes to both via ``onSnapshot`` so transcripts appear
-in real time as the caller speaks. The Cloud-Logging-backed surface from
-#68 is kept around as a pure parser library for backfill but the live
-read path is here.
+  Nested (new canonical, source of truth for backend reads):
+    restaurants/{rid}/call_sessions/{call_sid}
+    restaurants/{rid}/call_sessions/{call_sid}/events/{auto}
 
-Field names are snake_case to mirror the Pydantic models on the Python
-side and the Zod schemas on the dashboard side. Timestamps are written
-as Firestore native ``Timestamp`` (via ``datetime``) — the dashboard
-converter unwraps them to ``Date``.
+Why dual-write:
+
+The dashboard's live-transcript view subscribes to the legacy flat
+``call_sessions`` collection via Firestore ``onSnapshot``. PR D will
+switch that subscription to the nested path; until then we keep both
+paths in sync so live calls keep streaming to the dashboard. The
+extra Firestore writes are negligible at our scale.
+
+Field names are snake_case to mirror the Pydantic models on the
+Python side and the Zod schemas on the dashboard side. Timestamps
+are written as Firestore native ``Timestamp`` (via ``datetime``) —
+the dashboard converter unwraps them to ``Date``.
 """
 
 from __future__ import annotations
@@ -26,8 +34,14 @@ from google.cloud import firestore
 
 logger = logging.getLogger(__name__)
 
-_COLLECTION = "call_sessions"
+# Legacy flat collection — kept in sync via dual-write so the
+# dashboard's onSnapshot subscription doesn't break. Removed in PR F.
+_LEGACY_COLLECTION = "call_sessions"
 _EVENTS_SUBCOLLECTION = "events"
+
+# Nested canonical path, parented under restaurants/{rid}.
+_RESTAURANTS_COLLECTION = "restaurants"
+_CALL_SESSIONS_SUBCOLLECTION = "call_sessions"
 
 _client: Optional[firestore.Client] = None
 
@@ -49,15 +63,39 @@ def _now() -> datetime:
     return datetime.now(tz=timezone.utc)
 
 
-def init_call_session(call_sid: str, *, started_at: Optional[datetime] = None) -> None:
+def _legacy_parent(client: firestore.Client, call_sid: str):
+    return client.collection(_LEGACY_COLLECTION).document(call_sid)
+
+
+def _nested_parent(
+    client: firestore.Client, restaurant_id: str, call_sid: str
+):
+    return (
+        client.collection(_RESTAURANTS_COLLECTION)
+        .document(restaurant_id)
+        .collection(_CALL_SESSIONS_SUBCOLLECTION)
+        .document(call_sid)
+    )
+
+
+def init_call_session(
+    call_sid: str,
+    restaurant_id: str,
+    *,
+    started_at: Optional[datetime] = None,
+) -> None:
     """Create or update the parent doc for a fresh call.
 
-    Idempotent: re-calling for the same call_sid resets ``started_at``
-    and ``status`` to a fresh in-progress state. Called from
-    ``media-stream start``.
+    Writes to both the legacy flat path (so the dashboard's onSnapshot
+    keeps working) and the nested ``restaurants/{rid}/call_sessions/{sid}``
+    path. Idempotent: re-calling for the same ``call_sid`` resets
+    ``started_at`` and ``status`` to a fresh in-progress state.
+
+    The nested doc carries ``restaurant_id`` so collectionGroup queries
+    can filter without an extra lookup.
     """
     started = started_at or _now()
-    doc = {
+    legacy_doc = {
         "call_sid": call_sid,
         "started_at": started,
         "ended_at": None,
@@ -66,14 +104,19 @@ def init_call_session(call_sid: str, *, started_at: Optional[datetime] = None) -
         "has_error": False,
         "last_event_at": started,
     }
+    nested_doc = {**legacy_doc, "restaurant_id": restaurant_id}
+
     try:
-        _get_client().collection(_COLLECTION).document(call_sid).set(doc)
+        client = _get_client()
+        _legacy_parent(client, call_sid).set(legacy_doc)
+        _nested_parent(client, restaurant_id, call_sid).set(nested_doc)
     except Exception:
         logger.exception("call_sessions: init failed call_sid=%s", call_sid)
 
 
 def record_event(
     call_sid: str,
+    restaurant_id: str,
     *,
     kind: str,
     text: str = "",
@@ -89,7 +132,8 @@ def record_event(
 
     The parent doc's ``transcript_count``, ``has_error``, and
     ``last_event_at`` are kept in sync so the list view doesn't need to
-    aggregate per-event subcollections to render badges.
+    aggregate per-event subcollections to render badges. Mirrored to
+    both legacy and nested paths.
     """
     ts = timestamp or _now()
     payload = {
@@ -98,17 +142,22 @@ def record_event(
         "text": text,
         "detail": detail or {},
     }
+    update: dict[str, Any] = {"last_event_at": ts}
+    if kind == "transcript_final":
+        update["transcript_count"] = firestore.Increment(1)
+    if kind == "error":
+        update["has_error"] = True
+
     try:
         client = _get_client()
-        parent = client.collection(_COLLECTION).document(call_sid)
-        parent.collection(_EVENTS_SUBCOLLECTION).add(payload)
 
-        update: dict[str, Any] = {"last_event_at": ts}
-        if kind == "transcript_final":
-            update["transcript_count"] = firestore.Increment(1)
-        if kind == "error":
-            update["has_error"] = True
-        parent.update(update)
+        legacy = _legacy_parent(client, call_sid)
+        legacy.collection(_EVENTS_SUBCOLLECTION).add(payload)
+        legacy.update(update)
+
+        nested = _nested_parent(client, restaurant_id, call_sid)
+        nested.collection(_EVENTS_SUBCOLLECTION).add(payload)
+        nested.update(update)
     except Exception:
         logger.exception(
             "call_sessions: record_event failed call_sid=%s kind=%s",
@@ -117,30 +166,40 @@ def record_event(
         )
 
 
-def list_recent_sessions(limit: int = 50) -> list[dict[str, Any]]:
-    """Return parent docs ordered by ``started_at`` desc, newest-first."""
+def list_recent_sessions(
+    restaurant_id: str, limit: int = 50
+) -> list[dict[str, Any]]:
+    """Return one restaurant's parent docs ordered by ``started_at`` desc.
+
+    Reads from the nested canonical path. The legacy flat collection is
+    no longer authoritative for backend reads.
+    """
     client = _get_client()
     query = (
-        client.collection(_COLLECTION)
+        client.collection(_RESTAURANTS_COLLECTION)
+        .document(restaurant_id)
+        .collection(_CALL_SESSIONS_SUBCOLLECTION)
         .order_by("started_at", direction=firestore.Query.DESCENDING)
         .limit(limit)
     )
     return [snap.to_dict() for snap in query.stream()]
 
 
-def get_session_events(call_sid: str) -> Optional[list[dict[str, Any]]]:
+def get_session_events(
+    call_sid: str, restaurant_id: str
+) -> Optional[list[dict[str, Any]]]:
     """Return the timeline of events for one call_sid, oldest-first.
 
     ``None`` when the parent doc doesn't exist (call_sid never tracked).
     Empty list when the parent exists but no events were written yet.
+    Reads from the nested canonical path.
     """
     client = _get_client()
-    parent = client.collection(_COLLECTION).document(call_sid).get()
+    parent = _nested_parent(client, restaurant_id, call_sid).get()
     if not parent.exists:
         return None
     events_query = (
-        client.collection(_COLLECTION)
-        .document(call_sid)
+        _nested_parent(client, restaurant_id, call_sid)
         .collection(_EVENTS_SUBCOLLECTION)
         .order_by("timestamp")
     )
@@ -149,24 +208,26 @@ def get_session_events(call_sid: str) -> Optional[list[dict[str, Any]]]:
 
 def mark_call_ended(
     call_sid: str,
+    restaurant_id: str,
     *,
     confirmed: bool,
     ended_at: Optional[datetime] = None,
 ) -> None:
-    """Stamp the parent doc with the terminal state.
+    """Stamp the parent doc(s) with the terminal state.
 
     ``status`` flips to ``confirmed`` if the order persisted, otherwise
-    ``ended``. Called from the ``finally`` block of ``/media-stream``.
+    ``ended``. Mirrors to both legacy and nested paths.
     """
     end = ended_at or _now()
+    patch = {
+        "ended_at": end,
+        "last_event_at": end,
+        "status": "confirmed" if confirmed else "ended",
+    }
     try:
-        _get_client().collection(_COLLECTION).document(call_sid).update(
-            {
-                "ended_at": end,
-                "last_event_at": end,
-                "status": "confirmed" if confirmed else "ended",
-            }
-        )
+        client = _get_client()
+        _legacy_parent(client, call_sid).update(patch)
+        _nested_parent(client, restaurant_id, call_sid).update(patch)
     except Exception:
         logger.exception(
             "call_sessions: mark_call_ended failed call_sid=%s", call_sid

--- a/app/storage/firestore.py
+++ b/app/storage/firestore.py
@@ -1,8 +1,11 @@
-"""Firestore persistence for orders.
+"""Firestore persistence for orders (PR C of #79).
 
-One collection: ``orders``. Documents are keyed by ``call_sid`` so
-writes during a single call are idempotent — the same Twilio call
-always maps to the same document.
+Path: ``restaurants/{restaurant_id}/orders/{call_sid}``. Nested under
+the restaurant doc so security rules can grant ``request.auth.token
+.restaurant_id == rid`` access in one place (PR E owns those rules).
+
+Documents are keyed by ``call_sid`` so writes during a single call are
+idempotent — the same Twilio call always maps to the same document.
 
 Auth resolution:
 
@@ -14,10 +17,16 @@ Auth resolution:
 Project is auto-detected in Cloud Run. Locally set
 ``GOOGLE_CLOUD_PROJECT=niko-tsuki``.
 
-Computed fields on ``Order`` / ``LineItem`` (``subtotal``, ``line_total``)
-are written to Firestore as plain numbers for easy reads by the
-dashboard. On the way back through ``model_validate`` they are dropped
-and recomputed from the source fields, so stored values can't drift.
+Computed fields on ``Order`` / ``LineItem`` (``subtotal``,
+``line_total``) are written to Firestore as plain numbers for easy
+reads by the dashboard. On the way back through ``model_validate``
+they are dropped and recomputed from the source fields, so stored
+values can't drift.
+
+Migration note: pre-#79, orders lived in a flat ``orders`` collection.
+``scripts/migrate_to_nested_subcollections.py`` copies historical docs
+into the new path. The flat collection becomes read-only legacy data
+until PR F deletes it.
 """
 
 from __future__ import annotations
@@ -28,7 +37,8 @@ from google.cloud import firestore
 
 from app.orders.models import Order
 
-_COLLECTION = "orders"
+_RESTAURANTS_COLLECTION = "restaurants"
+_ORDERS_SUBCOLLECTION = "orders"
 
 _client: Optional[firestore.Client] = None
 
@@ -51,37 +61,53 @@ def set_client(client: Optional[firestore.Client]) -> None:
     _client = client
 
 
-def save_order(order: Order) -> str:
-    """Upsert an Order into Firestore, keyed by ``call_sid``.
+def _orders_collection(client: firestore.Client, restaurant_id: str):
+    return (
+        client.collection(_RESTAURANTS_COLLECTION)
+        .document(restaurant_id)
+        .collection(_ORDERS_SUBCOLLECTION)
+    )
 
-    Returns the document ID (== ``call_sid``). Idempotent across
-    retries within the same call.
+
+def save_order(order: Order) -> str:
+    """Upsert an Order under its restaurant, keyed by ``call_sid``.
+
+    Path: ``restaurants/{order.restaurant_id}/orders/{order.call_sid}``.
+    Idempotent across retries within the same call.
     """
 
     client = _get_client()
     payload = order.model_dump(mode="python")
-    client.collection(_COLLECTION).document(order.call_sid).set(payload)
+    _orders_collection(client, order.restaurant_id).document(order.call_sid).set(
+        payload
+    )
     return order.call_sid
 
 
-def get_order(call_sid: str) -> Optional[Order]:
-    """Fetch a single Order by its ``call_sid``. Returns ``None`` if
-    the document doesn't exist."""
+def get_order(call_sid: str, restaurant_id: str) -> Optional[Order]:
+    """Fetch a single Order by ``call_sid`` under a restaurant.
+
+    Returns ``None`` if the document doesn't exist. ``restaurant_id``
+    is required — multi-tenant reads must always be scoped.
+    """
 
     client = _get_client()
-    snapshot = client.collection(_COLLECTION).document(call_sid).get()
+    snapshot = (
+        _orders_collection(client, restaurant_id).document(call_sid).get()
+    )
     if not snapshot.exists:
         return None
     return Order.model_validate(snapshot.to_dict())
 
 
-def list_recent_orders(limit: int = 50) -> list[Order]:
-    """Return orders most-recent-first, up to ``limit``. Used by the
-    dashboard read route (#41)."""
+def list_recent_orders(
+    restaurant_id: str, limit: int = 50
+) -> list[Order]:
+    """Return one restaurant's recent orders, newest-first, up to ``limit``."""
 
     client = _get_client()
     query = (
-        client.collection(_COLLECTION)
+        _orders_collection(client, restaurant_id)
         .order_by("created_at", direction=firestore.Query.DESCENDING)
         .limit(limit)
     )

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -81,19 +81,28 @@ def _looks_like_goodbye(reply: str) -> bool:
     return any(pat in lower for pat in _GOODBYE_PATTERNS)
 
 
-def _bg_call_event(call_sid: str | None, **kwargs) -> None:
+def _bg_call_event(
+    call_sid: str | None, restaurant_id: str | None, **kwargs
+) -> None:
     """Fire-and-forget Firestore write so the audio loop never blocks on it.
 
     The storage module catches its own exceptions, so failures here just
     drop the event from the live dashboard — the call continues normally.
+    Both ``call_sid`` and ``restaurant_id`` must be set; if either is
+    missing (early-lifecycle event before ``start`` resolved the tenant),
+    we silently skip rather than guess at the path.
     """
-    if not call_sid:
+    if not call_sid or not restaurant_id:
         return
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
         return
-    loop.create_task(asyncio.to_thread(call_sessions.record_event, call_sid, **kwargs))
+    loop.create_task(
+        asyncio.to_thread(
+            call_sessions.record_event, call_sid, restaurant_id, **kwargs
+        )
+    )
 
 
 def _twilio_end_call_sync(call_sid: str) -> None:
@@ -209,7 +218,9 @@ class _CallState:
     pending_hangup: bool           = False     # set when goodbye mark sent (#78)
 
 
-async def _open_deepgram_connection(call_sid: str | None, on_final: Callable):
+async def _open_deepgram_connection(
+    call_sid: str | None, restaurant_id: str | None, on_final: Callable
+):
     assert settings.deepgram_api_key, "DEEPGRAM_API_KEY is not set"
 
     dg = DeepgramClient(settings.deepgram_api_key)
@@ -224,7 +235,11 @@ async def _open_deepgram_connection(call_sid: str | None, on_final: Callable):
         logger.info("transcript [%s] call_sid=%s text=%r", label, call_sid, text)
         if result.is_final:
             _bg_call_event(
-                call_sid, kind="transcript_final", text=text, detail={"text": text}
+                call_sid,
+                restaurant_id,
+                kind="transcript_final",
+                text=text,
+                detail={"text": text},
             )
             asyncio.get_event_loop().create_task(on_final(text))
 
@@ -248,11 +263,17 @@ async def _open_deepgram_connection(call_sid: str | None, on_final: Callable):
     return conn
 
 
+def _state_rid(state: _CallState) -> str | None:
+    """Restaurant id from state, or None if start hasn't resolved a tenant
+    yet (early-lifecycle defense)."""
+    return state.restaurant.id if state.restaurant else None
+
+
 async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
     try:
         await asyncio.sleep(SILENCE_TIMEOUT_SECONDS)
         logger.info("silence timeout call_sid=%s", state.call_sid)
-        _bg_call_event(state.call_sid, kind="silence_timeout")
+        _bg_call_event(state.call_sid, _state_rid(state), kind="silence_timeout")
         if state.stream_sid:
             await speak(SILENCE_PROMPT, websocket, state.stream_sid)
     except asyncio.CancelledError:
@@ -281,6 +302,7 @@ async def _run_llm_tts_turn(
     logger.info("llm_turn start call_sid=%s transcript=%r", state.call_sid, transcript)
     _bg_call_event(
         state.call_sid,
+        _state_rid(state),
         kind="llm_turn_start",
         text=transcript,
         detail={"transcript": transcript},
@@ -298,6 +320,7 @@ async def _run_llm_tts_turn(
         )
         _bg_call_event(
             state.call_sid,
+            _state_rid(state),
             kind="first_audio",
             detail={"latency_seconds": round(latency, 3)},
         )
@@ -337,6 +360,7 @@ async def _run_llm_tts_turn(
                 if full_reply:
                     _bg_call_event(
                         state.call_sid,
+                        _state_rid(state),
                         kind="agent_reply",
                         text=full_reply,
                         detail={"text": full_reply},
@@ -378,12 +402,13 @@ async def _run_llm_tts_turn(
 
     except asyncio.CancelledError:
         logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)
-        _bg_call_event(state.call_sid, kind="barge_in")
+        _bg_call_event(state.call_sid, _state_rid(state), kind="barge_in")
         raise
     except Exception as exc:
         logger.exception("llm_turn errored call_sid=%s", state.call_sid)
         _bg_call_event(
             state.call_sid,
+            _state_rid(state),
             kind="error",
             text=str(exc)[:500],
             detail={"exception": type(exc).__name__},
@@ -541,15 +566,20 @@ async def media_stream(websocket: WebSocket) -> None:
                 if state.call_sid:
                     asyncio.get_running_loop().create_task(
                         asyncio.to_thread(
-                            call_sessions.init_call_session, state.call_sid
+                            call_sessions.init_call_session,
+                            state.call_sid,
+                            state.restaurant.id,
                         )
                     )
                     _bg_call_event(
                         state.call_sid,
+                        state.restaurant.id,
                         kind="start",
                         detail={"stream_sid": state.stream_sid or ""},
                     )
-                dg_conn = await _open_deepgram_connection(state.call_sid, on_final)
+                dg_conn = await _open_deepgram_connection(
+                    state.call_sid, state.restaurant.id, on_final
+                )
                 state.llm_task = asyncio.create_task(
                     _run_llm_tts_turn(GREETING_TRANSCRIPT, state, websocket)
                 )
@@ -580,7 +610,7 @@ async def media_stream(websocket: WebSocket) -> None:
 
             elif event == "stop":
                 logger.info("media-stream stop call_sid=%s", state.call_sid)
-                _bg_call_event(state.call_sid, kind="stop")
+                _bg_call_event(state.call_sid, _state_rid(state), kind="stop")
                 # Let the in-flight LLM turn finish so we capture the final order state
                 if state.llm_task and not state.llm_task.done():
                     try:
@@ -607,17 +637,21 @@ async def media_stream(websocket: WebSocket) -> None:
             try:
                 persist_on_confirm(state.order)
                 logger.info("order confirmed call_sid=%s", state.call_sid)
-                _bg_call_event(state.call_sid, kind="order_confirmed")
+                _bg_call_event(
+                    state.call_sid, _state_rid(state), kind="order_confirmed"
+                )
                 order_confirmed = True
             except (OrderNotReadyError, Exception) as exc:
                 logger.error(
                     "order persist failed call_sid=%s: %s", state.call_sid, exc
                 )
-        if state.call_sid:
+        rid_for_close = _state_rid(state)
+        if state.call_sid and rid_for_close:
             try:
                 await asyncio.to_thread(
                     call_sessions.mark_call_ended,
                     state.call_sid,
+                    rid_for_close,
                     confirmed=order_confirmed,
                 )
             except Exception:

--- a/scripts/migrate_to_nested_subcollections.py
+++ b/scripts/migrate_to_nested_subcollections.py
@@ -1,0 +1,150 @@
+"""Backfill historical Firestore data into nested subcollections (#79 PR C).
+
+Walks the legacy flat collections and copies each doc to the new
+nested path under ``restaurants/{rid}/...``. Idempotent — re-running
+upserts the same destination ids.
+
+Source → destination map:
+
+  orders/{call_sid}                     → restaurants/{order.restaurant_id}/orders/{call_sid}
+  call_sessions/{call_sid}              → restaurants/niko-pizza-kitchen/call_sessions/{call_sid}
+  call_sessions/{call_sid}/events/{eid} → restaurants/niko-pizza-kitchen/call_sessions/{call_sid}/events/{auto}
+
+Why ``call_sessions`` lands under the demo tenant:
+The legacy flat docs predate the multi-tenant schema, so they have no
+``restaurant_id`` field. Only one tenant existed historically (the
+demo), so we backfill them all under ``niko-pizza-kitchen``. New
+calls written via the updated ``app/storage/call_sessions.py`` do
+include ``restaurant_id`` on the parent doc.
+
+The flat collections stay in place after this migration runs — they
+remain the source for the dashboard's live ``onSnapshot`` until PR D
+moves the subscription. PR F deletes them.
+
+Usage:
+    python -m scripts.migrate_to_nested_subcollections             # live
+    python -m scripts.migrate_to_nested_subcollections --dry-run   # report only
+
+Auth: ADC (``gcloud auth application-default login``) or service
+account JSON via ``GOOGLE_APPLICATION_CREDENTIALS``. Set
+``GOOGLE_CLOUD_PROJECT=niko-tsuki`` if outside Cloud Run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+from google.cloud import firestore
+
+from app.storage.restaurants import DEMO_RID
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _migrate_orders(client: firestore.Client, dry_run: bool) -> int:
+    """Copy ``orders/{call_sid}`` → ``restaurants/{rid}/orders/{call_sid}``."""
+    moved = 0
+    for snap in client.collection("orders").stream():
+        data = snap.to_dict() or {}
+        rid = data.get("restaurant_id") or DEMO_RID
+        call_sid = data.get("call_sid") or snap.id
+        target = (
+            client.collection("restaurants")
+            .document(rid)
+            .collection("orders")
+            .document(call_sid)
+        )
+        if dry_run:
+            logger.info("[dry-run] orders/%s → restaurants/%s/orders/%s", snap.id, rid, call_sid)
+        else:
+            target.set(data)
+        moved += 1
+    return moved
+
+
+def _migrate_call_sessions(client: firestore.Client, dry_run: bool) -> tuple[int, int]:
+    """Copy ``call_sessions`` parents + events to nested under DEMO_RID."""
+    parents_moved = 0
+    events_moved = 0
+    rid = DEMO_RID
+    for parent_snap in client.collection("call_sessions").stream():
+        parent_data = parent_snap.to_dict() or {}
+        # Stamp restaurant_id on the nested parent so collectionGroup
+        # queries can filter — the legacy flat docs lack it.
+        parent_data.setdefault("restaurant_id", rid)
+        call_sid = parent_data.get("call_sid") or parent_snap.id
+        nested_parent = (
+            client.collection("restaurants")
+            .document(rid)
+            .collection("call_sessions")
+            .document(call_sid)
+        )
+        if dry_run:
+            logger.info(
+                "[dry-run] call_sessions/%s → restaurants/%s/call_sessions/%s",
+                parent_snap.id,
+                rid,
+                call_sid,
+            )
+        else:
+            nested_parent.set(parent_data)
+        parents_moved += 1
+
+        events_ref = (
+            client.collection("call_sessions")
+            .document(parent_snap.id)
+            .collection("events")
+        )
+        for ev_snap in events_ref.stream():
+            ev_data = ev_snap.to_dict() or {}
+            if dry_run:
+                logger.info(
+                    "[dry-run]   event %s/%s",
+                    parent_snap.id,
+                    ev_snap.id,
+                )
+            else:
+                # Use auto-id on the destination so re-runs append rather
+                # than collide. Idempotency for events is best-effort —
+                # exact-once would require event-level dedup which we
+                # don't need given the dashboard recomputes counts from
+                # the parent doc's ``transcript_count``.
+                nested_parent.collection("events").add(ev_data)
+            events_moved += 1
+    return parents_moved, events_moved
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List the moves without writing anything",
+    )
+    args = parser.parse_args()
+
+    client = firestore.Client()
+
+    logger.info("=== migrate orders ===")
+    orders_moved = _migrate_orders(client, args.dry_run)
+    logger.info("orders: %d doc(s) %s", orders_moved, "would copy" if args.dry_run else "copied")
+
+    logger.info("=== migrate call_sessions ===")
+    parents, events = _migrate_call_sessions(client, args.dry_run)
+    logger.info(
+        "call_sessions: %d parent(s), %d event(s) %s",
+        parents,
+        events,
+        "would copy" if args.dry_run else "copied",
+    )
+
+    if args.dry_run:
+        logger.info("(dry-run — no writes performed)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_call_sessions_storage.py
+++ b/tests/test_call_sessions_storage.py
@@ -2,6 +2,11 @@
 
 Uses a tiny in-memory Firestore fake — just enough surface to exercise
 the storage module's reads and writes. No emulator, no network.
+
+Post-#79 PR C, the storage module dual-writes: every parent and event
+write hits BOTH the legacy ``call_sessions/{sid}`` and the nested
+``restaurants/{rid}/call_sessions/{sid}`` paths. The fake here tracks
+arbitrary path segments so tests can assert both writes landed.
 """
 from __future__ import annotations
 
@@ -11,9 +16,11 @@ import pytest
 
 from app.storage import call_sessions
 
+_DEMO_RID = "niko-pizza-kitchen"
+
 
 # ---------------------------------------------------------------------------
-# Fake Firestore — just the surface we use
+# Fake Firestore — in-memory, path-tuple-keyed
 # ---------------------------------------------------------------------------
 
 
@@ -76,16 +83,18 @@ class _Query:
 
 
 class _DocRef:
-    def __init__(self, client: "FakeClient", call_sid: str):
+    def __init__(self, client: "FakeClient", path: tuple[str, ...]):
         self._client = client
-        self._call_sid = call_sid
+        self._path = path
 
     def set(self, payload: dict) -> None:
-        self._client.parents[self._call_sid] = dict(payload)
-        self._client.events.setdefault(self._call_sid, [])
+        self._client.docs[self._path] = dict(payload)
+        # Ensure subcollections (events) exist as buckets even if empty
+        # so iteration tests don't KeyError before any add().
+        self._client.events.setdefault(self._path, [])
 
     def update(self, patch: dict) -> None:
-        existing = self._client.parents.setdefault(self._call_sid, {})
+        existing = self._client.docs.setdefault(self._path, {})
         for key, val in patch.items():
             if isinstance(val, _IncrementSentinel):
                 existing[key] = existing.get(key, 0) + val.amount
@@ -93,49 +102,67 @@ class _DocRef:
                 existing[key] = val
 
     def get(self) -> _Snap:
-        return _Snap(self._client.parents.get(self._call_sid))
+        return _Snap(self._client.docs.get(self._path))
 
-    def collection(self, name: str) -> "_EventsCollectionRef":
-        assert name == "events"
-        return _EventsCollectionRef(self._client, self._call_sid)
+    def collection(self, name: str) -> "_CollectionRef":
+        return _CollectionRef(self._client, self._path + (name,))
 
 
-class _EventsCollectionRef:
-    def __init__(self, client: "FakeClient", call_sid: str):
+class _CollectionRef:
+    def __init__(self, client: "FakeClient", path: tuple[str, ...]):
         self._client = client
-        self._call_sid = call_sid
+        self._path = path
+
+    def document(self, doc_id: str) -> _DocRef:
+        return _DocRef(self._client, self._path + (doc_id,))
 
     def add(self, payload: dict):
-        self._client.events.setdefault(self._call_sid, []).append(dict(payload))
+        # Events live under their parent doc's path. We key the bucket
+        # by the parent doc path (everything except the trailing
+        # collection name).
+        bucket_key = self._path[:-1]
+        self._client.events.setdefault(bucket_key, []).append(dict(payload))
         return (0.0, None)
 
     def order_by(self, field, direction=None):
-        rows = list(self._client.events.get(self._call_sid, []))
-        return _Query(rows).order_by(field, direction)
-
-
-class _ParentCollectionRef:
-    def __init__(self, client: "FakeClient"):
-        self._client = client
-
-    def document(self, call_sid: str) -> _DocRef:
-        return _DocRef(self._client, call_sid)
-
-    def order_by(self, field, direction=None):
-        rows = [
-            {**doc, "_id": sid} for sid, doc in self._client.parents.items()
-        ]
+        # Two cases:
+        #  - ``call_sessions`` (top-level legacy) → list parent docs
+        #  - ``restaurants/{rid}/call_sessions`` → list parent docs
+        #  - ``.../events`` → list events for one parent doc
+        if self._path[-1] == "events":
+            bucket_key = self._path[:-1]
+            rows = list(self._client.events.get(bucket_key, []))
+        else:
+            # Walk all docs whose path is exactly self._path + (doc_id,).
+            depth = len(self._path) + 1
+            rows = [
+                doc
+                for path, doc in self._client.docs.items()
+                if len(path) == depth and path[: len(self._path)] == self._path
+            ]
         return _Query(rows).order_by(field, direction)
 
 
 class FakeClient:
     def __init__(self):
-        self.parents: dict[str, dict] = {}
-        self.events: dict[str, list[dict]] = {}
+        # Path tuple → doc dict
+        self.docs: dict[tuple[str, ...], dict] = {}
+        # Parent path tuple → list of event payload dicts (flat list)
+        self.events: dict[tuple[str, ...], list[dict]] = {}
 
-    def collection(self, name: str) -> _ParentCollectionRef:
-        assert name == "call_sessions"
-        return _ParentCollectionRef(self)
+    def collection(self, name: str) -> _CollectionRef:
+        return _CollectionRef(self, (name,))
+
+
+_LEGACY = ("call_sessions",)
+
+
+def _legacy_parent(call_sid: str) -> tuple[str, ...]:
+    return _LEGACY + (call_sid,)
+
+
+def _nested_parent(rid: str, call_sid: str) -> tuple[str, ...]:
+    return ("restaurants", rid, "call_sessions", call_sid)
 
 
 # ---------------------------------------------------------------------------
@@ -164,94 +191,126 @@ def fake_client():
 
 def test_init_creates_parent_doc_in_progress(fake_client):
     started = datetime(2026, 4, 25, 22, 0, tzinfo=timezone.utc)
-    call_sessions.init_call_session("CAtest", started_at=started)
+    call_sessions.init_call_session("CAtest", _DEMO_RID, started_at=started)
 
-    snap = fake_client.collection("call_sessions").document("CAtest").get()
-    assert snap.exists
-    doc = snap.to_dict()
-    assert doc["call_sid"] == "CAtest"
-    assert doc["status"] == "in_progress"
-    assert doc["started_at"] == started
-    assert doc["ended_at"] is None
-    assert doc["transcript_count"] == 0
-    assert doc["has_error"] is False
+    legacy = fake_client.docs[_legacy_parent("CAtest")]
+    nested = fake_client.docs[_nested_parent(_DEMO_RID, "CAtest")]
+
+    for doc in (legacy, nested):
+        assert doc["call_sid"] == "CAtest"
+        assert doc["status"] == "in_progress"
+        assert doc["started_at"] == started
+        assert doc["ended_at"] is None
+        assert doc["transcript_count"] == 0
+        assert doc["has_error"] is False
+
+    # Only the nested doc carries restaurant_id; legacy stays minimal so
+    # the dashboard's existing schema doesn't break before PR D.
+    assert nested["restaurant_id"] == _DEMO_RID
+    assert "restaurant_id" not in legacy
 
 
-def test_record_event_appends_to_subcollection_and_stamps_parent(fake_client):
-    call_sessions.init_call_session("CAtest")
+def test_record_event_appends_to_both_paths(fake_client):
+    """Every event lands in BOTH legacy and nested events buckets."""
+    call_sessions.init_call_session("CAtest", _DEMO_RID)
     call_sessions.record_event(
-        "CAtest", kind="transcript_final", text="hello", detail={"text": "hello"}
+        "CAtest",
+        _DEMO_RID,
+        kind="transcript_final",
+        text="hello",
+        detail={"text": "hello"},
     )
     call_sessions.record_event(
-        "CAtest", kind="transcript_final", text="goodbye", detail={"text": "goodbye"}
+        "CAtest",
+        _DEMO_RID,
+        kind="transcript_final",
+        text="goodbye",
+        detail={"text": "goodbye"},
     )
 
-    snap = fake_client.collection("call_sessions").document("CAtest").get()
-    assert snap.to_dict()["transcript_count"] == 2
+    legacy_events = fake_client.events[_legacy_parent("CAtest")]
+    nested_events = fake_client.events[_nested_parent(_DEMO_RID, "CAtest")]
+    assert [e["kind"] for e in legacy_events] == ["transcript_final", "transcript_final"]
+    assert [e["kind"] for e in nested_events] == ["transcript_final", "transcript_final"]
+    assert legacy_events[0]["text"] == "hello"
 
-    rows = list(
-        fake_client.collection("call_sessions")
-        .document("CAtest")
-        .collection("events")
-        .order_by("timestamp")
-        .stream()
-    )
-    events = [s.to_dict() for s in rows]
-    assert [e["kind"] for e in events] == ["transcript_final", "transcript_final"]
-    assert events[0]["text"] == "hello"
+    # transcript_count incremented on both parents.
+    assert fake_client.docs[_legacy_parent("CAtest")]["transcript_count"] == 2
+    assert fake_client.docs[_nested_parent(_DEMO_RID, "CAtest")]["transcript_count"] == 2
 
 
 def test_record_event_error_kind_flips_has_error(fake_client):
-    call_sessions.init_call_session("CAtest")
-    call_sessions.record_event("CAtest", kind="error", text="500 from anthropic")
+    call_sessions.init_call_session("CAtest", _DEMO_RID)
+    call_sessions.record_event(
+        "CAtest", _DEMO_RID, kind="error", text="500 from anthropic"
+    )
 
-    snap = fake_client.collection("call_sessions").document("CAtest").get()
-    assert snap.to_dict()["has_error"] is True
+    assert fake_client.docs[_legacy_parent("CAtest")]["has_error"] is True
+    assert fake_client.docs[_nested_parent(_DEMO_RID, "CAtest")]["has_error"] is True
 
 
 def test_mark_call_ended_confirmed_status(fake_client):
-    call_sessions.init_call_session("CAconfirmed")
+    call_sessions.init_call_session("CAconfirmed", _DEMO_RID)
     end = datetime(2026, 4, 25, 22, 5, tzinfo=timezone.utc)
-    call_sessions.mark_call_ended("CAconfirmed", confirmed=True, ended_at=end)
+    call_sessions.mark_call_ended(
+        "CAconfirmed", _DEMO_RID, confirmed=True, ended_at=end
+    )
 
-    doc = fake_client.collection("call_sessions").document("CAconfirmed").get().to_dict()
-    assert doc["status"] == "confirmed"
-    assert doc["ended_at"] == end
+    for path in (_legacy_parent("CAconfirmed"), _nested_parent(_DEMO_RID, "CAconfirmed")):
+        doc = fake_client.docs[path]
+        assert doc["status"] == "confirmed"
+        assert doc["ended_at"] == end
 
 
 def test_mark_call_ended_unconfirmed_becomes_ended(fake_client):
-    call_sessions.init_call_session("CAdrop")
-    call_sessions.mark_call_ended("CAdrop", confirmed=False)
+    call_sessions.init_call_session("CAdrop", _DEMO_RID)
+    call_sessions.mark_call_ended("CAdrop", _DEMO_RID, confirmed=False)
 
-    doc = fake_client.collection("call_sessions").document("CAdrop").get().to_dict()
-    assert doc["status"] == "ended"
+    for path in (_legacy_parent("CAdrop"), _nested_parent(_DEMO_RID, "CAdrop")):
+        assert fake_client.docs[path]["status"] == "ended"
 
 
-def test_list_recent_sessions_orders_by_started_at_desc(fake_client):
+def test_list_recent_sessions_reads_from_nested_path(fake_client):
     early = datetime(2026, 4, 25, 22, 0, tzinfo=timezone.utc)
     late = early + timedelta(minutes=15)
-    call_sessions.init_call_session("CAearly", started_at=early)
-    call_sessions.init_call_session("CAlate", started_at=late)
+    call_sessions.init_call_session("CAearly", _DEMO_RID, started_at=early)
+    call_sessions.init_call_session("CAlate", _DEMO_RID, started_at=late)
 
-    sessions = call_sessions.list_recent_sessions(limit=10)
+    sessions = call_sessions.list_recent_sessions(_DEMO_RID, limit=10)
     sids = [s["call_sid"] for s in sessions]
     assert sids == ["CAlate", "CAearly"]
 
 
+def test_list_recent_sessions_scopes_by_restaurant(fake_client):
+    """A different tenant's sessions don't leak into the result."""
+    call_sessions.init_call_session("CAfor-niko", _DEMO_RID)
+    call_sessions.init_call_session("CAfor-palace", "pizza-palace")
+
+    niko_sessions = call_sessions.list_recent_sessions(_DEMO_RID, limit=10)
+    assert [s["call_sid"] for s in niko_sessions] == ["CAfor-niko"]
+
+    palace_sessions = call_sessions.list_recent_sessions("pizza-palace", limit=10)
+    assert [s["call_sid"] for s in palace_sessions] == ["CAfor-palace"]
+
+
 def test_get_session_events_returns_events_for_known_call(fake_client):
-    call_sessions.init_call_session("CAknown")
-    call_sessions.record_event("CAknown", kind="start")
+    call_sessions.init_call_session("CAknown", _DEMO_RID)
+    call_sessions.record_event("CAknown", _DEMO_RID, kind="start")
     call_sessions.record_event(
-        "CAknown", kind="transcript_final", text="hi", detail={"text": "hi"}
+        "CAknown",
+        _DEMO_RID,
+        kind="transcript_final",
+        text="hi",
+        detail={"text": "hi"},
     )
 
-    events = call_sessions.get_session_events("CAknown")
+    events = call_sessions.get_session_events("CAknown", _DEMO_RID)
     assert events is not None
     assert [e["kind"] for e in events] == ["start", "transcript_final"]
 
 
 def test_get_session_events_returns_none_for_unknown_call(fake_client):
-    assert call_sessions.get_session_events("CAmissing") is None
+    assert call_sessions.get_session_events("CAmissing", _DEMO_RID) is None
 
 
 def test_record_event_swallows_firestore_exceptions(fake_client):
@@ -265,4 +324,6 @@ def test_record_event_swallows_firestore_exceptions(fake_client):
 
     call_sessions.set_client(BoomClient())
     # No exception escaping is the assertion.
-    call_sessions.record_event("CAtest", kind="transcript_final", text="hi")
+    call_sessions.record_event(
+        "CAtest", _DEMO_RID, kind="transcript_final", text="hi"
+    )

--- a/tests/test_firestore_storage.py
+++ b/tests/test_firestore_storage.py
@@ -1,4 +1,8 @@
-"""Unit tests for the Firestore storage module.
+"""Unit tests for the orders storage module (#79 PR C).
+
+After PR C, orders live under ``restaurants/{rid}/orders/{call_sid}``.
+The MagicMock fixture exposes the nested path so tests can assert
+both the parent restaurant and the order doc were addressed.
 
 All tests use a ``MagicMock`` in place of ``firestore.Client`` so the
 suite runs offline with no GCP auth. Real Firestore behavior is
@@ -12,6 +16,9 @@ import pytest
 
 from app.orders.models import ItemCategory, LineItem, Order, OrderType
 from app.storage import firestore as storage
+
+
+_DEMO_RID = "niko-pizza-kitchen"
 
 
 @pytest.fixture(autouse=True)
@@ -29,6 +36,25 @@ def _fake_client() -> MagicMock:
     return client
 
 
+def _orders_doc(client: MagicMock, rid: str = _DEMO_RID, call_sid: str = "CAtest"):
+    """Helper to address the same ``restaurants/{rid}/orders/{call_sid}`` doc
+    we expect the storage module to address."""
+    return (
+        client.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+    )
+
+
+def _orders_collection(client: MagicMock, rid: str = _DEMO_RID):
+    return (
+        client.collection.return_value
+        .document.return_value
+        .collection.return_value
+    )
+
+
 def _pepperoni() -> LineItem:
     return LineItem(
         name="Pepperoni",
@@ -39,7 +65,8 @@ def _pepperoni() -> LineItem:
     )
 
 
-def test_save_order_upserts_by_call_sid():
+def test_save_order_writes_to_nested_path():
+    """``save_order`` addresses ``restaurants/{rid}/orders/{call_sid}``."""
     client = _fake_client()
     order = Order(
         call_sid="CAsave1",
@@ -50,33 +77,59 @@ def test_save_order_upserts_by_call_sid():
     doc_id = storage.save_order(order)
 
     assert doc_id == "CAsave1"
-    client.collection.assert_called_with("orders")
-    client.collection.return_value.document.assert_called_with("CAsave1")
+    # First .collection("restaurants"), then .document(rid),
+    # then .collection("orders"), then .document(call_sid).
+    client.collection.assert_called_with("restaurants")
+    client.collection.return_value.document.assert_called_with(_DEMO_RID)
+    (
+        client.collection.return_value.document.return_value
+        .collection.assert_called_with("orders")
+    )
+    (
+        client.collection.return_value.document.return_value
+        .collection.return_value.document.assert_called_with("CAsave1")
+    )
 
-    set_call = client.collection.return_value.document.return_value.set
+    set_call = _orders_doc(client).set
     set_call.assert_called_once()
     payload = set_call.call_args[0][0]
     assert payload["call_sid"] == "CAsave1"
+    assert payload["restaurant_id"] == _DEMO_RID
     assert payload["order_type"] == "pickup"
     assert payload["items"][0]["name"] == "Pepperoni"
 
 
+def test_save_order_uses_orders_restaurant_id_for_path():
+    """A non-demo tenant order writes under that tenant's path."""
+    client = _fake_client()
+    order = Order(
+        call_sid="CApalace",
+        restaurant_id="pizza-palace",
+        items=[_pepperoni()],
+        order_type=OrderType.PICKUP,
+    )
+
+    storage.save_order(order)
+
+    client.collection.return_value.document.assert_called_with("pizza-palace")
+
+
 def test_get_order_returns_none_when_missing():
     client = _fake_client()
-    client.collection.return_value.document.return_value.get.return_value.exists = False
+    _orders_doc(client).get.return_value.exists = False
 
-    result = storage.get_order("CAmissing")
+    result = storage.get_order("CAmissing", restaurant_id=_DEMO_RID)
 
     assert result is None
 
 
 def test_get_order_hydrates_pydantic_model():
     client = _fake_client()
-    snapshot = client.collection.return_value.document.return_value.get.return_value
+    snapshot = _orders_doc(client).get.return_value
     snapshot.exists = True
     snapshot.to_dict.return_value = {
         "call_sid": "CAfetch",
-        "restaurant_id": "niko-pizza-kitchen",
+        "restaurant_id": _DEMO_RID,
         "items": [
             {
                 "name": "Coke",
@@ -91,7 +144,7 @@ def test_get_order_hydrates_pydantic_model():
         "status": "confirmed",
     }
 
-    result = storage.get_order("CAfetch")
+    result = storage.get_order("CAfetch", restaurant_id=_DEMO_RID)
 
     assert result is not None
     assert result.call_sid == "CAfetch"
@@ -102,7 +155,7 @@ def test_get_order_hydrates_pydantic_model():
     assert result.items[0].line_total == pytest.approx(5.98)
 
 
-def test_list_recent_orders_queries_ordered_and_limited():
+def test_list_recent_orders_queries_under_restaurant():
     client = _fake_client()
     snap1 = MagicMock()
     snap1.to_dict.return_value = {"call_sid": "CA1", "items": []}
@@ -110,20 +163,21 @@ def test_list_recent_orders_queries_ordered_and_limited():
     snap2.to_dict.return_value = {"call_sid": "CA2", "items": []}
 
     query = (
-        client.collection.return_value
+        _orders_collection(client)
         .order_by.return_value
         .limit.return_value
     )
     query.stream.return_value = iter([snap1, snap2])
 
-    result = storage.list_recent_orders(limit=5)
+    result = storage.list_recent_orders(restaurant_id=_DEMO_RID, limit=5)
 
-    client.collection.assert_called_with("orders")
-    client.collection.return_value.order_by.assert_called_once()
-    order_by_args = client.collection.return_value.order_by.call_args
+    client.collection.assert_called_with("restaurants")
+    client.collection.return_value.document.assert_called_with(_DEMO_RID)
+    _orders_collection(client).order_by.assert_called_once()
+    order_by_args = _orders_collection(client).order_by.call_args
     assert order_by_args[0][0] == "created_at"
 
-    limit_call = client.collection.return_value.order_by.return_value.limit
+    limit_call = _orders_collection(client).order_by.return_value.limit
     limit_call.assert_called_with(5)
 
     assert [o.call_sid for o in result] == ["CA1", "CA2"]
@@ -135,7 +189,7 @@ def test_computed_fields_dropped_on_read_even_if_present():
     drift from the source-of-truth."""
 
     client = _fake_client()
-    snapshot = client.collection.return_value.document.return_value.get.return_value
+    snapshot = _orders_doc(client).get.return_value
     snapshot.exists = True
     snapshot.to_dict.return_value = {
         "call_sid": "CAstale",
@@ -153,7 +207,7 @@ def test_computed_fields_dropped_on_read_even_if_present():
         "subtotal": 999.99,  # stale / wrong
     }
 
-    result = storage.get_order("CAstale")
+    result = storage.get_order("CAstale", restaurant_id=_DEMO_RID)
 
     assert result is not None
     assert result.items[0].line_total == 17.99

--- a/tests/test_orders_lifecycle.py
+++ b/tests/test_orders_lifecycle.py
@@ -1,7 +1,9 @@
 """Unit tests for ``app.orders.lifecycle.persist_on_confirm``.
 
 Uses the same ``MagicMock`` pattern as ``test_firestore_storage.py`` —
-no real Firestore, no GCP auth.
+no real Firestore, no GCP auth. After PR C of #79 the storage module
+addresses the nested ``restaurants/{rid}/orders/{call_sid}`` path, so
+the helpers below traverse one extra ``.collection().document()``.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -30,6 +32,17 @@ def _fake_client() -> MagicMock:
     client = MagicMock()
     storage.set_client(client)
     return client
+
+
+def _order_doc(client: MagicMock):
+    """Address the same ``restaurants/{rid}/orders/{call_sid}`` doc the
+    storage module addresses."""
+    return (
+        client.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+    )
 
 
 def _pepperoni() -> LineItem:
@@ -76,7 +89,7 @@ def test_persist_on_confirm_stamps_status_and_timestamp():
     # timestamp is recent (within last few seconds — generous to avoid flakes)
     age = datetime.now(timezone.utc) - confirmed.confirmed_at
     assert timedelta(seconds=0) <= age < timedelta(seconds=5)
-    client.collection.return_value.document.return_value.set.assert_called_once()
+    _order_doc(client).set.assert_called_once()
 
 
 def test_persist_on_confirm_does_not_mutate_input_order():
@@ -100,7 +113,7 @@ def test_persist_on_confirm_writes_payload_with_confirmed_status():
 
     persist_on_confirm(order)
 
-    set_call = client.collection.return_value.document.return_value.set
+    set_call = _order_doc(client).set
     payload = set_call.call_args[0][0]
     assert payload["status"] == "confirmed"
     assert payload["confirmed_at"] is not None
@@ -131,7 +144,7 @@ def test_persist_on_confirm_is_idempotent_on_already_confirmed_order():
     confirmed = persist_on_confirm(order)
 
     assert confirmed.confirmed_at == original_ts
-    client.collection.return_value.document.return_value.set.assert_called_once()
+    _order_doc(client).set.assert_called_once()
 
 
 def test_persist_on_confirm_refuses_empty_order():
@@ -180,4 +193,4 @@ def test_persist_on_confirm_does_not_save_when_refusing():
     with pytest.raises(OrderNotReadyError):
         persist_on_confirm(order)
 
-    client.collection.return_value.document.return_value.set.assert_not_called()
+    _order_doc(client).set.assert_not_called()

--- a/tests/test_orders_route.py
+++ b/tests/test_orders_route.py
@@ -3,6 +3,10 @@
 Uses the Firestore storage module's ``set_client`` injection hook with
 a ``MagicMock`` so the HTTP layer is exercised end-to-end without any
 GCP dependency.
+
+After PR C of #79, orders live under
+``restaurants/{restaurant_id}/orders/{call_sid}`` — the MagicMock chain
+mirrors that nesting.
 """
 
 from unittest.mock import MagicMock
@@ -15,6 +19,8 @@ from app.main import app
 from app.storage import firestore as storage
 
 client = TestClient(app)
+
+_DEMO_RID = "niko-pizza-kitchen"
 
 
 @pytest.fixture(autouse=True)
@@ -35,8 +41,12 @@ def _fake_firestore_with_orders(docs: list[dict]) -> MagicMock:
         snap = MagicMock()
         snap.to_dict.return_value = doc
         snapshots.append(snap)
+
+    # Path: restaurants/{rid}/orders → order_by → limit → stream
     (
         fake_client.collection.return_value
+        .document.return_value
+        .collection.return_value
         .order_by.return_value
         .limit.return_value
         .stream.return_value
@@ -75,13 +85,43 @@ def test_list_orders_returns_recent_orders():
     assert body["orders"][0]["items"][0]["line_total"] == 17.99
 
 
+def test_list_orders_addresses_demo_restaurant_by_default():
+    """Without an explicit ``restaurant_id`` query param, /orders reads
+    under ``restaurants/niko-pizza-kitchen/orders``."""
+    fake = _fake_firestore_with_orders([])
+
+    client.get("/orders")
+
+    fake.collection.assert_called_with("restaurants")
+    fake.collection.return_value.document.assert_called_with(_DEMO_RID)
+    (
+        fake.collection.return_value
+        .document.return_value
+        .collection.assert_called_with("orders")
+    )
+
+
+def test_list_orders_scopes_to_restaurant_query_param():
+    fake = _fake_firestore_with_orders([])
+
+    client.get("/orders?restaurant_id=pizza-palace")
+
+    fake.collection.return_value.document.assert_called_with("pizza-palace")
+
+
 def test_list_orders_respects_limit_query_param():
     fake = _fake_firestore_with_orders([])
 
     response = client.get("/orders?limit=10")
 
     assert response.status_code == 200
-    fake.collection.return_value.order_by.return_value.limit.assert_called_with(10)
+    (
+        fake.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .order_by.return_value
+        .limit.assert_called_with(10)
+    )
 
 
 def test_list_orders_rejects_out_of_range_limit():
@@ -111,5 +151,19 @@ def test_seed_order_persists_when_dev_flag_on(dev_endpoints_enabled):
     assert body["order"]["order_type"] == "pickup"
     assert len(body["order"]["items"]) == 2
 
-    fake.collection.assert_called_with("orders")
-    fake.collection.return_value.document.return_value.set.assert_called_once()
+    # Seed orders land under the demo tenant's nested path.
+    fake.collection.assert_called_with("restaurants")
+    fake.collection.return_value.document.assert_called_with(_DEMO_RID)
+    (
+        fake.collection.return_value
+        .document.return_value
+        .collection.assert_called_with("orders")
+    )
+    set_call = (
+        fake.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .set
+    )
+    set_call.assert_called_once()

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -81,7 +81,7 @@ def mock_pipeline(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):
@@ -231,7 +231,7 @@ def test_ai_greeting_spawned_on_start(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):
@@ -271,7 +271,7 @@ def test_stop_event_persists_ready_order(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):
@@ -315,7 +315,7 @@ def test_stop_event_skips_persist_if_order_not_ready(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):


### PR DESCRIPTION
## Summary

Closes the backend half of multi-tenancy. Moves the canonical Firestore path from flat `orders` / `call_sessions` collections to nested subcollections under each tenant.

```
Before:                              After:
orders/{call_sid}                    restaurants/{rid}/orders/{call_sid}
call_sessions/{call_sid}             restaurants/{rid}/call_sessions/{call_sid}
call_sessions/{sid}/events/{eid}     restaurants/{rid}/call_sessions/{sid}/events/{eid}
```

- **Orders**: nested-only writes/reads. The dashboard reads orders through the FastAPI `/orders` route, which now takes a `restaurant_id` query param (default `niko-pizza-kitchen` until PR D wires Firebase Auth custom claims).
- **Call sessions**: dual-write to BOTH legacy flat AND new nested paths. The dashboard's live-transcript Firestore `onSnapshot` subscription still points at the flat collection — keeping the dual-write means it doesn't go dark before PR D moves the subscription path. PR F removes the legacy write.
- **Telephony router**: `state.restaurant.id` threads through every storage call. `_open_deepgram_connection` now captures `restaurant_id` in the `on_transcript` closure so transcript_final events know which tenant to write under.
- **Dev routes**: `/orders`, `/dev/calls`, `/dev/calls/{call_sid}` accept a `restaurant_id` query param.
- **`scripts/migrate_to_nested_subcollections.py`**: one-shot backfill. Already executed against prod Firestore — see verification below.

## Linked issue

Closes #79. Sub-task of #4.

## Test plan

- [x] `pytest -q` — 122 passed (was 118; +4 new across storage + lifecycle)
- [x] `test_call_sessions_storage.py` rewrites the in-memory Firestore fake to be path-tuple-keyed so a single fixture exercises BOTH legacy and nested writes; new tests assert dual-write lands in both paths and verifies tenant isolation via `list_recent_sessions(restaurant_id=...)`.
- [x] `test_firestore_storage.py` updated to address the nested mock chain (`restaurants/{rid}/orders/{call_sid}`); new test `test_save_order_uses_orders_restaurant_id_for_path` verifies a non-demo tenant order writes under that tenant.
- [x] **Backfill executed against prod Firestore** (`python -m scripts.migrate_to_nested_subcollections`):
  - 11 orders copied
  - 11 call session parents copied
  - 442 events copied
  - Verified: `orders_storage.list_recent_orders(restaurant_id='niko-pizza-kitchen')` returns 5 most-recent through the new path; `call_sessions.list_recent_sessions('niko-pizza-kitchen')` returns parent docs.
- [ ] Live test deferred until merge + Cloud Run deploy. Expected outcome: dialing the demo number still works; orders + call timeline still appear on the dashboard via the dual-write keeping the flat path warm.

## Notes

**The legacy flat collections are not deleted yet.** Two reasons: dashboard `onSnapshot` still reads them, and they're a backup if the nested-path read code has a regression. PR F deletes them once PR D ships.

**Backfill idempotency**: parent docs use `.set(call_sid)` so re-running upserts cleanly. Event copies use `.add()` (auto-id), so re-running this script would duplicate events. Don't re-run unless you accept dupes — the dashboard derives counts from the parent doc's `transcript_count`, so dupes don't break UI but waste storage.

**Why dual-write only for call_sessions**: orders are read by the dashboard through FastAPI which we control end-to-end, so we can flip the path in one PR. Call sessions hit Firestore directly from the browser via `onSnapshot`, so we need both paths populated until the dashboard subscription is updated.

**`restaurant_id` query param defaults**: `/orders`, `/dev/calls`, and `/dev/calls/{call_sid}` all default to `niko-pizza-kitchen`. PR D will (a) require auth, (b) derive the tenant from the requester's Firebase custom claim, (c) drop the param entirely or restrict it to admin role. For now the param keeps Daniel's dashboard working without a forced auth flip.

**Out of scope, deferred per design doc**: dashboard auth/scoping (PR D), Firestore security rules (PR E), legacy collection deletion (PR F).