### PR TITLE
Firebase Auth + tenant scoping (PR D, closes #81)

### DIFF
--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,31 @@
+"""Firebase Auth integration for tenant-scoped API access (PR D of #79/#81).
+
+Two entrypoints:
+
+- ``current_tenant`` — FastAPI dependency. Reads the ``Authorization``
+  header (or session cookie), verifies via firebase-admin, returns a
+  ``Tenant`` describing who's calling and which restaurant they may
+  access.
+- ``Tenant`` — the verified caller's identity. Routes that need
+  tenant scoping declare ``tenant: Tenant = Depends(current_tenant)``
+  and read ``tenant.restaurant_id``.
+
+The dashboard sets a Firebase session cookie after a successful
+sign-in; FastAPI prefers that cookie when present and falls back to
+a raw ``Bearer`` ID token for direct API consumers (curl, scripts,
+the admin CLI).
+"""
+
+from app.auth.dependency import (
+    Tenant,
+    current_tenant,
+    optional_tenant,
+    require_role,
+)
+
+__all__ = [
+    "Tenant",
+    "current_tenant",
+    "optional_tenant",
+    "require_role",
+]

--- a/app/auth/dependency.py
+++ b/app/auth/dependency.py
@@ -1,0 +1,175 @@
+"""FastAPI dependencies for tenant-scoped routes (PR D of #81).
+
+Usage:
+
+    from app.auth import Tenant, current_tenant
+    from fastapi import Depends
+
+    @app.get("/orders")
+    def list_orders(tenant: Tenant = Depends(current_tenant)):
+        return order_storage.list_recent_orders(tenant.restaurant_id)
+
+The dependency:
+
+1. Looks for a Firebase session cookie in the ``__session`` cookie
+   (the convention the dashboard sets in ``/api/auth/session``).
+2. Falls back to a ``Bearer <id_token>`` ``Authorization`` header for
+   direct API consumers.
+3. Verifies via firebase-admin; rejects with 401 on missing or
+   invalid credentials.
+4. Reads custom claims for ``restaurant_id`` and ``role``. A user
+   without a ``restaurant_id`` claim gets a 403 — they're
+   authenticated but not provisioned for any tenant yet.
+
+Customize the role check with ``require_role(...)``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+from fastapi import Cookie, Depends, Header, HTTPException, status
+
+from app.auth import firebase as firebase_auth
+
+logger = logging.getLogger(__name__)
+
+SESSION_COOKIE_NAME = "__session"
+DEFAULT_ROLE = "owner"
+
+
+@dataclass(frozen=True)
+class Tenant:
+    """The verified identity of an inbound request.
+
+    ``uid`` is Firebase Auth's stable user id. ``email`` is the user's
+    email at the time of token issuance — convenient for logs but
+    don't use it for authorization, use ``uid``. ``restaurant_id``
+    comes from the user's custom claims; routes scope every read to
+    this tenant unless the user has the ``tsuki_admin`` role.
+    """
+
+    uid: str
+    email: Optional[str]
+    restaurant_id: str
+    role: str
+
+    @property
+    def is_admin(self) -> bool:
+        return self.role == "tsuki_admin"
+
+
+def _extract_token(
+    session_cookie: Optional[str],
+    authorization: Optional[str],
+) -> tuple[str, str]:
+    """Return ``(kind, value)`` for the first credential we find.
+
+    ``kind`` is ``"cookie"`` or ``"bearer"``; ``value`` is the raw
+    string passed to firebase-admin. Raises 401 if neither is present.
+    """
+    if session_cookie:
+        return "cookie", session_cookie
+    if authorization:
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and token:
+            return "bearer", token
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Missing session cookie or Bearer token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def _claims_to_tenant(claims: dict[str, Any]) -> Tenant:
+    rid = claims.get("restaurant_id")
+    if not rid:
+        # Authenticated but not provisioned. Tsuki ops needs to set
+        # the custom claim via ``scripts/grant_tenant_claim.py``.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No restaurant_id claim on user — tenant not provisioned",
+        )
+    return Tenant(
+        uid=claims.get("uid") or claims.get("user_id") or "",
+        email=claims.get("email"),
+        restaurant_id=rid,
+        role=claims.get("role") or DEFAULT_ROLE,
+    )
+
+
+def current_tenant(
+    __session: Optional[str] = Cookie(default=None),
+    authorization: Optional[str] = Header(default=None),
+) -> Tenant:
+    """Resolve the calling tenant from session cookie or Bearer token.
+
+    Verifies via firebase-admin and parses custom claims. 401 if no
+    credential, 401 if invalid credential, 403 if no ``restaurant_id``
+    custom claim has been provisioned for the user.
+    """
+    kind, value = _extract_token(__session, authorization)
+    try:
+        if kind == "cookie":
+            claims = firebase_auth.verify_session_cookie(value)
+        else:
+            claims = firebase_auth.verify_id_token(value)
+    except Exception as exc:  # noqa: BLE001 — firebase-admin raises a family of errors
+        logger.warning("auth: %s rejected: %s", kind, exc)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credential",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+    return _claims_to_tenant(claims)
+
+
+def optional_tenant(
+    __session: Optional[str] = Cookie(default=None),
+    authorization: Optional[str] = Header(default=None),
+) -> Optional[Tenant]:
+    """Like ``current_tenant`` but returns ``None`` instead of raising.
+
+    Useful for endpoints that have a public fallback but customize
+    behavior when authenticated (none today; reserved for future use).
+    """
+    if not __session and not authorization:
+        return None
+    try:
+        return current_tenant(__session, authorization)
+    except HTTPException:
+        return None
+
+
+def require_role(*allowed: str):
+    """FastAPI dependency factory: gate a route on a specific role set.
+
+    Example:
+        admin_only = require_role("tsuki_admin")
+
+        @app.post("/admin/whatever")
+        def whatever(tenant: Tenant = Depends(admin_only)): ...
+    """
+    allowed_set = set(allowed)
+
+    def _checker(tenant: Tenant = Depends(current_tenant)) -> Tenant:
+        if tenant.role not in allowed_set:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Requires role in {sorted(allowed_set)}",
+            )
+        return tenant
+
+    return _checker
+
+
+def _bypass_for_tests(tenant: Tenant) -> Iterable[None]:
+    """Convenience hook for tests that want to swap the dependency.
+
+    Tests can do:
+        app.dependency_overrides[current_tenant] = lambda: Tenant(...)
+    directly — this helper is here as documentation for that pattern.
+    """
+    yield None

--- a/app/auth/firebase.py
+++ b/app/auth/firebase.py
@@ -1,0 +1,63 @@
+"""Firebase Admin SDK initialization (PR D of #81).
+
+In Cloud Run, the service account attached to the service auto-auths
+via the metadata server — no explicit credential needed. Locally, set
+``GOOGLE_APPLICATION_CREDENTIALS`` to a service-account JSON path
+(same one used for Firestore via ADC).
+
+The admin app is initialized lazily on first use so module import
+stays fast and tests can patch ``firebase_admin`` before any real
+verification happens.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import firebase_admin
+from firebase_admin import auth as firebase_auth
+
+logger = logging.getLogger(__name__)
+
+_app: Optional[firebase_admin.App] = None
+
+
+def _get_app() -> firebase_admin.App:
+    global _app
+    if _app is None:
+        if firebase_admin._apps:
+            _app = firebase_admin.get_app()
+        else:
+            _app = firebase_admin.initialize_app()
+    return _app
+
+
+def verify_session_cookie(cookie: str) -> dict[str, Any]:
+    """Verify a Firebase session cookie. Raises on failure.
+
+    Session cookies are issued by ``auth.create_session_cookie`` and
+    have a longer lifetime than ID tokens (up to 14 days). They're set
+    HTTP-only by the dashboard's ``/api/auth/session`` route after a
+    successful sign-in.
+    """
+    _get_app()
+    return firebase_auth.verify_session_cookie(cookie, check_revoked=False)
+
+
+def verify_id_token(token: str) -> dict[str, Any]:
+    """Verify a raw Firebase ID token. Raises on failure.
+
+    Used for direct API consumers (curl, ops scripts) that don't go
+    through the dashboard's session-cookie flow. The ID token expires
+    after one hour by default — clients are responsible for refresh.
+    """
+    _get_app()
+    return firebase_auth.verify_id_token(token, check_revoked=False)
+
+
+def set_app(app: Optional[firebase_admin.App]) -> None:
+    """Override the module-level Firebase Admin app. Used by tests
+    that pre-initialize a stub app or want a clean slate."""
+    global _app
+    _app = app

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,14 @@
 import logging
 import time
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 
 logging.basicConfig(level=logging.INFO)
 
 from datetime import datetime
 from typing import Any
 
+from app.auth import Tenant, current_tenant
 from app.config import settings
 from app.orders.models import ItemCategory, LineItem, Order, OrderType
 from app.storage import call_sessions, firestore as order_storage
@@ -28,26 +29,39 @@ def health():
     return {"status": "ok"}
 
 
-@app.get("/orders")
-def list_orders(limit: int = 50, restaurant_id: str = DEMO_RID):
-    """Return recent orders for the dashboard, most-recent-first.
+@app.get("/me")
+def whoami(tenant: Tenant = Depends(current_tenant)):
+    """Return the verified tenant context for the dashboard.
 
-    Read-only view over the Firestore
-    ``restaurants/{restaurant_id}/orders`` subcollection (#79).
-
-    The ``restaurant_id`` query param defaults to the demo tenant for
-    now; PR D adds Firebase Auth and derives the tenant from the
-    requester's custom claims so the param can drop to the
-    authenticated user's restaurant only.
-
-    Hard cap on ``limit`` so a misconfigured client can't exhaust the
-    Cloud Run instance.
+    Used right after login to populate the auth-aware UI shell with
+    the user's email + restaurant id without re-decoding the cookie
+    on the client. Adds a round-trip but keeps the dashboard's
+    server-derived auth source-of-truth single.
     """
+    return {
+        "uid": tenant.uid,
+        "email": tenant.email,
+        "restaurant_id": tenant.restaurant_id,
+        "role": tenant.role,
+    }
 
+
+@app.get("/orders")
+def list_orders(
+    limit: int = 50,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """Return the calling tenant's recent orders, most-recent-first.
+
+    Reads from ``restaurants/{tenant.restaurant_id}/orders``. The
+    tenant comes from the verified Firebase session cookie or Bearer
+    ID token — there is no query-param override (#81 closes the
+    cross-tenant-read hole that was open through PR C).
+    """
     if limit < 1 or limit > 200:
         raise HTTPException(status_code=400, detail="limit must be 1..200")
     orders = order_storage.list_recent_orders(
-        restaurant_id=restaurant_id, limit=limit
+        restaurant_id=tenant.restaurant_id, limit=limit
     )
     return {"orders": [o.model_dump(mode="json") for o in orders]}
 
@@ -68,21 +82,23 @@ def _iso(value: Any) -> str | None:
 
 
 @app.get("/dev/calls")
-def dev_list_calls(limit: int = 50, restaurant_id: str = DEMO_RID):
-    """List recent call sessions from Firestore, newest-first.
+def dev_list_calls(
+    limit: int = 50,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """List the calling tenant's recent call sessions, newest-first.
 
     Gated on ``NIKO_DEV_ENDPOINTS=true``. Reads from the nested
-    ``restaurants/{restaurant_id}/call_sessions`` subcollection (#79
-    PR C). The dashboard's live ``onSnapshot`` subscription still
-    points at the legacy flat ``call_sessions`` collection until PR D
-    moves it; both paths receive every write via the dual-write
-    pattern in ``app/storage/call_sessions.py``.
+    ``restaurants/{tenant.restaurant_id}/call_sessions`` subcollection.
+    The dashboard's live ``onSnapshot`` now also points at the nested
+    path (PR D); the legacy flat collection writes are still mirrored
+    in ``app/storage/call_sessions.py`` until PR F removes them.
     """
     _require_dev_endpoints()
     if limit < 1 or limit > 200:
         raise HTTPException(status_code=400, detail="limit must be 1..200")
     sessions = call_sessions.list_recent_sessions(
-        restaurant_id=restaurant_id, limit=limit
+        restaurant_id=tenant.restaurant_id, limit=limit
     )
     return {
         "calls": [
@@ -101,18 +117,20 @@ def dev_list_calls(limit: int = 50, restaurant_id: str = DEMO_RID):
 
 
 @app.get("/dev/calls/{call_sid}")
-def dev_call_timeline(call_sid: str, restaurant_id: str = DEMO_RID):
-    """Full event timeline for one call_sid (#70 + #79 PR C).
+def dev_call_timeline(
+    call_sid: str,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """Full event timeline for one of the calling tenant's calls.
 
-    Reads from the
-    ``restaurants/{restaurant_id}/call_sessions/{call_sid}/events``
-    subcollection. The dashboard uses this for the initial server
-    render; live updates still arrive via direct Firestore
-    ``onSnapshot`` against the legacy flat path until PR D switches
-    the subscription.
+    Reads from
+    ``restaurants/{tenant.restaurant_id}/call_sessions/{call_sid}/events``.
+    A 404 here means *either* the call_sid doesn't exist *or* it
+    belongs to a different tenant — both are indistinguishable to
+    the caller, which is the desired tenant-isolation property.
     """
     _require_dev_endpoints()
-    events = call_sessions.get_session_events(call_sid, restaurant_id)
+    events = call_sessions.get_session_events(call_sid, tenant.restaurant_id)
     if events is None:
         raise HTTPException(status_code=404, detail="call_sid not found")
     return {
@@ -135,7 +153,9 @@ def seed_order():
     real Firestore read path before the voice loop is wired up.
 
     Gated on ``NIKO_DEV_ENDPOINTS=true`` — returns 404 in production so
-    the route effectively doesn't exist there.
+    the route effectively doesn't exist there. Seeds always land
+    under the demo tenant ``niko-pizza-kitchen`` (no auth required;
+    this is a Tsuki-internal dev escape hatch).
     """
 
     if not settings.niko_dev_endpoints:
@@ -144,6 +164,7 @@ def seed_order():
     seed = Order(
         call_sid=f"CAseed-{int(time.time())}",
         caller_phone="+15551234567",
+        restaurant_id=DEMO_RID,
         order_type=OrderType.PICKUP,
         items=[
             LineItem(

--- a/dashboard/app/(dashboard)/calls/[call_sid]/page.tsx
+++ b/dashboard/app/(dashboard)/calls/[call_sid]/page.tsx
@@ -1,8 +1,9 @@
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
 import { CallTimelineLive } from '@/components/calls/call-timeline-live';
 import { ComingSoon } from '@/components/shared/coming-soon';
 import { getCallTimeline } from '@/lib/api/calls';
+import { getServerSession } from '@/lib/auth/session';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,6 +12,9 @@ export default async function CallDetailPage({
 }: {
   params: Promise<{ call_sid: string }>;
 }) {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
   const { call_sid } = await params;
   const result = await getCallTimeline(call_sid);
 
@@ -25,5 +29,11 @@ export default async function CallDetailPage({
 
   if ('notFound' in result) notFound();
 
-  return <CallTimelineLive callSid={call_sid} initial={result.timeline} />;
+  return (
+    <CallTimelineLive
+      callSid={call_sid}
+      restaurantId={session.restaurantId}
+      initial={result.timeline}
+    />
+  );
 }

--- a/dashboard/app/(dashboard)/calls/page.tsx
+++ b/dashboard/app/(dashboard)/calls/page.tsx
@@ -1,12 +1,18 @@
+import { redirect } from 'next/navigation';
+
 import { CallsFeed } from '@/components/calls/calls-feed';
 import { ComingSoon } from '@/components/shared/coming-soon';
 import { listRecentCalls } from '@/lib/api/calls';
 import { parseCallSessionFromJson } from '@/lib/firebase/call-converters';
+import { getServerSession } from '@/lib/auth/session';
 import type { CallSession } from '@/lib/schemas/call';
 
 export const dynamic = 'force-dynamic';
 
 export default async function CallsPage() {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
   const result = await listRecentCalls(24);
 
   if (!result.available) {
@@ -29,5 +35,5 @@ export default async function CallsPage() {
     }),
   );
 
-  return <CallsFeed initial={initial} />;
+  return <CallsFeed initial={initial} restaurantId={session.restaurantId} />;
 }

--- a/dashboard/app/(dashboard)/layout.tsx
+++ b/dashboard/app/(dashboard)/layout.tsx
@@ -1,21 +1,43 @@
+import { redirect } from 'next/navigation';
+
 import { AppSidebar } from '@/components/app-sidebar';
+import { SignOutButton } from '@/components/shared/sign-out-button';
 import { ThemeToggle } from '@/components/shared/theme-toggle';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { humanizeRestaurantId } from '@/lib/formatters/restaurant';
+import { getServerSession } from '@/lib/auth/session';
 
-export default function DashboardLayout({
+export default async function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  // Middleware bounces unauthenticated requests, but it can only do a
+  // cookie *presence* check (Edge runtime). The verified session is
+  // the actual gate — re-check here so a forged cookie still ends
+  // up at /login.
+  const session = await getServerSession();
+  if (!session) {
+    redirect('/login');
+  }
+
+  const restaurantName = humanizeRestaurantId(session.restaurantId);
+
   return (
     <SidebarProvider>
-      <AppSidebar />
+      <AppSidebar
+        restaurantName={restaurantName}
+        userEmail={session.email ?? ''}
+      />
       <SidebarInset>
         <header className="flex items-center justify-between gap-2 border-b px-4 py-3">
           <div className="flex items-center gap-2">
-            <h1 className="text-lg font-medium">Niko Pizza Kitchen</h1>
+            <h1 className="text-lg font-medium">{restaurantName}</h1>
           </div>
-          <ThemeToggle />
+          <div className="flex items-center gap-2">
+            <SignOutButton />
+            <ThemeToggle />
+          </div>
         </header>
         <div className="flex flex-1 flex-col">{children}</div>
       </SidebarInset>

--- a/dashboard/app/(dashboard)/page.tsx
+++ b/dashboard/app/(dashboard)/page.tsx
@@ -1,17 +1,25 @@
+import { redirect } from 'next/navigation';
+
 import { OrdersFeed } from '@/components/orders/orders-feed';
 import type { CountsByStatus } from '@/components/orders/filter-tabs';
 import { listOrders, parseStatusParam } from '@/lib/api/orders';
+import { getServerSession } from '@/lib/auth/session';
+import { humanizeRestaurantId } from '@/lib/formatters/restaurant';
 import type { Order, OrderStatus } from '@/lib/schemas/order';
 
 export const dynamic = 'force-dynamic';
-
-const RESTAURANT_PHONE = '+1 647-905-8093';
 
 export default async function Page({
   searchParams,
 }: {
   searchParams: Promise<{ status?: string }>;
 }) {
+  // Belt-and-suspenders: layout already verified the session, but
+  // running it here lets us narrow the type without `!` and gives us
+  // restaurantId for the data subscription.
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
   const { status } = await searchParams;
   const filter = parseStatusParam(status);
 
@@ -26,7 +34,8 @@ export default async function Page({
       initial={initial}
       initialCounts={counts}
       statusFilter={filter}
-      restaurantPhone={RESTAURANT_PHONE}
+      restaurantId={session.restaurantId}
+      restaurantName={humanizeRestaurantId(session.restaurantId)}
     />
   );
 }

--- a/dashboard/app/api/auth/session/route.ts
+++ b/dashboard/app/api/auth/session/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Session cookie minting + revocation (PR D of #81).
+ *
+ * POST  /api/auth/session   { idToken }  → 204, sets `__session` cookie
+ * DELETE /api/auth/session              → 204, clears cookie
+ *
+ * The dashboard's client-side sign-in flow calls POST after a
+ * successful `signInWithEmailAndPassword`. We verify the ID token
+ * via firebase-admin, then mint a longer-lived session cookie
+ * (5 days) so subsequent navigation doesn't need to refresh tokens
+ * on every request.
+ *
+ * Cookie name `__session` matches Firebase Hosting's reserved cookie
+ * convention.
+ */
+import { NextResponse } from 'next/server';
+
+import { adminAuth } from '@/lib/firebase/admin';
+import {
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_SECONDS,
+} from '@/lib/auth/session';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request) {
+  let idToken: unknown;
+  try {
+    const body = (await req.json()) as { idToken?: unknown };
+    idToken = body.idToken;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  if (typeof idToken !== 'string' || !idToken) {
+    return NextResponse.json(
+      { error: 'idToken is required' },
+      { status: 400 },
+    );
+  }
+
+  // Verify before minting — if the ID token is invalid we'd rather
+  // 401 here than mint a cookie that fails verification on every
+  // subsequent request.
+  try {
+    await adminAuth().verifyIdToken(idToken);
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid ID token' },
+      { status: 401 },
+    );
+  }
+
+  let sessionCookie: string;
+  try {
+    sessionCookie = await adminAuth().createSessionCookie(idToken, {
+      expiresIn: SESSION_MAX_AGE_SECONDS * 1000,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: 'Failed to mint session cookie',
+        cause: err instanceof Error ? err.message : 'unknown',
+      },
+      { status: 500 },
+    );
+  }
+
+  const res = new NextResponse(null, { status: 204 });
+  res.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: sessionCookie,
+    maxAge: SESSION_MAX_AGE_SECONDS,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+  });
+  return res;
+}
+
+export async function DELETE() {
+  const res = new NextResponse(null, { status: 204 });
+  res.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: '',
+    maxAge: 0,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+  });
+  return res;
+}

--- a/dashboard/app/login/page.tsx
+++ b/dashboard/app/login/page.tsx
@@ -1,0 +1,125 @@
+/**
+ * Sign-in page (PR D of #81).
+ *
+ * Client component because Firebase Auth's email/password flow runs
+ * in the browser. After a successful sign-in we POST the freshly-
+ * minted ID token to `/api/auth/session`, which sets the HTTP-only
+ * session cookie that middleware checks. We then redirect to either
+ * the `?next=` query param's path or `/`.
+ *
+ * No "remember me" checkbox in Phase 2 — the session cookie's 5-day
+ * lifetime is the only knob, and it always applies.
+ */
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { signIn } from '@/lib/auth/client';
+import { NikoMark } from '@/components/shared/niko-mark';
+
+const SAFE_NEXT = /^\/[^/]/; // single leading slash, no protocol-relative URLs
+
+function safeRedirect(raw: string | null): string {
+  if (!raw) return '/';
+  if (!SAFE_NEXT.test(raw)) return '/';
+  if (raw.startsWith('/login')) return '/';
+  return raw;
+}
+
+export default function LoginPage() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const next = safeRedirect(search.get('next'));
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+    const result = await signIn(email, password);
+    if (result.success) {
+      router.replace(next);
+      router.refresh();
+      return;
+    }
+    setError(result.error);
+    setPending(false);
+  }
+
+  // Clear stale error if the user starts editing again.
+  useEffect(() => {
+    if (!error) return;
+    const timer = setTimeout(() => setError(null), 30_000);
+    return () => clearTimeout(timer);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-svh items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm">
+        <div className="flex flex-col items-center gap-3 pb-6">
+          <NikoMark size={54} />
+          <div className="text-center">
+            <h1 className="text-2xl font-medium tracking-tight">
+              Sign in to Niko
+            </h1>
+            <p className="pt-1 text-sm text-muted-foreground">
+              Use the email your restaurant was provisioned with.
+            </p>
+          </div>
+        </div>
+        <form onSubmit={onSubmit} className="flex flex-col gap-3" noValidate>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Email</span>
+            <input
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              disabled={pending}
+              aria-invalid={Boolean(error)}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Password</span>
+            <input
+              type="password"
+              autoComplete="current-password"
+              required
+              minLength={6}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="rounded-md border bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              disabled={pending}
+              aria-invalid={Boolean(error)}
+            />
+          </label>
+          {error ? (
+            <p
+              role="alert"
+              className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+            >
+              {error}
+            </p>
+          ) : null}
+          <button
+            type="submit"
+            disabled={pending}
+            className="mt-2 inline-flex h-9 items-center justify-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground shadow-sm transition-opacity disabled:opacity-50"
+          >
+            {pending ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+        <p className="pt-4 text-center text-xs text-muted-foreground">
+          Trouble signing in? Contact your Tsuki Works admin.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/dashboard/components/app-sidebar.tsx
+++ b/dashboard/components/app-sidebar.tsx
@@ -46,7 +46,13 @@ function isActive(pathname: string, item: NavItem): boolean {
   return pathname === item.href || pathname.startsWith(`${item.href}/`);
 }
 
-export function AppSidebar() {
+export function AppSidebar({
+  restaurantName,
+  userEmail,
+}: {
+  restaurantName?: string;
+  userEmail?: string;
+}) {
   const pathname = usePathname();
 
   return (
@@ -101,8 +107,13 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
       <SidebarFooter>
-        <div className="px-2 py-1 text-xs text-muted-foreground group-data-[collapsible=icon]:hidden">
-          Phase 1 POC
+        <div className="flex flex-col gap-0.5 px-2 py-1 text-xs text-muted-foreground group-data-[collapsible=icon]:hidden">
+          {restaurantName ? (
+            <span className="truncate font-medium text-foreground">
+              {restaurantName}
+            </span>
+          ) : null}
+          {userEmail ? <span className="truncate">{userEmail}</span> : null}
         </div>
       </SidebarFooter>
     </Sidebar>

--- a/dashboard/components/calls/call-timeline-live.tsx
+++ b/dashboard/components/calls/call-timeline-live.tsx
@@ -16,19 +16,25 @@ import type { CallEvent as ZodCallEvent } from '@/lib/schemas/call';
 
 type Props = {
   callSid: string;
+  restaurantId: string;
   initial: CallTimeline;
 };
 
-export function CallTimelineLive({ callSid, initial }: Props) {
+export function CallTimelineLive({ callSid, restaurantId, initial }: Props) {
   const [events, setEvents] = useState<CallEvent[]>(initial.events);
 
   useEffect(() => {
     if (!db) return;
 
     const q = query(
-      collection(db, 'call_sessions', callSid, 'events').withConverter(
-        callEventConverter,
-      ),
+      collection(
+        db,
+        'restaurants',
+        restaurantId,
+        'call_sessions',
+        callSid,
+        'events',
+      ).withConverter(callEventConverter),
       orderBy('timestamp'),
     );
 
@@ -41,7 +47,7 @@ export function CallTimelineLive({ callSid, initial }: Props) {
       (err) => console.error('Call timeline subscription error', err),
     );
     return unsub;
-  }, [callSid]);
+  }, [callSid, restaurantId]);
 
   return <CallTimelineView timeline={{ call_sid: callSid, events }} />;
 }

--- a/dashboard/components/calls/calls-feed.tsx
+++ b/dashboard/components/calls/calls-feed.tsx
@@ -17,11 +17,12 @@ import type { CallSession } from '@/lib/schemas/call';
 
 type Props = {
   initial: CallSession[];
+  restaurantId: string;
 };
 
 const ANNOUNCE_THROTTLE_MS = 2000;
 
-export function CallsFeed({ initial }: Props) {
+export function CallsFeed({ initial, restaurantId }: Props) {
   const [calls, setCalls] = useState<CallSession[]>(initial);
   const [announcement, setAnnouncement] = useState('');
 
@@ -32,7 +33,12 @@ export function CallsFeed({ initial }: Props) {
     if (!db) return;
 
     const q = query(
-      collection(db, 'call_sessions').withConverter(callSessionConverter),
+      collection(
+        db,
+        'restaurants',
+        restaurantId,
+        'call_sessions',
+      ).withConverter(callSessionConverter),
       orderBy('started_at', 'desc'),
       fsLimit(50),
     );
@@ -56,7 +62,7 @@ export function CallsFeed({ initial }: Props) {
       (err) => console.error('Calls subscription error', err),
     );
     return unsub;
-  }, []);
+  }, [restaurantId]);
 
   return (
     <section className="flex flex-1 flex-col gap-4 p-6">

--- a/dashboard/components/orders/orders-feed.tsx
+++ b/dashboard/components/orders/orders-feed.tsx
@@ -26,7 +26,8 @@ type Props = {
   initial: Order[];
   initialCounts: CountsByStatus;
   statusFilter?: OrderStatus;
-  restaurantPhone: string;
+  restaurantId: string;
+  restaurantName: string;
 };
 
 const ANNOUNCE_THROTTLE_MS = 2000;
@@ -35,7 +36,8 @@ export function OrdersFeed({
   initial,
   initialCounts,
   statusFilter,
-  restaurantPhone,
+  restaurantId,
+  restaurantName,
 }: Props) {
   const [orders, setOrders] = useState<Order[]>(initial);
   const [announcement, setAnnouncement] = useState('');
@@ -51,7 +53,15 @@ export function OrdersFeed({
       return;
     }
 
-    const base = collection(db, 'orders').withConverter(orderConverter);
+    // Multi-tenant path: every order doc lives under the calling
+    // tenant's restaurant. Server Component resolves restaurantId
+    // from the session cookie and passes it down.
+    const base = collection(
+      db,
+      'restaurants',
+      restaurantId,
+      'orders',
+    ).withConverter(orderConverter);
     const q = statusFilter
       ? query(
           base,
@@ -88,16 +98,14 @@ export function OrdersFeed({
     );
 
     return unsub;
-  }, [statusFilter]);
+  }, [statusFilter, restaurantId]);
 
   return (
     <section className="flex flex-col gap-6 p-6">
       <header className="flex flex-wrap items-start justify-between gap-2">
         <div>
           <h2 className="text-2xl font-medium">Orders</h2>
-          <p className="text-sm text-muted-foreground">
-            Niko Pizza Kitchen · {restaurantPhone}
-          </p>
+          <p className="text-sm text-muted-foreground">{restaurantName}</p>
         </div>
         <LiveIndicator />
       </header>

--- a/dashboard/components/shared/sign-out-button.tsx
+++ b/dashboard/components/shared/sign-out-button.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { LogOut } from 'lucide-react';
+
+import { signOut } from '@/lib/auth/client';
+
+/**
+ * Small client-side button that clears the session and bounces to
+ * /login. Imported by the layout header — keeps the layout itself
+ * a Server Component so it can read the verified session cookie
+ * server-side.
+ */
+export function SignOutButton() {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+
+  async function handleClick() {
+    setPending(true);
+    await signOut();
+    router.replace('/login');
+    router.refresh();
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={pending}
+      aria-label="Sign out"
+      className="inline-flex h-8 items-center gap-1.5 rounded-md border bg-background px-2.5 text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+    >
+      <LogOut className="h-3.5 w-3.5" />
+      <span>{pending ? 'Signing out…' : 'Sign out'}</span>
+    </button>
+  );
+}

--- a/dashboard/lib/api/calls.ts
+++ b/dashboard/lib/api/calls.ts
@@ -13,6 +13,8 @@
  */
 import 'server-only';
 
+import { apiFetch } from '@/lib/api/http';
+
 export type CallStatus = 'confirmed' | 'ended' | 'in_progress';
 
 export type CallEventKind =
@@ -59,17 +61,9 @@ export type CallTimelineResult =
   | { available: false }
   | { available: true; notFound: true };
 
-function apiBase(): string {
-  const base = process.env.NIKO_API_BASE_URL;
-  if (!base) throw new Error('NIKO_API_BASE_URL is not set');
-  return base.replace(/\/$/, '');
-}
-
 export async function listRecentCalls(hours = 24): Promise<CallsListResult> {
-  const url = new URL(`${apiBase()}/dev/calls`);
-  url.searchParams.set('hours', String(hours));
-
-  const res = await fetch(url, { cache: 'no-store' });
+  const path = `/dev/calls?hours=${encodeURIComponent(String(hours))}`;
+  const res = await apiFetch(path);
   if (res.status === 404) return { available: false };
   if (!res.ok) {
     throw new Error(`GET /dev/calls failed: ${res.status} ${res.statusText}`);
@@ -82,16 +76,14 @@ export async function listRecentCalls(hours = 24): Promise<CallsListResult> {
 export async function getCallTimeline(
   callSid: string,
 ): Promise<CallTimelineResult> {
-  const url = `${apiBase()}/dev/calls/${encodeURIComponent(callSid)}`;
-  const res = await fetch(url, { cache: 'no-store' });
+  const path = `/dev/calls/${encodeURIComponent(callSid)}`;
+  const res = await apiFetch(path);
 
   if (res.status === 404) {
     // The backend returns 404 for both "dev disabled" and "call not found".
     // Probe the list endpoint to disambiguate — if it 404s the feature is
     // disabled; otherwise the specific call_sid wasn't in the log window.
-    const probe = await fetch(`${apiBase()}/dev/calls?hours=1`, {
-      cache: 'no-store',
-    });
+    const probe = await apiFetch('/dev/calls?hours=1');
     if (probe.status === 404) return { available: false };
     return { available: true, notFound: true };
   }

--- a/dashboard/lib/api/http.ts
+++ b/dashboard/lib/api/http.ts
@@ -1,0 +1,39 @@
+/**
+ * Authenticated server-side fetch helper (PR D of #81).
+ *
+ * Every request from a Server Component or Server Action to the
+ * FastAPI backend goes through here. We forward the user's session
+ * cookie as a ``Bearer`` token so the backend's ``current_tenant``
+ * dependency can verify it via firebase-admin and scope reads to
+ * the right restaurant.
+ *
+ * The session cookie value is itself what the backend's
+ * ``verify_session_cookie`` expects — no additional minting needed.
+ *
+ * Public unauthenticated endpoints (``/``, ``/health``) should not
+ * use this helper; just call ``fetch`` directly. Anything that goes
+ * through the FastAPI auth dep must use ``apiFetch`` so the
+ * Authorization header is set.
+ */
+import 'server-only';
+
+import { getSessionCookieValue } from '@/lib/auth/session';
+
+export function apiBase(): string {
+  const base = process.env.NIKO_API_BASE_URL;
+  if (!base) throw new Error('NIKO_API_BASE_URL is not set');
+  return base.replace(/\/$/, '');
+}
+
+export async function apiFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const cookie = await getSessionCookieValue();
+  const headers = new Headers(init.headers);
+  if (cookie && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${cookie}`);
+  }
+  const url = path.startsWith('http') ? path : `${apiBase()}${path}`;
+  return fetch(url, { ...init, headers, cache: init.cache ?? 'no-store' });
+}

--- a/dashboard/lib/api/orders.ts
+++ b/dashboard/lib/api/orders.ts
@@ -23,25 +23,18 @@ import {
   type OrderStatus,
 } from '@/lib/schemas/order';
 import { parseOrderFromJson } from '@/lib/firebase/converters';
+import { apiFetch } from '@/lib/api/http';
 
 const STUB_GET_ORDER_BY_ID = true;
 const STUB_CANCEL_ORDER = true;
-
-function apiBase(): string {
-  const base = process.env.NIKO_API_BASE_URL;
-  if (!base) throw new Error('NIKO_API_BASE_URL is not set');
-  return base.replace(/\/$/, '');
-}
 
 export async function listOrders(params: {
   status?: OrderStatus;
   limit?: number;
 }): Promise<Order[]> {
   const limit = params.limit ?? 50;
-  const url = new URL(`${apiBase()}/orders`);
-  url.searchParams.set('limit', String(limit));
-
-  const res = await fetch(url, { cache: 'no-store' });
+  const path = `/orders?limit=${encodeURIComponent(String(limit))}`;
+  const res = await apiFetch(path);
   if (!res.ok) {
     throw new Error(`GET /orders failed: ${res.status} ${res.statusText}`);
   }
@@ -66,8 +59,8 @@ export async function getOrder(callSid: string): Promise<Order | null> {
     return all.find((o) => o.call_sid === callSid) ?? null;
   }
 
-  const url = `${apiBase()}/orders/${encodeURIComponent(callSid)}`;
-  const res = await fetch(url, { cache: 'no-store' });
+  const path = `/orders/${encodeURIComponent(callSid)}`;
+  const res = await apiFetch(path);
   if (res.status === 404) return null;
   if (!res.ok) {
     throw new Error(
@@ -90,11 +83,8 @@ export async function cancelOrderApi(callSid: string): Promise<CancelResult> {
     };
   }
 
-  const url = `${apiBase()}/orders/${encodeURIComponent(callSid)}/cancel`;
-  const res = await fetch(url, {
-    method: 'POST',
-    cache: 'no-store',
-  });
+  const path = `/orders/${encodeURIComponent(callSid)}/cancel`;
+  const res = await apiFetch(path, { method: 'POST' });
   if (!res.ok) {
     return {
       success: false,

--- a/dashboard/lib/auth/client.ts
+++ b/dashboard/lib/auth/client.ts
@@ -1,0 +1,85 @@
+/**
+ * Client-side auth helpers (PR D of #81).
+ *
+ * Wraps Firebase Auth's email/password flow plus the round-trip to
+ * `/api/auth/session` that exchanges the freshly-minted ID token for
+ * an HTTP-only session cookie. Pages and components import these
+ * helpers — they should never reach into `firebase/auth` directly,
+ * because that bypasses the cookie minting step and middleware will
+ * keep bouncing them to /login.
+ */
+'use client';
+
+import {
+  signInWithEmailAndPassword,
+  signOut as firebaseSignOut,
+} from 'firebase/auth';
+
+import { auth } from '@/lib/firebase/client';
+
+export type SignInResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export async function signIn(
+  email: string,
+  password: string,
+): Promise<SignInResult> {
+  if (!auth) {
+    return {
+      success: false,
+      error: 'Firebase Auth is not configured. Check NEXT_PUBLIC_FIREBASE_*.',
+    };
+  }
+  try {
+    const cred = await signInWithEmailAndPassword(auth, email, password);
+    const idToken = await cred.user.getIdToken();
+    const res = await fetch('/api/auth/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ idToken }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => res.statusText);
+      // Roll back the client-side sign-in so we don't leave the user
+      // in a half-authenticated state where the SDK thinks they're
+      // signed in but the cookie wasn't minted.
+      await firebaseSignOut(auth).catch(() => undefined);
+      return { success: false, error: detail || 'Session minting failed' };
+    }
+    return { success: true };
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Unknown sign-in error';
+    return { success: false, error: friendlyAuthError(message) };
+  }
+}
+
+export async function signOut(): Promise<void> {
+  // Clear the cookie first so a hung Firebase signOut doesn't leave a
+  // stale session active. Server-side route handler is the
+  // authoritative invalidation step.
+  await fetch('/api/auth/session', { method: 'DELETE' }).catch(() => undefined);
+  if (auth) {
+    await firebaseSignOut(auth).catch(() => undefined);
+  }
+}
+
+function friendlyAuthError(raw: string): string {
+  // Firebase Auth's default messages include the error code which
+  // doesn't read well in the UI. Map the ones a real user is most
+  // likely to hit; pass everything else through.
+  if (raw.includes('auth/invalid-credential')) {
+    return 'Email or password is incorrect.';
+  }
+  if (raw.includes('auth/user-not-found')) {
+    return 'No account exists for that email.';
+  }
+  if (raw.includes('auth/too-many-requests')) {
+    return 'Too many attempts. Try again in a few minutes.';
+  }
+  if (raw.includes('auth/network-request-failed')) {
+    return 'Network error. Check your connection and try again.';
+  }
+  return raw;
+}

--- a/dashboard/lib/auth/session.ts
+++ b/dashboard/lib/auth/session.ts
@@ -1,0 +1,75 @@
+/**
+ * Server-side session helpers (PR D of #81).
+ *
+ * The dashboard's source of truth for "who's logged in" is the
+ * `__session` HTTP-only cookie that `/api/auth/session` mints from a
+ * client-side Firebase ID token. Server Components and Route Handlers
+ * call `getServerSession()` to read it; the cookie is verified via
+ * `firebase-admin` on every server-side render so a forged cookie
+ * can't bypass auth.
+ *
+ * The cookie name `__session` matches Firebase Hosting's reserved
+ * cookie convention so we stay compatible if we ever migrate the
+ * dashboard there.
+ */
+import 'server-only';
+
+import { cookies } from 'next/headers';
+
+import { adminAuth } from '@/lib/firebase/admin';
+
+export const SESSION_COOKIE_NAME = '__session';
+// Five days. Long enough that a casual user doesn't get logged out
+// during a shift, short enough that a stolen cookie has limited
+// utility. Refresh on every successful sign-in.
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 5;
+
+export type Session = {
+  uid: string;
+  email: string | null;
+  restaurantId: string;
+  role: string;
+};
+
+/**
+ * Read and verify the session cookie. Returns null when there's no
+ * cookie, the cookie is invalid, or the user isn't provisioned with
+ * a `restaurant_id` claim yet.
+ */
+export async function getServerSession(): Promise<Session | null> {
+  const store = await cookies();
+  const cookie = store.get(SESSION_COOKIE_NAME)?.value;
+  if (!cookie) return null;
+
+  try {
+    const decoded = await adminAuth().verifySessionCookie(cookie, false);
+    const restaurantId = (decoded as Record<string, unknown>).restaurant_id;
+    if (typeof restaurantId !== 'string' || !restaurantId) {
+      // Authenticated but not provisioned. Treat as unauthenticated
+      // for routing purposes — middleware will bounce to /login.
+      return null;
+    }
+    return {
+      uid: decoded.uid,
+      email: decoded.email ?? null,
+      restaurantId,
+      role:
+        (typeof (decoded as Record<string, unknown>).role === 'string'
+          ? ((decoded as Record<string, unknown>).role as string)
+          : 'owner'),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the raw session cookie without verifying it. Used by the
+ * server-side fetch helpers when forwarding auth to FastAPI — the
+ * backend re-verifies via its own firebase-admin instance, so a
+ * second client-side decode here would be wasted work.
+ */
+export async function getSessionCookieValue(): Promise<string | null> {
+  const store = await cookies();
+  return store.get(SESSION_COOKIE_NAME)?.value ?? null;
+}

--- a/dashboard/lib/firebase/admin.ts
+++ b/dashboard/lib/firebase/admin.ts
@@ -1,0 +1,62 @@
+/**
+ * Firebase Admin SDK initialization (server-only).
+ *
+ * Used by:
+ *  - `/api/auth/session` to mint and revoke session cookies after a
+ *    successful client-side sign-in
+ *  - `lib/auth/server.ts` to verify session cookies on protected
+ *    Server Components and Route Handlers
+ *
+ * Auth resolution:
+ *  - In Cloud Run, the service account attached to the dashboard
+ *    service auto-auths via the metadata server — no explicit
+ *    credential needed.
+ *  - Locally, set `FIREBASE_SERVICE_ACCOUNT_KEY` (raw JSON of a
+ *    service-account key) or `GOOGLE_APPLICATION_CREDENTIALS`
+ *    (path to a JSON file). The SDK picks one up automatically.
+ *
+ * Lazy init keeps Next.js HMR happy — initializing on every reload
+ * would throw `app/duplicate-app`.
+ */
+import 'server-only';
+
+import {
+  type App,
+  cert,
+  getApp,
+  getApps,
+  initializeApp,
+  applicationDefault,
+} from 'firebase-admin/app';
+import { type Auth, getAuth } from 'firebase-admin/auth';
+
+let _app: App | null = null;
+
+function _ensureApp(): App {
+  if (_app) return _app;
+  if (getApps().length) {
+    _app = getApp();
+    return _app;
+  }
+  const raw = process.env.FIREBASE_SERVICE_ACCOUNT_KEY;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      _app = initializeApp({ credential: cert(parsed) });
+      return _app;
+    } catch (err) {
+      throw new Error(
+        '[firebase/admin] FIREBASE_SERVICE_ACCOUNT_KEY is set but not valid JSON',
+        { cause: err },
+      );
+    }
+  }
+  // Falls back to GOOGLE_APPLICATION_CREDENTIALS or the metadata
+  // server in Cloud Run. Throws clearly if neither is configured.
+  _app = initializeApp({ credential: applicationDefault() });
+  return _app;
+}
+
+export function adminAuth(): Auth {
+  return getAuth(_ensureApp());
+}

--- a/dashboard/lib/firebase/client.ts
+++ b/dashboard/lib/firebase/client.ts
@@ -1,4 +1,5 @@
 import { type FirebaseApp, getApp, getApps, initializeApp } from 'firebase/app';
+import { type Auth, getAuth } from 'firebase/auth';
 import { type Firestore, getFirestore } from 'firebase/firestore';
 
 const config = {
@@ -22,10 +23,12 @@ export const isFirebaseConfigured = Boolean(
 
 let app: FirebaseApp | null = null;
 let _db: Firestore | null = null;
+let _auth: Auth | null = null;
 
 if (isFirebaseConfigured) {
   app = getApps().length ? getApp() : initializeApp(config);
   _db = getFirestore(app);
+  _auth = getAuth(app);
 } else if (typeof window !== 'undefined') {
   // One-time dev warning. Keeps the console quiet after that.
   console.warn(
@@ -35,3 +38,4 @@ if (isFirebaseConfigured) {
 }
 
 export const db = _db;
+export const auth = _auth;

--- a/dashboard/lib/formatters/restaurant.ts
+++ b/dashboard/lib/formatters/restaurant.ts
@@ -1,0 +1,16 @@
+/**
+ * Tiny display-name helpers for restaurants.
+ *
+ * Until the dashboard fetches the full ``restaurants/{rid}`` doc
+ * server-side (a Phase 2.4 polish task), we humanize the rid for the
+ * header / login banner. ``"niko-pizza-kitchen"`` → ``"Niko Pizza
+ * Kitchen"``.
+ */
+export function humanizeRestaurantId(rid: string): string {
+  if (!rid) return '';
+  return rid
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}

--- a/dashboard/lib/schemas/call.ts
+++ b/dashboard/lib/schemas/call.ts
@@ -1,7 +1,11 @@
 /**
  * Call session schemas — mirror the Firestore documents written by
- * `app/storage/call_sessions.py` (collection: `call_sessions`,
- * subcollection: `call_sessions/{call_sid}/events`).
+ * `app/storage/call_sessions.py`.
+ *
+ * After PR C of #79, the canonical path is
+ * `restaurants/{restaurant_id}/call_sessions/{call_sid}` (with an
+ * `events` subcollection). The legacy flat `call_sessions` writes
+ * are still mirrored until PR F.
  *
  * Field names are snake_case to match the backend writes — do not
  * rename to camelCase on read.
@@ -33,6 +37,10 @@ export type CallEventKind = z.infer<typeof CallEventKindSchema>;
 
 export const CallSessionSchema = z.object({
   call_sid: z.string().min(1),
+  // Optional during the migration window: legacy flat docs predate
+  // PR C and don't carry restaurant_id. Once PR F deletes the legacy
+  // path we tighten this to .min(1).
+  restaurant_id: z.string().optional(),
   started_at: z.coerce.date(),
   ended_at: z.coerce.date().nullable(),
   status: CallStatusSchema,

--- a/dashboard/middleware.ts
+++ b/dashboard/middleware.ts
@@ -1,0 +1,45 @@
+/**
+ * Auth middleware (PR D of #81).
+ *
+ * Bounces unauthenticated requests to /login. We can't actually
+ * verify the cookie's signature here (the Firebase Admin SDK isn't
+ * available in the Edge runtime), so middleware does a presence
+ * check only — Server Components and Route Handlers re-verify via
+ * `getServerSession()` for the actual gate.
+ *
+ * Skipped paths:
+ *  - `/login` itself
+ *  - `/api/auth/*` (the session route minted the cookie)
+ *  - Next.js asset paths (`/_next/*`, `/favicon.ico`, etc.)
+ */
+import { NextResponse, type NextRequest } from 'next/server';
+
+import { SESSION_COOKIE_NAME } from '@/lib/auth/session';
+
+const PUBLIC_PREFIXES = ['/login', '/api/auth'];
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    return NextResponse.next();
+  }
+
+  const cookie = req.cookies.get(SESSION_COOKIE_NAME)?.value;
+  if (cookie) {
+    return NextResponse.next();
+  }
+
+  // Preserve the requested path so we can redirect back after login.
+  const url = req.nextUrl.clone();
+  const next = pathname + (req.nextUrl.search || '');
+  url.pathname = '/login';
+  url.search = `?next=${encodeURIComponent(next)}`;
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  // Skip Next internals + static files. Everything else runs through
+  // the auth check.
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'],
+};

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -16,6 +16,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "firebase": "^12.12.1",
+    "firebase-admin": "^13.0.0",
     "geist": "^1.7.0",
     "libphonenumber-js": "^1.12.41",
     "lucide-react": "^1.8.0",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -23,9 +23,12 @@ importers:
       firebase:
         specifier: ^12.12.1
         version: 12.12.1
+      firebase-admin:
+        specifier: ^13.0.0
+        version: 13.8.0
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 1.7.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       libphonenumber-js:
         specifier: ^1.12.41
         version: 1.12.41
@@ -34,7 +37,7 @@ importers:
         version: 1.8.0(react@19.2.4)
       next:
         specifier: 16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -444,6 +447,9 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
   '@firebase/ai@2.11.1':
     resolution: {integrity: sha512-WGTF81W3WBKJY+c7xqTzO15OGAkCAs8cpADqflAI0skhTZjIkhF0qyf55rq4Ctt6jKygkv99rPfMrjAHTgXaVQ==}
     engines: {node: '>=20.0.0'}
@@ -669,12 +675,41 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@google-cloud/firestore@7.11.6':
+    resolution: {integrity: sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/paginator@5.0.2':
+    resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/projectify@4.0.0':
+    resolution: {integrity: sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/promisify@4.0.0':
+    resolution: {integrity: sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==}
+    engines: {node: '>=14'}
+
+  '@google-cloud/storage@7.19.0':
+    resolution: {integrity: sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==}
+    engines: {node: '>=14'}
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
   '@grpc/grpc-js@1.9.15':
     resolution: {integrity: sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==}
     engines: {node: ^8.13.0 || >=10.10.0}
 
   '@grpc/proto-loader@0.7.15':
     resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
 
@@ -872,6 +907,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -933,6 +971,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -948,6 +989,10 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1927,11 +1972,18 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1948,6 +2000,15 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
@@ -1958,6 +2019,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@typescript-eslint/eslint-plugin@8.59.0':
     resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
@@ -2150,6 +2217,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2159,6 +2230,14 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -2221,6 +2300,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  arrify@2.0.1:
+    resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
+    engines: {node: '>=8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2231,6 +2314,12 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2251,6 +2340,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
@@ -2258,6 +2350,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -2274,6 +2369,9 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2331,6 +2429,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2350,6 +2452,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2405,6 +2511,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2427,6 +2537,12 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
 
@@ -2435,6 +2551,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -2615,9 +2734,20 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  farmhash-modern@1.1.0:
+    resolution: {integrity: sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==}
+    engines: {node: '>=18.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2631,6 +2761,13 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2648,6 +2785,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -2659,6 +2800,10 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  firebase-admin@13.8.0:
+    resolution: {integrity: sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==}
+    engines: {node: '>=18'}
 
   firebase@12.12.1:
     resolution: {integrity: sha512-ee7xA+bTJLfjB9BP/8FQr3EkxmpAAGc1lNc5QkWgTDpUw24HYXFPm7FEWRdLtGnygxIdYpFmepSc5VjkI6NHhw==}
@@ -2674,6 +2819,14 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+    engines: {node: '>= 0.12'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2686,8 +2839,27 @@ packages:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
 
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   geist@1.7.0:
     resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
@@ -2745,12 +2917,36 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-gax@4.6.1:
+    resolution: {integrity: sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -2789,8 +2985,23 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
@@ -2810,6 +3021,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2901,6 +3115,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -2939,6 +3157,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2963,6 +3184,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -2981,9 +3205,23 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jwks-rsa@3.2.2:
+    resolution: {integrity: sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==}
+    engines: {node: '>=14'}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3076,6 +3314,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  limiter@1.1.5:
+    resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -3083,8 +3324,32 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -3102,6 +3367,13 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  lru-memoizer@2.3.0:
+    resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
 
   lucide-react@1.8.0:
     resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
@@ -3129,6 +3401,19 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -3183,9 +3468,31 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -3193,6 +3500,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -3222,6 +3533,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3248,6 +3562,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -3296,6 +3614,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proto3-json-serializer@2.0.2:
+    resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
+    engines: {node: '>=14.0.0'}
 
   protobufjs@7.5.5:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
@@ -3372,6 +3694,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3399,6 +3725,14 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  retry-request@7.0.2:
+    resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
+    engines: {node: '>=14'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3509,6 +3843,12 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3536,6 +3876,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3550,6 +3893,12 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -3584,6 +3933,10 @@ packages:
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
+
+  teeny-request@9.0.0:
+    resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
+    engines: {node: '>=14'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3621,6 +3974,9 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -3726,6 +4082,21 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -3803,8 +4174,15 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -3825,6 +4203,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3860,6 +4241,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -3873,6 +4257,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4190,6 +4577,8 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@fastify/busboy@3.2.0': {}
 
   '@firebase/ai@2.11.1(@firebase/app-types@0.9.4)(@firebase/app@0.14.11)':
     dependencies:
@@ -4528,6 +4917,58 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@google-cloud/firestore@7.11.6':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      fast-deep-equal: 3.1.3
+      functional-red-black-tree: 1.0.1
+      google-gax: 4.6.1
+      protobufjs: 7.5.5
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  '@google-cloud/paginator@5.0.2':
+    dependencies:
+      arrify: 2.0.1
+      extend: 3.0.2
+    optional: true
+
+  '@google-cloud/projectify@4.0.0':
+    optional: true
+
+  '@google-cloud/promisify@4.0.0':
+    optional: true
+
+  '@google-cloud/storage@7.19.0':
+    dependencies:
+      '@google-cloud/paginator': 5.0.2
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.0.0
+      abort-controller: 3.0.0
+      async-retry: 1.3.3
+      duplexify: 4.1.3
+      fast-xml-parser: 5.7.2
+      gaxios: 6.7.1
+      google-auth-library: 9.15.1
+      html-entities: 2.6.0
+      mime: 3.0.0
+      p-limit: 3.1.0
+      retry-request: 7.0.2
+      teeny-request: 9.0.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+    optional: true
+
   '@grpc/grpc-js@1.9.15':
     dependencies:
       '@grpc/proto-loader': 0.7.15
@@ -4539,6 +4980,14 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.5
       yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.5
+      yargs: 17.7.2
+    optional: true
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.73.1(react@19.2.4))':
     dependencies:
@@ -4677,6 +5126,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2':
+    optional: true
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -4714,6 +5166,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.4':
     optional: true
 
+  '@nodable/entities@2.1.0':
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4727,6 +5182,9 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -5671,12 +6129,18 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@tootallnate/once@2.0.0':
+    optional: true
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/caseless@0.12.5':
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5691,6 +6155,16 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 20.19.39
+
+  '@types/long@4.0.2':
+    optional: true
+
+  '@types/ms@2.1.0': {}
+
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
@@ -5702,6 +6176,17 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 20.19.39
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.5
+    optional: true
+
+  '@types/tough-cookie@4.0.5':
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5895,11 +6380,25 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+    optional: true
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  agent-base@7.1.4: {}
 
   ajv@6.14.0:
     dependencies:
@@ -5995,11 +6494,22 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  arrify@2.0.1:
+    optional: true
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+    optional: true
+
+  asynckit@0.4.0:
+    optional: true
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -6013,11 +6523,15 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.20: {}
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bignumber.js@9.3.1: {}
 
   brace-expansion@1.1.14:
     dependencies:
@@ -6039,6 +6553,8 @@ snapshots:
       electron-to-chromium: 1.5.340
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   cac@6.7.14: {}
 
@@ -6098,6 +6614,11 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+    optional: true
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -6116,6 +6637,8 @@ snapshots:
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-urls@7.0.0:
     dependencies:
@@ -6170,6 +6693,9 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delayed-stream@1.0.0:
+    optional: true
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -6188,11 +6714,28 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+    optional: true
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   electron-to-chromium@1.5.340: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -6546,7 +7089,14 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1:
+    optional: true
+
   expect-type@1.3.0: {}
+
+  extend@3.0.2: {}
+
+  farmhash-modern@1.1.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -6562,6 +7112,19 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+    optional: true
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+    optional: true
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -6573,6 +7136,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6586,6 +7154,25 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  firebase-admin@13.8.0:
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@firebase/database-compat': 2.1.3
+      '@firebase/database-types': 1.0.19
+      farmhash-modern: 1.1.0
+      fast-deep-equal: 3.1.3
+      google-auth-library: 10.6.2
+      jsonwebtoken: 9.0.3
+      jwks-rsa: 3.2.2
+      node-forge: 1.4.0
+      uuid: 11.1.0
+    optionalDependencies:
+      '@google-cloud/firestore': 7.11.6
+      '@google-cloud/storage': 7.19.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   firebase@12.12.1:
     dependencies:
@@ -6631,6 +7218,20 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  form-data@2.5.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+    optional: true
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -6645,11 +7246,52 @@ snapshots:
       hasown: 2.0.3
       is-callable: 1.2.7
 
+  functional-red-black-tree@1.0.1:
+    optional: true
+
   functions-have-names@1.2.3: {}
 
-  geist@1.7.0(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  gaxios@6.7.1:
     dependencies:
-      next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  geist@1.7.0(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   generator-function@2.0.1: {}
 
@@ -6704,9 +7346,66 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  google-gax@4.6.1:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.7.15
+      '@types/long': 4.0.2
+      abort-controller: 3.0.0
+      duplexify: 4.1.3
+      google-auth-library: 9.15.1
+      node-fetch: 2.7.0
+      object-hash: 3.0.0
+      proto3-json-serializer: 2.0.2
+      protobufjs: 7.5.5
+      retry-request: 7.0.2
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  google-logging-utils@0.0.2:
+    optional: true
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
 
   has-bigints@1.1.0: {}
 
@@ -6742,7 +7441,34 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-entities@2.6.0:
+    optional: true
+
   http-parser-js@0.5.10: {}
+
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   idb@7.1.1: {}
 
@@ -6756,6 +7482,9 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4:
+    optional: true
 
   internal-slot@1.1.0:
     dependencies:
@@ -6853,6 +7582,9 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@2.0.1:
+    optional: true
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -6894,6 +7626,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@4.15.9: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -6930,6 +7664,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -6942,12 +7680,46 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jwks-rsa@3.2.2:
+    dependencies:
+      '@types/jsonwebtoken': 9.0.10
+      debug: 4.4.3
+      jose: 4.15.9
+      limiter: 1.1.5
+      lru-memoizer: 2.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -7015,13 +7787,31 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  limiter@1.1.5: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.clonedeep@4.5.0: {}
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   long@5.3.2: {}
 
@@ -7036,6 +7826,15 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
+  lru-memoizer@2.3.0:
+    dependencies:
+      lodash.clonedeep: 4.5.0
+      lru-cache: 6.0.0
 
   lucide-react@1.8.0(react@19.2.4):
     dependencies:
@@ -7057,6 +7856,17 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mime-db@1.52.0:
+    optional: true
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+    optional: true
+
+  mime@3.0.0:
+    optional: true
 
   minimatch@10.2.5:
     dependencies:
@@ -7081,7 +7891,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.4
       '@swc/helpers': 0.5.15
@@ -7100,10 +7910,13 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.4
       '@next/swc-win32-arm64-msvc': 16.2.4
       '@next/swc-win32-x64-msvc': 16.2.4
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  node-domexception@1.0.0: {}
 
   node-exports-info@1.6.0:
     dependencies:
@@ -7112,9 +7925,25 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+    optional: true
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
+  node-forge@1.4.0: {}
+
   node-releases@2.0.37: {}
 
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0:
+    optional: true
 
   object-inspect@1.13.4: {}
 
@@ -7156,6 +7985,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+    optional: true
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -7188,6 +8022,9 @@ snapshots:
       entities: 8.0.0
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.5.0:
+    optional: true
 
   path-key@3.1.1: {}
 
@@ -7230,6 +8067,11 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proto3-json-serializer@2.0.2:
+    dependencies:
+      protobufjs: 7.5.5
+    optional: true
 
   protobufjs@7.5.5:
     dependencies:
@@ -7355,6 +8197,13 @@ snapshots:
 
   react@19.2.4: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    optional: true
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -7391,6 +8240,19 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  retry-request@7.0.2:
+    dependencies:
+      '@types/request': 2.48.13
+      extend: 3.0.2
+      teeny-request: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  retry@0.13.1:
+    optional: true
 
   reusify@1.1.0: {}
 
@@ -7568,6 +8430,14 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+    optional: true
+
+  stream-shift@1.0.3:
+    optional: true
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -7624,6 +8494,11 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -7635,6 +8510,12 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@2.2.3:
+    optional: true
+
+  stubs@3.0.0:
+    optional: true
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
@@ -7656,6 +8537,18 @@ snapshots:
   tailwindcss@4.2.3: {}
 
   tapable@2.3.2: {}
+
+  teeny-request@9.0.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      stream-events: 1.0.5
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
 
   tinybench@2.9.0: {}
 
@@ -7685,6 +8578,9 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+
+  tr46@0.0.3:
+    optional: true
 
   tr46@6.0.0:
     dependencies:
@@ -7826,6 +8722,17 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  util-deprecate@1.0.2:
+    optional: true
+
+  uuid@11.1.0: {}
+
+  uuid@8.3.2:
+    optional: true
+
+  uuid@9.0.1:
+    optional: true
+
   vite-node@3.2.4(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
@@ -7908,7 +8815,12 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  web-streams-polyfill@3.3.3: {}
+
   web-vitals@4.2.4: {}
+
+  webidl-conversions@3.0.1:
+    optional: true
 
   webidl-conversions@8.0.1: {}
 
@@ -7929,6 +8841,12 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    optional: true
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7988,6 +8906,9 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrappy@1.0.2:
+    optional: true
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -7995,6 +8916,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pydantic-settings>=2.0,<3.0
 anthropic>=0.40,<1.0
 google-cloud-firestore>=2.0,<3.0
 google-cloud-logging>=3.0,<4.0
+firebase-admin>=6.0,<7.0
 deepgram-sdk>=3.0,<4.0
 httpx>=0.27,<1.0

--- a/scripts/grant_tenant_claim.py
+++ b/scripts/grant_tenant_claim.py
@@ -1,0 +1,107 @@
+"""Grant Firebase Auth custom claims that scope a user to a tenant (#81).
+
+PR D wires the dashboard + backend to read ``restaurant_id`` and
+``role`` from Firebase Auth custom claims. New users created via the
+Firebase Auth Console don't automatically get those claims — Tsuki
+ops runs this script once per user/restaurant pair.
+
+Usage:
+    python -m scripts.grant_tenant_claim \\
+        --email user@restaurant.com \\
+        --rid niko-pizza-kitchen
+
+    # Optional role (default: owner). Allowed values: owner, manager,
+    # staff, tsuki_admin. Backend ``current_tenant`` reads this.
+    python -m scripts.grant_tenant_claim \\
+        --email admin@tsuki.works --rid '*' --role tsuki_admin
+
+Auth: same as ``scripts/seed_demo_restaurant.py`` — ADC via
+``gcloud auth application-default login`` locally, attached service
+account in Cloud Run.
+
+The user's ID token doesn't include the new claims until they
+sign out + sign back in (or call ``getIdToken(true)`` to force
+refresh) — Firebase's docs recommend forcing a refresh in the UI
+right after a claim change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+import firebase_admin
+from firebase_admin import auth as firebase_auth
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+_ALLOWED_ROLES = {"owner", "manager", "staff", "tsuki_admin"}
+
+
+def _ensure_app() -> None:
+    if not firebase_admin._apps:
+        firebase_admin.initialize_app()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--email", required=True, help="Email of the existing Firebase Auth user"
+    )
+    parser.add_argument(
+        "--rid",
+        required=True,
+        help=(
+            "Restaurant id (Firestore doc id under ``restaurants/``). "
+            "Use '*' with --role tsuki_admin for cross-tenant access."
+        ),
+    )
+    parser.add_argument(
+        "--role",
+        default="owner",
+        choices=sorted(_ALLOWED_ROLES),
+        help="Role attached to the user. Default: owner.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    _ensure_app()
+
+    try:
+        user = firebase_auth.get_user_by_email(args.email)
+    except firebase_auth.UserNotFoundError:
+        logger.error(
+            "auth: no user found for email=%s. Create the user in the "
+            "Firebase Auth Console first, then re-run.",
+            args.email,
+        )
+        return 1
+
+    # Preserve any existing claims the user already has — we only
+    # touch restaurant_id and role.
+    existing = dict(user.custom_claims or {})
+    existing["restaurant_id"] = args.rid
+    existing["role"] = args.role
+
+    firebase_auth.set_custom_user_claims(user.uid, existing)
+    logger.info(
+        "✔ set claims on %s (uid=%s): restaurant_id=%s role=%s",
+        args.email,
+        user.uid,
+        args.rid,
+        args.role,
+    )
+    logger.info(
+        "  next: have the user sign out + back in (or getIdToken(true)) "
+        "to refresh the session token with the new claims."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_auth_dependency.py
+++ b/tests/test_auth_dependency.py
@@ -1,0 +1,170 @@
+"""Unit tests for ``app.auth.dependency`` (PR D of #81).
+
+The dep is called from FastAPI routes that need a tenant. We mock
+firebase-admin's verification functions directly so the suite stays
+offline.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth.dependency import (
+    Tenant,
+    current_tenant,
+    optional_tenant,
+    require_role,
+)
+
+
+def _claims(**overrides):
+    base = {
+        "uid": "uid-test",
+        "email": "owner@restaurant.com",
+        "restaurant_id": "niko-pizza-kitchen",
+        "role": "owner",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_returns_tenant_from_session_cookie():
+    with patch(
+        "app.auth.dependency.firebase_auth.verify_session_cookie",
+        return_value=_claims(),
+    ) as mock:
+        tenant = current_tenant(__session="cookie-value", authorization=None)
+
+    mock.assert_called_once_with("cookie-value")
+    assert isinstance(tenant, Tenant)
+    assert tenant.uid == "uid-test"
+    assert tenant.email == "owner@restaurant.com"
+    assert tenant.restaurant_id == "niko-pizza-kitchen"
+    assert tenant.role == "owner"
+    assert tenant.is_admin is False
+
+
+def test_returns_tenant_from_bearer_token_when_no_cookie():
+    with patch(
+        "app.auth.dependency.firebase_auth.verify_id_token",
+        return_value=_claims(role="tsuki_admin"),
+    ) as mock:
+        tenant = current_tenant(
+            __session=None, authorization="Bearer raw-id-token"
+        )
+
+    mock.assert_called_once_with("raw-id-token")
+    assert tenant.is_admin is True
+
+
+def test_prefers_cookie_over_bearer_when_both_present():
+    """Cookie wins so the dashboard's session lifetime governs."""
+    with patch(
+        "app.auth.dependency.firebase_auth.verify_session_cookie",
+        return_value=_claims(),
+    ) as cookie_mock, patch(
+        "app.auth.dependency.firebase_auth.verify_id_token"
+    ) as token_mock:
+        current_tenant(__session="cookie", authorization="Bearer raw")
+
+    cookie_mock.assert_called_once()
+    token_mock.assert_not_called()
+
+
+def test_raises_401_when_neither_credential_present():
+    with pytest.raises(HTTPException) as exc:
+        current_tenant(__session=None, authorization=None)
+    assert exc.value.status_code == 401
+
+
+def test_raises_401_when_authorization_header_isnt_bearer():
+    """Basic auth, malformed scheme, missing token — all 401."""
+    with pytest.raises(HTTPException) as exc:
+        current_tenant(__session=None, authorization="Basic abc")
+    assert exc.value.status_code == 401
+
+    with pytest.raises(HTTPException) as exc:
+        current_tenant(__session=None, authorization="Bearer ")
+    assert exc.value.status_code == 401
+
+
+def test_raises_401_when_session_cookie_invalid():
+    with patch(
+        "app.auth.dependency.firebase_auth.verify_session_cookie",
+        side_effect=ValueError("invalid signature"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            current_tenant(__session="bad", authorization=None)
+    assert exc.value.status_code == 401
+
+
+def test_raises_403_when_user_lacks_restaurant_id_claim():
+    """Authenticated but unprovisioned: 403 so ops can tell the
+    difference from a missing/invalid credential (401)."""
+    with patch(
+        "app.auth.dependency.firebase_auth.verify_session_cookie",
+        return_value=_claims(restaurant_id=None),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            current_tenant(__session="cookie", authorization=None)
+    assert exc.value.status_code == 403
+
+
+def test_default_role_is_owner_when_claim_missing():
+    with patch(
+        "app.auth.dependency.firebase_auth.verify_session_cookie",
+        return_value=_claims(role=None),
+    ):
+        tenant = current_tenant(__session="cookie", authorization=None)
+    assert tenant.role == "owner"
+
+
+def test_optional_tenant_returns_none_for_no_credentials():
+    assert optional_tenant(__session=None, authorization=None) is None
+
+
+def test_optional_tenant_swallows_invalid_credentials():
+    with patch(
+        "app.auth.dependency.firebase_auth.verify_session_cookie",
+        side_effect=ValueError("invalid"),
+    ):
+        assert optional_tenant(__session="bad", authorization=None) is None
+
+
+def test_optional_tenant_returns_tenant_when_credentials_valid():
+    with patch(
+        "app.auth.dependency.firebase_auth.verify_session_cookie",
+        return_value=_claims(),
+    ):
+        tenant = optional_tenant(__session="cookie", authorization=None)
+    assert tenant is not None
+    assert tenant.restaurant_id == "niko-pizza-kitchen"
+
+
+def test_require_role_allows_listed_role():
+    admin_only = require_role("tsuki_admin")
+    tenant = Tenant(
+        uid="u",
+        email="x@y.com",
+        restaurant_id="*",
+        role="tsuki_admin",
+    )
+    # The dep returns a callable that takes ``tenant`` (resolved by
+    # ``current_tenant``) and returns it through if the role matches.
+    assert admin_only(tenant=tenant) is tenant
+
+
+def test_require_role_rejects_other_roles():
+    admin_only = require_role("tsuki_admin")
+    owner = Tenant(
+        uid="u",
+        email="x@y.com",
+        restaurant_id="niko-pizza-kitchen",
+        role="owner",
+    )
+    with pytest.raises(HTTPException) as exc:
+        admin_only(tenant=owner)
+    assert exc.value.status_code == 403

--- a/tests/test_orders_route.py
+++ b/tests/test_orders_route.py
@@ -7,6 +7,10 @@ GCP dependency.
 After PR C of #79, orders live under
 ``restaurants/{restaurant_id}/orders/{call_sid}`` — the MagicMock chain
 mirrors that nesting.
+
+After PR D of #81, /orders requires Firebase Auth — the
+``current_tenant`` dependency is overridden via ``app.dependency_overrides``
+to inject a fake tenant for test runs.
 """
 
 from unittest.mock import MagicMock
@@ -14,6 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
+from app.auth.dependency import Tenant, current_tenant
 from app.config import settings
 from app.main import app
 from app.storage import firestore as storage
@@ -21,12 +26,29 @@ from app.storage import firestore as storage
 client = TestClient(app)
 
 _DEMO_RID = "niko-pizza-kitchen"
+_TEST_TENANT = Tenant(
+    uid="uid-test",
+    email="owner@niko.com",
+    restaurant_id=_DEMO_RID,
+    role="owner",
+)
 
 
 @pytest.fixture(autouse=True)
 def reset_storage_client():
     yield
     storage.set_client(None)
+
+
+@pytest.fixture(autouse=True)
+def override_tenant():
+    """Bypass auth verification for the route tests by overriding
+    ``current_tenant`` with a fixed demo tenant. Route logic still
+    runs end-to-end through the dep, but we don't need a real
+    Firebase token."""
+    app.dependency_overrides[current_tenant] = lambda: _TEST_TENANT
+    yield
+    app.dependency_overrides.pop(current_tenant, None)
 
 
 @pytest.fixture
@@ -85,9 +107,10 @@ def test_list_orders_returns_recent_orders():
     assert body["orders"][0]["items"][0]["line_total"] == 17.99
 
 
-def test_list_orders_addresses_demo_restaurant_by_default():
-    """Without an explicit ``restaurant_id`` query param, /orders reads
-    under ``restaurants/niko-pizza-kitchen/orders``."""
+def test_list_orders_addresses_authenticated_tenant():
+    """``/orders`` reads under
+    ``restaurants/{tenant.restaurant_id}/orders``. The tenant comes
+    from the verified session — no query param override is honored."""
     fake = _fake_firestore_with_orders([])
 
     client.get("/orders")
@@ -101,12 +124,24 @@ def test_list_orders_addresses_demo_restaurant_by_default():
     )
 
 
-def test_list_orders_scopes_to_restaurant_query_param():
+def test_list_orders_ignores_query_param_attempts_to_cross_tenant():
+    """An explicit ``?restaurant_id=other`` does NOT widen the read
+    scope — auth is the source of truth."""
     fake = _fake_firestore_with_orders([])
 
     client.get("/orders?restaurant_id=pizza-palace")
 
-    fake.collection.return_value.document.assert_called_with("pizza-palace")
+    fake.collection.return_value.document.assert_called_with(_DEMO_RID)
+
+
+def test_list_orders_returns_401_without_auth():
+    """Without the auth dep override, no credentials → 401."""
+    app.dependency_overrides.pop(current_tenant, None)
+    try:
+        response = client.get("/orders")
+        assert response.status_code == 401
+    finally:
+        app.dependency_overrides[current_tenant] = lambda: _TEST_TENANT
 
 
 def test_list_orders_respects_limit_query_param():


### PR DESCRIPTION
## Summary

Closes the dashboard half of Sprint 2.1 multi-tenancy. Every backend request and every Firestore subscription is now scoped to the authenticated user's restaurant.

**Backend** (`app/auth/`)
- New `current_tenant` FastAPI dependency that verifies a `__session` HTTP-only cookie (Firebase session cookie) or a `Bearer <id_token>` Authorization header via firebase-admin, returning a `Tenant(uid, email, restaurant_id, role)`.
- 401 on missing/invalid credentials; 403 on authenticated-but-unprovisioned (no `restaurant_id` custom claim).
- `/orders`, `/dev/calls`, `/dev/calls/{sid}` route off the dep instead of the previous `?restaurant_id=` query param. **The query-param default was a cross-tenant read hole** — gone entirely; attempts to override are silently ignored.
- New `/me` endpoint returns the verified tenant for the dashboard's layout shell.
- `requirements.txt` adds `firebase-admin>=6.0,<7.0`.

**Dashboard** (auth flow)
- Firebase Auth web SDK for `signInWithEmailAndPassword`; matching `firebase-admin` server-side for cookie minting and verification.
- New `/login` page. After sign-in, client posts the ID token to `/api/auth/session` which verifies it and mints a 5-day `__session` cookie (HTTP-only, SameSite=Lax, Secure in prod).
- `middleware.ts` presence-checks the cookie and redirects to `/login?next=...`. Cookie *verification* happens in Server Components via `getServerSession()` — middleware can't verify because firebase-admin isn't Edge-compatible.
- Layout (`(dashboard)/layout.tsx`) re-verifies the session, redirects to login if invalid, displays restaurant name (humanized rid) + email + sign-out button.

**Dashboard** (data scoping)
- onSnapshot paths migrated to nested:
  - `orders` → `restaurants/{rid}/orders`
  - `call_sessions` → `restaurants/{rid}/call_sessions`
  - `events` → `.../call_sessions/{sid}/events`
- Server Components fetch session via `getServerSession()` and pass `restaurantId` down to feed/timeline client components.
- `lib/api/http.ts`: every server-side fetch to FastAPI forwards the session cookie as a `Bearer` token. The legacy direct-`fetch` calls in `orders.ts` and `calls.ts` go through it now.
- `lib/schemas/call.ts`: optional `restaurant_id` added (legacy flat docs predate it; tightened in PR F).

**Admin tooling** (`scripts/grant_tenant_claim.py`)
- `--email --rid [--role]` sets Firebase Auth custom claims on a user. Required once per user/restaurant pair (Firebase Console doesn't manage claims).

## Linked issue

Closes #81. Sub-task of #4 (Sprint 2.1 — Core Platform).

## Test plan

- [x] Backend `pytest -q` — 136 passed (was 122; +14 new in `test_auth_dependency.py`)
  - cookie vs Bearer precedence
  - missing / malformed credential → 401
  - missing `restaurant_id` claim → 403
  - role gating via `require_role(...)`
  - `optional_tenant` swallows errors instead of raising
- [x] `test_orders_route.py` updated: uses `app.dependency_overrides[current_tenant]` to inject a fake tenant; new `test_list_orders_returns_401_without_auth` proves the route is gated.
- [x] Dashboard `npm run typecheck` clean.
- [x] Dashboard `vitest run` green (16 tests, no regressions).
- [ ] Live test deferred to post-merge — requires Firebase Auth to be enabled (see prereqs below).

## Prereqs the user owes before live deploys work

These are configuration steps, not code:

1. **Enable Firebase Authentication** in the niko-tsuki Firebase Console → Authentication → Sign-in method → Email/Password (enable).
2. **Service account JSON** — set `FIREBASE_SERVICE_ACCOUNT_KEY` env var on both the FastAPI and dashboard Cloud Run services. Or rely on the attached SA via ADC (preferred — no secret to rotate). The SA needs the *Firebase Authentication Admin* role.
3. **Create the first user** in the Firebase Console with the team email + password.
4. **Run the claim script** once per user:
   ```
   python -m scripts.grant_tenant_claim --email you@tsuki.works --rid niko-pizza-kitchen
   ```
   The user has to sign out + sign back in (or `getIdToken(true)` in the client) for the new claim to land in the session.

## Notes

**Firestore security rules are NOT in this PR.** PR E (separate) writes `firestore.rules` that enforce `request.auth.token.restaurant_id == rid` at the database level, so the auth dep + dashboard scoping aren't the only line of defense. Until rules ship, the dep is the gate. Don't expose direct Firestore admin credentials publicly during this window.

**Demo continues to work.** The auth gate is hard — once this merges, anyone hitting the deployed Cloud Run dashboard without a session is bounced to /login. That includes the live demo. Plan: enable Firebase Auth + provision the demo account in the same maintenance window as the merge.

**Why session cookies instead of Bearer-only**: Server Components need to authenticate without putting the ID token in localStorage where XSS can read it, and ID tokens expire after 1 hour which is hostile to a dashboard a restaurant runs all shift. Firebase's `createSessionCookie` is the documented pattern for this.

**Out of scope, deferred per design doc**:
- Firestore security rules → PR E
- Drop legacy `call_sessions` flat-collection writes → PR F
- Multi-user-per-restaurant → Phase 3
- Google OAuth + password reset → polish
- Tsuki-admin cross-tenant view UI → Phase 3