### PR TITLE
Fix dashboard build: wrap useSearchParams in Suspense

### DIFF
--- a/dashboard/app/login/page.tsx
+++ b/dashboard/app/login/page.tsx
@@ -12,7 +12,7 @@
  */
 'use client';
 
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { signIn } from '@/lib/auth/client';
@@ -27,7 +27,18 @@ function safeRedirect(raw: string | null): string {
   return raw;
 }
 
+// Next 15 requires `useSearchParams` to be wrapped in <Suspense> so
+// the surrounding tree can statically prerender. Hoisting the form
+// into an inner component keeps the suspense boundary tight.
 export default function LoginPage() {
+  return (
+    <Suspense fallback={<LoginShell />}>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
+function LoginForm() {
   const router = useRouter();
   const search = useSearchParams();
   const next = safeRedirect(search.get('next'));
@@ -119,6 +130,31 @@ export default function LoginPage() {
         <p className="pt-4 text-center text-xs text-muted-foreground">
           Trouble signing in? Contact your Tsuki Works admin.
         </p>
+      </div>
+    </main>
+  );
+}
+
+/**
+ * Shown while the searchParams hook is suspended during prerender.
+ * Mirrors the LoginForm chrome so the layout doesn't pop in when the
+ * client takes over.
+ */
+function LoginShell() {
+  return (
+    <main className="flex min-h-svh items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm">
+        <div className="flex flex-col items-center gap-3 pb-6">
+          <NikoMark size={54} />
+          <div className="text-center">
+            <h1 className="text-2xl font-medium tracking-tight">
+              Sign in to Niko
+            </h1>
+            <p className="pt-1 text-sm text-muted-foreground">
+              Loading…
+            </p>
+          </div>
+        </div>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

Hotfix for the broken dashboard deploy on master after PR #89 merged.

The login page from PR D called \`useSearchParams()\` at the top of the default export. Next.js 16 requires that hook to live inside a \`<Suspense>\` boundary so the surrounding tree can statically prerender; without it the build errors out on \`/login\`:

\`\`\`
Error occurred prerendering page \"/login\":
useSearchParams() should be wrapped in a suspense boundary
\`\`\`

That failed the post-merge \"Deploy Dashboard to Cloud Run\" run, leaving master in a half-deployed state (backend bumped to auth-required routes, dashboard stuck on the pre-auth build → calls to \`/orders\` 401).

## Fix

Hoist the form into an inner \`LoginForm\` component and wrap it in \`<Suspense fallback={<LoginShell />}>\`. The shell mirrors the form chrome so the layout doesn't pop in when the client takes over.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm build\` — green; \`/login\` now emits as a static prerender (○ static)
- [ ] Post-merge: watch the dashboard deploy succeed and verify https://niko-dashboard-ciyyvuq2pq-uc.a.run.app/login renders.

## Linked

Follow-up to PR #89 (Firebase Auth + tenant scoping). No issue ref — pure deploy hotfix.