### PR TITLE
Fix dashboard 500: split auth constants out of session.ts

### DIFF
--- a/dashboard/lib/auth/constants.ts
+++ b/dashboard/lib/auth/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Auth-related constants that need to be readable from the Edge
+ * runtime (middleware) AND the Node runtime (route handlers,
+ * Server Components).
+ *
+ * Anything Node-specific — `firebase-admin`, `next/headers`,
+ * `cookies()` — has to live in `lib/auth/session.ts`. Importing
+ * that file from the middleware pulls those Node-only modules into
+ * the Edge bundle and crashes at request time with:
+ *
+ *     Error: The edge runtime does not support Node.js 'process' module.
+ *
+ * Keep this file tiny and dependency-free.
+ */
+
+export const SESSION_COOKIE_NAME = '__session';
+
+// Five days. Long enough that a casual user doesn't get logged out
+// during a shift, short enough that a stolen cookie has limited
+// utility. Refreshed on every successful sign-in.
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 5;

--- a/dashboard/lib/auth/session.ts
+++ b/dashboard/lib/auth/session.ts
@@ -17,12 +17,15 @@ import 'server-only';
 import { cookies } from 'next/headers';
 
 import { adminAuth } from '@/lib/firebase/admin';
+import {
+  SESSION_COOKIE_NAME,
+  SESSION_MAX_AGE_SECONDS,
+} from '@/lib/auth/constants';
 
-export const SESSION_COOKIE_NAME = '__session';
-// Five days. Long enough that a casual user doesn't get logged out
-// during a shift, short enough that a stolen cookie has limited
-// utility. Refresh on every successful sign-in.
-export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 5;
+// Re-exports for backwards compatibility with existing imports —
+// middleware.ts must import from `@/lib/auth/constants` directly to
+// stay Edge-runtime safe.
+export { SESSION_COOKIE_NAME, SESSION_MAX_AGE_SECONDS };
 
 export type Session = {
   uid: string;

--- a/dashboard/middleware.ts
+++ b/dashboard/middleware.ts
@@ -14,7 +14,11 @@
  */
 import { NextResponse, type NextRequest } from 'next/server';
 
-import { SESSION_COOKIE_NAME } from '@/lib/auth/session';
+// Edge-runtime safe: do NOT import from lib/auth/session here — that
+// file pulls in firebase-admin via lib/firebase/admin, which uses
+// Node's `process` module and crashes the Edge bundle. Keep
+// middleware imports limited to constants and Edge-compatible code.
+import { SESSION_COOKIE_NAME } from '@/lib/auth/constants';
 
 const PUBLIC_PREFIXES = ['/login', '/api/auth'];
 


### PR DESCRIPTION
## Summary

Second hotfix for the post-PR-#89 dashboard. PR #91 unstuck the build; this one unsticks the **runtime**.

Every dashboard request was 500ing with:

\`\`\`
Error: The edge runtime does not support Node.js 'process' module.
\`\`\`

\`middleware.ts\` runs in the Edge runtime. PR D's middleware imported \`SESSION_COOKIE_NAME\` from \`lib/auth/session.ts\`, which transitively imports \`lib/firebase/admin.ts\` (firebase-admin), which uses \`process\` — crashing the Edge bundle.

## Fix

Hoist the two constants (\`SESSION_COOKIE_NAME\`, \`SESSION_MAX_AGE_SECONDS\`) into a new \`dashboard/lib/auth/constants.ts\` — pure data, no Node-only imports.

- \`middleware.ts\` now imports from \`@/lib/auth/constants\`.
- \`lib/auth/session.ts\` re-exports the same names so existing call sites (route handlers, Server Components) keep compiling without churn.

Local \`pnpm build\` passed before and after — the Edge-runtime crash only surfaces at request time when Cloud Run evaluates the bundle, which is why both PR #89 and PR #91 deploys built green but served 500s.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm build\` green
- [ ] Post-merge: hit \`https://niko-dashboard-ciyyvuq2pq-uc.a.run.app/\` (no cookie) → expect 307 to \`/login?next=/\`. Hit \`/login\` → expect 200.

## Notes

Worth considering as a follow-up: a \`pnpm test:e2e\` step that boots the dashboard locally and probes a few routes. Would have caught this before deploy. Out of scope for the hotfix.

## Linked

Follow-up to PR #89 (Firebase Auth + tenant scoping) and PR #91 (Suspense fix).