### PR TITLE
Fix post-login 500: forward session cookie as Cookie header (not Bearer)

### DIFF
--- a/app/auth/dependency.py
+++ b/app/auth/dependency.py
@@ -100,6 +100,30 @@ def _claims_to_tenant(claims: dict[str, Any]) -> Tenant:
     )
 
 
+def _verify_credential(kind: str, value: str) -> dict:
+    """Verify a Firebase credential. Tries the kind-specific path
+    first; if Bearer fails an ID-token verify we retry as a session
+    cookie so callers that forward a session cookie via Bearer (some
+    server-to-server clients) still authenticate.
+
+    Raises the underlying firebase-admin exception on failure so
+    ``current_tenant`` can map it to a 401.
+    """
+    if kind == "cookie":
+        return firebase_auth.verify_session_cookie(value)
+    # Bearer path. Try ID token first — that's what
+    # ``signInWithEmailAndPassword`` produces. Fall back to session
+    # cookie verify when the issuer mismatches (the dashboard mints
+    # session cookies and forwards them; both should be accepted).
+    try:
+        return firebase_auth.verify_id_token(value)
+    except Exception as id_token_err:  # noqa: BLE001
+        try:
+            return firebase_auth.verify_session_cookie(value)
+        except Exception:  # noqa: BLE001
+            raise id_token_err
+
+
 def current_tenant(
     __session: Optional[str] = Cookie(default=None),
     authorization: Optional[str] = Header(default=None),
@@ -112,10 +136,7 @@ def current_tenant(
     """
     kind, value = _extract_token(__session, authorization)
     try:
-        if kind == "cookie":
-            claims = firebase_auth.verify_session_cookie(value)
-        else:
-            claims = firebase_auth.verify_id_token(value)
+        claims = _verify_credential(kind, value)
     except Exception as exc:  # noqa: BLE001 — firebase-admin raises a family of errors
         logger.warning("auth: %s rejected: %s", kind, exc)
         raise HTTPException(

--- a/dashboard/lib/api/http.ts
+++ b/dashboard/lib/api/http.ts
@@ -3,20 +3,21 @@
  *
  * Every request from a Server Component or Server Action to the
  * FastAPI backend goes through here. We forward the user's session
- * cookie as a ``Bearer`` token so the backend's ``current_tenant``
- * dependency can verify it via firebase-admin and scope reads to
- * the right restaurant.
- *
- * The session cookie value is itself what the backend's
- * ``verify_session_cookie`` expects — no additional minting needed.
+ * cookie via the ``Cookie`` header (as ``__session=<value>``) so the
+ * backend's ``current_tenant`` dependency can read it as a cookie
+ * and verify via ``verify_session_cookie`` — session cookies have a
+ * different issuer than ID tokens (``session.firebase.google.com``
+ * vs ``securetoken.google.com``), so forwarding via Bearer would
+ * tank ``verify_id_token`` with an "iss" claim mismatch.
  *
  * Public unauthenticated endpoints (``/``, ``/health``) should not
  * use this helper; just call ``fetch`` directly. Anything that goes
  * through the FastAPI auth dep must use ``apiFetch`` so the
- * Authorization header is set.
+ * cookie header is set.
  */
 import 'server-only';
 
+import { SESSION_COOKIE_NAME } from '@/lib/auth/constants';
 import { getSessionCookieValue } from '@/lib/auth/session';
 
 export function apiBase(): string {
@@ -31,8 +32,8 @@ export async function apiFetch(
 ): Promise<Response> {
   const cookie = await getSessionCookieValue();
   const headers = new Headers(init.headers);
-  if (cookie && !headers.has('Authorization')) {
-    headers.set('Authorization', `Bearer ${cookie}`);
+  if (cookie && !headers.has('Cookie')) {
+    headers.set('Cookie', `${SESSION_COOKIE_NAME}=${cookie}`);
   }
   const url = path.startsWith('http') ? path : `${apiBase()}${path}`;
   return fetch(url, { ...init, headers, cache: init.cache ?? 'no-store' });


### PR DESCRIPTION
## Summary

Third hotfix on the multi-tenant dashboard rollout. The login flow now mints the session cookie cleanly, but every Server Component that fetches the FastAPI backend was 401ing afterward, leaving the user staring at:

> A server error occurred. Reload to try again.

Backend log showed the cause:

\`\`\`
Firebase ID token has incorrect \"iss\" (issuer) claim.
Expected \"securetoken.google.com/niko-tsuki\"
but got    \"session.firebase.google.com/niko-tsuki\"
\`\`\`

The dashboard's \`apiFetch\` helper was forwarding the session-cookie value via \`Authorization: Bearer ...\`. The backend's auth dep treated that as an ID token and called \`verify_id_token\`, which rejects session cookies because they have a different issuer.

## Fix

**Two-pronged** so a future integration that confuses the two doesn't reintroduce the same break:

1. **Dashboard** (\`lib/api/http.ts\`) — forward the session cookie via the **\`Cookie\` header** (\`__session=<value>\`). Architecturally where it belongs; the FastAPI dep already reads it via \`Cookie(default=None)\`.
2. **Backend** (\`app/auth/dependency.py\`) — add a fallback so a Bearer token that fails \`verify_id_token\` is also tried against \`verify_session_cookie\`. Forgiving for direct API consumers (curl, ops scripts) that don't differentiate between the two.

## Test plan

- [x] \`pytest tests/test_auth_dependency.py\` — 13/13 pass; the new fallback path preserves the existing 401-on-invalid-credential contract.
- [ ] Post-merge: log into the deployed dashboard with the demo creds → expect orders feed to render instead of \"server error\".

## Linked

Follow-up to PR #89 (Firebase Auth + tenant scoping), PR #91 (Suspense fix), PR #92 (Edge runtime fix). Same rollout, different layer.