### PR TITLE
Add /onboard-restaurant skill (admin-assisted tenant onboarding)

### DIFF
--- a/.claude/skills/onboard-restaurant/SKILL.md
+++ b/.claude/skills/onboard-restaurant/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: onboard-restaurant
+description: Onboard a new restaurant tenant from its public website. Fetches name, phone, address, hours, and menu, fills the gaps by asking the user for anything missing, writes a menu JSON file, and runs `scripts/provision_restaurant.py`. Use when the user says "add a restaurant", "onboard <name>", "set up a new tenant", or hands you a restaurant URL.
+---
+
+# Onboard Restaurant
+
+End-to-end onboarding for a new restaurant tenant. The team gives a URL; this skill produces a Firestore tenant doc, a menu JSON file checked into the repo, and a Twilio number wired to our `/voice` webhook.
+
+This is the **admin-assisted** path documented in Sprint 2.1 — a true self-serve signup wizard is parked for Sprint 4.2. The script underneath (`scripts/provision_restaurant.py`) and the data model (`app/restaurants/models.py::Restaurant`, Firestore `restaurants/{id}`) are the source of truth — keep this skill in sync if either changes.
+
+## Inputs
+
+Required from the user (the only thing they have to give you to start):
+
+- **Website URL** (e.g. `https://twilightrestaurant.com/`) — entry point for scraping.
+
+Optional hints — accept if offered:
+
+- Display phone (E.164) if it's not on the site
+- Preferred area code for the new Twilio number (defaults to the area code of the display phone)
+- Restaurant slug / `rid` (defaults to a slug derived from the name)
+- Forwarding mode: `always` | `busy` | `noanswer` (default `always`)
+
+## What "done" looks like
+
+1. A menu file at `restaurants/<rid>.json` in the shape `{"pizzas": [...], "sides": [...], "drinks": [...]}`.
+2. A Firestore doc `restaurants/<rid>` with name, phones, address, hours, menu, `forwarding_mode`.
+3. A Twilio number purchased and pointed at `${BACKEND_URL}/voice`.
+4. The team knows what number to forward the restaurant's existing line to.
+
+## Flow
+
+### 1. Crawl the site
+
+Use `WebFetch` to pull these paths in parallel (skip 404s):
+
+- `/` — name, phone, address, hours, navigation hints
+- `/menu`, `/menu/`, `/our-menu`, `/food`
+- `/about`, `/about-us`
+- `/contact`, `/contact-us`, `/locations`
+- `/order`, `/order-online` — sometimes routes to a third party (ChowNow, Toast, DoorDash) where the menu is structured
+
+Prompt template per fetch: *"Extract: restaurant name, phone, full address, hours of operation, and every menu item with name, description, and price. Group menu items by category. Return as JSON when possible, otherwise structured markdown. Note explicitly if the menu is image-only or behind a third-party widget."*
+
+If a page redirects to a third-party ordering site (ChowNow, Toast, DoorDash, UberEats), follow the redirect once and extract from there.
+
+### 2. Map to the data model
+
+Build a draft `Restaurant`:
+
+| Field | Source |
+|---|---|
+| `id` | slug from name: lowercase, hyphens, ASCII only (e.g. "Twilight Family Restaurant" → `twilight-family-restaurant`) |
+| `name` | site header / `<title>` / about page |
+| `display_phone` | E.164 — convert any North American format to `+1XXXXXXXXXX` |
+| `address` | full street address |
+| `hours` | one-line summary, e.g. `Mon-Sun, 11am-10pm` (collapse identical days) |
+| `menu` | see "Menu shape" below |
+| `forwarding_mode` | default `always` unless user says otherwise |
+
+`twilio_phone` is filled by the provision script — do not set it yourself.
+
+### 3. Menu shape — important constraint
+
+The LLM prompt builder (`app/llm/prompts.py::_format_menu`) currently renders **only three keys**: `pizzas`, `sides`, `drinks`. Any other top-level keys are silently dropped from what the AI sees on calls.
+
+For a non-pizza restaurant, map the categories pragmatically:
+
+- **`pizzas`** → mains / entrees / specialties (whatever the restaurant's headline category is)
+- **`sides`** → appetizers, sides, desserts
+- **`drinks`** → drinks, beverages
+
+Per-item shape:
+
+```json
+// pizzas (must have sizes dict)
+{"name": "Butter Chicken", "description": "...", "sizes": {"regular": 14.99, "large": 18.99}}
+
+// sides / drinks (single price)
+{"name": "Garlic Naan", "price": 3.99}
+```
+
+If the source menu has only a single price for a "pizza"-bucket item, still use the `sizes` shape: `"sizes": {"regular": <price>}`. The prompt formatter expects it.
+
+When you flatten a multi-category menu into these three buckets, **tell the user** what you collapsed and offer to revise. Also flag it as a follow-up: `app/llm/prompts.py` should support dynamic categories before we onboard >2-3 non-pizza restaurants — open an issue if one isn't tracked.
+
+### 4. Identify gaps and ask
+
+For each required field that's missing or low-confidence, ask the user. Batch the questions in a single message; don't drip them one at a time.
+
+A required field is "low-confidence" when:
+
+- The site returned no useful text for it (image-only menu, JS-only render, paywalled)
+- Multiple conflicting values were found (two different phone numbers across pages)
+- The format is ambiguous (e.g. hours listed per-location with no clear primary)
+
+Example gap-fill prompt:
+
+> I pulled what I could from twilightrestaurant.com but a few things need confirming:
+>
+> 1. **Menu** — the menu page is image-only. Paste the menu items, link a structured source (DoorDash/Uber/ChowNow), or upload an image.
+> 2. **Hours** — site shows "Open Daily" with no times. Confirm hours, e.g. `Mon-Sun, 11am-10pm`.
+> 3. **Area code for the new Twilio number** — display phone is `+1-416-754-6894` so I'll default to **416**. Override?
+
+Never invent a missing field. If menu items can't be obtained, the skill stops and waits — provisioning a tenant with no menu means the AI has nothing to sell.
+
+### 5. Write the menu file
+
+Save to `restaurants/<rid>.json` (create the dir if missing — it's not gitignored, this file lands in the PR). Pretty-print with 2-space indent. Schema: top-level `{"pizzas": [...], "sides": [...], "drinks": [...]}`.
+
+### 6. Dry-run the provision script first
+
+Always dry-run before spending money:
+
+```bash
+python -m scripts.provision_restaurant \
+  --rid <rid> \
+  --name "<Name>" \
+  --display-phone <+1XXXXXXXXXX> \
+  --address "<Address>" \
+  --hours "<Hours>" \
+  --area-code <NXX> \
+  --menu-file restaurants/<rid>.json \
+  --dry-run
+```
+
+Show the user the dumped JSON. Confirm the data is correct.
+
+### 7. Live run — confirm cost first
+
+The live run **purchases a Twilio number** (~$1/month per number, real money charged to the shared Twilio account). Before running without `--dry-run`:
+
+> Ready to provision **<Name>**. This will:
+> - Buy a Twilio number in area code <NXX> (~$1/mo charged to the shared Twilio account)
+> - Configure its voice webhook → `${BACKEND_URL}/voice`
+> - Write `restaurants/<rid>` to Firestore
+>
+> Confirm to proceed (yes / no)?
+
+Required env for the live run:
+
+- `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` — fetch via `/shared-creds` if not in `.env`
+- `BACKEND_URL` — current Cloud Run URL (e.g. `https://niko-ciyyvuq2pq-uc.a.run.app`)
+- `GOOGLE_CLOUD_PROJECT=niko-tsuki`, `GOOGLE_APPLICATION_CREDENTIALS` — Firestore auth
+
+If `BACKEND_URL` isn't set, ask the user — there's no auto-discovery.
+
+### 8. Hand off
+
+After a successful live run, surface to the user:
+
+```
+✔ Provisioned <Name>
+  rid:           <rid>
+  twilio_phone:  +1XXXXXXXXXX  ← restaurant forwards their existing line here
+  display_phone: +1XXXXXXXXXX
+  menu file:     restaurants/<rid>.json (commit this)
+
+Next steps:
+  - Forward inbound calls on <display_phone> → <twilio_phone>
+  - Place a test call to <twilio_phone>
+  - Open a PR with the new menu file
+```
+
+If we're on `master` when this finished, kick into `/pr-driven-dev` rescue flow before committing the menu file.
+
+## Hard rules
+
+- **Never** run the provision script without `--dry-run` first.
+- **Never** run the live (number-buying) step without explicit user confirmation in this session — a prior "yes" doesn't carry across runs.
+- **Never** commit `.env` files or Twilio credentials to the menu JSON or anywhere else. Use `/shared-creds` to fetch creds; they belong in `.env` only.
+- **Never** invent menu items, prices, hours, or addresses. If you can't find it, ask. A wrong price quoted on a real call is worse than a delayed onboarding.
+- **Never** reuse an existing `rid`. Before writing, check: `gh api -X GET "/repos/tsuki-works/niko/contents/restaurants" 2>/dev/null` or `ls restaurants/` and refuse if `<rid>.json` already exists. If the user wants to overwrite, they must say so explicitly.
+
+## Common gotchas
+
+- **Image-only menus.** Most independent restaurants post their menu as a JPG/PDF. The OCR step is a manual paste from the user — don't try to OCR yourself.
+- **Third-party ordering widgets.** ChowNow, Toast, DoorDash often have the structured menu. Follow redirects once. If the widget is a JS iframe, ask for the direct ordering URL.
+- **Multi-location chains.** The skill onboards **one tenant** at a time — one phone number, one address. If the site lists 5 locations, ask which one.
+- **Non-NANP phone numbers.** The provision script searches Twilio's CA inventory first, then falls back to US. If the restaurant is outside CA/US, this skill doesn't currently work — surface that and stop.
+- **`pizzas`-only prompt rendering** — see step 3. Onboarding many non-pizza restaurants will eventually require generalizing `app/llm/prompts.py`.
+
+## Output template (what to show the user when starting)
+
+```
+Onboarding from <URL>
+
+Found:
+  ✓ Name:          <name>
+  ✓ Phone:         <phone>
+  ? Address:       <best-guess or ✗ missing>
+  ? Hours:         <best-guess or ✗ missing>
+  ? Menu:          <N items across X categories | ✗ image-only — needs paste>
+
+Need from you:
+  - <gap 1>
+  - <gap 2>
+
+Once confirmed I'll write `restaurants/<rid>.json`, dry-run the provision script, and ask once more before buying the Twilio number.
+```

--- a/.claude/skills/onboard-restaurant/SKILL.md
+++ b/.claude/skills/onboard-restaurant/SKILL.md
@@ -39,11 +39,23 @@ Use `WebFetch` to pull these paths in parallel (skip 404s):
 - `/menu`, `/menu/`, `/our-menu`, `/food`
 - `/about`, `/about-us`
 - `/contact`, `/contact-us`, `/locations`
-- `/order`, `/order-online` — sometimes routes to a third party (ChowNow, Toast, DoorDash) where the menu is structured
+- `/order`, `/order-online` — often the highest-value page; usually routes to a third party (UberEats, SkipTheDishes, DoorDash, ChowNow, Toast) where the menu is fully structured
 
 Prompt template per fetch: *"Extract: restaurant name, phone, full address, hours of operation, and every menu item with name, description, and price. Group menu items by category. Return as JSON when possible, otherwise structured markdown. Note explicitly if the menu is image-only or behind a third-party widget."*
 
-If a page redirects to a third-party ordering site (ChowNow, Toast, DoorDash, UberEats), follow the redirect once and extract from there.
+If a page redirects to a third-party ordering site, follow the redirect and extract from there. **In practice UberEats has the highest hit rate for Canadian restaurants** — DoorDash and ChowNow frequently return 403 to `WebFetch`. SkipTheDishes is hit-or-miss. If WebFetch's response looks truncated (categories listed but empty `items: []`), re-fetch with a focused prompt asking for only those specific sections.
+
+### 1a. Image-based menus — OCR via Read
+
+If the menu page is image-only (common for independents — JPG/PNG menu boards in a gallery), don't give up — Claude can read images directly:
+
+1. Ask `WebFetch` for the raw image URLs on the menu page (prompt: *"List every img src URL on this page, one per line. Also list any PDF links."*).
+2. Filter to plausible menu images by filename (e.g. `menu`, `prices`, `card`) or by selecting the largest images. Skip obvious food-photo filenames (`IMG_*`, `Take-Out-*`, `chicken-wings.jpg`).
+3. Download to a temp path: `curl -sL --max-time 15 -o /tmp/menu_<n>.jpg <url>` (Windows: resolve with `cygpath -w /tmp/menu_<n>.jpg` before passing to `Read`).
+4. Use the `Read` tool on the file — Claude is multimodal and will see the image content. Extract items + prices from what's visible.
+5. If the image is illegible (low resolution, decorative font), say so and ask the user to paste.
+
+This is the fallback when the site has no third-party ordering link. **If both UberEats/DoorDash/Skip and on-page images fail, ask the user to paste the menu** rather than guessing.
 
 ### 2. Map to the data model
 
@@ -127,16 +139,55 @@ python -m scripts.provision_restaurant \
 
 Show the user the dumped JSON. Confirm the data is correct.
 
-### 7. Live run — confirm cost first
+### 7. List Twilio number candidates and let the user pick
 
-The live run **purchases a Twilio number** (~$1/month per number, real money charged to the shared Twilio account). Before running without `--dry-run`:
+Before buying anything, surface 3-5 candidate numbers from Twilio's inventory so the team can pick a memorable one (or one in the right city) instead of accepting the first hit.
+
+```bash
+python -m scripts.list_twilio_numbers --area-code <NXX> --limit 5
+```
+
+Required env: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN` (fetch via `/shared-creds` if not in `.env`). The script is read-only — no purchase happens.
+
+Present the output to the user as a numbered list and ask them to pick one. Example:
+
+> Found these in 416:
+>
+> 1. **+14165550101** — Toronto, ON
+> 2. **+14165550149** — Toronto, ON
+> 3. **+14165550412** — Toronto, ON
+> 4. **+14165550767** — Toronto, ON
+> 5. **+14165550889** — Toronto, ON
+>
+> Which one should I buy? (1–5, or paste a different E.164)
+
+If the user has a strong preference for digit patterns ("ends in 4321", "no 666"), respect it — the script can be re-run with a higher `--limit` to surface more options.
+
+### 8. Live run — confirm cost with the chosen number
+
+The live run **purchases the picked Twilio number** (~$1/month per number, real money charged to the shared Twilio account). Before running without `--dry-run`:
 
 > Ready to provision **<Name>**. This will:
-> - Buy a Twilio number in area code <NXX> (~$1/mo charged to the shared Twilio account)
+> - Buy **<chosen E.164>** (~$1/mo charged to the shared Twilio account)
 > - Configure its voice webhook → `${BACKEND_URL}/voice`
 > - Write `restaurants/<rid>` to Firestore
 >
 > Confirm to proceed (yes / no)?
+
+A "yes" earlier in the same session does **not** carry forward — re-confirm every time. Once confirmed:
+
+```bash
+python -m scripts.provision_restaurant \
+  --rid <rid> \
+  --name "<Name>" \
+  --display-phone <+1XXXXXXXXXX> \
+  --address "<Address>" \
+  --hours "<Hours>" \
+  --phone-number <chosen E.164> \
+  --menu-file restaurants/<rid>.json
+```
+
+Note `--phone-number` (not `--area-code`) — this buys the specific number the user picked rather than re-searching.
 
 Required env for the live run:
 
@@ -172,6 +223,7 @@ If we're on `master` when this finished, kick into `/pr-driven-dev` rescue flow 
 - **Never** commit `.env` files or Twilio credentials to the menu JSON or anywhere else. Use `/shared-creds` to fetch creds; they belong in `.env` only.
 - **Never** invent menu items, prices, hours, or addresses. If you can't find it, ask. A wrong price quoted on a real call is worse than a delayed onboarding.
 - **Never** reuse an existing `rid`. Before writing, check: `gh api -X GET "/repos/tsuki-works/niko/contents/restaurants" 2>/dev/null` or `ls restaurants/` and refuse if `<rid>.json` already exists. If the user wants to overwrite, they must say so explicitly.
+- **Never** skip the candidate-listing step (`list_twilio_numbers.py`) and let the provision script auto-pick the first available number. The whole point of the two-step flow is human choice over which digits we lock in.
 
 ## Common gotchas
 

--- a/.claude/skills/onboard-restaurant/SKILL.md
+++ b/.claude/skills/onboard-restaurant/SKILL.md
@@ -24,7 +24,7 @@ Optional hints — accept if offered:
 
 ## What "done" looks like
 
-1. A menu file at `restaurants/<rid>.json` in the shape `{"pizzas": [...], "sides": [...], "drinks": [...]}`.
+1. A menu file at `restaurants/<rid>.json`, top-level keyed by category names that match the source menu (e.g. `appetizers`, `soups`, `mains`, `drinks` — see step 3).
 2. A Firestore doc `restaurants/<rid>` with name, phones, address, hours, menu, `forwarding_mode`.
 3. A Twilio number purchased and pointed at `${BACKEND_URL}/voice`.
 4. The team knows what number to forward the restaurant's existing line to.
@@ -73,29 +73,41 @@ Build a draft `Restaurant`:
 
 `twilio_phone` is filled by the provision script — do not set it yourself.
 
-### 3. Menu shape — important constraint
+### 3. Menu shape
 
-The LLM prompt builder (`app/llm/prompts.py::_format_menu`) currently renders **only three keys**: `pizzas`, `sides`, `drinks`. Any other top-level keys are silently dropped from what the AI sees on calls.
+The LLM prompt builder (`app/llm/prompts.py::_format_menu`) renders any keys the menu dict happens to have, title-casing snake_case keys for the section headers (`caribbean_appetizers` → "Caribbean Appetizers"). Pick categories that match the source menu's natural structure rather than collapsing into pizza-shop terms.
 
-For a non-pizza restaurant, map the categories pragmatically:
+**Pick category keys that read naturally when title-cased.** Good: `appetizers`, `caribbean_appetizers`, `soups`, `fried_rice`, `chow_mein`, `lo_mein`, `specialty_dishes`, `drinks`. Bad: `cat1`, `mainsAndStuff`, `Items` — those land in the system prompt verbatim and the AI has to figure out what they mean.
 
-- **`pizzas`** → mains / entrees / specialties (whatever the restaurant's headline category is)
-- **`sides`** → appetizers, sides, desserts
-- **`drinks`** → drinks, beverages
-
-Per-item shape:
+Per-item shape — pick the one that matches how the restaurant actually prices the item:
 
 ```json
-// pizzas (must have sizes dict)
-{"name": "Butter Chicken", "description": "...", "sizes": {"regular": 14.99, "large": 18.99}}
+// Single-priced item
+{"name": "Garlic Naan", "description": "Optional.", "price": 3.99}
 
-// sides / drinks (single price)
-{"name": "Garlic Naan", "price": 3.99}
+// Multi-size item — caller has to pick a size
+{"name": "Margherita", "description": "Tomato, fresh mozzarella, basil.", "sizes": {"small": 12.99, "medium": 16.99, "large": 20.99}}
+
+// Half/whole, regular/large, etc. all use sizes
+{"name": "Deep Fried Chicken", "sizes": {"half": 14.00, "whole": 24.50}}
 ```
 
-If the source menu has only a single price for a "pizza"-bucket item, still use the `sizes` shape: `"sizes": {"regular": <price>}`. The prompt formatter expects it.
+`description` is optional on either shape. If both `sizes` and `price` are set, `sizes` wins.
 
-When you flatten a multi-category menu into these three buckets, **tell the user** what you collapsed and offer to revise. Also flag it as a follow-up: `app/llm/prompts.py` should support dynamic categories before we onboard >2-3 non-pizza restaurants — open an issue if one isn't tracked.
+**Pin the rendering order with `_category_order`.** Firestore doesn't preserve dict insertion order on round-trip, so a tenant who cares about which category gets named first writes:
+
+```json
+{
+  "_category_order": ["appetizers", "soups", "mains", "drinks"],
+  "appetizers": [...],
+  "soups": [...],
+  ...
+}
+```
+
+Categories listed there render first in that order; anything else follows in whatever order the dict yields. Skip `_category_order` entirely if you don't care.
+
+Empty categories (`"soups": []`) are silently skipped, so leaving placeholders for future expansion is fine.
 
 ### 4. Identify gaps and ask
 
@@ -119,7 +131,7 @@ Never invent a missing field. If menu items can't be obtained, the skill stops a
 
 ### 5. Write the menu file
 
-Save to `restaurants/<rid>.json` (create the dir if missing — it's not gitignored, this file lands in the PR). Pretty-print with 2-space indent. Schema: top-level `{"pizzas": [...], "sides": [...], "drinks": [...]}`.
+Save to `restaurants/<rid>.json` (create the dir if missing — it's not gitignored, this file lands in the PR). Pretty-print with 2-space indent. Schema described in step 3 — top-level keys are categories chosen to match the source menu, plus the optional `_category_order` list.
 
 ### 6. Dry-run the provision script first
 
@@ -231,7 +243,7 @@ If we're on `master` when this finished, kick into `/pr-driven-dev` rescue flow 
 - **Third-party ordering widgets.** ChowNow, Toast, DoorDash often have the structured menu. Follow redirects once. If the widget is a JS iframe, ask for the direct ordering URL.
 - **Multi-location chains.** The skill onboards **one tenant** at a time — one phone number, one address. If the site lists 5 locations, ask which one.
 - **Non-NANP phone numbers.** The provision script searches Twilio's CA inventory first, then falls back to US. If the restaurant is outside CA/US, this skill doesn't currently work — surface that and stop.
-- **`pizzas`-only prompt rendering** — see step 3. Onboarding many non-pizza restaurants will eventually require generalizing `app/llm/prompts.py`.
+- **Category ordering on read.** Firestore doesn't preserve dict insertion order. If the order categories appear in matters (it usually does for the demo prompt log), set `_category_order` in the menu JSON.
 
 ## Output template (what to show the user when starting)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Key locations:
 - **`/current-sprint`** — surfaces the active sprint from the project board. Prefers items with Status = "In progress"; falls back to the earliest incomplete Phase.
 - **`/pr-driven-dev`** — enforces feature-branch + PR workflow; never commit directly to `master`. Includes a rescue flow if edits start on `master` by accident.
 - **`/shared-creds`** — fetches shared third-party credentials (Twilio, Deepgram, Anthropic, ElevenLabs, Square, etc.) from the private Discord `#shared-creds` channel via the Discord MCP. Encodes the don't-commit / don't-memory-save rules.
+- **`/onboard-restaurant`** — admin-assisted onboarding from a restaurant website URL: scrapes name/phone/address/hours/menu, asks for any gaps (image-only menus, missing hours, etc.), writes `restaurants/<rid>.json`, and dry-runs/then-confirms `scripts/provision_restaurant.py`. The Sprint 2.1 path; pre-dates the Sprint 4.2 self-serve wizard.
 
 ## Discord integration
 

--- a/scripts/list_twilio_numbers.py
+++ b/scripts/list_twilio_numbers.py
@@ -1,0 +1,122 @@
+"""List candidate Twilio phone numbers in an area code.
+
+Used by the ``/onboard-restaurant`` skill: present a few options to
+the user before purchasing, instead of buying the first available.
+Read-only — never purchases anything.
+
+Searches Canada first, falls back to US (matches the order in
+``scripts/provision_restaurant.py::_purchase_number``).
+
+Usage:
+    python -m scripts.list_twilio_numbers --area-code 416
+    python -m scripts.list_twilio_numbers --area-code 416 --limit 10
+
+Required env: ``TWILIO_ACCOUNT_SID``, ``TWILIO_AUTH_TOKEN``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+from twilio.rest import Client as TwilioClient
+
+from app.config import settings
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--area-code", required=True, help="3-digit NANP area code")
+    parser.add_argument(
+        "--limit", type=int, default=5, help="How many candidates to return (default 5)"
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of a human table",
+    )
+    return parser.parse_args()
+
+
+def _twilio_client() -> TwilioClient:
+    sid = settings.twilio_account_sid or os.environ.get("TWILIO_ACCOUNT_SID")
+    token = settings.twilio_auth_token or os.environ.get("TWILIO_AUTH_TOKEN")
+    if not sid or not token:
+        raise SystemExit("TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN are required")
+    return TwilioClient(sid, token)
+
+
+def _search(twilio: TwilioClient, area_code: str, limit: int) -> tuple[str, list]:
+    """Return (country, numbers). Try CA first, fall back to US."""
+    available = twilio.available_phone_numbers("CA").local.list(
+        area_code=area_code, limit=limit
+    )
+    if available:
+        return "CA", available
+    available = twilio.available_phone_numbers("US").local.list(
+        area_code=area_code, limit=limit
+    )
+    return "US", available
+
+
+def main() -> int:
+    args = _parse_args()
+    twilio = _twilio_client()
+    country, numbers = _search(twilio, args.area_code, args.limit)
+
+    if not numbers:
+        msg = f"No numbers available in area code {args.area_code} (CA or US)"
+        if args.json:
+            print(json.dumps({"country": None, "numbers": [], "error": msg}))
+        else:
+            logger.info(msg)
+        return 1
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "country": country,
+                    "numbers": [
+                        {
+                            "phone_number": n.phone_number,
+                            "friendly_name": n.friendly_name,
+                            "locality": getattr(n, "locality", None),
+                            "region": getattr(n, "region", None),
+                        }
+                        for n in numbers
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    logger.info(
+        "Available numbers in area code %s (%s) — %d shown:",
+        args.area_code,
+        country,
+        len(numbers),
+    )
+    for idx, n in enumerate(numbers, start=1):
+        locality = getattr(n, "locality", None) or ""
+        region = getattr(n, "region", None) or ""
+        loc = f" ({locality}, {region})" if locality or region else ""
+        logger.info("  %d. %s — %s%s", idx, n.phone_number, n.friendly_name, loc)
+    logger.info(
+        "\nTo provision with a specific number, pass it to provision_restaurant:"
+    )
+    logger.info(
+        "  python -m scripts.provision_restaurant ... --phone-number <E.164>"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/provision_restaurant.py
+++ b/scripts/provision_restaurant.py
@@ -22,6 +22,11 @@ Usage:
         --area-code 416 \\
         --menu-file restaurants/pizza-palace.json
 
+Pass ``--phone-number <E.164>`` instead of ``--area-code`` to buy a
+specific number you already picked (e.g. via
+``scripts/list_twilio_numbers.py``). The two flags are mutually
+exclusive in practice — supply exactly one.
+
 ``--menu-file`` is a JSON file in the shape ``{"pizzas":[...],
 "sides":[...], "drinks":[...]}`` — same as ``app.menu.MENU`` minus
 the top-level metadata fields.
@@ -60,7 +65,18 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--display-phone", required=True, help="E.164 customer-facing number")
     parser.add_argument("--address", required=True)
     parser.add_argument("--hours", required=True)
-    parser.add_argument("--area-code", required=True, help="3-digit area code for Twilio search")
+    parser.add_argument(
+        "--area-code",
+        help="3-digit area code for Twilio search. Required unless --phone-number is given.",
+    )
+    parser.add_argument(
+        "--phone-number",
+        help=(
+            "Specific E.164 number to purchase (e.g. +14165551234). When set, skip "
+            "the area-code search and buy this exact number — pair with "
+            "scripts/list_twilio_numbers.py to let a human pick from candidates."
+        ),
+    )
     parser.add_argument("--menu-file", required=True, help="Path to JSON menu file")
     parser.add_argument(
         "--forwarding-mode",
@@ -72,7 +88,10 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Skip Twilio purchase + Firestore write; just log what would happen",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if not args.phone_number and not args.area_code:
+        parser.error("either --phone-number or --area-code is required")
+    return args
 
 
 def _twilio_client() -> TwilioClient:
@@ -108,6 +127,14 @@ def _purchase_number(twilio: TwilioClient, area_code: str) -> str:
     return purchased.phone_number
 
 
+def _purchase_specific_number(twilio: TwilioClient, e164: str) -> str:
+    """Buy ``e164`` directly. Used when the operator has already picked
+    a number from ``scripts/list_twilio_numbers.py``."""
+    logger.info("twilio: purchasing %s (specific)", e164)
+    purchased = twilio.incoming_phone_numbers.create(phone_number=e164)
+    return purchased.phone_number
+
+
 def _configure_voice_webhook(twilio: TwilioClient, e164: str, backend_url: str) -> None:
     voice_url = f"{backend_url}/voice"
     numbers = twilio.incoming_phone_numbers.list(phone_number=e164, limit=1)
@@ -126,12 +153,18 @@ def main() -> int:
         menu = json.load(fh)
 
     if args.dry_run:
-        twilio_phone = "+10000000000"
-        logger.info("[dry-run] would purchase a number in area code %s", args.area_code)
+        twilio_phone = args.phone_number or "+10000000000"
+        if args.phone_number:
+            logger.info("[dry-run] would purchase %s", args.phone_number)
+        else:
+            logger.info("[dry-run] would purchase a number in area code %s", args.area_code)
     else:
         twilio = _twilio_client()
         backend_url = _backend_url()
-        twilio_phone = _purchase_number(twilio, args.area_code)
+        if args.phone_number:
+            twilio_phone = _purchase_specific_number(twilio, args.phone_number)
+        else:
+            twilio_phone = _purchase_number(twilio, args.area_code)
         _configure_voice_webhook(twilio, twilio_phone, backend_url)
 
     restaurant = Restaurant(


### PR DESCRIPTION
## Summary
- New `/onboard-restaurant` skill at `.claude/skills/onboard-restaurant/SKILL.md` — takes a restaurant website URL and walks through the full Sprint 2.1 admin-assisted onboarding flow (scrape → ask for gaps → write `restaurants/<rid>.json` → dry-run → confirm → run `scripts/provision_restaurant.py`).
- Lists the skill in `CLAUDE.md` alongside the other project skills.

## Linked issue
Relates to #4 (Sprint 2.1 — Core Platform). The "Restaurant onboarding flow" deliverable in #4 doesn't have a sub-issue yet; this skill is the lightweight path while we save the full self-serve wizard for Sprint 4.2 (#12).

## Test plan
- [ ] In a fresh Claude Code session, type `/onboard-restaurant https://twilightrestaurant.com/` — confirm Claude follows the flow, identifies the image-only menu, and asks for a paste rather than inventing items.
- [ ] Verify the skill never runs the live (number-buying) provision step without a fresh user confirmation.
- [ ] Verify the dry-run JSON output matches the `Restaurant` model in `app/restaurants/models.py`.

## Notes
Two non-obvious constraints encoded in the skill, worth a quick review:

1. **`pizzas`/`sides`/`drinks` are the only menu keys the LLM prompt currently renders** (`app/llm/prompts.py::_format_menu`). Non-pizza tenants must collapse mains → `pizzas` for now. Skill flags this as a follow-up — generalizing prompts.py is a small task that should land before we onboard >2-3 non-pizza restaurants.
2. **Live provision spends Twilio money.** The skill enforces dry-run-first and a fresh per-session confirmation, even if the user said "yes" earlier. This matches the "executing actions with care" guidance — a prior approval doesn't carry across runs.

Out of scope: the actual Twilight onboarding (gated on the user picking dry-run vs real Twilio purchase) and any changes to `prompts.py` itself.