### PR TITLE
Call quality fixes from 2026-04-26 Twilight transcript

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -54,13 +54,21 @@ UPDATE_ORDER_TOOL: dict[str, Any] = {
                         "name": {"type": "string"},
                         "category": {
                             "type": "string",
-                            "enum": ["pizza", "side", "drink"],
+                            "description": (
+                                "Free-form category from the menu (e.g. "
+                                "appetizer, main, soup, drink, dessert). "
+                                "Used for grouping in the dashboard — not "
+                                "validated against a fixed enum, since "
+                                "tenants pick their own category names."
+                            ),
                         },
                         "size": {
                             "type": ["string", "null"],
                             "description": (
-                                "For pizzas: small | medium | large. "
-                                "Null for sides and drinks."
+                                "Required when the menu item is multi-size "
+                                "(small/medium/large, half/whole, etc.) — "
+                                "use whichever size keys the menu shows. "
+                                "Null for single-priced items."
                             ),
                         },
                         "quantity": {"type": "integer", "minimum": 1},
@@ -155,6 +163,24 @@ def _serialize_block(block: Any) -> dict[str, Any]:
             "input": block.input,
         }
     raise ValueError(f"Unsupported content block type: {block.type!r}")
+
+
+def _summarize_order(order: Order) -> str:
+    """Server-side summary fed back to the LLM as a ``tool_result``.
+
+    Returning the post-apply subtotal + item list closes the
+    accuracy hole observed on the 2026-04-26 Twilight call where
+    Haiku quoted a $50.50 total for an order that actually summed to
+    $49.25 — without a server-verified number in the tool_result, the
+    model fabricates totals from its memory of unit prices. Now it
+    has a ground-truth subtotal to read back instead.
+    """
+    if not order.items:
+        return "Order updated. Subtotal: $0.00. (no items yet)"
+    items_summary = ", ".join(
+        f"{item.quantity}× {item.name}" for item in order.items
+    )
+    return f"Order updated. Subtotal: ${order.subtotal:.2f}. Items: {items_summary}."
 
 
 def _tool_result_block(tool_use_id: str, content: str = "Order updated.") -> dict[str, Any]:
@@ -252,8 +278,12 @@ def generate_reply(
             tool_uses.append({"id": block.id, "input": block.input})
 
     updated_order = order
+    tool_results: list[dict[str, Any]] = []
     for tu in tool_uses:
         updated_order = _apply_update(updated_order, tu["input"])
+        tool_results.append(
+            _tool_result_block(tu["id"], _summarize_order(updated_order))
+        )
 
     assistant_content = [_serialize_block(block) for block in response.content]
     new_history = [
@@ -264,10 +294,7 @@ def generate_reply(
     if tool_uses:
         new_history = [
             *new_history,
-            {
-                "role": "user",
-                "content": [_tool_result_block(tu["id"]) for tu in tool_uses],
-            },
+            {"role": "user", "content": tool_results},
         ]
 
     if not reply_text_parts and tool_uses:
@@ -341,8 +368,12 @@ async def stream_reply(
             tool_uses.append({"id": block.id, "input": block.input})
 
     updated_order = order
+    tool_results: list[dict[str, Any]] = []
     for tu in tool_uses:
         updated_order = _apply_update(updated_order, tu["input"])
+        tool_results.append(
+            _tool_result_block(tu["id"], _summarize_order(updated_order))
+        )
 
     assistant_content = [_serialize_block(block) for block in first_message.content]
     new_history = [
@@ -353,10 +384,7 @@ async def stream_reply(
     if tool_uses:
         new_history = [
             *new_history,
-            {
-                "role": "user",
-                "content": [_tool_result_block(tu["id"]) for tu in tool_uses],
-            },
+            {"role": "user", "content": tool_results},
         ]
 
     text_emitted = bool(text_parts)

--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -66,6 +66,19 @@ _PREAMBLE = dedent("""\
     If a caller asks for something off-menu, politely say you don't offer it and
     suggest a close alternative. If you're unsure what they said, ask them to
     repeat rather than guessing.
+
+    When the caller hesitates or starts a sentence and trails off ("I'd like...",
+    "uhhh", "I would also..."), DO NOT fill the silence with prompts like
+    "take your time" or "I'm listening". Stay quiet and wait for them to finish
+    their thought. Repeated reassurances on every micro-pause feel like the AI
+    is rushing them. Only respond once they've actually finished speaking — a
+    real sentence, not a fragment. The phrase you use when you do need to nudge
+    is "take your time" — never "take your breath" or other variants.
+
+    When you tell the caller their total, use the subtotal returned by the
+    most recent update_order tool_result — never compute totals yourself from
+    unit prices. The tool_result's "Subtotal: $X.XX" is the server-verified
+    number; your math from memory will drift.
 """)
 
 

--- a/app/orders/models.py
+++ b/app/orders/models.py
@@ -37,6 +37,17 @@ class OrderStatus(str, Enum):
 
 
 class ItemCategory(str, Enum):
+    """Legacy fixed-enum categories from the pizza-shop demo era.
+
+    Kept around because existing Firestore order docs are written with
+    these literal values, and the LLM tool schema used to require them.
+    Post-#98 (dynamic prompt categories), the LineItem.category field
+    is a free-form string — tenants pick their own categories
+    (appetizer, soup, main, ...). This enum is no longer authoritative;
+    treat it as "values that have appeared historically" rather than
+    "the only allowed values".
+    """
+
     PIZZA = "pizza"
     SIDE = "side"
     DRINK = "drink"
@@ -48,7 +59,12 @@ def _now_utc() -> datetime:
 
 class LineItem(BaseModel):
     name: str
-    category: ItemCategory
+    # Free-form per-tenant category (matches the menu key, e.g.
+    # ``appetizers``, ``mains``, ``soups``). Was a fixed ItemCategory
+    # enum during the pizza-shop POC; relaxed to ``str`` after #98 so
+    # the LLM's tool_use payloads survive validation when a Caribbean
+    # menu emits ``category="appetizer"``.
+    category: str
     size: Optional[str] = None
     quantity: int = Field(ge=1)
     unit_price: float = Field(ge=0)

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -249,13 +249,25 @@ async def _open_deepgram_connection(
     conn.on(LiveTranscriptionEvents.Transcript, on_transcript)
     conn.on(LiveTranscriptionEvents.Error, on_error)
 
+    # endpointing + utterance_end_ms together control how aggressively
+    # Deepgram closes a turn. We picked 800/1000 after a 2026-04-26
+    # Twilight test call where endpointing=300 fired ~7 false barge-ins
+    # in 3 minutes — every micro-pause mid-sentence ("i would like to"
+    # <breath> "have") was treated as a turn ending, and the AI kept
+    # saying "take your time" because it thought the caller had spoken.
+    # 800ms is Deepgram's recommended value for conversational flow;
+    # utterance_end_ms=1000 layers a prosody-aware end-of-utterance
+    # signal on top so we wait for "actually finished" instead of just
+    # "stopped making noise".
     options = LiveOptions(
         model="nova-2",
         encoding="mulaw",
         sample_rate=8000,
         channels=1,
         interim_results=True,
-        endpointing=300,
+        endpointing=800,
+        utterance_end_ms=1000,
+        vad_events=True,
     )
     started = await conn.start(options)
     if not started:

--- a/dashboard/lib/schemas/order.ts
+++ b/dashboard/lib/schemas/order.ts
@@ -24,7 +24,13 @@ export const OrderStatusSchema = z.enum([
 ]);
 export type OrderStatus = z.infer<typeof OrderStatusSchema>;
 
-export const ItemCategorySchema = z.enum(['pizza', 'side', 'drink']);
+// Free-form per-tenant category string. Was a fixed enum
+// (`pizza`/`side`/`drink`) during the pizza-shop POC; relaxed to a
+// plain string post-#98 so a Caribbean tenant can write
+// `category="appetizer"` without parse failure. The dashboard never
+// branches on the value — it's just displayed/grouped — so widening
+// is a safe schema-only change.
+export const ItemCategorySchema = z.string();
 export type ItemCategory = z.infer<typeof ItemCategorySchema>;
 
 export const LineItemSchema = z.object({

--- a/restaurants/twilight-family-restaurant.json
+++ b/restaurants/twilight-family-restaurant.json
@@ -16,7 +16,7 @@
     {"name": "Spicy French Fries", "price": 7.50},
     {"name": "Sweet and Sour Chicken Balls (8)", "price": 13.25},
     {"name": "Deep Fried Chicken Wings", "price": 13.50},
-    {"name": "Chicken Wings Flavored", "description": "BBQ, honey garlic, sweet chilli, hot and spicy, or buffalo.", "price": 14.50},
+    {"name": "Flavored Chicken Wings", "description": "Choice of BBQ, honey garlic, sweet chilli, hot and spicy, or buffalo.", "price": 14.50},
     {"name": "Chicken Wings and Fries (6)", "price": 13.25},
     {"name": "Deep Fried Chicken", "sizes": {"half": 14.00, "whole": 24.50}},
     {"name": "Deep Fried Chicken Wonton (12)", "price": 12.25},

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -216,17 +216,96 @@ def test_text_plus_tool_use_appends_tool_result_to_history():
 
     # No follow-up call — text was emitted.
     assert fake_client.messages.create.call_count == 1
-    # History ends with a synthetic tool_result so the next turn is valid.
-    assert result.history[-1] == {
-        "role": "user",
-        "content": [
-            {
-                "type": "tool_result",
-                "tool_use_id": "toolu_committed",
-                "content": "Order updated.",
-            }
-        ],
-    }
+    # History ends with a synthetic tool_result so the next turn is valid,
+    # AND that result carries the server-computed subtotal so Haiku can
+    # quote a verified number instead of fabricating one (per the 2026-04-26
+    # Twilight $50.50-vs-$49.25 incident).
+    last = result.history[-1]
+    assert last["role"] == "user"
+    assert len(last["content"]) == 1
+    block = last["content"][0]
+    assert block["type"] == "tool_result"
+    assert block["tool_use_id"] == "toolu_committed"
+    assert "Subtotal: $19.99" in block["content"]
+    assert "Margarita" in block["content"]
+
+
+def test_tool_result_carries_post_apply_subtotal():
+    """Each update_order tool_result feeds the post-apply subtotal back
+    to Haiku so it can quote a server-verified number to the caller
+    (regression for the 2026-04-26 Twilight call where the model
+    fabricated a $50.50 total for an order that summed to $49.25).
+    Multiple tool_uses in one turn each get their own snapshot."""
+
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [
+            FakeBlock(type="text", text="Adding those now."),
+            FakeBlock(
+                type="tool_use",
+                id="toolu_one",
+                name="update_order",
+                input={
+                    "items": [
+                        {
+                            "name": "Wings",
+                            "category": "appetizers",
+                            "size": None,
+                            "quantity": 1,
+                            "unit_price": 14.50,
+                        }
+                    ],
+                    "status": "in_progress",
+                },
+            ),
+            FakeBlock(
+                type="tool_use",
+                id="toolu_two",
+                name="update_order",
+                input={
+                    "items": [
+                        {
+                            "name": "Wings",
+                            "category": "appetizers",
+                            "size": None,
+                            "quantity": 1,
+                            "unit_price": 14.50,
+                        },
+                        {
+                            "name": "Fries",
+                            "category": "appetizers",
+                            "size": None,
+                            "quantity": 1,
+                            "unit_price": 7.50,
+                        },
+                    ],
+                    "status": "in_progress",
+                },
+            ),
+        ]
+    )
+
+    result = generate_reply(
+        transcript="add wings and fries",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    )
+
+    last = result.history[-1]
+    assert last["role"] == "user"
+    blocks = last["content"]
+    assert len(blocks) == 2
+    # First tool_result: state after applying tool_one (just wings).
+    assert blocks[0]["tool_use_id"] == "toolu_one"
+    assert "Subtotal: $14.50" in blocks[0]["content"]
+    assert "Wings" in blocks[0]["content"]
+    # Second tool_result: state after applying tool_two (wings + fries).
+    assert blocks[1]["tool_use_id"] == "toolu_two"
+    assert "Subtotal: $22.00" in blocks[1]["content"]
+    assert "Wings" in blocks[1]["content"] and "Fries" in blocks[1]["content"]
 
 
 def test_next_transcript_merges_into_pending_tool_result():


### PR DESCRIPTION
## Summary
Targets the four issues found in call `CA22d3e86cdf8b72570303025f150aae37` (3:18, Twilight Family Restaurant, 2026-04-26).

1. **Endpointing 300 → 800ms + utterance_end_ms=1000 + vad_events** — eliminates the false-barge-in cascade that fired ~7 turns on caller mid-sentence pauses and made the AI repeat "take your time" five times in 30 seconds.
2. **Subtotal in `update_order` tool_result** — closes the $50.50-vs-$49.25 accuracy hole. Each tool_result now carries the post-apply subtotal + item list so Haiku quotes a server-verified number instead of computing one from memory.
3. **Free-form `category` field** — relaxes the fixed `["pizza", "side", "drink"]` enum across the tool schema, Pydantic LineItem, and Zod ItemCategorySchema. Twilight (and any future non-pizza tenant) can now write `category="appetizer"` without force-mapping into pizza-shop buckets.
4. **Prompt nudges** — explicit "don't fill silence on hesitation, wait for a real sentence" rule, and "use the tool_result subtotal, never compute totals yourself" rule. Plus pinned "take your time" as the only nudge phrasing (no more "take your breath").

Plus a tiny menu rename: `Chicken Wings Flavored` → `Flavored Chicken Wings`. Already pushed to Firestore via `upsert_restaurant.py`.

## Test plan
- [x] Backend pytest: 141 passed, 6 skipped (was 140 + 6). One new test (`test_tool_result_carries_post_apply_subtotal`) explicitly covers the multi-tool-use subtotal-snapshot behavior.
- [x] Dashboard: tsc clean, 16 vitest tests pass.
- [ ] Real test call to `+1 647-905-8093` after deploy: caller hesitates mid-sentence; AI should wait quietly instead of injecting "take your time". Confirm subtotal quoted at wrap-up matches `Subtotal: $X.XX` in the tool_result log.

## Risk
- **Existing Firestore order docs** still have `category: "pizza"|"side"|"drink"` — those stay valid (schema relaxed, not removed). Going forward, Twilight orders will have `category` set to whatever Haiku decides matches the menu key (e.g. `"appetizers"`).
- **Endpointing increase** adds up to 500ms latency on quick "yes/no" answers — accepted in exchange for eliminating the false-interrupt loop. If real calls feel sluggish, dial endpointing back to 600.

## Notes
The transcript-driven workflow (review a real call → identify root cause in code → ship a fix) is genuinely useful and worth doing after every demo call until quality stabilizes. Worth flagging to the team.