### PR TITLE
Item customizations + order confirmation read-back (Sprint 2.2)

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -178,7 +178,9 @@ def _summarize_order(order: Order) -> str:
     if not order.items:
         return "Order updated. Subtotal: $0.00. (no items yet)"
     items_summary = ", ".join(
-        f"{item.quantity}× {item.name}" for item in order.items
+        f"{item.quantity}× {item.name}"
+        + (f" ({', '.join(item.modifications)})" if item.modifications else "")
+        for item in order.items
     )
     return f"Order updated. Subtotal: ${order.subtotal:.2f}. Items: {items_summary}."
 

--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -33,9 +33,39 @@ _PREAMBLE = dedent("""\
     Conversation flow:
     - Greet the caller briefly and ask how you can help.
     - Identify intent — ordering, question, or something else.
-    - If ordering, walk through item, size, quantity, and any modifications.
-    - Confirm the full order (items plus total) before wrapping up.
+    - If ordering, walk through item, size, and quantity.
     - If delivery, collect the caller's delivery address.
+
+    Item customizations:
+    - After the caller picks an item and size, ask once whether they have
+      any customizations ("Any modifications — extra cheese, no onions?").
+    - If they say no or give nothing, move on — do not ask again.
+    - Accept any free-text customization; capture it exactly as stated.
+      Do not validate against a fixed list and do not invent customizations
+      the caller did not request.
+    - Contradictory modifiers ("no cheese, extra cheese"): ask to clarify
+      once before recording. Do not record both.
+    - Mid-sentence mods ("...and make that one without onions"): capture
+      them exactly as if stated separately.
+    - If a requested modifier does not make sense for the item (e.g. "extra
+      anchovies on a milkshake"), politely decline it once and ask if they
+      meant something else. Do not record a nonsensical modifier.
+
+    Order confirmation read-back:
+    - Before asking for confirmation, read back every item with its
+      quantity, size (if applicable), and any modifications. For example:
+      "So that's one large Margherita with extra cheese and no basil, and
+      one Coke — your total is twenty-one ninety-nine. Does that sound right?"
+    - Use the subtotal returned by the update_order tool — never compute
+      it yourself from unit prices.
+    - If an item has no modifications, omit the modifier clause entirely —
+      do not say "no modifications."
+    - If the caller corrects something mid-read-back, update via
+      update_order and re-read the full corrected order before asking for
+      confirmation again.
+    - Only flip status="confirmed" and say the terminal goodbye after the
+      caller explicitly confirms ("yes", "yep", "that's right", "sounds
+      good") — not on a vague "uh huh" mid-conversation.
 
     Closing the call:
     - Once the caller has confirmed the summary (e.g. "yes that's right",

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.llm import client as client_module
-from app.llm.client import _apply_update, generate_reply, stream_reply
+from app.llm.client import _apply_update, _summarize_order, generate_reply, stream_reply
 from app.orders.models import Order, OrderStatus, OrderType
 
 _TEST_SYSTEM_PROMPT = "you are a test agent"
@@ -810,3 +810,53 @@ def test_modifications_round_trip_into_line_item():
     )
 
     assert result.order.items[0].modifications == ["extra cheese", "no basil"]
+
+
+def test_summarize_order_includes_modifications():
+    """Sprint 2.2 #2 — _summarize_order must include modification strings in
+    the tool_result so the agent can read them back to the caller verbatim."""
+    order = Order(call_sid="CAtest")
+    order = _apply_update(
+        order,
+        {
+            "items": [
+                {
+                    "name": "Margherita",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 1,
+                    "unit_price": 20.99,
+                    "modifications": ["extra cheese", "no basil"],
+                }
+            ],
+            "status": "in_progress",
+        },
+    )
+    result = _summarize_order(order)
+    assert "extra cheese, no basil" in result
+    assert "Margherita" in result
+
+
+def test_summarize_order_omits_parentheses_when_no_modifications():
+    """Sprint 2.2 #3 — when an item has no modifications the summary must not
+    emit a parenthesized clause; the agent should omit the modifier phrase
+    entirely per the read-back instruction."""
+    order = Order(call_sid="CAtest")
+    order = _apply_update(
+        order,
+        {
+            "items": [
+                {
+                    "name": "Margherita",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 1,
+                    "unit_price": 20.99,
+                    "modifications": [],
+                }
+            ],
+            "status": "in_progress",
+        },
+    )
+    result = _summarize_order(order)
+    assert "(" not in result

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -218,3 +218,27 @@ def test_prompt_skips_empty_and_non_list_categories():
     # Scalar value not surfaced as if it were a category
     assert "Promo Text:" not in prompt
     assert "Half off Tuesdays" not in prompt
+
+
+def test_prompt_includes_customization_guidance():
+    """Sprint 2.2 #2 — prompt must instruct the agent to capture free-text
+    modifications, not invent them, and to clarify contradictory or
+    nonsensical ones."""
+    prompt = build_system_prompt(_demo())
+    lower = prompt.lower()
+    assert "customization" in lower
+    assert "do not invent" in lower
+    assert "clarify" in lower
+    assert "does not make sense" in lower
+
+
+def test_prompt_includes_readback_instruction():
+    """Sprint 2.2 #3 — prompt must direct the agent to read back the full
+    order using the server-verified update_order subtotal, and only
+    confirm on an explicit caller yes."""
+    prompt = build_system_prompt(_demo())
+    lower = prompt.lower()
+    assert "read back" in lower
+    assert "update_order" in lower
+    assert "does that sound right" in lower
+    assert "explicitly confirms" in lower


### PR DESCRIPTION
## Summary
Sprint 2.2 deliverables #2 and #3 from issue #5 — sharpens call-flow prompt language for capturing item customizations and reading the order back before confirmation.

- **Customizations**: prompt now governs when to ask, how to capture free-text mods, contradictory modifiers, mid-sentence mods, and declining nonsensical mods (e.g. "extra anchovies on a milkshake").
- **Read-back**: prompt now requires reading every item with quantity/size/mods using the subtotal from `update_order`, and only flipping `status=confirmed` on an explicit caller "yes".
- **Latent bug fix**: `_summarize_order` was dropping `LineItem.modifications`, so the LLM's `tool_result` view of the order silently disagreed with the read-back. Now rendered inline.

No model changes — `LineItem.modifications` and the `modifications` field on `UPDATE_ORDER_TOOL` already existed. `app/orders/models.py` untouched.

Refs #5 (deliverables #2 and #3 only — does not close the issue).

## Test plan
- [x] `pytest tests/test_prompts.py tests/test_llm_client.py` — 33/33 pass (4 new).
- [ ] Manual: place a test call, request a customization, confirm the read-back includes it and matches the `update_order` subtotal.
- [ ] Manual: request a contradictory modifier, confirm the agent asks to clarify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)