### PR TITLE
Add ExitPlanMode to niko-developer agent tool list

### DIFF
--- a/.claude/agents/niko-developer.md
+++ b/.claude/agents/niko-developer.md
@@ -1,7 +1,7 @@
 ---
 name: niko-developer
 description: Implements features and fixes in the niko backend (FastAPI/Python in `app/`) or dashboard (Next.js/TypeScript in `dashboard/`). Use for call-flow changes, prompt menu work, restaurant onboarding, orders lifecycle, dashboard UI, Firestore storage, telephony routing. Should NOT do code review or release management — hand off to niko-reviewer / niko-pm for those.
-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch
+tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, ExitPlanMode
 model: sonnet
 ---
 


### PR DESCRIPTION
## Summary
- When `niko-developer` is spawned with `mode: "plan"` (e.g. as a teammate where plan approval is required before edits), the agent must call `ExitPlanMode` to surface its plan. The tool was missing from the agent's declared tool list, so plan-mode spawns silently ended turns idle without ever presenting a plan.
- Discovered during the Sprint 2.2 team setup (PR #101) — the developer teammate went idle five times before we figured out the tool wasn't in its allowlist.

## Test plan
- [ ] Spawn an agent team with `niko-developer` in plan mode and confirm the agent surfaces an ExitPlanMode plan on its first turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)