### PR TITLE
Kitchen workflow UI (B3 of B, #111)

### DIFF
--- a/dashboard/app/actions/transition-order.ts
+++ b/dashboard/app/actions/transition-order.ts
@@ -1,0 +1,68 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { z } from 'zod';
+
+import {
+  markPreparingApi,
+  markReadyApi,
+  markCompletedApi,
+} from '@/lib/api/orders';
+
+const InputSchema = z.object({
+  call_sid: z.string().min(1),
+});
+
+export type TransitionActionResult =
+  | { success: true }
+  | { success: false; error: string };
+
+/**
+ * Server Actions for the kitchen workflow transitions, mirroring the
+ * existing cancelOrder action shape.
+ *
+ * Each action validates input, calls the corresponding FastAPI endpoint
+ * via the API client, revalidates the orders feed + the order's detail
+ * page on success, and returns a typed discriminated union.
+ *
+ * Race note: the backend is the single writer for these transitions
+ * (no AI-side races post-call). The dashboard relies on Firestore
+ * onSnapshot to reflect the new state in addition to revalidation.
+ */
+
+async function runTransition(
+  input: unknown,
+  apiCall: (callSid: string) => Promise<{ success: boolean; error?: string }>,
+): Promise<TransitionActionResult> {
+  const parsed = InputSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: 'Invalid input' };
+  }
+
+  const result = await apiCall(parsed.data.call_sid);
+  if (!result.success) {
+    return { success: false, error: result.error ?? 'Unknown error' };
+  }
+
+  revalidatePath('/');
+  revalidatePath(`/orders/${parsed.data.call_sid}`);
+  return { success: true };
+}
+
+export async function markPreparingAction(
+  input: unknown,
+): Promise<TransitionActionResult> {
+  return runTransition(input, markPreparingApi);
+}
+
+export async function markReadyAction(
+  input: unknown,
+): Promise<TransitionActionResult> {
+  return runTransition(input, markReadyApi);
+}
+
+export async function markCompletedAction(
+  input: unknown,
+): Promise<TransitionActionResult> {
+  return runTransition(input, markCompletedApi);
+}

--- a/dashboard/components/orders/filter-tabs.tsx
+++ b/dashboard/components/orders/filter-tabs.tsx
@@ -15,6 +15,9 @@ const TABS: Tab[] = [
   { key: 'all', label: 'All', href: '/' },
   { key: 'in_progress', label: 'Live', href: '/?status=in_progress' },
   { key: 'confirmed', label: 'Confirmed', href: '/?status=confirmed' },
+  { key: 'preparing', label: 'Preparing', href: '/?status=preparing' },
+  { key: 'ready', label: 'Ready', href: '/?status=ready' },
+  { key: 'completed', label: 'Completed', href: '/?status=completed' },
   { key: 'cancelled', label: 'Cancelled', href: '/?status=cancelled' },
 ];
 

--- a/dashboard/components/orders/order-detail.tsx
+++ b/dashboard/components/orders/order-detail.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Play } from 'lucide-react';
 import { CallDuration } from '@/components/orders/call-duration';
 import { CancelOrderButton } from '@/components/orders/cancel-order-button';
 import { StatusBadge } from '@/components/orders/status-badge';
+import { TransitionButton } from '@/components/orders/transition-button';
 import { LocalTime } from '@/components/shared/local-time';
 import { Button } from '@/components/ui/button';
 import {
@@ -27,8 +28,11 @@ export function OrderDetail({ order }: { order: Order }) {
       <CallerCard order={order} />
       <ItemsCard order={order} />
       <SubtotalCard order={order} />
-      {order.status === 'confirmed' && (
-        <div className="pt-2">
+      {(order.status === 'confirmed' ||
+        order.status === 'preparing' ||
+        order.status === 'ready') && (
+        <div className="flex flex-wrap items-center gap-2 pt-2">
+          <TransitionButton order={order} />
           <CancelOrderButton callSid={order.call_sid} />
         </div>
       )}
@@ -56,6 +60,12 @@ function Header({ order }: { order: Order }) {
 
 function headerTimestamp(order: Order): React.ReactNode {
   switch (order.status) {
+    case 'in_progress':
+      return (
+        <>
+          Started <LocalTime date={order.created_at} mode="absolute" />
+        </>
+      );
     case 'confirmed':
       return order.confirmed_at ? (
         <>
@@ -64,18 +74,46 @@ function headerTimestamp(order: Order): React.ReactNode {
       ) : (
         <>Confirmed</>
       );
+    case 'preparing':
+      return order.preparing_at ? (
+        <>
+          Started prep <LocalTime date={order.preparing_at} mode="absolute" />
+        </>
+      ) : (
+        <>Preparing</>
+      );
+    case 'ready':
+      return order.ready_at ? (
+        <>
+          Ready <LocalTime date={order.ready_at} mode="absolute" />
+        </>
+      ) : (
+        <>Ready</>
+      );
+    case 'completed':
+      return order.completed_at ? (
+        <>
+          Completed <LocalTime date={order.completed_at} mode="absolute" />
+        </>
+      ) : (
+        <>Completed</>
+      );
     case 'cancelled':
-      return (
+      return order.cancelled_at ? (
+        <>
+          Cancelled <LocalTime date={order.cancelled_at} mode="absolute" />
+        </>
+      ) : (
         <>
           Cancelled <LocalTime date={order.created_at} mode="absolute" />
         </>
       );
-    case 'in_progress':
-      return (
-        <>
-          Started <LocalTime date={order.created_at} mode="absolute" />
-        </>
-      );
+    default: {
+      // Exhaustiveness check: if a new OrderStatus is added without a
+      // case here, TypeScript will error on this line.
+      const _exhaustive: never = order.status;
+      return _exhaustive;
+    }
   }
 }
 

--- a/dashboard/components/orders/orders-table.tsx
+++ b/dashboard/components/orders/orders-table.tsx
@@ -3,6 +3,7 @@ import { PhoneIncoming } from 'lucide-react';
 
 import { LocalTime } from '@/components/shared/local-time';
 import { StatusBadge } from '@/components/orders/status-badge';
+import { TransitionButton } from '@/components/orders/transition-button';
 import { type Order, orderShortId } from '@/lib/schemas/order';
 import { formatCAD } from '@/lib/formatters/money';
 import { formatPhone } from '@/lib/formatters/phone';
@@ -31,6 +32,7 @@ export function OrdersTable({
             <Th>Items</Th>
             <Th className="w-32 text-right">Subtotal</Th>
             <Th className="w-32">Status</Th>
+            <Th className="w-36">Action</Th>
           </tr>
         </thead>
         <tbody>
@@ -118,6 +120,9 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
         <Link href={`/orders/${encodeURIComponent(order.call_sid)}`}>
           <StatusBadge status={order.status} />
         </Link>
+      </Td>
+      <Td>
+        <TransitionButton order={order} />
       </Td>
     </tr>
   );

--- a/dashboard/components/orders/transition-button.tsx
+++ b/dashboard/components/orders/transition-button.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useTransition } from 'react';
+import { toast } from 'sonner';
+
+import {
+  markPreparingAction,
+  markReadyAction,
+  markCompletedAction,
+  type TransitionActionResult,
+} from '@/app/actions/transition-order';
+import { Button } from '@/components/ui/button';
+import { type Order, orderShortId } from '@/lib/schemas/order';
+
+type TransitionConfig = {
+  label: string;
+  pendingLabel: string;
+  variant: 'default' | 'outline';
+  successMessage: string;
+  action: (input: { call_sid: string }) => Promise<TransitionActionResult>;
+};
+
+/**
+ * Status-aware action button. Renders the next-action button for orders
+ * in confirmed/preparing/ready; renders nothing for terminal or
+ * not-yet-confirmed orders.
+ *
+ * No confirmation dialog — kitchen wants single-tap speed. Cancel
+ * (which IS destructive) keeps its own dialog in CancelOrderButton.
+ */
+export function TransitionButton({ order }: { order: Order }) {
+  const config = configFor(order);
+  if (!config) return null;
+
+  return <ActiveButton order={order} config={config} />;
+}
+
+function configFor(order: Order): TransitionConfig | null {
+  switch (order.status) {
+    case 'confirmed':
+      return {
+        label: 'Start Preparing',
+        pendingLabel: 'Starting…',
+        variant: 'default',
+        successMessage: `Order ${orderShortId(order)} is now preparing`,
+        action: (input) => markPreparingAction(input),
+      };
+    case 'preparing':
+      return {
+        label: 'Mark Ready',
+        pendingLabel: 'Marking…',
+        variant: 'default',
+        successMessage: `Order ${orderShortId(order)} is ready`,
+        action: (input) => markReadyAction(input),
+      };
+    case 'ready':
+      return {
+        label: 'Mark Completed',
+        pendingLabel: 'Completing…',
+        variant: 'outline',
+        successMessage: `Order ${orderShortId(order)} is completed`,
+        action: (input) => markCompletedAction(input),
+      };
+    case 'in_progress':
+    case 'completed':
+    case 'cancelled':
+      return null;
+  }
+}
+
+function ActiveButton({
+  order,
+  config,
+}: {
+  order: Order;
+  config: TransitionConfig;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  function onClick() {
+    startTransition(async () => {
+      const result = await config.action({ call_sid: order.call_sid });
+      if (result.success) {
+        toast.success(config.successMessage);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <Button
+      variant={config.variant}
+      size="sm"
+      onClick={onClick}
+      disabled={isPending}
+    >
+      {isPending ? config.pendingLabel : config.label}
+    </Button>
+  );
+}

--- a/dashboard/lib/api/orders.ts
+++ b/dashboard/lib/api/orders.ts
@@ -111,6 +111,61 @@ export async function cancelOrderApi(callSid: string): Promise<CancelResult> {
   return { success: true, order: parsed.data };
 }
 
+// ---------------------------------------------------------------------------
+// B3 transition API functions (Sprint 2.2 #111)
+// ---------------------------------------------------------------------------
+// Each is a thin wrapper around POST /orders/{call_sid}/{transition}.
+// Same shape as cancelOrderApi: returns { success: true, order } on 200,
+// { success: false, error } on 4xx/5xx (FastAPI's { detail } surfaced).
+
+export type TransitionResult =
+  | { success: true; order: Order }
+  | { success: false; error: string };
+
+async function postTransition(
+  callSid: string,
+  transition: 'preparing' | 'ready' | 'completed',
+): Promise<TransitionResult> {
+  const path = `/orders/${encodeURIComponent(callSid)}/${transition}`;
+  const res = await apiFetch(path, { method: 'POST' });
+
+  if (!res.ok) {
+    // FastAPI returns { detail: string } on 4xx — surface that to the user.
+    let detail: string;
+    try {
+      const body = (await res.json()) as { detail?: unknown };
+      detail =
+        typeof body.detail === 'string'
+          ? body.detail
+          : `${res.status} ${res.statusText}`;
+    } catch {
+      detail = `${res.status} ${res.statusText}`;
+    }
+    return { success: false, error: detail };
+  }
+
+  const body = await res.json();
+  const parsed = OrderSchema.safeParse(
+    body && typeof body === 'object' && 'order' in body ? body.order : body,
+  );
+  if (!parsed.success) {
+    return { success: false, error: `${transition} response failed validation` };
+  }
+  return { success: true, order: parsed.data };
+}
+
+export function markPreparingApi(callSid: string): Promise<TransitionResult> {
+  return postTransition(callSid, 'preparing');
+}
+
+export function markReadyApi(callSid: string): Promise<TransitionResult> {
+  return postTransition(callSid, 'ready');
+}
+
+export function markCompletedApi(callSid: string): Promise<TransitionResult> {
+  return postTransition(callSid, 'completed');
+}
+
 export function parseStatusParam(raw: string | undefined): OrderStatus | undefined {
   if (!raw) return undefined;
   const parsed = OrderStatusSchema.safeParse(raw);

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.3
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -104,6 +107,9 @@ importers:
         version: 3.2.4(@types/node@20.19.39)(jiti@2.6.1)(jsdom@29.0.2)(lightningcss@1.32.0)(tsx@4.21.0)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1957,6 +1963,10 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -2447,6 +2457,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2532,6 +2545,9 @@ packages:
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3022,6 +3038,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -3415,6 +3435,10 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3698,6 +3722,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3886,6 +3914,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -4283,6 +4315,8 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -6119,6 +6153,15 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -6634,6 +6677,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
@@ -6707,6 +6752,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -7483,6 +7530,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inherits@2.0.4:
     optional: true
 
@@ -7868,6 +7917,8 @@ snapshots:
   mime@3.0.0:
     optional: true
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -8204,6 +8255,11 @@ snapshots:
       util-deprecate: 1.0.2
     optional: true
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -8504,6 +8560,10 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 

--- a/dashboard/tests/setup.ts
+++ b/dashboard/tests/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});

--- a/dashboard/tests/transition-actions.test.ts
+++ b/dashboard/tests/transition-actions.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the API client and Next.js cache before importing the actions.
+vi.mock('@/lib/api/orders', () => ({
+  markPreparingApi: vi.fn(),
+  markReadyApi: vi.fn(),
+  markCompletedApi: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import {
+  markPreparingApi,
+  markReadyApi,
+  markCompletedApi,
+} from '@/lib/api/orders';
+import { revalidatePath } from 'next/cache';
+
+import {
+  markPreparingAction,
+  markReadyAction,
+  markCompletedAction,
+} from '@/app/actions/transition-order';
+
+import type { OrderStatus } from '@/lib/schemas/order';
+
+const okOrder = (call_sid: string, status: OrderStatus) => ({
+  success: true as const,
+  order: {
+    call_sid,
+    caller_phone: null,
+    restaurant_id: 'r',
+    items: [],
+    order_type: 'pickup' as const,
+    delivery_address: null,
+    status,
+    created_at: new Date(),
+    confirmed_at: new Date(),
+    subtotal: 0,
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('markPreparingAction', () => {
+  it('returns success and revalidates paths on 200', async () => {
+    vi.mocked(markPreparingApi).mockResolvedValueOnce(
+      okOrder('CAtest', 'preparing'),
+    );
+    const result = await markPreparingAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: true });
+    expect(markPreparingApi).toHaveBeenCalledWith('CAtest');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(revalidatePath).toHaveBeenCalledWith('/orders/CAtest');
+  });
+
+  it('returns failure when the API client returns failure', async () => {
+    vi.mocked(markPreparingApi).mockResolvedValueOnce({
+      success: false,
+      error: 'Cannot transition order CAtest to preparing: ...',
+    });
+    const result = await markPreparingAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({
+      success: false,
+      error: 'Cannot transition order CAtest to preparing: ...',
+    });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty call_sid input', async () => {
+    const result = await markPreparingAction({ call_sid: '' });
+    expect(result).toEqual({ success: false, error: 'Invalid input' });
+    expect(markPreparingApi).not.toHaveBeenCalled();
+  });
+});
+
+describe('markReadyAction', () => {
+  it('returns success and revalidates paths on 200', async () => {
+    vi.mocked(markReadyApi).mockResolvedValueOnce(okOrder('CAtest', 'ready'));
+    const result = await markReadyAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: true });
+    expect(markReadyApi).toHaveBeenCalledWith('CAtest');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(revalidatePath).toHaveBeenCalledWith('/orders/CAtest');
+  });
+
+  it('returns failure when the API client returns failure', async () => {
+    vi.mocked(markReadyApi).mockResolvedValueOnce({
+      success: false,
+      error: 'Cannot transition',
+    });
+    const result = await markReadyAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: false, error: 'Cannot transition' });
+  });
+
+  it('rejects empty call_sid input', async () => {
+    const result = await markReadyAction({ call_sid: '' });
+    expect(result).toEqual({ success: false, error: 'Invalid input' });
+  });
+});
+
+describe('markCompletedAction', () => {
+  it('returns success and revalidates paths on 200', async () => {
+    vi.mocked(markCompletedApi).mockResolvedValueOnce(
+      okOrder('CAtest', 'completed'),
+    );
+    const result = await markCompletedAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: true });
+    expect(markCompletedApi).toHaveBeenCalledWith('CAtest');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(revalidatePath).toHaveBeenCalledWith('/orders/CAtest');
+  });
+
+  it('returns failure when the API client returns failure', async () => {
+    vi.mocked(markCompletedApi).mockResolvedValueOnce({
+      success: false,
+      error: 'Cannot transition',
+    });
+    const result = await markCompletedAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: false, error: 'Cannot transition' });
+  });
+
+  it('rejects empty call_sid input', async () => {
+    const result = await markCompletedAction({ call_sid: '' });
+    expect(result).toEqual({ success: false, error: 'Invalid input' });
+  });
+});

--- a/dashboard/tests/transition-button.test.tsx
+++ b/dashboard/tests/transition-button.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/app/actions/transition-order', () => ({
+  markPreparingAction: vi.fn(),
+  markReadyAction: vi.fn(),
+  markCompletedAction: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  markPreparingAction,
+  markReadyAction,
+  markCompletedAction,
+} from '@/app/actions/transition-order';
+import { toast } from 'sonner';
+
+import { TransitionButton } from '@/components/orders/transition-button';
+import type { Order, OrderStatus } from '@/lib/schemas/order';
+
+function makeOrder(status: OrderStatus): Order {
+  return {
+    call_sid: 'CA1234ABCD',
+    caller_phone: null,
+    restaurant_id: 'r',
+    items: [],
+    order_type: 'pickup',
+    delivery_address: null,
+    status,
+    created_at: new Date(),
+    confirmed_at: new Date(),
+    subtotal: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it('renders nothing for in_progress orders', () => {
+  const { container } = render(<TransitionButton order={makeOrder('in_progress')} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('renders nothing for completed orders', () => {
+  const { container } = render(<TransitionButton order={makeOrder('completed')} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('renders nothing for cancelled orders', () => {
+  const { container } = render(<TransitionButton order={makeOrder('cancelled')} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('renders Start Preparing for confirmed orders and calls markPreparingAction on click', async () => {
+  vi.mocked(markPreparingAction).mockResolvedValueOnce({ success: true });
+  render(<TransitionButton order={makeOrder('confirmed')} />);
+
+  const button = screen.getByRole('button', { name: /start preparing/i });
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(markPreparingAction).toHaveBeenCalledWith({ call_sid: 'CA1234ABCD' });
+  });
+  await waitFor(() => {
+    expect(toast.success).toHaveBeenCalled();
+  });
+});
+
+it('renders Mark Ready for preparing orders and calls markReadyAction on click', async () => {
+  vi.mocked(markReadyAction).mockResolvedValueOnce({ success: true });
+  render(<TransitionButton order={makeOrder('preparing')} />);
+
+  const button = screen.getByRole('button', { name: /mark ready/i });
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(markReadyAction).toHaveBeenCalledWith({ call_sid: 'CA1234ABCD' });
+  });
+});
+
+it('renders Mark Completed for ready orders and calls markCompletedAction on click', async () => {
+  vi.mocked(markCompletedAction).mockResolvedValueOnce({ success: true });
+  render(<TransitionButton order={makeOrder('ready')} />);
+
+  const button = screen.getByRole('button', { name: /mark completed/i });
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(markCompletedAction).toHaveBeenCalledWith({ call_sid: 'CA1234ABCD' });
+  });
+});
+
+it('shows error toast when the action returns failure', async () => {
+  vi.mocked(markPreparingAction).mockResolvedValueOnce({
+    success: false,
+    error: 'order not found',
+  });
+  render(<TransitionButton order={makeOrder('confirmed')} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /start preparing/i }));
+
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith('order not found');
+  });
+  expect(toast.success).not.toHaveBeenCalled();
+});

--- a/dashboard/vitest.config.mts
+++ b/dashboard/vitest.config.mts
@@ -11,5 +11,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
+    setupFiles: ['tests/setup.ts'],
   },
 });

--- a/docs/superpowers/plans/2026-04-29-kitchen-workflow-ui.md
+++ b/docs/superpowers/plans/2026-04-29-kitchen-workflow-ui.md
@@ -1,0 +1,1056 @@
+# Kitchen Workflow UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the kitchen-facing UI to the transition endpoints from B1. Each order shows a single status-aware action button (Start Preparing → Mark Ready → Mark Completed) on both the row and the detail page. Filter tabs grow to surface each lifecycle stage.
+
+**Architecture:** Mirror the existing `cancelOrder` / `cancelOrderApi` / `CancelOrderButton` pattern. Three new API client functions + three new Server Actions + one shared status-aware `TransitionButton` component. Each transition is a thin wrapper around `POST /orders/{call_sid}/{transition}`. UI is integrated by adding an "Action" column to `OrdersTable`, a button on the order-detail page, and three new entries in `FilterTabs`. The B1 follow-up `headerTimestamp` gap is fixed in this PR.
+
+**Tech Stack:** Next.js 15 + React 19 + TypeScript strict; Tailwind v4 (OKLCH tokens); Vitest 3.2 + `@testing-library/react` + jsdom; sonner for toasts; Zod for input validation.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-kitchen-workflow-ui-design.md`
+**Tracking issue:** [#111](https://github.com/tsuki-works/niko/issues/111)
+**Branch:** `feat/111-kitchen-workflow-ui` (already created; spec already committed at `bca80c1`)
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `dashboard/lib/api/orders.ts` | Modify | 3 new functions (`markPreparingApi`, `markReadyApi`, `markCompletedApi`) — thin wrappers around `apiFetch` returning a discriminated-union result, mirroring `cancelOrderApi` |
+| `dashboard/app/actions/transition-order.ts` | Create | 3 Server Actions (`markPreparingAction`, `markReadyAction`, `markCompletedAction`) — Zod input validation, call API client, `revalidatePath`, return discriminated union |
+| `dashboard/components/orders/transition-button.tsx` | Create | Status-aware button: renders nothing for terminal states; renders the next-action button for `confirmed`/`preparing`/`ready`. Uses `useTransition` + sonner toast |
+| `dashboard/components/orders/orders-table.tsx` | Modify | Add a 6th right-most "Action" column rendering `<TransitionButton order={order} />` |
+| `dashboard/components/orders/order-detail.tsx` | Modify | Render `<TransitionButton order={order} />` next to the existing `<CancelOrderButton>`; broaden cancel render condition to `confirmed | preparing | ready`; add `headerTimestamp` cases for the 3 new statuses with `never` default |
+| `dashboard/components/orders/filter-tabs.tsx` | Modify | Extend `TABS` array with 3 entries (preparing / ready / completed) |
+| `dashboard/tests/transition-actions.test.ts` | Create | Vitest: 9 tests (3 actions × 3 patterns: 200 success, 4xx with detail, input validation) — mocks `apiFetch` |
+| `dashboard/tests/transition-button.test.tsx` | Create | Vitest with `// @vitest-environment jsdom` + RTL: 7 tests covering each status branch + toast feedback + pending state |
+
+The work decomposes naturally into 5 layers: API client → Server Actions → Button component → 3 small UI integrations → final review/PR. Each lower layer is a dependency for the next.
+
+---
+
+## Task 1: API client functions in `dashboard/lib/api/orders.ts`
+
+**Files:**
+- Modify: `dashboard/lib/api/orders.ts` (append 3 new exported functions; reuse the existing `CancelResult` type by renaming it, OR add a sibling `TransitionResult` type — implementer's call, both are acceptable)
+
+- [ ] **Step 1: Add the 3 new functions to `dashboard/lib/api/orders.ts`**
+
+Open `dashboard/lib/api/orders.ts`. Find the existing `CancelResult` type definition (around line 73) and the `cancelOrderApi` function. Immediately AFTER `cancelOrderApi` ends (before `parseStatusParam`), insert this block:
+
+```typescript
+
+// ---------------------------------------------------------------------------
+// B3 transition API functions (Sprint 2.2 #111)
+// ---------------------------------------------------------------------------
+// Each is a thin wrapper around POST /orders/{call_sid}/{transition}.
+// Same shape as cancelOrderApi: returns { success: true, order } on 200,
+// { success: false, error } on 4xx/5xx (FastAPI's { detail } surfaced).
+
+export type TransitionResult =
+  | { success: true; order: Order }
+  | { success: false; error: string };
+
+async function postTransition(
+  callSid: string,
+  transition: 'preparing' | 'ready' | 'completed',
+): Promise<TransitionResult> {
+  const path = `/orders/${encodeURIComponent(callSid)}/${transition}`;
+  const res = await apiFetch(path, { method: 'POST' });
+
+  if (!res.ok) {
+    // FastAPI returns { detail: string } on 4xx — surface that to the user.
+    let detail: string;
+    try {
+      const body = (await res.json()) as { detail?: unknown };
+      detail =
+        typeof body.detail === 'string'
+          ? body.detail
+          : `${res.status} ${res.statusText}`;
+    } catch {
+      detail = `${res.status} ${res.statusText}`;
+    }
+    return { success: false, error: detail };
+  }
+
+  const body = await res.json();
+  const parsed = OrderSchema.safeParse(
+    body && typeof body === 'object' && 'order' in body ? body.order : body,
+  );
+  if (!parsed.success) {
+    return { success: false, error: `${transition} response failed validation` };
+  }
+  return { success: true, order: parsed.data };
+}
+
+export function markPreparingApi(callSid: string): Promise<TransitionResult> {
+  return postTransition(callSid, 'preparing');
+}
+
+export function markReadyApi(callSid: string): Promise<TransitionResult> {
+  return postTransition(callSid, 'ready');
+}
+
+export function markCompletedApi(callSid: string): Promise<TransitionResult> {
+  return postTransition(callSid, 'completed');
+}
+```
+
+- [ ] **Step 2: Verify TS compiles**
+
+Run from repo root: `(cd dashboard && pnpm tsc --noEmit)`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/lib/api/orders.ts
+git commit -m "Add transition API client functions (#111)
+
+Three new exports — markPreparingApi, markReadyApi, markCompletedApi —
+each a thin wrapper around POST /orders/{call_sid}/{transition} via
+the existing apiFetch helper. Return TransitionResult discriminated
+union mirroring cancelOrderApi's shape. Internal postTransition helper
+de-dupes the response-handling logic across the three transitions.
+
+Server Actions wrapping these land in the next commit."
+```
+
+Stage ONLY `dashboard/lib/api/orders.ts`.
+
+---
+
+## Task 2: Server Actions in `dashboard/app/actions/transition-order.ts`
+
+**Files:**
+- Create: `dashboard/app/actions/transition-order.ts`
+- Create: `dashboard/tests/transition-actions.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `dashboard/tests/transition-actions.test.ts` with this exact content:
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the API client and Next.js cache before importing the actions.
+vi.mock('@/lib/api/orders', () => ({
+  markPreparingApi: vi.fn(),
+  markReadyApi: vi.fn(),
+  markCompletedApi: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import {
+  markPreparingApi,
+  markReadyApi,
+  markCompletedApi,
+} from '@/lib/api/orders';
+import { revalidatePath } from 'next/cache';
+
+import {
+  markPreparingAction,
+  markReadyAction,
+  markCompletedAction,
+} from '@/app/actions/transition-order';
+
+const okOrder = (call_sid: string, status: string) => ({
+  success: true as const,
+  order: {
+    call_sid,
+    caller_phone: null,
+    restaurant_id: 'r',
+    items: [],
+    order_type: 'pickup' as const,
+    delivery_address: null,
+    status,
+    created_at: new Date(),
+    confirmed_at: new Date(),
+    subtotal: 0,
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---- markPreparingAction --------------------------------------------------
+
+describe('markPreparingAction', () => {
+  it('returns success and revalidates paths on 200', async () => {
+    vi.mocked(markPreparingApi).mockResolvedValueOnce(
+      okOrder('CAtest', 'preparing'),
+    );
+    const result = await markPreparingAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: true });
+    expect(markPreparingApi).toHaveBeenCalledWith('CAtest');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(revalidatePath).toHaveBeenCalledWith('/orders/CAtest');
+  });
+
+  it('returns failure when the API client returns failure', async () => {
+    vi.mocked(markPreparingApi).mockResolvedValueOnce({
+      success: false,
+      error: 'Cannot transition order CAtest to preparing: ...',
+    });
+    const result = await markPreparingAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({
+      success: false,
+      error: 'Cannot transition order CAtest to preparing: ...',
+    });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty call_sid input', async () => {
+    const result = await markPreparingAction({ call_sid: '' });
+    expect(result).toEqual({ success: false, error: 'Invalid input' });
+    expect(markPreparingApi).not.toHaveBeenCalled();
+  });
+});
+
+// ---- markReadyAction ------------------------------------------------------
+
+describe('markReadyAction', () => {
+  it('returns success and revalidates paths on 200', async () => {
+    vi.mocked(markReadyApi).mockResolvedValueOnce(okOrder('CAtest', 'ready'));
+    const result = await markReadyAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: true });
+    expect(markReadyApi).toHaveBeenCalledWith('CAtest');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(revalidatePath).toHaveBeenCalledWith('/orders/CAtest');
+  });
+
+  it('returns failure when the API client returns failure', async () => {
+    vi.mocked(markReadyApi).mockResolvedValueOnce({
+      success: false,
+      error: 'Cannot transition',
+    });
+    const result = await markReadyAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: false, error: 'Cannot transition' });
+  });
+
+  it('rejects empty call_sid input', async () => {
+    const result = await markReadyAction({ call_sid: '' });
+    expect(result).toEqual({ success: false, error: 'Invalid input' });
+  });
+});
+
+// ---- markCompletedAction --------------------------------------------------
+
+describe('markCompletedAction', () => {
+  it('returns success and revalidates paths on 200', async () => {
+    vi.mocked(markCompletedApi).mockResolvedValueOnce(
+      okOrder('CAtest', 'completed'),
+    );
+    const result = await markCompletedAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: true });
+    expect(markCompletedApi).toHaveBeenCalledWith('CAtest');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(revalidatePath).toHaveBeenCalledWith('/orders/CAtest');
+  });
+
+  it('returns failure when the API client returns failure', async () => {
+    vi.mocked(markCompletedApi).mockResolvedValueOnce({
+      success: false,
+      error: 'Cannot transition',
+    });
+    const result = await markCompletedAction({ call_sid: 'CAtest' });
+    expect(result).toEqual({ success: false, error: 'Cannot transition' });
+  });
+
+  it('rejects empty call_sid input', async () => {
+    const result = await markCompletedAction({ call_sid: '' });
+    expect(result).toEqual({ success: false, error: 'Invalid input' });
+  });
+});
+```
+
+- [ ] **Step 2: Confirm tests fail**
+
+Run from repo root: `(cd dashboard && pnpm vitest run tests/transition-actions.test.ts 2>&1 | tail -10)`
+Expected: error like `Cannot find module '@/app/actions/transition-order'`.
+
+- [ ] **Step 3: Implement the Server Actions**
+
+Create `dashboard/app/actions/transition-order.ts` with this exact content:
+
+```typescript
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { z } from 'zod';
+
+import {
+  markPreparingApi,
+  markReadyApi,
+  markCompletedApi,
+} from '@/lib/api/orders';
+
+const InputSchema = z.object({
+  call_sid: z.string().min(1),
+});
+
+export type TransitionActionResult =
+  | { success: true }
+  | { success: false; error: string };
+
+/**
+ * Server Actions for the kitchen workflow transitions, mirroring the
+ * existing cancelOrder action shape.
+ *
+ * Each action validates input, calls the corresponding FastAPI endpoint
+ * via the API client, revalidates the orders feed + the order's detail
+ * page on success, and returns a typed discriminated union.
+ *
+ * Race note: the backend is the single writer for these transitions
+ * (no AI-side races post-call). The dashboard relies on Firestore
+ * onSnapshot to reflect the new state in addition to revalidation.
+ */
+
+async function runTransition(
+  input: unknown,
+  apiCall: (callSid: string) => Promise<{ success: boolean; error?: string }>,
+): Promise<TransitionActionResult> {
+  const parsed = InputSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: 'Invalid input' };
+  }
+
+  const result = await apiCall(parsed.data.call_sid);
+  if (!result.success) {
+    return { success: false, error: result.error ?? 'Unknown error' };
+  }
+
+  revalidatePath('/');
+  revalidatePath(`/orders/${parsed.data.call_sid}`);
+  return { success: true };
+}
+
+export async function markPreparingAction(
+  input: unknown,
+): Promise<TransitionActionResult> {
+  return runTransition(input, markPreparingApi);
+}
+
+export async function markReadyAction(
+  input: unknown,
+): Promise<TransitionActionResult> {
+  return runTransition(input, markReadyApi);
+}
+
+export async function markCompletedAction(
+  input: unknown,
+): Promise<TransitionActionResult> {
+  return runTransition(input, markCompletedApi);
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run from repo root: `(cd dashboard && pnpm vitest run tests/transition-actions.test.ts 2>&1 | tail -15)`
+Expected: 9 PASSED.
+
+- [ ] **Step 5: Run the full dashboard suite + typecheck**
+
+Run from repo root: `(cd dashboard && pnpm vitest run && pnpm tsc --noEmit)`
+Expected: all green; TS clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/actions/transition-order.ts dashboard/tests/transition-actions.test.ts
+git commit -m "Add transition Server Actions + 9 vitest unit tests (#111)
+
+Three new Server Actions — markPreparingAction, markReadyAction,
+markCompletedAction — mirror the existing cancelOrder action pattern.
+Each validates input via Zod, calls the corresponding API client
+function, revalidates the orders feed + the order's detail page on
+success, and returns a typed discriminated union.
+
+A small runTransition helper de-dupes the validate/call/revalidate
+boilerplate across the three actions.
+
+9 vitest tests cover success/failure/invalid-input per action with
+mocked API client + mocked next/cache."
+```
+
+---
+
+## Task 3: `TransitionButton` component + tests
+
+**Files:**
+- Create: `dashboard/components/orders/transition-button.tsx`
+- Create: `dashboard/tests/transition-button.test.tsx`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `dashboard/tests/transition-button.test.tsx` with this exact content:
+
+```typescript
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the Server Actions.
+vi.mock('@/app/actions/transition-order', () => ({
+  markPreparingAction: vi.fn(),
+  markReadyAction: vi.fn(),
+  markCompletedAction: vi.fn(),
+}));
+
+// Mock sonner toast.
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  markPreparingAction,
+  markReadyAction,
+  markCompletedAction,
+} from '@/app/actions/transition-order';
+import { toast } from 'sonner';
+
+import { TransitionButton } from '@/components/orders/transition-button';
+import type { Order, OrderStatus } from '@/lib/schemas/order';
+
+function makeOrder(status: OrderStatus): Order {
+  return {
+    call_sid: 'CA1234ABCD',
+    caller_phone: null,
+    restaurant_id: 'r',
+    items: [],
+    order_type: 'pickup',
+    delivery_address: null,
+    status,
+    created_at: new Date(),
+    confirmed_at: new Date(),
+    subtotal: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it('renders nothing for in_progress orders', () => {
+  const { container } = render(<TransitionButton order={makeOrder('in_progress')} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('renders nothing for completed orders', () => {
+  const { container } = render(<TransitionButton order={makeOrder('completed')} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('renders nothing for cancelled orders', () => {
+  const { container } = render(<TransitionButton order={makeOrder('cancelled')} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('renders Start Preparing for confirmed orders and calls markPreparingAction on click', async () => {
+  vi.mocked(markPreparingAction).mockResolvedValueOnce({ success: true });
+  render(<TransitionButton order={makeOrder('confirmed')} />);
+
+  const button = screen.getByRole('button', { name: /start preparing/i });
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(markPreparingAction).toHaveBeenCalledWith({ call_sid: 'CA1234ABCD' });
+  });
+  await waitFor(() => {
+    expect(toast.success).toHaveBeenCalled();
+  });
+});
+
+it('renders Mark Ready for preparing orders and calls markReadyAction on click', async () => {
+  vi.mocked(markReadyAction).mockResolvedValueOnce({ success: true });
+  render(<TransitionButton order={makeOrder('preparing')} />);
+
+  const button = screen.getByRole('button', { name: /mark ready/i });
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(markReadyAction).toHaveBeenCalledWith({ call_sid: 'CA1234ABCD' });
+  });
+});
+
+it('renders Mark Completed for ready orders and calls markCompletedAction on click', async () => {
+  vi.mocked(markCompletedAction).mockResolvedValueOnce({ success: true });
+  render(<TransitionButton order={makeOrder('ready')} />);
+
+  const button = screen.getByRole('button', { name: /mark completed/i });
+  fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(markCompletedAction).toHaveBeenCalledWith({ call_sid: 'CA1234ABCD' });
+  });
+});
+
+it('shows error toast when the action returns failure', async () => {
+  vi.mocked(markPreparingAction).mockResolvedValueOnce({
+    success: false,
+    error: 'order not found',
+  });
+  render(<TransitionButton order={makeOrder('confirmed')} />);
+
+  fireEvent.click(screen.getByRole('button', { name: /start preparing/i }));
+
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith('order not found');
+  });
+  expect(toast.success).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Confirm tests fail**
+
+Run from repo root: `(cd dashboard && pnpm vitest run tests/transition-button.test.tsx 2>&1 | tail -10)`
+Expected: error like `Cannot find module '@/components/orders/transition-button'`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `dashboard/components/orders/transition-button.tsx` with this exact content:
+
+```typescript
+'use client';
+
+import { useTransition } from 'react';
+import { toast } from 'sonner';
+
+import {
+  markPreparingAction,
+  markReadyAction,
+  markCompletedAction,
+  type TransitionActionResult,
+} from '@/app/actions/transition-order';
+import { Button } from '@/components/ui/button';
+import { type Order, orderShortId } from '@/lib/schemas/order';
+
+type TransitionConfig = {
+  label: string;
+  pendingLabel: string;
+  variant: 'default' | 'outline';
+  successMessage: string;
+  action: (input: { call_sid: string }) => Promise<TransitionActionResult>;
+};
+
+/**
+ * Status-aware action button. Renders the next-action button for orders
+ * in confirmed/preparing/ready; renders nothing for terminal or
+ * not-yet-confirmed orders.
+ *
+ * No confirmation dialog — kitchen wants single-tap speed. Cancel
+ * (which IS destructive) keeps its own dialog in CancelOrderButton.
+ */
+export function TransitionButton({ order }: { order: Order }) {
+  const config = configFor(order);
+  if (!config) return null;
+
+  return <ActiveButton order={order} config={config} />;
+}
+
+function configFor(order: Order): TransitionConfig | null {
+  switch (order.status) {
+    case 'confirmed':
+      return {
+        label: 'Start Preparing',
+        pendingLabel: 'Starting…',
+        variant: 'default',
+        successMessage: `Order ${orderShortId(order)} is now preparing`,
+        action: (input) => markPreparingAction(input),
+      };
+    case 'preparing':
+      return {
+        label: 'Mark Ready',
+        pendingLabel: 'Marking…',
+        variant: 'default',
+        successMessage: `Order ${orderShortId(order)} is ready`,
+        action: (input) => markReadyAction(input),
+      };
+    case 'ready':
+      return {
+        label: 'Mark Completed',
+        pendingLabel: 'Completing…',
+        variant: 'outline',
+        successMessage: `Order ${orderShortId(order)} is completed`,
+        action: (input) => markCompletedAction(input),
+      };
+    case 'in_progress':
+    case 'completed':
+    case 'cancelled':
+      return null;
+  }
+}
+
+function ActiveButton({
+  order,
+  config,
+}: {
+  order: Order;
+  config: TransitionConfig;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  function onClick() {
+    startTransition(async () => {
+      const result = await config.action({ call_sid: order.call_sid });
+      if (result.success) {
+        toast.success(config.successMessage);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <Button
+      variant={config.variant}
+      size="sm"
+      onClick={onClick}
+      disabled={isPending}
+    >
+      {isPending ? config.pendingLabel : config.label}
+    </Button>
+  );
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+Run from repo root: `(cd dashboard && pnpm vitest run tests/transition-button.test.tsx 2>&1 | tail -15)`
+Expected: 7 PASSED.
+
+- [ ] **Step 5: Run the full dashboard suite + typecheck**
+
+Run from repo root: `(cd dashboard && pnpm vitest run && pnpm tsc --noEmit)`
+Expected: all green; TS clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/components/orders/transition-button.tsx dashboard/tests/transition-button.test.tsx
+git commit -m "Add TransitionButton component + 7 vitest tests (#111)
+
+Single status-aware button: renders the next-action button for orders
+in confirmed/preparing/ready; renders nothing for terminal or
+not-yet-confirmed orders. Wraps the corresponding Server Action with
+useTransition + sonner toast feedback. No confirmation dialog for
+forward transitions — kitchen wants single-tap speed.
+
+7 vitest tests cover all 6 status branches + error toast flow."
+```
+
+---
+
+## Task 4: Wire `TransitionButton` into `OrdersTable` + `OrderDetail` + `FilterTabs`
+
+This task is one logical chunk: three small UI integrations. Single commit at the end.
+
+**Files:**
+- Modify: `dashboard/components/orders/orders-table.tsx` (add Action column)
+- Modify: `dashboard/components/orders/order-detail.tsx` (render button + fix headerTimestamp + broaden cancel render condition)
+- Modify: `dashboard/components/orders/filter-tabs.tsx` (extend TABS array)
+
+- [ ] **Step 1: `OrdersTable` — add Action column**
+
+In `dashboard/components/orders/orders-table.tsx`:
+
+#### Step 1a — Add the import
+
+Find the existing imports near the top:
+
+```typescript
+import { LocalTime } from '@/components/shared/local-time';
+import { StatusBadge } from '@/components/orders/status-badge';
+```
+
+Add `TransitionButton`:
+
+```typescript
+import { LocalTime } from '@/components/shared/local-time';
+import { StatusBadge } from '@/components/orders/status-badge';
+import { TransitionButton } from '@/components/orders/transition-button';
+```
+
+#### Step 1b — Add the Action column header
+
+Find the existing `<thead>` block (around line 25):
+
+```typescript
+        <thead className="bg-muted/40 text-muted-foreground">
+          <tr>
+            <Th className="w-28">Order</Th>
+            <Th className="w-24">Time</Th>
+            <Th>Items</Th>
+            <Th className="w-32 text-right">Subtotal</Th>
+            <Th className="w-32">Status</Th>
+          </tr>
+        </thead>
+```
+
+Replace with (add a 6th column header):
+
+```typescript
+        <thead className="bg-muted/40 text-muted-foreground">
+          <tr>
+            <Th className="w-28">Order</Th>
+            <Th className="w-24">Time</Th>
+            <Th>Items</Th>
+            <Th className="w-32 text-right">Subtotal</Th>
+            <Th className="w-32">Status</Th>
+            <Th className="w-36">Action</Th>
+          </tr>
+        </thead>
+```
+
+#### Step 1c — Render the button in each row
+
+Find the `<Td>` block at the end of `OrderRow` (the Status column, around line 108-112):
+
+```typescript
+      <Td>
+        <Link href={`/orders/${encodeURIComponent(order.call_sid)}`}>
+          <StatusBadge status={order.status} />
+        </Link>
+      </Td>
+    </tr>
+  );
+}
+```
+
+Replace with (add a 6th `<Td>` for the action button — note the cell is OUTSIDE the `<Link>`, since clicking the button should NOT navigate to the detail page):
+
+```typescript
+      <Td>
+        <Link href={`/orders/${encodeURIComponent(order.call_sid)}`}>
+          <StatusBadge status={order.status} />
+        </Link>
+      </Td>
+      <Td>
+        <TransitionButton order={order} />
+      </Td>
+    </tr>
+  );
+}
+```
+
+- [ ] **Step 2: `OrderDetail` — render button + fix headerTimestamp + broaden cancel condition**
+
+In `dashboard/components/orders/order-detail.tsx`:
+
+#### Step 2a — Add the import
+
+Find the existing imports:
+
+```typescript
+import { CancelOrderButton } from '@/components/orders/cancel-order-button';
+import { StatusBadge } from '@/components/orders/status-badge';
+```
+
+Add `TransitionButton`:
+
+```typescript
+import { CancelOrderButton } from '@/components/orders/cancel-order-button';
+import { StatusBadge } from '@/components/orders/status-badge';
+import { TransitionButton } from '@/components/orders/transition-button';
+```
+
+#### Step 2b — Render the TransitionButton + broaden cancel render condition
+
+Find the existing render block at the bottom of `OrderDetail` (around line 30-34):
+
+```typescript
+      {order.status === 'confirmed' && (
+        <div className="pt-2">
+          <CancelOrderButton callSid={order.call_sid} />
+        </div>
+      )}
+```
+
+Replace with (broaden cancel condition + add TransitionButton to the same actions row):
+
+```typescript
+      {(order.status === 'confirmed' ||
+        order.status === 'preparing' ||
+        order.status === 'ready') && (
+        <div className="flex flex-wrap items-center gap-2 pt-2">
+          <TransitionButton order={order} />
+          <CancelOrderButton callSid={order.call_sid} />
+        </div>
+      )}
+```
+
+#### Step 2c — Fix `headerTimestamp` for the new statuses with exhaustive `never` default
+
+Find the existing `headerTimestamp` function (around line 57-80):
+
+```typescript
+function headerTimestamp(order: Order): React.ReactNode {
+  switch (order.status) {
+    case 'confirmed':
+      return order.confirmed_at ? (
+        <>
+          Confirmed <LocalTime date={order.confirmed_at} mode="absolute" />
+        </>
+      ) : (
+        <>Confirmed</>
+      );
+    case 'cancelled':
+      return (
+        <>
+          Cancelled <LocalTime date={order.created_at} mode="absolute" />
+        </>
+      );
+    case 'in_progress':
+      return (
+        <>
+          Started <LocalTime date={order.created_at} mode="absolute" />
+        </>
+      );
+  }
+}
+```
+
+Replace with (add the 3 new cases + exhaustive `never` default that forces a TS error if a future status is added):
+
+```typescript
+function headerTimestamp(order: Order): React.ReactNode {
+  switch (order.status) {
+    case 'in_progress':
+      return (
+        <>
+          Started <LocalTime date={order.created_at} mode="absolute" />
+        </>
+      );
+    case 'confirmed':
+      return order.confirmed_at ? (
+        <>
+          Confirmed <LocalTime date={order.confirmed_at} mode="absolute" />
+        </>
+      ) : (
+        <>Confirmed</>
+      );
+    case 'preparing':
+      return order.preparing_at ? (
+        <>
+          Started prep <LocalTime date={order.preparing_at} mode="absolute" />
+        </>
+      ) : (
+        <>Preparing</>
+      );
+    case 'ready':
+      return order.ready_at ? (
+        <>
+          Ready <LocalTime date={order.ready_at} mode="absolute" />
+        </>
+      ) : (
+        <>Ready</>
+      );
+    case 'completed':
+      return order.completed_at ? (
+        <>
+          Completed <LocalTime date={order.completed_at} mode="absolute" />
+        </>
+      ) : (
+        <>Completed</>
+      );
+    case 'cancelled':
+      return order.cancelled_at ? (
+        <>
+          Cancelled <LocalTime date={order.cancelled_at} mode="absolute" />
+        </>
+      ) : (
+        <>
+          Cancelled <LocalTime date={order.created_at} mode="absolute" />
+        </>
+      );
+    default: {
+      // Exhaustiveness check: if a new OrderStatus is added without a
+      // case here, TypeScript will error on this line.
+      const _exhaustive: never = order.status;
+      return _exhaustive;
+    }
+  }
+}
+```
+
+- [ ] **Step 3: `FilterTabs` — extend the TABS array**
+
+In `dashboard/components/orders/filter-tabs.tsx`, find the existing `TABS` array (around line 14-19):
+
+```typescript
+const TABS: Tab[] = [
+  { key: 'all', label: 'All', href: '/' },
+  { key: 'in_progress', label: 'Live', href: '/?status=in_progress' },
+  { key: 'confirmed', label: 'Confirmed', href: '/?status=confirmed' },
+  { key: 'cancelled', label: 'Cancelled', href: '/?status=cancelled' },
+];
+```
+
+Replace with (insert the 3 new entries between `confirmed` and `cancelled` to match the lifecycle order):
+
+```typescript
+const TABS: Tab[] = [
+  { key: 'all', label: 'All', href: '/' },
+  { key: 'in_progress', label: 'Live', href: '/?status=in_progress' },
+  { key: 'confirmed', label: 'Confirmed', href: '/?status=confirmed' },
+  { key: 'preparing', label: 'Preparing', href: '/?status=preparing' },
+  { key: 'ready', label: 'Ready', href: '/?status=ready' },
+  { key: 'completed', label: 'Completed', href: '/?status=completed' },
+  { key: 'cancelled', label: 'Cancelled', href: '/?status=cancelled' },
+];
+```
+
+- [ ] **Step 4: Run the full dashboard suite + typecheck**
+
+Run from repo root: `(cd dashboard && pnpm vitest run && pnpm tsc --noEmit)`
+Expected: all green; TS clean.
+
+If TS errors anywhere because the `headerTimestamp`'s `never` assertion catches a previously-untested branch, that's the exhaustiveness mechanism working — investigate. Likely the existing tests still pass because they use the old surface; the new surface is just additive.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/components/orders/orders-table.tsx dashboard/components/orders/order-detail.tsx dashboard/components/orders/filter-tabs.tsx
+git commit -m "Wire TransitionButton + grow filter tabs + fix headerTimestamp (#111)
+
+Three coordinated UI integrations:
+
+1. OrdersTable gains a 6th right-most 'Action' column rendering
+   <TransitionButton/> per row. The cell sits OUTSIDE the row's
+   <Link> wrapper so clicking the button doesn't navigate.
+
+2. OrderDetail renders <TransitionButton/> next to <CancelOrderButton/>
+   in the bottom actions area. Cancel render condition broadens from
+   'confirmed' alone to 'confirmed|preparing|ready' (B1's cancel
+   endpoint accepts any pre-completed source state).
+
+3. OrderDetail's headerTimestamp switch gains cases for the 3 new
+   statuses, each showing the relevant per-transition timestamp.
+   Adds an exhaustive 'never' default so future OrderStatus additions
+   force a TypeScript error here.
+
+4. FilterTabs grows from 4 to 7 entries (additive; no renames):
+   All | Live | Confirmed | Preparing | Ready | Completed | Cancelled.
+   URL pattern unchanged."
+```
+
+---
+
+## Task 5: Sprint 2.2 (#5) checklist update + final review + push + PR
+
+- [ ] **Step 1: Sanity sweep across both stacks**
+
+Run from repo root:
+
+```bash
+(cd dashboard && pnpm tsc --noEmit && pnpm vitest run)
+python -m pytest tests/ 2>&1 | tail -5
+```
+
+Expected: dashboard TS clean + dashboard vitest green; backend full suite green (no backend changes in this branch but worth a sanity run).
+
+- [ ] **Step 2: Skim the cumulative diff**
+
+```bash
+git log master..HEAD --oneline
+git diff master..HEAD --stat
+```
+
+Confirm no surprise file changes — only the 8 paths in the File Structure table plus the spec/plan docs.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/111-kitchen-workflow-ui
+```
+
+```bash
+gh pr create --repo tsuki-works/niko --base master --head feat/111-kitchen-workflow-ui \
+  --title "Kitchen workflow UI (B3 of B, #111)" \
+  --body-file - <<'EOF'
+## Summary
+- New `TransitionButton` component (`dashboard/components/orders/transition-button.tsx`) — single status-aware button per row + per detail page. Renders "Start Preparing" / "Mark Ready" / "Mark Completed" based on the order's current status; renders nothing for terminal/in-progress states. Single-tap speed (no confirmation dialog) — cancel keeps its destructive dialog.
+- Three new Server Actions (`dashboard/app/actions/transition-order.ts`) and three new API client functions (`dashboard/lib/api/orders.ts`) — thin wrappers around `POST /orders/{call_sid}/{transition}`, mirroring the existing `cancelOrder` / `cancelOrderApi` pattern.
+- `OrdersTable` grows from 5 to 6 columns with a right-most "Action" column.
+- `OrderDetail` renders the button alongside `<CancelOrderButton>`; cancel render condition broadens from `confirmed` alone to `confirmed | preparing | ready` (matches B1's cancel endpoint contract).
+- `OrderDetail`'s `headerTimestamp` switch gains cases for the 3 new statuses + an exhaustive `never` default — future enum additions force a TypeScript error at compile time. (Closes the B1 follow-up flagged in #108's review.)
+- `FilterTabs` grows from 4 to 7 entries (additive; no renames).
+- 9 vitest tests for the Server Actions; 7 vitest tests for `TransitionButton`.
+
+## Linked issue
+Closes #111. Final sub-project on parent feature B (order queueing + restaurant notifications). B1 (#108) shipped the lifecycle data layer; B2 (#110) shipped the tablet alert experience. With B3 merged, the entire parent feature B is done — and Sprint 2.2 (#5) reaches all 6 deliverables.
+
+## Spec & plan
+- Spec: `docs/superpowers/specs/2026-04-29-kitchen-workflow-ui-design.md`
+- Plan: `docs/superpowers/plans/2026-04-29-kitchen-workflow-ui.md`
+
+## Test plan
+- [x] Vitest unit tests for Server Actions (`pnpm vitest run tests/transition-actions.test.ts`): **9/9 PASSED**
+- [x] Vitest unit tests for `TransitionButton` (`pnpm vitest run tests/transition-button.test.tsx`): **7/7 PASSED**
+- [x] Full dashboard vitest suite (`pnpm vitest run`): green
+- [x] Dashboard typecheck (`pnpm tsc --noEmit`): clean
+- [x] Backend full suite (`pytest tests/`): green (no backend changes; sanity run)
+- [ ] **Manual smoke (pre-merge)** — on a real tablet (or Chrome dev tools mobile mode):
+  - Place a test order. Verify the row shows status "Confirmed" + a "Start Preparing" button.
+  - Tap "Start Preparing" → row updates to "Preparing" within ~500ms; toast confirms; button now reads "Mark Ready".
+  - Tap "Mark Ready" → status "Ready"; button reads "Mark Completed".
+  - Tap "Mark Completed" → status "Completed", button disappears.
+  - Place another order, walk to "Preparing", then tap "Cancel order" on the detail page — verify it transitions to "Cancelled".
+  - Visit `?status=preparing`, `?status=ready`, `?status=completed` — verify each filter shows the right orders.
+  - Verify the detail-page header timestamp shows the right transition timestamp for each status.
+
+## Notes
+- **No backend changes.** The endpoints + lifecycle were shipped in B1 (#108). This PR is purely the dashboard wiring.
+- **No optimistic updates.** The `onSnapshot` live feed reflects transitions within ~100-500ms; sonner toast surfaces success/error. `useOptimistic` polish is a Sprint 2.4 concern.
+- **No undo for accidental forward transitions.** Kitchen can `cancel_order` from any pre-completed state if they need to off-ramp.
+- The B2 audible/visual alert from #110 still fires on new orders entering the live feed — `useNewOrderAlert` is keyed off the `orders` array, not on the status transitions.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 4: Surface the PR URL**
+
+The `gh pr create` output is the URL — relay it.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- (1) `TransitionButton` component (status-aware) → Task 3 ✓
+- (2) Filter tabs grow from 4 to 7 → Task 4 step 3 ✓
+- (3) Server Actions (3 new) → Task 2 ✓
+- (4) API client functions (3 new) → Task 1 ✓
+- (5) `OrdersTable` integration (Action column) → Task 4 step 1 ✓
+- (6) `OrderDetail` integration (button + broaden cancel + headerTimestamp fix) → Task 4 step 2 ✓
+- 7 vitest tests for `TransitionButton` → Task 3 ✓
+- 9 vitest tests for Server Actions → Task 2 ✓
+- Manual smoke test → Task 5 PR description ✓
+
+**Placeholder scan:** no TBDs. Manual smoke checklist in PR description is intentional (user action, not automated step).
+
+**Type consistency:**
+- `TransitionResult` (API client) and `TransitionActionResult` (Server Action) types are distinct but consistent shape — discriminated union with `success: true` / `success: false; error: string`. Server Action returns `{success: true}` (no order, only success flag) per the cancel pattern.
+- `TransitionConfig` type local to `TransitionButton`, consistent with how it's consumed.
+- Action function signatures `(input: { call_sid: string }) => Promise<TransitionActionResult>` consistent in component (`config.action`) and tests (`expect(markPreparingAction).toHaveBeenCalledWith({call_sid: 'CA1234ABCD'})`).
+- `OrderStatus` enum values consistent across switch cases in `headerTimestamp`, `configFor`, and tests.
+
+**One ambiguity left for the implementer:** the `Th className="w-36"` width for the Action column in Task 4 Step 1b is a guess based on existing column widths. If the button overflows or the column looks too narrow at iPad portrait, adjust. Not worth pinning in advance.

--- a/docs/superpowers/specs/2026-04-29-kitchen-workflow-ui-design.md
+++ b/docs/superpowers/specs/2026-04-29-kitchen-workflow-ui-design.md
@@ -1,0 +1,172 @@
+# Kitchen Workflow UI (Design Spec — B3)
+
+**Date:** 2026-04-29
+**Sprint:** 2.2 — Order Taking Excellence (#5)
+**Tracking issue:** #111
+**Owner:** Meet
+**Status:** Approved — ready for implementation plan
+**Parent feature:** B (Order queueing + restaurant notifications). B1 (#108) and B2 (#110) are merged. B3 closes out parent feature B and Sprint 2.2.
+
+## Goal
+
+Wire the kitchen-facing UI to the transition endpoints from B1. Each order shows a single status-aware action button (Start Preparing → Mark Ready → Mark Completed) on both the row and the detail page. Filter tabs grow to surface each lifecycle stage. Server Actions wrap the FastAPI calls; toast feedback surfaces success/error.
+
+## In scope
+
+### (1) `TransitionButton` component — single button, status-aware
+
+A new shared component renders ONE button based on the order's current status:
+
+| Status | Button label | Visual | Server Action |
+|---|---|---|---|
+| `confirmed` | "Start Preparing" | Primary, emerald | `markPreparingAction` |
+| `preparing` | "Mark Ready" | Primary, emerald | `markReadyAction` |
+| `ready` | "Mark Completed" | Outline, neutral | `markCompletedAction` |
+| `completed` / `cancelled` / `in_progress` | — | — | None (renders nothing) |
+
+- **No confirmation dialog** for forward transitions — kitchen wants single-tap speed. The cancel button keeps its existing dialog (destructive + irreversible).
+- Disabled while `useTransition` is pending.
+- Uses sonner for success/error toasts: `"Order #ABCD is now preparing"` / `"Order #ABCD is ready"` / `"Order #ABCD is completed"`. Error toast surfaces FastAPI's `{ detail: string }` field.
+
+### (2) Filter tabs grow from 4 to 7 (additive, no renames)
+
+`dashboard/components/orders/filter-tabs.tsx`'s `TABS` array gains 3 entries:
+
+```
+All | Live | Confirmed | Preparing | Ready | Completed | Cancelled
+```
+
+URL pattern unchanged (`?status=preparing`, etc.). The page route's status query parsing is already enum-driven via the Zod schema (extended in B1) — no parsing changes needed.
+
+### (3) Server Actions
+
+A new file `dashboard/app/actions/transition-order.ts` exports three Server Actions, each parallel to `cancelOrder`:
+
+- `markPreparingAction({ call_sid }) → { success: true } | { success: false, error: string }`
+- `markReadyAction({ call_sid }) → { success: true } | { success: false, error: string }`
+- `markCompletedAction({ call_sid }) → { success: true } | { success: false, error: string }`
+
+Each:
+- Validates input via Zod (`{ call_sid: z.string().min(1) }`)
+- Calls the corresponding API client function (below)
+- `revalidatePath('/')` and `revalidatePath('/orders/${call_sid}')` on success
+- Returns the discriminated-union shape
+
+### (4) API client functions
+
+`dashboard/lib/api/orders.ts` gains three functions parallel to `cancelOrderApi`:
+
+- `markPreparingApi(call_sid: string): Promise<{ success: true } | { success: false; error: string }>` — calls `POST /orders/{call_sid}/preparing` via `apiFetch`
+- `markReadyApi(call_sid: string)` — calls `POST /orders/{call_sid}/ready`
+- `markCompletedApi(call_sid: string)` — calls `POST /orders/{call_sid}/completed`
+
+All three surface FastAPI's `{ detail: string }` field as the error message on 4xx, falling back to `${res.status} ${res.statusText}` if the body can't be parsed (mirrors `cancelOrderApi`).
+
+### (5) `OrdersTable` integration — new "Action" column
+
+The table grows from 5 columns to 6 by adding a right-most "Action" column rendering `<TransitionButton order={order} />`. Existing column widths/styles preserved. When the button is `null` (terminal/inapplicable status), the cell renders empty — no layout jump.
+
+Existing `freshIds` highlight from B2 still applies (the row, not the button).
+
+### (6) `OrderDetail` integration
+
+Two changes to `dashboard/components/orders/order-detail.tsx`:
+
+1. **Action button** — render `<TransitionButton order={order} />` in the existing actions area at the bottom of the detail page, alongside the existing `<CancelOrderButton>`. The cancel button's render condition broadens from just `confirmed` to `confirmed | preparing | ready` (you can cancel any pre-completed order — B1 endpoint allows it).
+
+2. **`headerTimestamp` fix** (B1 follow-up): the existing switch only covers `confirmed`/`cancelled`/`in_progress`. Add cases for the 3 new statuses, each showing the relevant transition timestamp:
+   - `preparing` → `"Started prep <preparing_at>"`
+   - `ready` → `"Ready <ready_at>"`
+   - `completed` → `"Completed <completed_at>"`
+   - Fallback (defensive): if the timestamp field is `null`, render the bare label without a date.
+
+## Out of scope
+
+- **Kitchen card-grid layout** (big tiles instead of dense table rows). Sprint 2.4 polish.
+- **Optimistic UI** via `useOptimistic`. The existing `onSnapshot` live feed reflects transitions within 100-500ms; if a transition fails, the toast surfaces it. `useOptimistic` is a Sprint 2.4 concern.
+- **Undo** for accidental forward transitions. No backward transition endpoint exists; users can `cancel_order` from any pre-completed state if they need to off-ramp.
+- **Per-status sound variations** (different bell for "ready" vs "preparing"). The single ding-dong from B2 covers all transitions — kitchen uses the visual cue (status badge color + table position) to disambiguate.
+- **Undoing the rename of "Confirmed" to "Incoming"** — keeping "Confirmed" as the tab label since the term is well-established in the codebase + dashboard CLAUDE.md.
+
+## Approach
+
+**Mirror the cancel pattern.** `CancelOrderButton`/`cancelOrder`/`cancelOrderApi` are the existing template for "kitchen-facing UI button → Server Action → FastAPI". The three new transitions follow the exact same shape. This keeps the review surface small + the failure modes uniform.
+
+**One status-aware button instead of three buttons + one cancel.** A single `<TransitionButton>` per row branches on status to render the right label/action. This:
+- Shows only the *next* action — no decision fatigue ("should I tap Ready or Completed?")
+- Avoids cluttering rows with 3 disabled-most-of-the-time buttons
+- Naturally enforces the lifecycle (you can't tap "Mark Ready" on a `confirmed` order — the button doesn't exist)
+
+**Cancel stays separate** — it's the destructive off-ramp, semantically different from forward transitions, and benefits from its own dialog.
+
+**No Optimistic UI.** The live `onSnapshot` feed reconciles within ~500ms. Adding `useOptimistic` introduces complexity (revert on failure, key-stable updates) without much UX gain when the live feed is already fast.
+
+### Why no confirmation dialog for forward transitions
+
+The kitchen workflow is a tight loop: order arrives → tap Start Preparing → cook → tap Mark Ready → tap Mark Completed when handed off. Asking "Are you sure you want to start preparing?" on every tap is friction the kitchen will hate. The cost of a mis-tap is small (kitchen marked something ready early; their workflow self-corrects). The cost of friction is high (every order takes longer).
+
+## Test plan
+
+### Vitest unit tests
+
+**`dashboard/tests/transition-button.test.tsx`** (NEW, uses `// @vitest-environment jsdom` + `@testing-library/react`):
+
+Mock the three Server Actions. Test cases:
+
+1. Renders nothing for `in_progress` / `completed` / `cancelled` orders.
+2. Renders "Start Preparing" for `confirmed` orders; click triggers `markPreparingAction({call_sid})` once.
+3. Renders "Mark Ready" for `preparing` orders; click triggers `markReadyAction`.
+4. Renders "Mark Completed" for `ready` orders; click triggers `markCompletedAction`.
+5. On success, fires success toast.
+6. On failure, fires error toast with the action's error string.
+7. Button disabled while pending.
+
+**`dashboard/tests/transition-actions.test.ts`** (NEW):
+
+Mock `apiFetch`. Test cases per action (3 actions × 3 patterns = ~9 tests):
+
+1. Returns `{success: true}` when the API responds 200.
+2. Returns `{success: false, error: detail}` when the API responds 4xx with a `{detail}` body.
+3. Returns `{success: false, error: ${status} ${statusText}}` when the body isn't parseable.
+4. Validates input (rejects empty `call_sid` with `{success: false, error: 'Invalid input'}`).
+5. Calls `revalidatePath('/')` and `revalidatePath('/orders/{call_sid}')` on success.
+
+### Manual smoke (pre-merge)
+
+On a real tablet (or Chrome dev tools mobile mode):
+
+1. Place a test order via `/dev/seed-order` or a real call. Verify it shows up in the live feed with status `confirmed` and a "Start Preparing" button.
+2. Tap "Start Preparing". Verify the row's status badge updates to "Preparing" within ~500ms; toast says "Order #ABCD is now preparing"; the button now reads "Mark Ready".
+3. Tap "Mark Ready". Same flow → status "Ready" → button reads "Mark Completed".
+4. Tap "Mark Completed". Status badge → "Completed", muted color; button disappears (terminal state).
+5. Place another order. Walk it to `preparing`, then tap the existing "Cancel order" button on the detail page. Verify the order moves to `cancelled` (B1's cancel endpoint accepts pre-completed states).
+6. Visit `?status=preparing`, `?status=ready`, `?status=completed`. Verify each filter shows the right orders.
+7. Verify the detail-page header timestamp shows the right transition timestamp for each new status.
+
+## Done criteria
+
+- All vitest unit tests green
+- Dashboard typecheck (`pnpm tsc --noEmit`) clean
+- Full vitest suite green
+- Manual smoke test verified (results captured in PR description)
+- `niko-reviewer` sign-off
+- Sprint 2.2 (#5) checklist marks "Order queueing and notification to restaurant" done
+
+## Risks and mitigations
+
+- **Risk:** Kitchen taps "Mark Ready" too early (food still cooking), then realizes mid-flow. **Mitigation:** no undo for MVP — kitchen can `cancel_order` if needed. Sprint 2.4 can add backward transitions if real call data shows this is common.
+- **Risk:** A row's button is for a state the user hasn't seen yet because their `?status=` filter is set narrowly (e.g. they're on the "Confirmed" tab and the order moves to `preparing`). **Mitigation:** the live `onSnapshot` query reflects status changes, so the order naturally drops out of the filtered view as it transitions. Toast still confirms the change occurred. The user can navigate to the "Preparing" tab to find it.
+- **Risk:** Optimistic-update absence makes the dashboard feel sluggish on slow networks. **Mitigation:** `useTransition` provides a "pending" indicator on the button; the button text becomes "Working…" while waiting. Live feed reconciles when the round-trip completes. If real-call data shows this is meaningfully slow, add `useOptimistic` in Sprint 2.4.
+- **Risk:** `OrdersTable` gaining a 6th column overflows on iPad portrait mode (768px wide). **Mitigation:** test in Chrome dev tools at 768×1024; if overflow, the existing `overflow-hidden` on the wrapper means horizontal scroll is the fallback (acceptable for MVP). Card-grid layout in Sprint 2.4 supersedes the table for kitchen view anyway.
+- **Risk:** `headerTimestamp`'s switch could go stale if a *future* status is added without updating it (the existing one was stale from B1 and we're fixing it now). **Mitigation:** add a `default` branch with a `never` assertion so a future enum addition forces a TypeScript error at compile time.
+
+## Files touched (anticipated)
+
+- `dashboard/components/orders/transition-button.tsx` — NEW (the status-aware action button)
+- `dashboard/components/orders/orders-table.tsx` — add "Action" column rendering `<TransitionButton>`
+- `dashboard/components/orders/order-detail.tsx` — render `<TransitionButton>`; broaden cancel render condition to all pre-completed states; fix `headerTimestamp` for new statuses with exhaustive `never` default
+- `dashboard/components/orders/filter-tabs.tsx` — extend `TABS` array with 3 entries
+- `dashboard/lib/api/orders.ts` — `markPreparingApi`, `markReadyApi`, `markCompletedApi`
+- `dashboard/app/actions/transition-order.ts` — NEW (3 Server Actions)
+- `dashboard/tests/transition-button.test.tsx` — NEW (7 vitest tests, jsdom env, RTL)
+- `dashboard/tests/transition-actions.test.ts` — NEW (~9 vitest tests, mocked `apiFetch`)


### PR DESCRIPTION
## Summary
- New `TransitionButton` component (`dashboard/components/orders/transition-button.tsx`) — single status-aware button per row + per detail page. Renders "Start Preparing" / "Mark Ready" / "Mark Completed" based on the order's current status; renders nothing for terminal/in-progress states. Single-tap speed (no confirmation dialog) — cancel keeps its destructive dialog.
- Three new Server Actions (`dashboard/app/actions/transition-order.ts`) and three new API client functions (`dashboard/lib/api/orders.ts`) — thin wrappers around `POST /orders/{call_sid}/{transition}`, mirroring the existing `cancelOrder` / `cancelOrderApi` pattern. A small `runTransition` / `postTransition` helper de-dupes boilerplate.
- `OrdersTable` grows from 5 to 6 columns with a right-most "Action" column.
- `OrderDetail` renders the button alongside `<CancelOrderButton>`; cancel render condition broadens from `confirmed` alone to `confirmed | preparing | ready` (matches B1's cancel endpoint contract).
- `OrderDetail`'s `headerTimestamp` switch gains cases for the 3 new statuses + an exhaustive `never` default — future enum additions force a TypeScript error at compile time. Closes the B1 follow-up flagged in #108's review.
- `FilterTabs` grows from 4 to 7 entries (additive; no renames): `All | Live | Confirmed | Preparing | Ready | Completed | Cancelled`.
- 9 vitest tests for the Server Actions + 7 for `TransitionButton` (16 new tests total).

## Linked issue
Closes #111. Final sub-project on parent feature B (order queueing + restaurant notifications). B1 (#108) shipped the lifecycle data layer; B2 (#110) shipped the tablet alert experience. **With this PR merged, the entire parent feature B is done — and Sprint 2.2 (#5) reaches all 6 deliverables.**

## Spec & plan
- Spec: `docs/superpowers/specs/2026-04-29-kitchen-workflow-ui-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-kitchen-workflow-ui.md`

## Test plan
- [x] Vitest unit tests for Server Actions (`pnpm vitest run tests/transition-actions.test.ts`): **9/9 PASSED**
- [x] Vitest unit tests for `TransitionButton` (`pnpm vitest run tests/transition-button.test.tsx`): **7/7 PASSED**
- [x] Full dashboard vitest suite (`pnpm vitest run`): **43/43 PASSED**
- [x] Dashboard typecheck (`pnpm tsc --noEmit`): clean
- [ ] **Manual smoke (pre-merge)** — on a real tablet (or Chrome dev tools mobile mode):
  - Place a test order. Verify the row shows status "Confirmed" + a "Start Preparing" button.
  - Tap "Start Preparing" → row updates to "Preparing" within ~500ms; toast confirms; button now reads "Mark Ready".
  - Tap "Mark Ready" → status "Ready"; button reads "Mark Completed".
  - Tap "Mark Completed" → status "Completed"; button disappears.
  - Place another order, walk to "Preparing", then tap "Cancel order" on the detail page — verify it transitions to "Cancelled".
  - Visit `?status=preparing`, `?status=ready`, `?status=completed` — verify each filter shows the right orders.
  - Verify the detail-page header timestamp shows the right transition timestamp for each status.

## Notes
- **No backend changes.** The endpoints + lifecycle were shipped in B1 (#108). This PR is purely the dashboard wiring.
- **No optimistic updates.** The `onSnapshot` live feed reflects transitions within ~100-500ms; sonner toast surfaces success/error. The button's `useTransition` `disabled` state prevents double-tap during the brief reconciliation gap. `useOptimistic` polish is a Sprint 2.4 concern.
- **No undo for accidental forward transitions.** Kitchen can `cancel_order` from any pre-completed state if they need to off-ramp.
- The B2 audible/visual alert from #110 still fires on new orders entering the live feed — `useNewOrderAlert` is keyed off the `orders` array, not on the status transitions.

## Drive-by additions
- `dashboard/tests/setup.ts` (NEW) + vitest config update + `@testing-library/jest-dom` (devDependency) — required for the `toBeEmptyDOMElement` matcher in the new TransitionButton tests, and adds proper inter-test DOM cleanup. Disclosed in commit `745dec3`'s body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)