### PR TITLE
LLM client: cache system prompt with Anthropic ephemeral cache_control

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -194,6 +194,23 @@ def _tool_result_block(tool_use_id: str, content: str = "Order updated.") -> dic
     }
 
 
+def _system_cache_block(system_prompt: str) -> list[dict[str, Any]]:
+    """Wrap the system prompt for Anthropic prompt caching.
+
+    Passing system as a list with cache_control=ephemeral tells Anthropic
+    to cache the block server-side for up to 5 minutes. Cache hits reduce
+    system-prompt token cost by ~90% and shave first-token latency on
+    turns 2+ of the same call — near-certain for any call lasting > 20s.
+    """
+    return [
+        {
+            "type": "text",
+            "text": system_prompt,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
 def _append_user_transcript(
     history: list[dict[str, Any]], transcript: str
 ) -> list[dict[str, Any]]:
@@ -307,7 +324,7 @@ def generate_reply(
     response = api.messages.create(
         model=MODEL,
         max_tokens=MAX_TOKENS,
-        system=system_prompt,
+        system=_system_cache_block(system_prompt),
         tools=[UPDATE_ORDER_TOOL],
         messages=new_history,
     )
@@ -346,7 +363,7 @@ def generate_reply(
         followup = api.messages.create(
             model=MODEL,
             max_tokens=MAX_TOKENS,
-            system=system_prompt,
+            system=_system_cache_block(system_prompt),
             tools=[UPDATE_ORDER_TOOL],
             messages=new_history,
         )
@@ -399,7 +416,7 @@ async def stream_reply(
     async with api.messages.stream(
         model=MODEL,
         max_tokens=MAX_TOKENS,
-        system=system_prompt,
+        system=_system_cache_block(system_prompt),
         tools=[UPDATE_ORDER_TOOL],
         messages=new_history,
     ) as stream:
@@ -439,7 +456,7 @@ async def stream_reply(
         async with api.messages.stream(
             model=MODEL,
             max_tokens=MAX_TOKENS,
-            system=system_prompt,
+            system=_system_cache_block(system_prompt),
             tools=[UPDATE_ORDER_TOOL],
             messages=new_history,
         ) as followup_stream:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1090,6 +1090,68 @@ def test_correction_invalid_delivery_address_is_rejected_and_signaled():
     assert "Delivery address incomplete" in last["content"][0]["content"]
 
 
+def test_generate_reply_sends_system_as_cache_block():
+    """generate_reply wraps system_prompt in a cache_control block."""
+    captured: dict = {}
+
+    class FakeMessage:
+        content = [FakeBlock(type="text", text="Hello!")]
+        stop_reason = "end_turn"
+
+    class FakeClient:
+        class messages:
+            @staticmethod
+            def create(**kwargs):
+                captured["kwargs"] = kwargs
+                return FakeMessage()
+
+    generate_reply(
+        transcript="hi",
+        history=[],
+        order=Order(call_sid="CA123", restaurant_id="r1"),
+        system_prompt="You are niko.",
+        client=FakeClient(),
+    )
+
+    system = captured["kwargs"]["system"]
+    assert isinstance(system, list), "system must be a list, not a string"
+    assert system[0]["type"] == "text"
+    assert system[0]["text"] == "You are niko."
+    assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+async def test_stream_reply_sends_system_as_cache_block():
+    """stream_reply wraps system_prompt in a cache_control block."""
+    captured: dict = {}
+
+    fake_stream = _FakeAsyncStream(
+        deltas=["Hi there!"],
+        blocks=[FakeBlock(type="text", text="Hi there!")],
+    )
+
+    def _capture_stream(**kwargs):
+        captured["kwargs"] = kwargs
+        return fake_stream
+
+    fake_client = MagicMock()
+    fake_client.messages.stream = _capture_stream
+
+    async for _ in stream_reply(
+        transcript="hi",
+        history=[],
+        order=Order(call_sid="CA123", restaurant_id="r1"),
+        system_prompt="You are niko.",
+        client=fake_client,
+    ):
+        pass
+
+    system = captured["kwargs"]["system"]
+    assert isinstance(system, list)
+    assert system[0]["type"] == "text"
+    assert system[0]["text"] == "You are niko."
+    assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+
 def test_apply_validation_passes_through_explicit_address_clears():
     """Sprint 2.2 #105 — when Haiku ships delivery_address=None or ""
     (e.g. swapping from delivery to pickup), that's a legitimate clear,


### PR DESCRIPTION
## Summary

- Wraps the system prompt in a `cache_control: {type: ephemeral}` block at all four `messages.create` / `messages.stream` call sites in `app/llm/client.py`.
- Anthropic now caches the system block server-side for ~5 minutes. Turn 1 is a cache write (~1.25x cost); turns 2+ are cache reads (~10% of normal token cost on the system block, plus a 10-30 ms first-token latency shave).
- A typical call runs 3-10 minutes, so cache hits are near-certain after turn 1. Multi-tenant safety unaffected — the cache is content-keyed, so each restaurant's distinct system prompt produces its own cache entry.

## Linked issue

Closes #113

## Test plan

- [x] Unit tests: two new asserts in `tests/test_llm_client.py` confirm `system` is sent as a list with `cache_control={"type": "ephemeral"}` from both `generate_reply` and `stream_reply`. 30/30 LLM client tests pass; 155/155 collectable across the suite.
- [ ] After merge + deploy: place a 2-3 turn test call against the live agent, watch Anthropic usage logs for `cache_creation_input_tokens` on turn 1 and `cache_read_input_tokens` on turns 2+.
- [ ] Subjectively check that turn-2 first-token feels faster — should be a 10-30 ms shave.

## Notes

- Followup `messages.create`/`messages.stream` paths (Haiku tool_use with no text) use the same helper but aren't directly exercised by the new unit tests. Same helper, low regression risk; flagged in code review as a NIT, not a blocker.
- This is the first of ten conversational-quality issues under #83. Pairs naturally with #115 (history trimming) and #118 (reduce MAX_TOKENS); intentionally landed alone for the smallest reviewable unit.