### PR TITLE
Add Twilio call recording + dashboard audio player

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,13 @@ TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
 
+# Public HTTPS base URL of this service. Required for Twilio call
+# recording: handed to Twilio when starting a recording, then
+# reconstructed in /recording-status to validate Twilio's signature.
+# Local: your ngrok URL, e.g. https://abc123.ngrok.app
+# Cloud Run: the service URL, e.g. https://niko-xxxxx.a.run.app
+PUBLIC_BASE_URL=
+
 # Square — POS sandbox (Phase 2.3)
 SQUARE_ACCESS_TOKEN=
 SQUARE_APPLICATION_ID=

--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,14 @@ class Settings(BaseSettings):
     twilio_auth_token: Optional[str] = None
     twilio_phone_number: Optional[str] = None
 
+    # Public HTTPS base URL of this service (e.g. "https://niko-xyz.run.app"
+    # or an ngrok URL locally). Required for Twilio recording callbacks:
+    # the URL we hand Twilio when starting a recording must equal the URL
+    # we reconstruct in /recording-status to validate Twilio's signature.
+    # Building it from the request's Host header would defeat the
+    # signature check, since the Host header is client-controlled.
+    public_base_url: Optional[str] = None
+
     square_access_token: Optional[str] = None
     square_application_id: Optional[str] = None
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
 import logging
 import time
 
+import httpx
 from fastapi import Depends, FastAPI, HTTPException
+from fastapi.responses import Response as HTTPResponse
 
 logging.basicConfig(level=logging.INFO)
 
@@ -260,6 +262,51 @@ def dev_call_timeline(
             for e in events
         ],
     }
+
+
+@app.get("/calls/{call_sid}/recording")
+async def get_call_recording(
+    call_sid: str,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """Proxy the Twilio recording MP3 for the calling tenant's call.
+
+    Twilio recordings require HTTP Basic Auth, so the browser can't fetch
+    them directly. This endpoint looks up the recording URL from Firestore
+    (tenant-scoped, so cross-tenant reads return 404), fetches the MP3
+    from Twilio with credentials, and streams it to the browser.
+
+    Returns 404 while the recording is still processing or if this call
+    has no recording.
+    """
+    session = call_sessions.get_session(call_sid, tenant.restaurant_id)
+    if not session or not session.get("recording_url"):
+        raise HTTPException(status_code=404, detail="recording not available yet")
+
+    sid = settings.twilio_account_sid
+    token = settings.twilio_auth_token
+    if not sid or not token:
+        raise HTTPException(status_code=503, detail="Twilio credentials not configured")
+
+    recording_url = session["recording_url"]
+    if not recording_url.endswith(".mp3"):
+        recording_url += ".mp3"
+
+    # Buffered fetch: recordings are short (<5 min ≈ <5 MB) so we fetch
+    # the whole MP3 before responding. This lets us check the Twilio status
+    # code before committing to a 200, avoiding the broken-stream problem
+    # that arises when raising HTTPException inside a generator.
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        twilio_resp = await client.get(recording_url, auth=(sid, token))
+
+    if twilio_resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="Failed to fetch recording from Twilio")
+
+    return HTTPResponse(
+        content=twilio_resp.content,
+        media_type="audio/mpeg",
+        headers={"Content-Disposition": f'inline; filename="{call_sid}.mp3"'},
+    )
 
 
 @app.post("/dev/seed-order")

--- a/app/main.py
+++ b/app/main.py
@@ -289,6 +289,12 @@ async def get_call_recording(
         raise HTTPException(status_code=503, detail="Twilio credentials not configured")
 
     recording_url = session["recording_url"]
+    # Defense-in-depth: even though /recording-status validates the URL
+    # before persisting, refuse to fetch anything outside Twilio's host
+    # so any stale or forged document can never turn this proxy into an
+    # SSRF with Twilio Basic creds attached.
+    if not recording_url.startswith("https://api.twilio.com/"):
+        raise HTTPException(status_code=502, detail="invalid recording URL")
     if not recording_url.endswith(".mp3"):
         recording_url += ".mp3"
 

--- a/app/storage/call_sessions.py
+++ b/app/storage/call_sessions.py
@@ -206,6 +206,64 @@ def get_session_events(
     return [snap.to_dict() for snap in events_query.stream()]
 
 
+def mark_recording_ready(
+    call_sid: str,
+    restaurant_id: str,
+    *,
+    recording_url: str,
+    recording_sid: str,
+    duration_seconds: int,
+) -> None:
+    """Stamp the call session with the completed Twilio recording URL.
+
+    Patches both parent docs with recording metadata and appends a
+    ``recording_ready`` event to the events subcollection so the live
+    dashboard's onSnapshot can surface the audio player without polling.
+    The raw ``recording_url`` is stored server-side only; the frontend
+    proxies playback through ``GET /calls/{call_sid}/recording``.
+    """
+    ts = _now()
+    patch: dict[str, Any] = {
+        "recording_url": recording_url,
+        "recording_sid": recording_sid,
+        "recording_duration_seconds": duration_seconds,
+        "last_event_at": ts,
+    }
+    event_payload = {
+        "timestamp": ts,
+        "kind": "recording_ready",
+        "text": "",
+        "detail": {
+            "recording_sid": recording_sid,
+            "duration_seconds": duration_seconds,
+        },
+    }
+    try:
+        client = _get_client()
+        legacy = _legacy_parent(client, call_sid)
+        legacy.update(patch)
+        legacy.collection(_EVENTS_SUBCOLLECTION).add(event_payload)
+
+        nested = _nested_parent(client, restaurant_id, call_sid)
+        nested.update(patch)
+        nested.collection(_EVENTS_SUBCOLLECTION).add(event_payload)
+    except Exception:
+        logger.exception(
+            "call_sessions: mark_recording_ready failed call_sid=%s", call_sid
+        )
+
+
+def get_session(
+    call_sid: str, restaurant_id: str
+) -> Optional[dict[str, Any]]:
+    """Return the parent call session doc, or None if it doesn't exist."""
+    client = _get_client()
+    snap = _nested_parent(client, restaurant_id, call_sid).get()
+    if not snap.exists:
+        return None
+    return snap.to_dict()
+
+
 def mark_call_ended(
     call_sid: str,
     restaurant_id: str,

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -25,6 +25,7 @@ from typing import Callable
 
 from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
+from twilio.request_validator import RequestValidator
 from twilio.twiml.voice_response import Connect, VoiceResponse
 
 from app.config import settings
@@ -105,28 +106,48 @@ def _bg_call_event(
     )
 
 
-def _start_recording_sync(call_sid: str, host: str, restaurant_id: str) -> None:
+def _start_recording_sync(call_sid: str, restaurant_id: str) -> None:
     """Start a Twilio dual-channel recording for a live call.
 
     Runs in a worker thread so the audio loop never blocks on network I/O.
     Uses the restaurant_id in the callback URL so the status webhook can
-    write to the right Firestore path without a second lookup.
+    write to the right Firestore path without a second lookup. The
+    callback host comes from ``settings.public_base_url`` rather than the
+    inbound WebSocket's Host header — the WS Host is client-controlled
+    and would let an attacker redirect Twilio's POSTs.
     """
     sid = settings.twilio_account_sid
     token = settings.twilio_auth_token
+    base = (settings.public_base_url or "").rstrip("/")
     if not sid or not token:
         logger.warning(
             "twilio creds missing; skipping recording call_sid=%s", call_sid
         )
         return
-    from twilio.rest import Client as TwilioRestClient
+    if not base:
+        logger.warning(
+            "PUBLIC_BASE_URL not set; skipping recording call_sid=%s", call_sid
+        )
+        return
+    try:
+        from twilio.rest import Client as TwilioRestClient
 
-    callback_url = f"https://{host}/recording-status/{restaurant_id}/{call_sid}"
-    TwilioRestClient(sid, token).calls(call_sid).recordings.create(
-        recording_status_callback=callback_url,
-        recording_status_callback_method="POST",
-    )
-    logger.info("recording started call_sid=%s callback=%s", call_sid, callback_url)
+        callback_url = f"{base}/recording-status/{restaurant_id}/{call_sid}"
+        TwilioRestClient(sid, token).calls(call_sid).recordings.create(
+            recording_status_callback=callback_url,
+            recording_status_callback_method="POST",
+        )
+        logger.info(
+            "recording started call_sid=%s callback=%s", call_sid, callback_url
+        )
+    except Exception:
+        # Swallow the error — call audio must keep flowing even if Twilio's
+        # recording API rejects the request. Without this guard the
+        # exception lands on an unawaited Task and surfaces only as a
+        # garbage-collection warning.
+        logger.exception(
+            "recording: failed to start Twilio recording call_sid=%s", call_sid
+        )
 
 
 def _twilio_end_call_sync(call_sid: str) -> None:
@@ -611,7 +632,6 @@ async def media_stream(websocket: WebSocket) -> None:
                         asyncio.to_thread(
                             _start_recording_sync,
                             state.call_sid,
-                            websocket.headers.get("host", "localhost:8000"),
                             state.restaurant.id,
                         )
                     )
@@ -707,6 +727,13 @@ async def media_stream(websocket: WebSocket) -> None:
             await dg_conn.finish()
 
 
+# The recording URL Twilio sends in the callback must live under this
+# host. Anything else is rejected before being persisted, so a forged
+# (or legacy-data) URL can never become an SSRF target when the dashboard
+# proxies it through GET /calls/{call_sid}/recording.
+_TWILIO_RECORDING_URL_PREFIX = "https://api.twilio.com/"
+
+
 @router.post("/recording-status/{restaurant_id}/{call_sid}")
 async def recording_status(
     restaurant_id: str, call_sid: str, request: Request
@@ -718,11 +745,38 @@ async def recording_status(
     the recording was started in ``_start_recording_sync``) so no
     additional Firestore lookup is needed to find the right tenant path.
 
+    Authenticity is enforced via Twilio's ``X-Twilio-Signature`` header
+    (HMAC-SHA1 of the request URL + sorted form fields, keyed by the
+    account auth token). Without this check the endpoint would let any
+    unauthenticated POST inject an arbitrary ``RecordingUrl`` into the
+    tenant's call session.
+
     On ``completed``, stores the recording URL on the call session doc
     and emits a ``recording_ready`` event so the live dashboard can show
     the audio player.
     """
+    auth_token = settings.twilio_auth_token
+    base = (settings.public_base_url or "").rstrip("/")
+    if not auth_token or not base:
+        logger.error(
+            "recording-status: server not configured for signature validation "
+            "(twilio_auth_token=%s, public_base_url=%s)",
+            bool(auth_token),
+            bool(base),
+        )
+        return Response(content="", status_code=503)
+
     form = await request.form()
+    form_dict = {k: v for k, v in form.items()}
+    signature = request.headers.get("X-Twilio-Signature", "")
+    full_url = f"{base}/recording-status/{restaurant_id}/{call_sid}"
+    validator = RequestValidator(auth_token)
+    if not validator.validate(full_url, form_dict, signature):
+        logger.warning(
+            "recording-status: invalid Twilio signature call_sid=%s", call_sid
+        )
+        return Response(content="", status_code=403)
+
     status = (form.get("RecordingStatus") or "").lower()
     recording_url = (form.get("RecordingUrl") or "").strip()
     recording_sid = (form.get("RecordingSid") or "").strip()
@@ -740,6 +794,13 @@ async def recording_status(
     )
 
     if status == "completed" and recording_url and recording_sid:
+        if not recording_url.startswith(_TWILIO_RECORDING_URL_PREFIX):
+            logger.warning(
+                "recording-status: rejecting non-Twilio RecordingUrl call_sid=%s url=%r",
+                call_sid,
+                recording_url,
+            )
+            return Response(content="", status_code=400)
         await asyncio.to_thread(
             call_sessions.mark_recording_ready,
             call_sid,

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -105,6 +105,30 @@ def _bg_call_event(
     )
 
 
+def _start_recording_sync(call_sid: str, host: str, restaurant_id: str) -> None:
+    """Start a Twilio dual-channel recording for a live call.
+
+    Runs in a worker thread so the audio loop never blocks on network I/O.
+    Uses the restaurant_id in the callback URL so the status webhook can
+    write to the right Firestore path without a second lookup.
+    """
+    sid = settings.twilio_account_sid
+    token = settings.twilio_auth_token
+    if not sid or not token:
+        logger.warning(
+            "twilio creds missing; skipping recording call_sid=%s", call_sid
+        )
+        return
+    from twilio.rest import Client as TwilioRestClient
+
+    callback_url = f"https://{host}/recording-status/{restaurant_id}/{call_sid}"
+    TwilioRestClient(sid, token).calls(call_sid).recordings.create(
+        recording_status_callback=callback_url,
+        recording_status_callback_method="POST",
+    )
+    logger.info("recording started call_sid=%s callback=%s", call_sid, callback_url)
+
+
 def _twilio_end_call_sync(call_sid: str) -> None:
     """End a Twilio call via the REST API. Runs in a worker thread so the
     audio loop never blocks on network I/O."""
@@ -583,6 +607,14 @@ async def media_stream(websocket: WebSocket) -> None:
                             state.restaurant.id,
                         )
                     )
+                    asyncio.get_running_loop().create_task(
+                        asyncio.to_thread(
+                            _start_recording_sync,
+                            state.call_sid,
+                            websocket.headers.get("host", "localhost:8000"),
+                            state.restaurant.id,
+                        )
+                    )
                     _bg_call_event(
                         state.call_sid,
                         state.restaurant.id,
@@ -673,3 +705,48 @@ async def media_stream(websocket: WebSocket) -> None:
                 )
         if dg_conn is not None:
             await dg_conn.finish()
+
+
+@router.post("/recording-status/{restaurant_id}/{call_sid}")
+async def recording_status(
+    restaurant_id: str, call_sid: str, request: Request
+) -> Response:
+    """Twilio recording status callback.
+
+    Twilio POSTs here when a recording finishes processing. The
+    ``restaurant_id`` and ``call_sid`` are encoded in the URL (set when
+    the recording was started in ``_start_recording_sync``) so no
+    additional Firestore lookup is needed to find the right tenant path.
+
+    On ``completed``, stores the recording URL on the call session doc
+    and emits a ``recording_ready`` event so the live dashboard can show
+    the audio player.
+    """
+    form = await request.form()
+    status = (form.get("RecordingStatus") or "").lower()
+    recording_url = (form.get("RecordingUrl") or "").strip()
+    recording_sid = (form.get("RecordingSid") or "").strip()
+    try:
+        duration_seconds = int(form.get("RecordingDuration") or 0)
+    except ValueError:
+        duration_seconds = 0
+
+    logger.info(
+        "recording-status call_sid=%s status=%s recording_sid=%s duration=%ss",
+        call_sid,
+        status,
+        recording_sid,
+        duration_seconds,
+    )
+
+    if status == "completed" and recording_url and recording_sid:
+        await asyncio.to_thread(
+            call_sessions.mark_recording_ready,
+            call_sid,
+            restaurant_id,
+            recording_url=recording_url,
+            recording_sid=recording_sid,
+            duration_seconds=duration_seconds,
+        )
+
+    return Response(content="", status_code=204)

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -5,7 +5,7 @@ NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=
 NEXT_PUBLIC_FIREBASE_APP_ID=
 
-# FastAPI base URL for order reads + the (soon) cancel endpoint.
+# FastAPI base URL for order reads and call recording proxy.
 # Local dev: http://localhost:8000
 # Production: the Cloud Run URL.
 NIKO_API_BASE_URL=http://localhost:8000

--- a/dashboard/app/api/calls/[call_sid]/recording/route.ts
+++ b/dashboard/app/api/calls/[call_sid]/recording/route.ts
@@ -1,0 +1,36 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { apiFetch } from '@/lib/api/http';
+
+/**
+ * Proxy the Twilio call recording MP3 through Next.js so the browser can
+ * play it without needing the FastAPI base URL exposed client-side or any
+ * CORS headers on the backend.
+ *
+ * The session cookie is forwarded automatically by `apiFetch`, which means
+ * the FastAPI `current_tenant` dep enforces tenant isolation — you can only
+ * play recordings that belong to your restaurant.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ call_sid: string }> },
+) {
+  const { call_sid } = await params;
+  const upstream = await apiFetch(
+    `/calls/${encodeURIComponent(call_sid)}/recording`,
+  );
+
+  if (!upstream.ok) {
+    return new NextResponse(null, { status: upstream.status });
+  }
+
+  return new NextResponse(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'audio/mpeg',
+      'Content-Disposition': `inline; filename="${call_sid}.mp3"`,
+      // Allow range requests so the browser can seek within the audio.
+      'Accept-Ranges': 'bytes',
+    },
+  });
+}

--- a/dashboard/components/calls/call-timeline-live.tsx
+++ b/dashboard/components/calls/call-timeline-live.tsx
@@ -49,7 +49,15 @@ export function CallTimelineLive({ callSid, restaurantId, initial }: Props) {
     return unsub;
   }, [callSid, restaurantId]);
 
-  return <CallTimelineView timeline={{ call_sid: callSid, events }} />;
+  const recording_available =
+    initial.recording_available ||
+    events.some((e) => e.kind === 'recording_ready');
+
+  return (
+    <CallTimelineView
+      timeline={{ call_sid: callSid, events, recording_available }}
+    />
+  );
 }
 
 function toApiEvent(e: ZodCallEvent): CallEvent {

--- a/dashboard/components/calls/call-timeline.tsx
+++ b/dashboard/components/calls/call-timeline.tsx
@@ -5,6 +5,7 @@ import {
   Mic,
   PhoneCall,
   PhoneOff,
+  Radio,
   Sparkles,
   Volume2,
   Zap,
@@ -17,6 +18,10 @@ import type { CallEvent, CallTimeline } from '@/lib/api/calls';
 import { cn } from '@/lib/utils';
 
 export function CallTimelineView({ timeline }: { timeline: CallTimeline }) {
+  const recordingUrl = timeline.recording_available
+    ? `/api/calls/${timeline.call_sid}/recording`
+    : null;
+
   return (
     <section className="flex flex-1 flex-col gap-4 p-6">
       <header className="flex items-center gap-3">
@@ -38,6 +43,22 @@ export function CallTimelineView({ timeline }: { timeline: CallTimeline }) {
         </div>
         <TimelineExport timeline={timeline} />
       </div>
+
+      {recordingUrl && (
+        <div className="flex flex-col gap-1.5 rounded-xl border bg-card p-4">
+          <p className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <Radio className="h-3.5 w-3.5" aria-hidden />
+            Call recording
+          </p>
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <audio
+            controls
+            src={recordingUrl}
+            className="w-full"
+            aria-label="Call recording audio player"
+          />
+        </div>
+      )}
 
       <ol className="flex flex-col gap-2 rounded-xl border bg-card p-4">
         {timeline.events.map((event, i) => (
@@ -170,6 +191,15 @@ function renderEvent(event: CallEvent): RenderedEvent {
         label: 'silence timeout',
         body: 'no caller activity for 10s — bot prompted',
       };
+    case 'recording_ready': {
+      const duration = event.detail.duration_seconds as number | undefined;
+      return {
+        Icon: Radio,
+        accent: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+        label: 'recording ready',
+        body: typeof duration === 'number' ? `${duration}s recording available` : 'recording available',
+      };
+    }
     case 'error':
       return {
         Icon: AlertTriangle,

--- a/dashboard/lib/api/calls.ts
+++ b/dashboard/lib/api/calls.ts
@@ -28,6 +28,7 @@ export type CallEventKind =
   | 'silence_timeout'
   | 'stop'
   | 'order_confirmed'
+  | 'recording_ready'
   | 'error'
   | 'log';
 
@@ -50,6 +51,10 @@ export type CallEvent = {
 export type CallTimeline = {
   call_sid: string;
   events: CallEvent[];
+  // True when Twilio has finished processing the recording. Absent/false
+  // while the recording is still processing or if the call has none.
+  // The audio player proxies through GET /calls/{call_sid}/recording.
+  recording_available?: boolean;
 };
 
 export type CallsListResult =
@@ -94,6 +99,7 @@ export async function getCallTimeline(
     );
   }
 
-  const body = (await res.json()) as CallTimeline;
-  return { available: true, timeline: body };
+  const body = (await res.json()) as Omit<CallTimeline, 'recording_available'> & { events: CallEvent[] };
+  const recording_available = body.events.some((e) => e.kind === 'recording_ready');
+  return { available: true, timeline: { ...body, recording_available } };
 }

--- a/dashboard/lib/schemas/call.ts
+++ b/dashboard/lib/schemas/call.ts
@@ -30,6 +30,7 @@ export const CallEventKindSchema = z.enum([
   'silence_timeout',
   'stop',
   'order_confirmed',
+  'recording_ready',
   'error',
   'log',
 ]);
@@ -47,6 +48,10 @@ export const CallSessionSchema = z.object({
   transcript_count: z.number().int().min(0).default(0),
   has_error: z.boolean().default(false),
   last_event_at: z.coerce.date().nullish(),
+  // Set by the backend once the Twilio recording is processed. Absent on
+  // calls that have no recording yet. Frontend never sees the raw URL —
+  // it proxies playback through GET /calls/{call_sid}/recording.
+  recording_url: z.string().optional(),
 });
 export type CallSession = z.infer<typeof CallSessionSchema>;
 

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -496,3 +496,113 @@ async def test_clear_twilio_audio_swallows_websocket_disconnect():
 
     # No exception escaping is the assertion.
     await clear_twilio_audio(ws, "MZtest456")
+
+
+# ---------------------------------------------------------------------------
+# POST /recording-status — Twilio signature validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _recording_status_env(monkeypatch):
+    """Configure settings so /recording-status doesn't immediately 503.
+    Tests for the 503 path override the env explicitly."""
+    from app.config import settings
+    from app.telephony import router as telephony_router
+
+    monkeypatch.setattr(settings, "twilio_auth_token", "test_token", raising=False)
+    monkeypatch.setattr(
+        settings, "public_base_url", "http://testserver", raising=False
+    )
+    captured: list[dict] = []
+
+    def _fake_mark(call_sid, restaurant_id, **kw):
+        captured.append({"call_sid": call_sid, "restaurant_id": restaurant_id, **kw})
+
+    monkeypatch.setattr(
+        telephony_router.call_sessions, "mark_recording_ready", _fake_mark
+    )
+    return captured
+
+
+def _force_signature_valid(monkeypatch, valid: bool) -> None:
+    monkeypatch.setattr(
+        "app.telephony.router.RequestValidator.validate",
+        lambda self, url, params, sig: valid,
+    )
+
+
+def test_recording_status_rejects_invalid_signature(
+    _recording_status_env, monkeypatch
+):
+    """No (or wrong) X-Twilio-Signature → 403, no Firestore write.
+    This is the P0 the original PR shipped without."""
+    _force_signature_valid(monkeypatch, False)
+    response = client.post(
+        "/recording-status/niko-pizza-kitchen/CAtest123",
+        data={
+            "RecordingStatus": "completed",
+            "RecordingUrl": "https://api.twilio.com/2010-04-01/Recordings/REabc",
+            "RecordingSid": "REabc",
+            "RecordingDuration": "42",
+        },
+    )
+    assert response.status_code == 403
+    assert _recording_status_env == []
+
+
+def test_recording_status_returns_503_when_public_base_url_unset(monkeypatch):
+    """Without PUBLIC_BASE_URL we cannot reconstruct the signed URL,
+    so the only safe behavior is to refuse all callbacks."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "twilio_auth_token", "test_token", raising=False)
+    monkeypatch.setattr(settings, "public_base_url", None, raising=False)
+    response = client.post(
+        "/recording-status/niko-pizza-kitchen/CAtest123",
+        data={"RecordingStatus": "completed"},
+    )
+    assert response.status_code == 503
+
+
+def test_recording_status_writes_firestore_with_valid_signature(
+    _recording_status_env, monkeypatch
+):
+    _force_signature_valid(monkeypatch, True)
+    response = client.post(
+        "/recording-status/niko-pizza-kitchen/CAtest123",
+        data={
+            "RecordingStatus": "completed",
+            "RecordingUrl": "https://api.twilio.com/2010-04-01/Recordings/REabc",
+            "RecordingSid": "REabc",
+            "RecordingDuration": "42",
+        },
+    )
+    assert response.status_code == 204
+    assert len(_recording_status_env) == 1
+    write = _recording_status_env[0]
+    assert write["call_sid"] == "CAtest123"
+    assert write["restaurant_id"] == "niko-pizza-kitchen"
+    assert write["recording_sid"] == "REabc"
+    assert write["duration_seconds"] == 42
+
+
+def test_recording_status_rejects_non_twilio_recording_url(
+    _recording_status_env, monkeypatch
+):
+    """Even with a valid signature, refuse to persist a RecordingUrl
+    that doesn't live on api.twilio.com — defense-in-depth against
+    malformed/spoofed payloads becoming an SSRF vector when the
+    dashboard later proxies the URL."""
+    _force_signature_valid(monkeypatch, True)
+    response = client.post(
+        "/recording-status/niko-pizza-kitchen/CAtest123",
+        data={
+            "RecordingStatus": "completed",
+            "RecordingUrl": "https://attacker.example/evil.mp3",
+            "RecordingSid": "REabc",
+            "RecordingDuration": "42",
+        },
+    )
+    assert response.status_code == 400
+    assert _recording_status_env == []


### PR DESCRIPTION
## Summary

- **Enable recording on every call** — `_start_recording_sync` fires via Twilio REST API on the WebSocket `start` event; `restaurant_id` + `call_sid` are encoded in the callback URL so no extra Firestore lookup is needed when the recording lands.
- **Store recording metadata in Firestore** — new `POST /recording-status/{restaurant_id}/{call_sid}` endpoint receives Twilio's completed callback, writes `recording_url` / `recording_sid` / `recording_duration_seconds` to the call session doc, and emits a `recording_ready` event to the events subcollection (dual-written to legacy + nested paths).
- **Proxy audio to the browser** — `GET /calls/{call_sid}/recording` on FastAPI fetches the authenticated Twilio MP3 (buffered, 30s timeout) and returns it; a Next.js route handler at `app/api/calls/[call_sid]/recording` proxies it same-origin so the browser `<audio>` element needs no CORS config or public env vars.
- **Dashboard audio player** — appears on the call detail page once `recording_available` is true (derived from `recording_ready` event in the live Firestore subscription). Shows duration in the timeline event row too.

## Linked issue

Relates to #82 (Sprint 2.1 — Call quality optimization)

## Test plan

- [ ] Make a test call via ngrok; confirm `recording started call_sid=CA…` appears in logs
- [ ] Wait ~30s after hang-up; confirm Twilio POSTs to `/recording-status/…` and the call session doc gains `recording_url` + a `recording_ready` event in Firestore
- [ ] Manually trigger the callback: `curl -X POST https://<ngrok>/recording-status/<rid>/<call_sid> -d "RecordingStatus=completed&RecordingUrl=https://api.twilio.com/…&RecordingSid=RE…&RecordingDuration=45"`
- [ ] Open call detail page — audio player card should appear above the timeline; `recording ready  45s recording available` row should appear in the events list
- [ ] Confirm audio plays and seeks correctly in the browser
- [ ] Confirm calls without a recording show no audio player (no regression)
- [ ] Confirm `GET /calls/<other_tenant_call_sid>/recording` returns 404 (tenant isolation)

## Notes

- Recording is always enabled; there is no per-tenant opt-out yet (Phase 2 follow-up if needed).
- `recording_available` is optional on `CallTimeline` — existing test fixtures and the `formatTimelineAsText` empty-timeline case are unaffected.
- The buffered download approach (vs streaming) is intentional: it lets us check Twilio's HTTP status before committing to a `200` response. Call recordings are short (<5 min ≈ <5 MB) so buffering is fine.