### PR TITLE
Auto-hangup reliability: drop false trigger + mark-echo fallback (#114)

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -49,6 +49,11 @@ GREETING_TRANSCRIPT = "[call started — greet the caller]"
 # squeeze in a late question before terminating the call.
 END_OF_CALL_MARK = "end_of_call"
 HANGUP_GRACE_SECONDS = 5.0
+# Fallback if Twilio never echoes the end_of_call mark back to us
+# (WebSocket dropped, mark lost in transit). After this many seconds
+# we trigger the grace window anyway so the call still terminates
+# instead of hanging open. Picked > typical mark round-trip (1-3s).
+MARK_ECHO_TIMEOUT_SECONDS = 8.0
 
 # Phrases the model uses when wrapping up. Used as a fallback signal
 # for auto-hangup when Haiku says a goodbye but forgets to mark the
@@ -172,6 +177,35 @@ async def _hang_up_after_grace(state: _CallState) -> None:
         )
 
 
+async def _hang_up_after_mark_timeout(state: _CallState) -> None:
+    """Fallback for when Twilio never echoes the end_of_call mark.
+
+    The primary path is: send mark → Twilio echoes when audio drains →
+    start grace timer. If the echo never arrives, this timer fires
+    after ``MARK_ECHO_TIMEOUT_SECONDS`` and starts the grace window
+    anyway, so the call still ends instead of hanging open.
+
+    Cancelled by the echo handler when the echo arrives, or by
+    ``_abort_pending_hangup`` when the caller speaks.
+    """
+    try:
+        await asyncio.sleep(MARK_ECHO_TIMEOUT_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.pending_hangup or not state.call_sid:
+        return
+    logger.warning(
+        "auto-hangup: mark echo timed out after %.1fs, falling back to "
+        "grace window call_sid=%s",
+        MARK_ECHO_TIMEOUT_SECONDS,
+        state.call_sid,
+    )
+    if state.hangup_task and not state.hangup_task.done():
+        state.hangup_task.cancel()
+    state.hangup_task = None
+    await _hang_up_after_grace(state)
+
+
 def _abort_pending_hangup(state: _CallState) -> None:
     """Cancel a pending auto-hangup because the caller spoke during
     the grace window. Safe to call when no hangup is pending."""
@@ -179,6 +213,9 @@ def _abort_pending_hangup(state: _CallState) -> None:
     if state.hangup_task and not state.hangup_task.done():
         state.hangup_task.cancel()
     state.hangup_task = None
+    if state.mark_timeout_task and not state.mark_timeout_task.done():
+        state.mark_timeout_task.cancel()
+    state.mark_timeout_task = None
 
 
 async def clear_twilio_audio(websocket: WebSocket, stream_sid: str | None) -> None:
@@ -211,9 +248,10 @@ class _CallState:
     history:      list[dict]       = field(default_factory=list)
     restaurant:   Restaurant | None = None     # tenant for this call (#79)
     system_prompt: str             = ""        # built from restaurant on start
-    llm_task:     asyncio.Task | None = None   # current LLM→TTS turn
-    silence_task: asyncio.Task | None = None   # silence watchdog
-    hangup_task:  asyncio.Task | None = None   # pending auto-hangup (#78)
+    llm_task:          asyncio.Task | None = None   # current LLM→TTS turn
+    silence_task:      asyncio.Task | None = None   # silence watchdog
+    hangup_task:       asyncio.Task | None = None   # pending auto-hangup (#78)
+    mark_timeout_task: asyncio.Task | None = None   # mark-echo fallback (#114)
     pending_hangup: bool           = False     # set when goodbye mark sent (#78)
 
 
@@ -410,6 +448,9 @@ async def _run_llm_tts_turn(
                         )
                         if sent:
                             state.pending_hangup = True
+                            state.mark_timeout_task = asyncio.create_task(
+                                _hang_up_after_mark_timeout(state)
+                            )
 
     except asyncio.CancelledError:
         logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)
@@ -613,6 +654,9 @@ async def media_stream(websocket: WebSocket) -> None:
                         "auto-hangup: end_of_call mark received call_sid=%s",
                         state.call_sid,
                     )
+                    if state.mark_timeout_task and not state.mark_timeout_task.done():
+                        state.mark_timeout_task.cancel()
+                    state.mark_timeout_task = None
                     if state.hangup_task and not state.hangup_task.done():
                         state.hangup_task.cancel()
                     state.hangup_task = asyncio.create_task(

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -448,6 +448,8 @@ async def _run_llm_tts_turn(
                         )
                         if sent:
                             state.pending_hangup = True
+                            if state.mark_timeout_task and not state.mark_timeout_task.done():
+                                state.mark_timeout_task.cancel()
                             state.mark_timeout_task = asyncio.create_task(
                                 _hang_up_after_mark_timeout(state)
                             )

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -48,7 +48,7 @@ GREETING_TRANSCRIPT = "[call started — greet the caller]"
 # heard the goodbye; we then hold for the grace window in case they
 # squeeze in a late question before terminating the call.
 END_OF_CALL_MARK = "end_of_call"
-HANGUP_GRACE_SECONDS = 3.0
+HANGUP_GRACE_SECONDS = 5.0
 
 # Phrases the model uses when wrapping up. Used as a fallback signal
 # for auto-hangup when Haiku says a goodbye but forgets to mark the
@@ -64,7 +64,6 @@ _GOODBYE_PATTERNS = (
     "have a great day",
     "have a good day",
     "enjoy your",
-    "coming right up",
 )
 
 

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -457,7 +457,7 @@ async def test_hang_up_after_grace_calls_twilio_when_pending(monkeypatch):
 
     assert ended == ["CAtest"]
     # Sanity: original constant unchanged.
-    assert HANGUP_GRACE_SECONDS == 3.0
+    assert HANGUP_GRACE_SECONDS == 5.0
 
 
 @pytest.mark.asyncio
@@ -481,6 +481,19 @@ async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
     await _hang_up_after_grace(state)
 
     assert ended == []
+
+
+def test_looks_like_goodbye_excludes_coming_right_up():
+    """'coming right up' is mid-order, not a wrap-up — must NOT trigger fallback."""
+    from app.telephony.router import _looks_like_goodbye
+    assert _looks_like_goodbye("One large Margherita coming right up.") is False
+    assert _looks_like_goodbye("Two Cokes coming right up!") is False
+
+
+def test_hangup_grace_seconds_is_five():
+    """Grace window must be 5s so callers can add late items."""
+    from app.telephony.router import HANGUP_GRACE_SECONDS
+    assert HANGUP_GRACE_SECONDS == 5.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -497,6 +497,37 @@ def test_hangup_grace_seconds_is_five():
 
 
 @pytest.mark.asyncio
+async def test_mark_echo_timeout_fires_grace_window(monkeypatch):
+    """If Twilio never echoes the end_of_call mark, the timeout fires
+    the grace window anyway so the call terminates."""
+    import asyncio
+    from app.telephony import router as router_mod
+    from app.telephony.router import (
+        _CallState,
+        _hang_up_after_mark_timeout,
+    )
+
+    monkeypatch.setattr(router_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
+
+    state = _CallState()
+    state.call_sid = "CA_timeout_test"
+    state.pending_hangup = True
+
+    grace_started = {"flag": False}
+
+    async def fake_grace(s):
+        grace_started["flag"] = True
+
+    monkeypatch.setattr(router_mod, "_hang_up_after_grace", fake_grace)
+
+    await _hang_up_after_mark_timeout(state)
+
+    assert grace_started["flag"] is True, (
+        "mark echo timeout must trigger grace window when no echo arrives"
+    )
+
+
+@pytest.mark.asyncio
 async def test_clear_twilio_audio_swallows_websocket_disconnect():
     """If the caller already hung up, the clear send raises — but we
     must not let that exception escape into the call loop."""

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -490,6 +490,16 @@ def test_looks_like_goodbye_excludes_coming_right_up():
     assert _looks_like_goodbye("Two Cokes coming right up!") is False
 
 
+def test_looks_like_goodbye_remaining_patterns_still_match():
+    """Positive coverage so a drive-by removal of a pattern is caught."""
+    from app.telephony.router import _looks_like_goodbye
+    assert _looks_like_goodbye("Thanks for ordering, see you soon!")
+    assert _looks_like_goodbye("Your order is in — we'll have it ready shortly.")
+    assert _looks_like_goodbye("Thanks for calling!")
+    assert _looks_like_goodbye("Have a great day.")
+    assert _looks_like_goodbye("Enjoy your meal!")
+
+
 def test_hangup_grace_seconds_is_five():
     """Grace window must be 5s so callers can add late items."""
     from app.telephony.router import HANGUP_GRACE_SECONDS
@@ -525,6 +535,54 @@ async def test_mark_echo_timeout_fires_grace_window(monkeypatch):
     assert grace_started["flag"] is True, (
         "mark echo timeout must trigger grace window when no echo arrives"
     )
+
+
+@pytest.mark.asyncio
+async def test_mark_echo_timeout_skips_grace_when_pending_hangup_cleared(monkeypatch):
+    """If pending_hangup is cleared during the 8s sleep (caller spoke and
+    _abort_pending_hangup raced), the timeout must NOT fire the grace window."""
+    import asyncio
+    from app.telephony import router as router_mod
+    from app.telephony.router import _CallState, _hang_up_after_mark_timeout
+
+    monkeypatch.setattr(router_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
+
+    state = _CallState()
+    state.call_sid = "CA_abort_race"
+    state.pending_hangup = False  # already cleared before timeout fires
+
+    grace_started = {"flag": False}
+
+    async def fake_grace(s):
+        grace_started["flag"] = True
+
+    monkeypatch.setattr(router_mod, "_hang_up_after_grace", fake_grace)
+
+    await _hang_up_after_mark_timeout(state)
+
+    assert grace_started["flag"] is False, (
+        "timeout must not fire grace when pending_hangup was already cleared"
+    )
+
+
+@pytest.mark.asyncio
+async def test_abort_pending_hangup_cancels_mark_timeout_task():
+    """_abort_pending_hangup must cancel mark_timeout_task so the fallback
+    timer doesn't fire after the caller speaks during the grace window."""
+    import asyncio
+    from app.telephony.router import _CallState, _abort_pending_hangup
+
+    state = _CallState(call_sid="CAtest", pending_hangup=True)
+
+    async def _noop():
+        await asyncio.sleep(60)
+
+    state.mark_timeout_task = asyncio.create_task(_noop())
+
+    _abort_pending_hangup(state)
+
+    assert state.mark_timeout_task is None
+    assert state.pending_hangup is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Remove `"coming right up"` from `_GOODBYE_PATTERNS` — it fires on every item acknowledgement (e.g. "One Margherita coming right up") and was the primary cause of premature mid-order hangup
- Bump `HANGUP_GRACE_SECONDS` 3 → 5s so callers have room to add a late item after confirmation
- Add `_hang_up_after_mark_timeout`: if Twilio never echoes the `end_of_call` mark (WebSocket drop, mark lost in transit), a 8s fallback timer fires the grace window anyway — fixes calls that hung open after goodbye until the caller manually hung up (observed in call CAe95eab754941779ac396f36b2ff0d5b8)

## Linked issue
Closes #114

## Test plan
- [ ] Make a test call, confirm the agent auto-hangs up after the goodbye without waiting for the caller to hang up
- [ ] Say "One chicken fried rice coming right up" mid-order — verify it does NOT trigger hangup
- [ ] All 198 unit tests pass (`pytest tests/ --ignore=tests/test_llm_integration.py`)

## Notes
The 2 failing `test_llm_integration.py` tests (`remove_item`, `delivery_address_uhh_then_real`) are pre-existing non-deterministic LLM failures unrelated to this change. The primary auto-hangup path (mark echo → grace → REST end-call) is unchanged; this PR only adds the fallback for when the echo never arrives and tightens the heuristic trigger.