### PR TITLE
Start call recording from /voice handler (fixes 404 on Recordings.create)

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -589,6 +589,7 @@ async def voice(request: Request) -> Response:
     """
     form = await request.form()
     to_e164 = (form.get("To") or "").strip()
+    call_sid = (form.get("CallSid") or "").strip()
     restaurant = _resolve_restaurant_for_voice(to_e164)
 
     twiml = VoiceResponse()
@@ -599,6 +600,18 @@ async def voice(request: Request) -> Response:
         twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
         twiml.hangup()
         return Response(content=str(twiml), media_type="application/xml")
+
+    # Kick off the recording REST call before returning TwiML. We can't
+    # do this on the WebSocket start event because by then Twilio has
+    # routed the call into <Connect> and the Recordings API returns 404
+    # ("not eligible"). Triggering it from the inbound voice webhook —
+    # while the call is still in Twilio's normal in-progress state —
+    # avoids the race entirely. The task is fire-and-forget; the audio
+    # path must never block on Twilio REST latency.
+    if call_sid:
+        asyncio.get_running_loop().create_task(
+            asyncio.to_thread(_start_recording_sync, call_sid, restaurant.id)
+        )
 
     host = request.headers.get("host", "localhost:8000")
     connect = Connect()
@@ -666,13 +679,6 @@ async def media_stream(websocket: WebSocket) -> None:
                     asyncio.get_running_loop().create_task(
                         asyncio.to_thread(
                             call_sessions.init_call_session,
-                            state.call_sid,
-                            state.restaurant.id,
-                        )
-                    )
-                    asyncio.get_running_loop().create_task(
-                        asyncio.to_thread(
-                            _start_recording_sync,
                             state.call_sid,
                             state.restaurant.id,
                         )

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -190,6 +190,50 @@ def test_voice_rejects_unmapped_number(monkeypatch):
     assert "<Connect" not in body
 
 
+def test_voice_schedules_recording_start(monkeypatch):
+    """Recording must be kicked off from /voice — not the WS start event.
+    On WS start, Twilio has already routed the call into <Connect> state
+    and the Recordings REST API returns 404 ('not eligible'). Triggering
+    from /voice avoids that race entirely (#82 follow-up)."""
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
+    captured: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "app.telephony.router._start_recording_sync",
+        lambda call_sid, restaurant_id: captured.append((call_sid, restaurant_id)),
+    )
+    response = client.post("/voice", data=_VOICE_FORM)
+    assert response.status_code == 200
+    # The recording start runs via asyncio.to_thread — give the executor a
+    # moment to drain before asserting.
+    import time as _t
+    for _ in range(50):
+        if captured:
+            break
+        _t.sleep(0.02)
+    assert captured == [("CAtest", "niko-pizza-kitchen")]
+
+
+def test_voice_skips_recording_when_no_call_sid(monkeypatch):
+    """Defensive: if Twilio's webhook ever lands without a CallSid (test
+    harnesses, future TwiML changes), don't crash trying to start a
+    recording with an empty SID."""
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
+    called: list = []
+    monkeypatch.setattr(
+        "app.telephony.router._start_recording_sync",
+        lambda *a, **kw: called.append(a),
+    )
+    response = client.post(
+        "/voice", data={"From": "+10000000000", "To": _DEMO_TO}  # no CallSid
+    )
+    assert response.status_code == 200
+    assert called == []
+
+
 # ---------------------------------------------------------------------------
 # WS /media-stream — basic lifecycle
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #127. The Recordings REST API was returning **HTTP 404 / `Unable to create record`** on every prod call — recording feature has been silently broken since #127 merged. Confirmed in Cloud Run logs:

```
twilio.base.exceptions.TwilioRestException: HTTP 404 error: Unable to create record:
The requested resource /2010-04-01/Accounts/AC.../Calls/CA.../Recordings
```

Root cause: by the time the WebSocket `start` event fires, Twilio has already routed the inbound call into `<Connect>` state — the audio is owned by the streamed leg, and the Recordings API treats the call as ineligible (returns 404, not the more specific 21220 it returns for fully-completed calls).

Fix: trigger `_start_recording_sync` from the inbound `/voice` HTTP webhook instead. At that point the call is in Twilio's normal `in-progress` state, fully indexed in their API, and not yet handed off to `<Connect>`. The CallSid is already in the form body Twilio POSTs.

## Changes

- `app/telephony/router.py`:
  - `voice()` reads `CallSid` from the form and schedules `_start_recording_sync` as a background task before returning TwiML.
  - The duplicate trigger from the WebSocket `start` handler is removed.
- `tests/test_telephony.py`:
  - New: `test_voice_schedules_recording_start` — asserts `/voice` triggers recording with the right call_sid + restaurant_id.
  - New: `test_voice_skips_recording_when_no_call_sid` — defensive guard.

No new env vars; no new dependencies. The Twilio signature validation, host pinning, and SSRF allowlist from #127 are unchanged.

## Linked issue

Sub-task of #82. Same architectural bug also affects `_twilio_end_call_sync` (auto-hangup) — REST call against a `<Connect>`-routed call returns 404 — but the symptom is invisible because callers hang up themselves. Tracked separately.

## Test plan

- [x] Parse + unit tests pass locally
- [ ] After merge: place a test call to +1 647 905 8093, then verify in Cloud Run logs:
  ```
  recording started call_sid=CA... callback=https://niko-ciyyvuq2pq-uc.a.run.app/recording-status/...
  ```
  …and after hangup, a `recording-status call_sid=... status=completed` log line.
- [ ] Open the call detail page in the dashboard, confirm the audio player renders and plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)