### PR TITLE
Await recording REST call inline in /voice (fixes 404 again)

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -602,16 +602,23 @@ async def voice(request: Request) -> Response:
         return Response(content=str(twiml), media_type="application/xml")
 
     # Start the recording synchronously before returning TwiML. The REST
-    # call MUST complete before Twilio reads our <Connect><Stream> response
-    # — once the call enters <Connect> state, the Recordings API returns
-    # 404 ("not eligible"). Firing this as a background task isn't enough:
-    # the executor can run it after TwiML has already been parsed and the
-    # call routed. ~300-500ms of added latency on /voice is fine — the
-    # caller just hears a beat more of PSTN ringing before we answer, and
-    # _start_recording_sync swallows its own exceptions so a Twilio
-    # outage cannot block the call from being answered.
+    # call must land before Twilio reads our <Connect><Stream> response —
+    # once the call enters <Connect> state, the Recordings API returns
+    # 404. The 2s ceiling caps how long /voice can block: Twilio drops a
+    # voice webhook at ~15s, so even a hung Twilio API can never strand
+    # the caller. Recording is non-essential to call flow; on timeout we
+    # log and continue.
     if call_sid:
-        await asyncio.to_thread(_start_recording_sync, call_sid, restaurant.id)
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(_start_recording_sync, call_sid, restaurant.id),
+                timeout=2.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "recording: start timed out (>2s) call_sid=%s — answering call without recording",
+                call_sid,
+            )
 
     host = request.headers.get("host", "localhost:8000")
     connect = Connect()

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -601,17 +601,17 @@ async def voice(request: Request) -> Response:
         twiml.hangup()
         return Response(content=str(twiml), media_type="application/xml")
 
-    # Kick off the recording REST call before returning TwiML. We can't
-    # do this on the WebSocket start event because by then Twilio has
-    # routed the call into <Connect> and the Recordings API returns 404
-    # ("not eligible"). Triggering it from the inbound voice webhook —
-    # while the call is still in Twilio's normal in-progress state —
-    # avoids the race entirely. The task is fire-and-forget; the audio
-    # path must never block on Twilio REST latency.
+    # Start the recording synchronously before returning TwiML. The REST
+    # call MUST complete before Twilio reads our <Connect><Stream> response
+    # — once the call enters <Connect> state, the Recordings API returns
+    # 404 ("not eligible"). Firing this as a background task isn't enough:
+    # the executor can run it after TwiML has already been parsed and the
+    # call routed. ~300-500ms of added latency on /voice is fine — the
+    # caller just hears a beat more of PSTN ringing before we answer, and
+    # _start_recording_sync swallows its own exceptions so a Twilio
+    # outage cannot block the call from being answered.
     if call_sid:
-        asyncio.get_running_loop().create_task(
-            asyncio.to_thread(_start_recording_sync, call_sid, restaurant.id)
-        )
+        await asyncio.to_thread(_start_recording_sync, call_sid, restaurant.id)
 
     host = request.headers.get("host", "localhost:8000")
     connect = Connect()

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -191,10 +191,11 @@ def test_voice_rejects_unmapped_number(monkeypatch):
 
 
 def test_voice_schedules_recording_start(monkeypatch):
-    """Recording must be kicked off from /voice — not the WS start event.
-    On WS start, Twilio has already routed the call into <Connect> state
-    and the Recordings REST API returns 404 ('not eligible'). Triggering
-    from /voice avoids that race entirely (#82 follow-up)."""
+    """Recording must be kicked off from /voice — and awaited inline,
+    not fire-and-forget. If we return TwiML before the REST call lands,
+    Twilio routes the call into <Connect> and the Recordings API
+    returns 404 ('not eligible'). Awaiting guarantees the REST call
+    completes before our TwiML response (#82 follow-up)."""
     monkeypatch.setattr(
         restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
     )
@@ -205,13 +206,7 @@ def test_voice_schedules_recording_start(monkeypatch):
     )
     response = client.post("/voice", data=_VOICE_FORM)
     assert response.status_code == 200
-    # The recording start runs via asyncio.to_thread — give the executor a
-    # moment to drain before asserting.
-    import time as _t
-    for _ in range(50):
-        if captured:
-            break
-        _t.sleep(0.02)
+    # Awaited inline — must be populated by the time the response returns.
     assert captured == [("CAtest", "niko-pizza-kitchen")]
 
 


### PR DESCRIPTION
## Summary

Follow-up to #132 — same 404 returned. Logs from a test call on revision `niko-00069-9tf`:

```
02:54:55.143  media-stream start (call entered <Connect>)
02:54:55.452  POST /Calls/.../Recordings.json   ← 309ms LATE
02:54:55.737  ERROR: failed to start Twilio recording  (404)
```

#132 moved the trigger to the `/voice` handler but kept it as a fire-and-forget `asyncio.create_task(asyncio.to_thread(...))`. The TwiML response returned before the executor got around to running the REST call. By the time it did run, Twilio had already parsed the TwiML and routed the call into `<Connect>` — same race, just shifted by a few hundred ms.

Fix: `await` the `to_thread` inline. Adds ~300-500ms of latency to `/voice` (caller hears a beat more PSTN ringing — Twilio's voice-webhook timeout is 15s so this is well inside budget). When TwiML returns, the recording is already running.

`_start_recording_sync` already swallows its own exceptions, so even if Twilio's API is down, `/voice` will still return TwiML and answer the call — recording will just be missing for that one call.

## Changes

- `app/telephony/router.py:611` — `await asyncio.to_thread(...)` instead of `create_task(asyncio.to_thread(...))`. Comment block updated to explain the synchronous requirement.
- `tests/test_telephony.py` — drop the polling loop in `test_voice_schedules_recording_start`; now the assertion runs the moment the response returns.

## Linked issue

Sub-task of #82 (closes the recording-not-starting symptom for real this time).

## Test plan

- [x] Parse + unit tests OK locally
- [ ] After deploy: place a test call, expect log line `recording started call_sid=CA... callback=https://...` BEFORE any `media-stream start` log line for the same call_sid
- [ ] After hangup, dashboard audio player on `/orders/{call_sid}` plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)