### PR TITLE
dashboard: read-only menu view (Sprint 2.4)

### DIFF
--- a/dashboard/app/(dashboard)/menu/loading.tsx
+++ b/dashboard/app/(dashboard)/menu/loading.tsx
@@ -1,0 +1,47 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function MenuLoading() {
+  return (
+    <section className="flex flex-1 flex-col gap-10 p-6 lg:p-10">
+      <header className="flex max-w-3xl flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <Skeleton className="h-9 w-24" />
+          <span aria-hidden className="h-px flex-1 translate-y-[-0.5rem] bg-border" />
+        </div>
+        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-3 w-56" />
+      </header>
+
+      <div className="grid gap-10 lg:grid-cols-[12rem_minmax(0,1fr)] lg:gap-16">
+        <div className="hidden flex-col gap-2 lg:flex">
+          <Skeleton className="mb-2 h-3 w-16" />
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-5 w-full" />
+          ))}
+        </div>
+        <div className="flex flex-col gap-14">
+          {Array.from({ length: 2 }).map((_, c) => (
+            <section key={c}>
+              <header className="mb-6 flex items-baseline gap-4 border-b border-border pb-3">
+                <Skeleton className="h-7 w-40" />
+                <span aria-hidden className="h-px flex-1 bg-border/60" />
+                <Skeleton className="h-4 w-16" />
+              </header>
+              <ul className="grid gap-x-12 gap-y-6 sm:grid-cols-2">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <li key={i}>
+                    <div className="flex items-baseline gap-3">
+                      <Skeleton className="h-5 w-40" />
+                      <span aria-hidden className="min-w-4 flex-1 translate-y-[-0.25rem] border-b border-dotted border-border" />
+                      <Skeleton className="h-5 w-14" />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/(dashboard)/menu/page.tsx
+++ b/dashboard/app/(dashboard)/menu/page.tsx
@@ -1,10 +1,50 @@
-import { ComingSoon } from '@/components/shared/coming-soon';
+import { redirect } from 'next/navigation';
 
-export default function MenuPage() {
+import { MenuEmptyState } from '@/components/menu/menu-empty-state';
+import { MenuParseError } from '@/components/menu/menu-parse-error';
+import { MenuView } from '@/components/menu/menu-view';
+import { getMyRestaurant } from '@/lib/api/restaurant';
+import { getServerSession } from '@/lib/auth/session';
+import { humanizeRestaurantId } from '@/lib/formatters/restaurant';
+import { parseMenu } from '@/lib/schemas/menu';
+
+// Menu config is admin-driven — Firestore writes are rare and we want the
+// page to always reflect the latest doc, not a cached render.
+export const dynamic = 'force-dynamic';
+
+export default async function MenuPage() {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
+  let restaurantName = humanizeRestaurantId(session.restaurantId);
+  let rawMenu: Record<string, unknown> = {};
+
+  try {
+    const restaurant = await getMyRestaurant();
+    restaurantName = restaurant.name || restaurantName;
+    rawMenu = restaurant.menu;
+  } catch (err) {
+    console.error('[menu page] /restaurants/me fetch failed', err);
+    return (
+      <MenuParseError reason="Could not reach the backend to load the restaurant configuration." />
+    );
+  }
+
+  const hasCategories = Object.keys(rawMenu).some((k) => !k.startsWith('_'));
+  if (!hasCategories) {
+    return <MenuEmptyState restaurantName={restaurantName} />;
+  }
+
+  const result = parseMenu(rawMenu);
+  if ('error' in result) {
+    return <MenuParseError reason={result.error} />;
+  }
+
   return (
-    <ComingSoon
-      title="Menu"
-      description="Menu management moves here once the hardcoded demo menu in app/menu.py migrates to Firestore."
+    <MenuView
+      categories={result.categories}
+      itemCount={result.itemCount}
+      restaurantName={restaurantName}
     />
   );
 }

--- a/dashboard/components/menu/menu-empty-state.tsx
+++ b/dashboard/components/menu/menu-empty-state.tsx
@@ -1,0 +1,23 @@
+import { UtensilsCrossed } from 'lucide-react';
+
+export function MenuEmptyState({ restaurantName }: { restaurantName: string }) {
+  return (
+    <section className="flex flex-1 items-center justify-center p-6">
+      <div className="flex max-w-md flex-col items-center gap-3 rounded-xl border bg-card p-10 text-center">
+        <UtensilsCrossed
+          className="h-8 w-8 text-muted-foreground"
+          aria-hidden
+        />
+        <h2 className="text-lg font-medium">No menu yet</h2>
+        <p className="text-sm text-muted-foreground">
+          {restaurantName} hasn&apos;t loaded a menu into the platform.
+          Onboard the menu via{' '}
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">
+            scripts/provision_restaurant.py
+          </code>{' '}
+          (or the upcoming menu editor) and refresh.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/components/menu/menu-parse-error.tsx
+++ b/dashboard/components/menu/menu-parse-error.tsx
@@ -1,0 +1,17 @@
+import { TriangleAlert } from 'lucide-react';
+
+export function MenuParseError({ reason }: { reason: string }) {
+  return (
+    <section className="flex flex-1 items-center justify-center p-6">
+      <div className="flex max-w-md flex-col items-center gap-3 rounded-xl border border-destructive/40 bg-card p-10 text-center">
+        <TriangleAlert className="h-8 w-8 text-destructive" aria-hidden />
+        <h2 className="text-lg font-medium">Menu unavailable</h2>
+        <p className="text-sm text-muted-foreground">{reason}</p>
+        <p className="text-xs text-muted-foreground">
+          The agent will keep using whatever menu it last loaded — this is a
+          dashboard-side display issue, not a call-flow outage.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/components/menu/menu-view.tsx
+++ b/dashboard/components/menu/menu-view.tsx
@@ -1,0 +1,194 @@
+/**
+ * Read-only menu view — Sprint 2.4 (Phase 2 MVP).
+ *
+ * Visual language: editorial menu, not data table. The owner is checking
+ * "is this what my AI is reading on the phone?" — a printed-menu metaphor
+ * (typeset items, leader-dot price runs, category nav rail) reads more
+ * naturally than a CRUD admin grid. CRUD lands in a follow-up PR; this
+ * view is intentionally still and quiet.
+ *
+ * All Server Components — no interactivity in this PR. The category nav
+ * uses plain anchor links so it works without JS.
+ */
+import { Fragment } from 'react';
+
+import { formatCAD } from '@/lib/formatters/money';
+import {
+  type Category,
+  type MenuItem,
+  humanizeCategoryKey,
+  isSizedItem,
+} from '@/lib/schemas/menu';
+
+type Props = {
+  categories: Category[];
+  itemCount: number;
+  restaurantName: string;
+};
+
+export function MenuView({ categories, itemCount, restaurantName }: Props) {
+  return (
+    <section className="flex flex-1 flex-col gap-10 p-6 lg:p-10">
+      <MenuHeader
+        categoryCount={categories.length}
+        itemCount={itemCount}
+        restaurantName={restaurantName}
+      />
+
+      <div className="grid gap-10 lg:grid-cols-[12rem_minmax(0,1fr)] lg:gap-16">
+        <CategoryNav categories={categories} />
+        <div className="flex flex-col gap-14">
+          {categories.map((c) => (
+            <CategorySection key={c.key} category={c} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MenuHeader({
+  categoryCount,
+  itemCount,
+  restaurantName,
+}: {
+  categoryCount: number;
+  itemCount: number;
+  restaurantName: string;
+}) {
+  return (
+    <header className="flex max-w-3xl flex-col gap-3">
+      <div className="flex items-baseline gap-3">
+        <h2 className="text-3xl font-medium tracking-tight">Menu</h2>
+        <span
+          aria-hidden
+          className="h-px flex-1 translate-y-[-0.5rem] bg-border"
+        />
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {restaurantName}
+        <span className="mx-2 text-muted-foreground/40">·</span>
+        <span className="tabular-nums">{categoryCount}</span>{' '}
+        {categoryCount === 1 ? 'category' : 'categories'}
+        <span className="mx-2 text-muted-foreground/40">·</span>
+        <span className="tabular-nums">{itemCount}</span>{' '}
+        {itemCount === 1 ? 'item' : 'items'}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        This is what the agent reads to callers. Editing arrives in a
+        follow-up release.
+      </p>
+    </header>
+  );
+}
+
+function CategoryNav({ categories }: { categories: Category[] }) {
+  return (
+    <nav
+      aria-label="Menu sections"
+      className="hidden lg:sticky lg:top-6 lg:block lg:self-start"
+    >
+      <p className="mb-3 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        Sections
+      </p>
+      <ul className="flex flex-col gap-px border-l border-border">
+        {categories.map((c) => (
+          <li key={c.key}>
+            <a
+              href={`#category-${c.key}`}
+              className="group -ml-px flex items-baseline justify-between gap-3 border-l border-transparent py-1.5 pl-4 text-sm text-muted-foreground transition-colors hover:border-l-foreground hover:text-foreground"
+            >
+              <span className="truncate">{humanizeCategoryKey(c.key)}</span>
+              <span className="text-xs tabular-nums opacity-60">
+                {c.items.length}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+function CategorySection({ category }: { category: Category }) {
+  const label = humanizeCategoryKey(category.key);
+  const headingId = `heading-${category.key}`;
+  return (
+    <section
+      id={`category-${category.key}`}
+      aria-labelledby={headingId}
+      className="scroll-mt-8"
+    >
+      <header className="mb-6 flex items-baseline gap-4 border-b border-border pb-3">
+        <h3 id={headingId} className="text-xl font-medium tracking-tight">
+          {label}
+        </h3>
+        <span aria-hidden className="h-px flex-1 bg-border/60" />
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {category.items.length}{' '}
+          {category.items.length === 1 ? 'item' : 'items'}
+        </span>
+      </header>
+
+      <ul className="grid gap-x-12 gap-y-6 sm:grid-cols-2">
+        {category.items.map((item, idx) => (
+          <li key={`${category.key}-${idx}-${item.name}`}>
+            <ItemRow item={item} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ItemRow({ item }: { item: MenuItem }) {
+  return (
+    <article className="flex flex-col gap-1.5">
+      <div className="flex items-baseline gap-3">
+        <h4 className="font-medium leading-snug text-foreground">
+          {item.name}
+        </h4>
+        <span
+          aria-hidden
+          className="min-w-4 flex-1 translate-y-[-0.25rem] border-b border-dotted border-border"
+        />
+        <PriceTag item={item} />
+      </div>
+      {item.description ? (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {item.description}
+        </p>
+      ) : null}
+    </article>
+  );
+}
+
+function PriceTag({ item }: { item: MenuItem }) {
+  if (isSizedItem(item)) {
+    const sizes = Object.entries(item.sizes);
+    return (
+      <span className="flex items-baseline gap-2 font-mono text-sm tabular-nums text-foreground">
+        {sizes.map(([size, price], i) => (
+          <Fragment key={size}>
+            {i > 0 ? (
+              <span aria-hidden className="text-muted-foreground/50">
+                ·
+              </span>
+            ) : null}
+            <span className="flex items-baseline gap-1.5">
+              <span className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                {size}
+              </span>
+              <span>{formatCAD(price)}</span>
+            </span>
+          </Fragment>
+        ))}
+      </span>
+    );
+  }
+  return (
+    <span className="font-mono text-sm tabular-nums text-foreground">
+      {formatCAD(item.price)}
+    </span>
+  );
+}

--- a/dashboard/lib/schemas/menu.ts
+++ b/dashboard/lib/schemas/menu.ts
@@ -1,0 +1,150 @@
+/**
+ * Menu schema — narrows the free-form `restaurant.menu` dict that the
+ * backend stores at `restaurants/{id}.menu` (see
+ * `app/restaurants/models.py`).
+ *
+ * Shape per the backend:
+ *   {
+ *     _category_order?: string[],    // optional ordering hint
+ *     <category_key>: MenuItem[],    // each non-underscored key
+ *     ...
+ *   }
+ *
+ * Per-item shape is one of:
+ *   - { name, price, description? }                       single-priced
+ *   - { name, sizes: { small: 12.99, ... }, description? } multi-size
+ *
+ * The Pydantic model (`Restaurant.menu: dict[str, Any]`) is intentionally
+ * loose so different tenants can use different category keys (pizzas vs.
+ * caribbean_appetizers vs. fried_rice) — see the comment block in
+ * `app/restaurants/models.py`. We tighten validation here at the read
+ * boundary so the dashboard never has to handle ad-hoc shapes downstream.
+ *
+ * Sprint 2.4 owns menu CRUD; this schema is the read-side groundwork.
+ * Phase 2+ will move per-item structure to a stricter `MenuItem` Pydantic
+ * model in the backend with stable IDs and modifier groups (see deferred
+ * list in `dashboard/CLAUDE.md`).
+ */
+import { z } from 'zod';
+
+const RESERVED_PREFIX = '_';
+const CATEGORY_ORDER_KEY = '_category_order';
+
+export const SizedItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  sizes: z
+    .record(z.string().min(1), z.number().nonnegative())
+    .refine((s) => Object.keys(s).length > 0, {
+      message: 'sizes must contain at least one entry',
+    }),
+});
+export type SizedItem = z.infer<typeof SizedItemSchema>;
+
+export const SinglePriceItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  price: z.number().nonnegative(),
+});
+export type SinglePriceItem = z.infer<typeof SinglePriceItemSchema>;
+
+// Order matters: an object that has both `sizes` and `price` (shouldn't,
+// but defense in depth) is treated as sized.
+export const MenuItemSchema = z.union([SizedItemSchema, SinglePriceItemSchema]);
+export type MenuItem = z.infer<typeof MenuItemSchema>;
+
+export type Category = {
+  key: string;
+  items: MenuItem[];
+};
+
+export type ParsedMenu = {
+  categories: Category[];
+  itemCount: number;
+};
+
+export type MenuParseFailure = {
+  error: string;
+};
+
+export function isSizedItem(item: MenuItem): item is SizedItem {
+  return 'sizes' in item;
+}
+
+/**
+ * Parse and order a raw menu dict.
+ *
+ * Returns either the ordered categories (with item counts) or a string-
+ * keyed error describing which category failed validation. The page-level
+ * error boundary renders the message verbatim — keep it human-readable.
+ *
+ * Empty categories are dropped from the rendered list (an owner viewing
+ * the menu doesn't need to see "Drinks (0)").
+ */
+export function parseMenu(
+  raw: Record<string, unknown>,
+): ParsedMenu | MenuParseFailure {
+  const orderHint = z.array(z.string()).safeParse(raw[CATEGORY_ORDER_KEY]);
+  const explicitOrder = orderHint.success ? orderHint.data : null;
+
+  const categoryKeys = Object.keys(raw).filter(
+    (k) => !k.startsWith(RESERVED_PREFIX),
+  );
+
+  // Honor _category_order, then append any keys not mentioned in it
+  // (insertion order). Keys in the hint that don't exist are skipped.
+  const orderedKeys = explicitOrder
+    ? [
+        ...explicitOrder.filter((k) => categoryKeys.includes(k)),
+        ...categoryKeys.filter((k) => !explicitOrder.includes(k)),
+      ]
+    : categoryKeys;
+
+  const categories: Category[] = [];
+  let itemCount = 0;
+
+  for (const key of orderedKeys) {
+    const parsed = z.array(MenuItemSchema).safeParse(raw[key]);
+    if (!parsed.success) {
+      return {
+        error: `Category "${key}" has an unexpected shape — backend menu doc may be out of sync with the dashboard schema.`,
+      };
+    }
+    if (parsed.data.length === 0) continue;
+    categories.push({ key, items: parsed.data });
+    itemCount += parsed.data.length;
+  }
+
+  return { categories, itemCount };
+}
+
+export function itemPriceRange(item: MenuItem): { min: number; max: number } {
+  if (isSizedItem(item)) {
+    const values = Object.values(item.sizes);
+    return { min: Math.min(...values), max: Math.max(...values) };
+  }
+  return { min: item.price, max: item.price };
+}
+
+const CATEGORY_LABEL_OVERRIDES: Record<string, string> = {
+  bbq: 'BBQ',
+  llb: 'LLB',
+};
+
+/**
+ * `caribbean_appetizers` → `Caribbean Appetizers`. Acronym overrides keep
+ * `bbq` from rendering as `Bbq`.
+ */
+export function humanizeCategoryKey(key: string): string {
+  return key
+    .split('_')
+    .filter((part) => part.length > 0)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (CATEGORY_LABEL_OVERRIDES[lower]) {
+        return CATEGORY_LABEL_OVERRIDES[lower];
+      }
+      return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+    })
+    .join(' ');
+}

--- a/dashboard/tests/menu-schema.test.ts
+++ b/dashboard/tests/menu-schema.test.ts
@@ -1,0 +1,185 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  MenuItemSchema,
+  SinglePriceItemSchema,
+  SizedItemSchema,
+  humanizeCategoryKey,
+  isSizedItem,
+  itemPriceRange,
+  parseMenu,
+} from '@/lib/schemas/menu';
+
+describe('MenuItemSchema', () => {
+  it('parses a single-priced item', () => {
+    const parsed = MenuItemSchema.parse({
+      name: 'French Fries',
+      price: 7.25,
+    });
+    expect(parsed).toEqual({ name: 'French Fries', price: 7.25 });
+    expect(isSizedItem(parsed)).toBe(false);
+  });
+
+  it('parses a single-priced item with description', () => {
+    const parsed = MenuItemSchema.parse({
+      name: 'Vegetable Spring Roll',
+      description: 'Each.',
+      price: 2,
+    });
+    expect(parsed).toMatchObject({ name: 'Vegetable Spring Roll', price: 2 });
+  });
+
+  it('parses a sized item', () => {
+    const parsed = MenuItemSchema.parse({
+      name: 'Deep Fried Chicken',
+      sizes: { half: 14, whole: 24.5 },
+    });
+    expect(isSizedItem(parsed)).toBe(true);
+    if (isSizedItem(parsed)) {
+      expect(parsed.sizes).toEqual({ half: 14, whole: 24.5 });
+    }
+  });
+
+  it('rejects items with neither price nor sizes', () => {
+    expect(() => MenuItemSchema.parse({ name: 'Mystery' })).toThrow();
+  });
+
+  it('rejects sized items with empty sizes object', () => {
+    expect(() =>
+      SizedItemSchema.parse({ name: 'X', sizes: {} }),
+    ).toThrow(/at least one entry/);
+  });
+
+  it('rejects negative prices', () => {
+    expect(() =>
+      SinglePriceItemSchema.parse({ name: 'X', price: -1 }),
+    ).toThrow();
+  });
+});
+
+describe('parseMenu — twilight-family-restaurant fixture', () => {
+  // Fixture lives at repo root; tests run from dashboard/, so go up one.
+  const fixturePath = resolve(
+    __dirname,
+    '..',
+    '..',
+    'restaurants',
+    'twilight-family-restaurant.json',
+  );
+  const fixture = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+
+  it('parses cleanly', () => {
+    const result = parseMenu(fixture);
+    expect('error' in result).toBe(false);
+  });
+
+  it('honors _category_order', () => {
+    const result = parseMenu(fixture);
+    if ('error' in result) throw new Error(result.error);
+    const expectedOrder = fixture._category_order as string[];
+    const actualOrder = result.categories.map((c) => c.key);
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+
+  it('reports a sensible item count', () => {
+    const result = parseMenu(fixture);
+    if ('error' in result) throw new Error(result.error);
+    // Sum the fixture's category arrays directly so the test is robust
+    // to menu edits.
+    const expected = (Object.entries(fixture) as [string, unknown][])
+      .filter(([k]) => !k.startsWith('_'))
+      .reduce((acc, [, items]) => acc + (items as unknown[]).length, 0);
+    expect(result.itemCount).toBe(expected);
+  });
+
+  it('strips reserved underscored keys from categories', () => {
+    const result = parseMenu(fixture);
+    if ('error' in result) throw new Error(result.error);
+    expect(
+      result.categories.find((c) => c.key.startsWith('_')),
+    ).toBeUndefined();
+  });
+});
+
+describe('parseMenu — edge cases', () => {
+  it('returns empty categories for an empty doc', () => {
+    expect(parseMenu({})).toEqual({ categories: [], itemCount: 0 });
+  });
+
+  it('drops empty categories from output', () => {
+    const result = parseMenu({ pizzas: [], drinks: [{ name: 'Water', price: 1 }] });
+    if ('error' in result) throw new Error(result.error);
+    expect(result.categories.map((c) => c.key)).toEqual(['drinks']);
+  });
+
+  it('appends categories not listed in _category_order', () => {
+    const result = parseMenu({
+      _category_order: ['pizzas'],
+      pizzas: [{ name: 'Margherita', price: 12 }],
+      drinks: [{ name: 'Water', price: 1 }],
+    });
+    if ('error' in result) throw new Error(result.error);
+    expect(result.categories.map((c) => c.key)).toEqual(['pizzas', 'drinks']);
+  });
+
+  it('skips _category_order entries that do not exist as keys', () => {
+    const result = parseMenu({
+      _category_order: ['ghost', 'pizzas'],
+      pizzas: [{ name: 'Margherita', price: 12 }],
+    });
+    if ('error' in result) throw new Error(result.error);
+    expect(result.categories.map((c) => c.key)).toEqual(['pizzas']);
+  });
+
+  it('returns an error for a category that is not an array', () => {
+    const result = parseMenu({ pizzas: { name: 'Wrong shape' } });
+    expect('error' in result).toBe(true);
+  });
+
+  it('returns an error for an item with an unexpected shape', () => {
+    const result = parseMenu({ pizzas: [{ name: 'X' }] });
+    expect('error' in result).toBe(true);
+  });
+});
+
+describe('humanizeCategoryKey', () => {
+  it('title-cases a single word', () => {
+    expect(humanizeCategoryKey('appetizers')).toBe('Appetizers');
+  });
+
+  it('title-cases a snake_case key', () => {
+    expect(humanizeCategoryKey('caribbean_appetizers')).toBe(
+      'Caribbean Appetizers',
+    );
+  });
+
+  it('title-cases multi-word keys', () => {
+    expect(humanizeCategoryKey('specialty_dishes')).toBe('Specialty Dishes');
+  });
+
+  it('preserves acronym overrides', () => {
+    expect(humanizeCategoryKey('bbq_sauces')).toBe('BBQ Sauces');
+  });
+
+  it('handles consecutive underscores gracefully', () => {
+    expect(humanizeCategoryKey('drinks__cold')).toBe('Drinks Cold');
+  });
+});
+
+describe('itemPriceRange', () => {
+  it('returns the same min/max for a single-priced item', () => {
+    expect(itemPriceRange({ name: 'X', price: 9.5 })).toEqual({
+      min: 9.5,
+      max: 9.5,
+    });
+  });
+
+  it('returns min and max across sizes', () => {
+    expect(
+      itemPriceRange({ name: 'X', sizes: { small: 10, medium: 14, large: 18 } }),
+    ).toEqual({ min: 10, max: 18 });
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the `ComingSoon` stub at `/menu` with a Server Component that fetches `restaurant.menu` from `/restaurants/me`, validates it through a new Zod schema, and renders an editorial menu (sticky category nav rail, leader-dot price rows, sized items inline).
- Adds `lib/schemas/menu.ts` to tighten the loose `dict[str, Any]` shape from `app/restaurants/models.py` at the dashboard read boundary — `_category_order` is honored, empty categories are dropped, malformed items surface as a graceful in-page error rather than a crash.
- Read-only first PR. CRUD (add / edit / delete / reorder) lands in a follow-up so this stays reviewable.

## Linked issue
Relates to #7 (Sprint 2.4 — Dashboard & Polish). Ticks the "Menu editor (CRUD)" — read view portion of that bullet; the write side is a stacked follow-up.

## Test plan
- [x] `pnpm test` — 23 new schema cases, full suite 72/72 green
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` on changed files — clean (4 pre-existing lint errors elsewhere on master are untouched)
- [ ] Manual browser walk-through against a live `/restaurants/me` (requires backend + auth cookie + Firestore creds — please verify before merge)
- [ ] Spot-check dark mode parity
- [ ] Spot-check mobile (<lg) layout — category nav is intentionally hidden, scroll-only

## Notes
- **Design language.** Stays in the existing Niko navy/cream warm palette; weights remain 400/500. No new fonts, no new tokens. The menu is editorial in proportion (long lists, item-level typography) but cohesive with the orders feed in chrome.
- **Schema strictness.** `MenuItemSchema` is a `union([SizedItemSchema, SinglePriceItemSchema])` — order matters: an object with both keys is treated as sized. Backend currently only writes one or the other.
- **`_category_order` policy.** Order hint wins; categories not listed are appended in insertion order; hint entries that don't exist as keys are silently skipped (matches the Python prompt builder's behavior in `app.llm.prompts._format_menu`).
- **Error surfaces are restrained.** A backend hiccup or a malformed menu doc renders an in-page `MenuParseError` with a one-line explainer that the call flow is unaffected — the agent keeps using whatever menu it last loaded.
- **Out of scope:** menu writes, hours editor, analytics, call history. Those each get their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)