### PR TITLE
dashboard: grow sidebar with tall pages

### DIFF
--- a/dashboard/components/app-sidebar.tsx
+++ b/dashboard/components/app-sidebar.tsx
@@ -58,11 +58,14 @@ export function AppSidebar({
   const pathname = usePathname();
 
   return (
-    // `collapsible="none"` means the sidebar is always expanded
-    // (no trigger, no icon-mode). The ShadCN primitive gives this
-    // variant only `h-full`, which can collapse to content height
-    // in a flex row — so we force `h-svh` to pin it to viewport.
-    <Sidebar collapsible="none" className="h-svh border-r">
+    // `collapsible="none"` means the sidebar is always expanded.
+    // The ShadCN primitive gives this variant only `h-full`, which
+    // doesn't resolve when SidebarProvider has only `min-h-svh` (no
+    // explicit parent height) — the sidebar collapses to nav content
+    // height. `min-h-svh` here gives it a viewport-height floor; the
+    // parent flex row's default `align-items: stretch` then grows it
+    // with tall pages (e.g. /menu) so the sidebar reaches the bottom.
+    <Sidebar collapsible="none" className="min-h-svh border-r">
       <SidebarHeader>
         <div className="flex items-center gap-2.5 px-2 py-3">
           {/* 48px lines up with the "Niko" + "by Tsuki Works" stack


### PR DESCRIPTION
## Summary
- `dashboard/components/app-sidebar.tsx` swaps `h-svh` → `min-h-svh` on the `Sidebar` wrapper.
- Caught after #134 shipped — the menu page is the first surface taller than the viewport, which exposed that the sidebar wasn't growing with the page.

## What was happening
The `Sidebar` primitive (with `collapsible="none"`) ships with `h-full`, which doesn't resolve in this layout because `SidebarProvider` only sets `min-h-svh` (no explicit parent height) — so we previously overrode with `h-svh` to pin the sidebar to viewport. That worked when every page fit in a viewport. On `/menu` with 80+ items, the parent flex row grows to match content height, but `h-svh` keeps the sidebar capped at viewport — leaving the page background visible below the sidebar.

## The fix
`min-h-svh` keeps the viewport-height floor (so the sidebar still pins down on short pages) but lets the parent flex row's default `align-items: stretch` grow the sidebar with the row. `h-full` from the primitive resolves to `auto` against a parent with no explicit `height`, which lets stretch take over.

## Linked issue
Follow-up to #134.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` on `components/app-sidebar.tsx` clean
- [ ] Manual: `/menu` (long content) — sidebar reaches the bottom of the page in light + dark mode
- [ ] Manual: `/` (orders feed, short) — sidebar still spans viewport, no collapse
- [ ] Manual: `/calls`, `/settings` — no regression in short-content pages

## Notes
CSS-only change, no test coverage added (no visual regression harness yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)