### PR TITLE
WS-side call recording (replaces broken Twilio REST recording)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -38,6 +38,15 @@ class Settings(BaseSettings):
     # signature check, since the Host header is client-controlled.
     public_base_url: Optional[str] = None
 
+    # Recordings bucket. Phase 2 default; can be overridden via env if we
+    # ever split prod/dev/staging buckets.
+    recordings_bucket: str = "niko-recordings"
+
+    # Default retention applied at upload time when a Restaurant doc
+    # doesn't carry its own ``recording_retention_days`` field. The bucket
+    # lifecycle rule deletes blobs whose ``custom_time`` has passed.
+    recording_default_retention_days: int = 90
+
     square_access_token: Optional[str] = None
     square_application_id: Optional[str] = None
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,9 @@
+import asyncio
 import logging
 import time
 
-import httpx
-from fastapi import Depends, FastAPI, HTTPException
-from fastapi.responses import Response as HTTPResponse
+from fastapi import Depends, FastAPI, HTTPException, Response
+from fastapi.responses import RedirectResponse
 
 logging.basicConfig(level=logging.INFO)
 
@@ -23,6 +23,7 @@ from app.orders.models import ItemCategory, LineItem, Order, OrderType
 from app.storage import (
     call_sessions,
     firestore as order_storage,
+    recordings,
     restaurants as restaurants_storage,
 )
 from app.storage.restaurants import DEMO_RID
@@ -269,50 +270,54 @@ async def get_call_recording(
     call_sid: str,
     tenant: Tenant = Depends(current_tenant),
 ):
-    """Proxy the Twilio recording MP3 for the calling tenant's call.
+    """Tenant-authed entry point for playback.
 
-    Twilio recordings require HTTP Basic Auth, so the browser can't fetch
-    them directly. This endpoint looks up the recording URL from Firestore
-    (tenant-scoped, so cross-tenant reads return 404), fetches the MP3
-    from Twilio with credentials, and streams it to the browser.
-
-    Returns 404 while the recording is still processing or if this call
-    has no recording.
+    Returns a 302 redirect to a 30-min V4 signed URL for the recording
+    blob in GCS. The browser's <audio> element follows the redirect
+    natively, so Cloud Run sees zero audio bytes for the playback path.
+    Cross-tenant lookups return 404 — same behavior as
+    ``call_sessions.get_session``.
     """
     session = call_sessions.get_session(call_sid, tenant.restaurant_id)
     if not session or not session.get("recording_url"):
         raise HTTPException(status_code=404, detail="recording not available yet")
-
-    sid = settings.twilio_account_sid
-    token = settings.twilio_auth_token
-    if not sid or not token:
-        raise HTTPException(status_code=503, detail="Twilio credentials not configured")
-
-    recording_url = session["recording_url"]
-    # Defense-in-depth: even though /recording-status validates the URL
-    # before persisting, refuse to fetch anything outside Twilio's host
-    # so any stale or forged document can never turn this proxy into an
-    # SSRF with Twilio Basic creds attached.
-    if not recording_url.startswith("https://api.twilio.com/"):
+    if not session["recording_url"].startswith("gs://"):
         raise HTTPException(status_code=502, detail="invalid recording URL")
-    if not recording_url.endswith(".mp3"):
-        recording_url += ".mp3"
-
-    # Buffered fetch: recordings are short (<5 min ≈ <5 MB) so we fetch
-    # the whole MP3 before responding. This lets us check the Twilio status
-    # code before committing to a 200, avoiding the broken-stream problem
-    # that arises when raising HTTPException inside a generator.
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        twilio_resp = await client.get(recording_url, auth=(sid, token))
-
-    if twilio_resp.status_code != 200:
-        raise HTTPException(status_code=502, detail="Failed to fetch recording from Twilio")
-
-    return HTTPResponse(
-        content=twilio_resp.content,
-        media_type="audio/mpeg",
-        headers={"Content-Disposition": f'inline; filename="{call_sid}.mp3"'},
+    signed = await asyncio.to_thread(
+        recordings.generate_signed_url,
+        call_sid=call_sid,
+        restaurant_id=tenant.restaurant_id,
     )
+    return RedirectResponse(url=signed, status_code=302)
+
+
+@app.delete("/calls/{call_sid}/recording", status_code=204)
+async def delete_call_recording(
+    call_sid: str,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """Owner-only: delete the recording blob from GCS, clear
+    ``recording_url`` from the call session doc, emit a
+    ``recording_deleted`` event. Idempotent — returns 204 even if the
+    blob was already gone or the call had no recording, as long as the
+    call session itself exists for this tenant.
+    """
+    if tenant.role != "owner":
+        raise HTTPException(status_code=403, detail="owner role required")
+    session = call_sessions.get_session(call_sid, tenant.restaurant_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="call not found")
+    await asyncio.to_thread(
+        recordings.delete_recording,
+        call_sid=call_sid,
+        restaurant_id=tenant.restaurant_id,
+    )
+    await asyncio.to_thread(
+        call_sessions.mark_recording_deleted,
+        call_sid,
+        tenant.restaurant_id,
+    )
+    return Response(status_code=204)
 
 
 @app.post("/dev/seed-order")

--- a/app/restaurants/models.py
+++ b/app/restaurants/models.py
@@ -81,5 +81,6 @@ class Restaurant(BaseModel):
     # Twilight Family Restaurant). Flip to False in Firestore for
     # pickup-only restaurants — the system prompt branches accordingly.
     offers_delivery: bool = True
+    recording_retention_days: int = Field(default=90, ge=1, le=3650)
     created_at: datetime = Field(default_factory=_now_utc)
     updated_at: datetime = Field(default_factory=_now_utc)

--- a/app/storage/call_sessions.py
+++ b/app/storage/call_sessions.py
@@ -253,6 +253,45 @@ def mark_recording_ready(
         )
 
 
+def mark_recording_deleted(call_sid: str, restaurant_id: str) -> None:
+    """Clear recording metadata from the call session doc and emit a
+    ``recording_deleted`` event so the dashboard's onSnapshot can hide
+    the audio player.
+
+    Mirrors the dual-write shape of ``mark_recording_ready`` —
+    patches both legacy flat and nested call-session docs and appends
+    a matching event on each. Idempotent: calling it twice on the
+    same call is a no-op for the dashboard (the second clear writes
+    the same Nones; the second event row is harmless).
+    """
+    ts = _now()
+    patch: dict[str, Any] = {
+        "recording_url": None,
+        "recording_sid": None,
+        "recording_duration_seconds": None,
+        "last_event_at": ts,
+    }
+    event_payload = {
+        "timestamp": ts,
+        "kind": "recording_deleted",
+        "text": "",
+        "detail": {},
+    }
+    try:
+        client = _get_client()
+        legacy = _legacy_parent(client, call_sid)
+        legacy.update(patch)
+        legacy.collection(_EVENTS_SUBCOLLECTION).add(event_payload)
+
+        nested = _nested_parent(client, restaurant_id, call_sid)
+        nested.update(patch)
+        nested.collection(_EVENTS_SUBCOLLECTION).add(event_payload)
+    except Exception:
+        logger.exception(
+            "call_sessions: mark_recording_deleted failed call_sid=%s", call_sid
+        )
+
+
 def get_session(
     call_sid: str, restaurant_id: str
 ) -> Optional[dict[str, Any]]:

--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -325,3 +325,25 @@ def delete_recording(*, call_sid: str, restaurant_id: str) -> None:
         )
 
 
+def generate_signed_url(
+    *, call_sid: str, restaurant_id: str, ttl_minutes: int = 30
+) -> str:
+    """Return a V4 signed GET URL for the recording blob. TTL defaults
+    to 30 minutes — long enough for a typical playback session, short
+    enough that a leaked URL ages out fast.
+
+    Cloud Run's runtime SA can sign V4 URLs without a private key file
+    by using the IAM ``signBlob`` API; the SA must hold
+    ``roles/iam.serviceAccountTokenCreator`` on itself. See
+    ``scripts/setup-recordings-bucket.sh``.
+    """
+    blob_name = f"{restaurant_id}/{call_sid}.mp3"
+    bucket = _get_storage_client().bucket(settings.recordings_bucket)
+    blob = bucket.blob(blob_name)
+    return blob.generate_signed_url(
+        version="v4",
+        method="GET",
+        expiration=timedelta(minutes=ttl_minutes),
+    )
+
+

--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 
 import logging
 import struct
+import time
+
+import requests
 
 logger = logging.getLogger(__name__)
 
@@ -174,3 +177,50 @@ def begin_recording(
         upload_url=upload_url,
         encoder=_make_encoder(),
     )
+
+
+def append_chunks(
+    session: RecordingUploadSession,
+    inbound_mu_law: bytes,
+    outbound_mu_law: bytes,
+) -> None:
+    """Decode + interleave + encode + buffer; flush a chunk when the
+    pending MP3 buffer reaches the 256 KB GCS-minimum.
+
+    No-op once ``session.broken`` is True (set by `_put_chunk` after two
+    consecutive failures).
+    """
+    if session.broken:
+        return
+
+    pcm = _compute_pcm_pair(inbound_mu_law, outbound_mu_law)
+    if not pcm:
+        return
+
+    # Track per-channel sample count for duration calc.
+    # Stereo PCM-16 = 4 bytes per (per-channel) sample-pair.
+    session.total_pcm_samples += len(pcm) // 4
+
+    mp3 = session.encoder.encode(pcm)
+    if mp3:
+        session.pending_mp3.extend(mp3)
+
+    while len(session.pending_mp3) >= _GCS_CHUNK_BYTES:
+        n = (len(session.pending_mp3) // _GCS_CHUNK_BYTES) * _GCS_CHUNK_BYTES
+        chunk = bytes(session.pending_mp3[:n])
+        del session.pending_mp3[:n]
+        _put_chunk(session, chunk, is_final=False, total=None)
+
+
+def _put_chunk(
+    session: RecordingUploadSession,
+    chunk: bytes,
+    *,
+    is_final: bool,
+    total: int | None,
+) -> None:
+    """PUT one resumable-upload chunk to the session URL.
+
+    Stub — real impl in Task 10.
+    """
+    raise NotImplementedError

--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -120,6 +120,7 @@ def _make_encoder() -> "lameenc.Encoder":
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
+from google.api_core.exceptions import NotFound
 from google.cloud import storage as gcs
 
 from app.config import settings
@@ -307,3 +308,20 @@ def finalize_recording(
         f"gs://{settings.recordings_bucket}/{session.blob_name}",
         duration_seconds,
     )
+
+
+def delete_recording(*, call_sid: str, restaurant_id: str) -> None:
+    """Delete the recording blob for one call. Idempotent: if the blob
+    is already gone, return cleanly. All other errors propagate so the
+    HTTP handler can decide how to surface them."""
+    blob_name = f"{restaurant_id}/{call_sid}.mp3"
+    bucket = _get_storage_client().bucket(settings.recordings_bucket)
+    blob = bucket.blob(blob_name)
+    try:
+        blob.delete()
+    except NotFound:
+        logger.info(
+            "recording: delete on missing blob (idempotent) call_sid=%s", call_sid
+        )
+
+

--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -221,6 +221,40 @@ def _put_chunk(
 ) -> None:
     """PUT one resumable-upload chunk to the session URL.
 
-    Stub — real impl in Task 10.
+    Builds the ``Content-Range`` header from the session's current
+    ``total_bytes_uploaded``. Retries once on 5xx with a 0.5 s pause; on
+    second failure, marks the session broken and stops further uploads.
+    GCS returns 308 ("Resume Incomplete") for a successful non-final
+    chunk and 200/201 for the final, so accept all three.
     """
-    raise NotImplementedError
+    start = session.total_bytes_uploaded
+    end = start + len(chunk) - 1
+    total_str = str(total) if (is_final and total is not None) else "*"
+    headers = {"Content-Range": f"bytes {start}-{end}/{total_str}"}
+
+    for attempt in range(2):
+        try:
+            resp = requests.put(
+                session.upload_url, data=chunk, headers=headers, timeout=30.0
+            )
+        except Exception:
+            logger.exception(
+                "recording: chunk PUT raised call_sid=%s attempt=%d",
+                session.call_sid, attempt,
+            )
+            resp = None
+
+        ok = resp is not None and resp.status_code in (200, 201, 308)
+        if ok:
+            session.total_bytes_uploaded += len(chunk)
+            return
+        if attempt == 0:
+            time.sleep(0.5)
+            continue
+        session.broken = True
+        logger.error(
+            "recording: chunk PUT failed twice — session broken call_sid=%s status=%s",
+            session.call_sid,
+            resp.status_code if resp else "(no response)",
+        )
+        return

--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -258,3 +258,52 @@ def _put_chunk(
             resp.status_code if resp else "(no response)",
         )
         return
+
+
+def finalize_recording(
+    session: RecordingUploadSession,
+) -> tuple[str, int]:
+    """Flush the encoder + send the final chunk with a known total length.
+
+    Returns ``(gs:// URL, duration_seconds)``. If the session never had
+    any audio (zero PCM samples), DELETEs the resumable session URL and
+    returns ``("", 0)`` so the caller can skip the Firestore write.
+    Returns ``("", 0)`` on a broken session too.
+    """
+    if session.broken:
+        return ("", 0)
+
+    if session.total_pcm_samples == 0:
+        # No data — cancel the resumable session so GCS doesn't keep an
+        # orphan around for 7 days.
+        try:
+            requests.delete(session.upload_url, timeout=10.0)
+        except Exception:
+            logger.exception(
+                "recording: failed to cancel empty session call_sid=%s",
+                session.call_sid,
+            )
+        return ("", 0)
+
+    # Flush the encoder tail. lameenc raises RuntimeError if flush() is
+    # called before any encode() call, so guard against that.
+    try:
+        tail = session.encoder.flush()
+    except RuntimeError:
+        tail = b""
+    if tail:
+        session.pending_mp3.extend(tail)
+
+    final_chunk = bytes(session.pending_mp3)
+    session.pending_mp3.clear()
+    total = session.total_bytes_uploaded + len(final_chunk)
+
+    _put_chunk(session, final_chunk, is_final=True, total=total)
+    if session.broken:
+        return ("", 0)
+
+    duration_seconds = session.total_pcm_samples // _PCM_SAMPLE_RATE
+    return (
+        f"gs://{settings.recordings_bucket}/{session.blob_name}",
+        duration_seconds,
+    )

--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -1,0 +1,176 @@
+"""WS-side call recording: encode + resumable GCS upload + signed URLs.
+
+The /media-stream WS hands raw μ-law payloads (per Twilio media event) to
+``append_chunks``. We decode each side to 16-bit linear PCM, interleave
+L=caller / R=agent, encode incrementally to MP3 via lameenc, and PUT
+~256 KB chunks to a GCS resumable upload session held on a per-call
+``RecordingUploadSession`` object.
+
+Replaces the broken Twilio-REST recording approach (PRs #127, #132, #133).
+See ``docs/superpowers/specs/2026-04-30-ws-recording-design.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+
+logger = logging.getLogger(__name__)
+
+
+# G.711 μ-law → 16-bit signed PCM decode table (256 entries).
+# stdlib ``audioop`` was removed in Python 3.13; we ship the table
+# directly so there is no runtime dependency. Generated once at import
+# time from the standard G.711 μ-law algorithm.
+def _build_ulaw_table() -> list[int]:
+    table: list[int] = []
+    for byte in range(256):
+        # Invert all bits (G.711 complement convention)
+        byte = ~byte & 0xFF
+        sign = byte & 0x80
+        exp = (byte >> 4) & 0x07
+        mantissa = byte & 0x0F
+        magnitude = ((mantissa << 1) | 1) << exp
+        # Add bias (33) applied during encode — subtract here to invert
+        magnitude = magnitude + 33 - 33  # net zero; keep for clarity
+        # The pre-bias that μ-law encoding adds is folded into exp/mantissa;
+        # the standard decode gives:
+        #   linear = sign * ((mantissa | 0x10) << (exp + 3)) - 132
+        # (ITU-T G.711, Appendix — simplified decoder)
+        linear = ((mantissa | 0x10) << (exp + 3)) - 132
+        if sign:
+            linear = -linear
+        # Clamp to int16 range
+        if linear > 32767:
+            linear = 32767
+        elif linear < -32768:
+            linear = -32768
+        table.append(linear)
+    return table
+
+
+_ULAW_TABLE: list[int] = _build_ulaw_table()
+
+
+def _ulaw2lin_16(mu_law_bytes: bytes) -> bytes:
+    """Decode G.711 μ-law bytes to 16-bit signed little-endian PCM.
+
+    Drop-in replacement for ``audioop.ulaw2lin(data, 2)`` that works on
+    Python 3.13+ where ``audioop`` is no longer in the stdlib.
+    """
+    return struct.pack(f"<{len(mu_law_bytes)}h", *(_ULAW_TABLE[b] for b in mu_law_bytes))
+
+
+def _compute_pcm_pair(inbound_mu_law: bytes, outbound_mu_law: bytes) -> bytes:
+    """Decode each μ-law track to 16-bit PCM, pad the shorter side with
+    PCM silence, and interleave L=inbound / R=outbound. Returns stereo
+    16-bit little-endian PCM ready to feed the MP3 encoder.
+
+    Pure function; no I/O. Keeps the hot-path math testable in isolation.
+    """
+    if not inbound_mu_law and not outbound_mu_law:
+        return b""
+
+    inbound_pcm = _ulaw2lin_16(inbound_mu_law)
+    outbound_pcm = _ulaw2lin_16(outbound_mu_law)
+
+    n_in = len(inbound_pcm) // 2
+    n_out = len(outbound_pcm) // 2
+    n = max(n_in, n_out)
+
+    inbound_pcm = inbound_pcm + b"\x00\x00" * (n - n_in)
+    outbound_pcm = outbound_pcm + b"\x00\x00" * (n - n_out)
+
+    out = bytearray(n * 4)
+    for i in range(n):
+        out[i * 4 : i * 4 + 2] = inbound_pcm[i * 2 : i * 2 + 2]
+        out[i * 4 + 2 : i * 4 + 4] = outbound_pcm[i * 2 : i * 2 + 2]
+    return bytes(out)
+
+
+import lameenc
+
+# Encoder constants. LAME quality levels are 0-9 (0 best, 9 worst).
+# 2 is the standard "good" preset and runs faster than 0 with no audible
+# difference at 32 kbps on phone audio.
+_MP3_BITRATE_KBPS = 32
+_MP3_QUALITY = 2
+_PCM_SAMPLE_RATE = 8000  # Twilio media is 8 kHz μ-law
+_PCM_CHANNELS = 2        # we encode the stereo (caller=L, agent=R) mix
+
+
+def _make_encoder() -> "lameenc.Encoder":
+    """Build a lameenc.Encoder configured for our telephony pipeline.
+
+    Bound per-call (each RecordingUploadSession owns its own encoder
+    instance; encoders are not safe to share across calls because they
+    carry internal state).
+    """
+    enc = lameenc.Encoder()
+    enc.set_bit_rate(_MP3_BITRATE_KBPS)
+    enc.set_in_sample_rate(_PCM_SAMPLE_RATE)
+    enc.set_channels(_PCM_CHANNELS)
+    enc.set_quality(_MP3_QUALITY)
+    return enc
+
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+from google.cloud import storage as gcs
+
+from app.config import settings
+
+
+@dataclass
+class RecordingUploadSession:
+    """Per-call state for a resumable GCS upload of an MP3 stream."""
+    call_sid: str
+    restaurant_id: str
+    blob_name: str
+    upload_url: str
+    encoder: "lameenc.Encoder"
+    pending_mp3: bytearray = field(default_factory=bytearray)
+    total_bytes_uploaded: int = 0
+    total_pcm_samples: int = 0  # per-channel sample count; drives duration
+    broken: bool = False
+
+
+# 256 KB — minimum non-final chunk size for GCS resumable uploads.
+_GCS_CHUNK_BYTES = 256 * 1024
+
+
+_storage_client_singleton: gcs.Client | None = None
+
+
+def _get_storage_client() -> gcs.Client:
+    """Lazy singleton. Cloud Run's runtime SA picks up ambient creds."""
+    global _storage_client_singleton
+    if _storage_client_singleton is None:
+        _storage_client_singleton = gcs.Client()
+    return _storage_client_singleton
+
+
+def begin_recording(
+    *, call_sid: str, restaurant_id: str, retention_days: int
+) -> RecordingUploadSession:
+    """Create a new GCS resumable upload session for this call.
+
+    Sets the blob's ``custom_time`` to ``now() + retention_days`` so the
+    bucket lifecycle rule (``daysSinceCustomTime: 0``) deletes the blob
+    on its scheduled date — per-tenant retention without per-tenant
+    bucket rules.
+    """
+    blob_name = f"{restaurant_id}/{call_sid}.mp3"
+    bucket = _get_storage_client().bucket(settings.recordings_bucket)
+    blob = bucket.blob(blob_name)
+    upload_url = blob.create_resumable_upload_session(content_type="audio/mpeg")
+    blob.custom_time = datetime.now(timezone.utc) + timedelta(days=retention_days)
+
+    return RecordingUploadSession(
+        call_sid=call_sid,
+        restaurant_id=restaurant_id,
+        blob_name=blob_name,
+        upload_url=upload_url,
+        encoder=_make_encoder(),
+    )

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -25,7 +25,6 @@ from typing import Callable
 
 from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
-from twilio.request_validator import RequestValidator
 from twilio.twiml.voice_response import Connect, VoiceResponse
 
 from app.config import settings
@@ -111,65 +110,6 @@ def _bg_call_event(
     )
 
 
-def _start_recording_sync(call_sid: str, restaurant_id: str) -> None:
-    """Start a Twilio dual-channel recording for a live call.
-
-    Runs in a worker thread so the audio loop never blocks on network I/O.
-    Uses the restaurant_id in the callback URL so the status webhook can
-    write to the right Firestore path without a second lookup. The
-    callback host comes from ``settings.public_base_url`` rather than the
-    inbound WebSocket's Host header — the WS Host is client-controlled
-    and would let an attacker redirect Twilio's POSTs.
-    """
-    sid = settings.twilio_account_sid
-    token = settings.twilio_auth_token
-    base = (settings.public_base_url or "").rstrip("/")
-    if not sid or not token:
-        logger.warning(
-            "twilio creds missing; skipping recording call_sid=%s", call_sid
-        )
-        return
-    if not base:
-        logger.warning(
-            "PUBLIC_BASE_URL not set; skipping recording call_sid=%s", call_sid
-        )
-        return
-    try:
-        from twilio.rest import Client as TwilioRestClient
-
-        callback_url = f"{base}/recording-status/{restaurant_id}/{call_sid}"
-        TwilioRestClient(sid, token).calls(call_sid).recordings.create(
-            recording_status_callback=callback_url,
-            recording_status_callback_method="POST",
-        )
-        logger.info(
-            "recording started call_sid=%s callback=%s", call_sid, callback_url
-        )
-    except Exception:
-        # Swallow the error — call audio must keep flowing even if Twilio's
-        # recording API rejects the request. Without this guard the
-        # exception lands on an unawaited Task and surfaces only as a
-        # garbage-collection warning.
-        logger.exception(
-            "recording: failed to start Twilio recording call_sid=%s", call_sid
-        )
-
-
-def _twilio_end_call_sync(call_sid: str) -> None:
-    """End a Twilio call via the REST API. Runs in a worker thread so the
-    audio loop never blocks on network I/O."""
-    sid = settings.twilio_account_sid
-    token = settings.twilio_auth_token
-    if not sid or not token:
-        logger.warning(
-            "twilio creds missing; cannot end call_sid=%s", call_sid
-        )
-        return
-    from twilio.rest import Client as TwilioRestClient
-
-    TwilioRestClient(sid, token).calls(call_sid).update(status="completed")
-
-
 async def send_end_of_call_mark(
     websocket: WebSocket, stream_sid: str | None
 ) -> bool:
@@ -201,12 +141,20 @@ async def send_end_of_call_mark(
 
 
 async def _hang_up_after_grace(state: _CallState) -> None:
-    """Wait HANGUP_GRACE_SECONDS, then end the call IFF the caller
-    didn't speak in the meantime.
+    """Wait HANGUP_GRACE_SECONDS, then close the WebSocket to end the
+    call.
 
-    The grace window lets a caller squeeze in a late follow-up like
-    *"how long does that take?"* — a final transcript clears
-    ``state.pending_hangup`` and we abort.
+    Closing our /media-stream WebSocket ends Twilio's <Connect>; with no
+    further TwiML the inbound call hangs up. This avoids the Twilio REST
+    Calls.update endpoint, which returns 404 on calls in <Connect> state
+    (same root cause as the recording 404). The grace window lets a
+    caller squeeze in a late follow-up like *"how long does that
+    take?"* — a final transcript clears ``state.pending_hangup`` and
+    we abort.
+
+    ``state.should_hangup`` is also set as a fallback signal in case
+    the WS close doesn't immediately unblock ``receive_text()`` (rare,
+    but harmless to set both).
     """
     try:
         await asyncio.sleep(HANGUP_GRACE_SECONDS)
@@ -214,13 +162,18 @@ async def _hang_up_after_grace(state: _CallState) -> None:
         return
     if not state.pending_hangup or not state.call_sid:
         return
-    try:
-        await asyncio.to_thread(_twilio_end_call_sync, state.call_sid)
-        logger.info("call ended by server call_sid=%s", state.call_sid)
-    except Exception:
-        logger.exception(
-            "auto-hangup: REST end_call failed call_sid=%s", state.call_sid
-        )
+    state.should_hangup.set()
+    if state.websocket is not None:
+        try:
+            await state.websocket.close(code=1000)
+            logger.info(
+                "call ended by server (WS-close path) call_sid=%s",
+                state.call_sid,
+            )
+        except Exception:
+            logger.exception(
+                "auto-hangup: WS close failed call_sid=%s", state.call_sid
+            )
 
 
 async def _hang_up_after_mark_timeout(state: _CallState) -> None:
@@ -301,6 +254,11 @@ class _CallState:
     pending_hangup: bool           = False     # set when goodbye mark sent (#78)
     recording_session: "RecordingUploadSession | None" = None
     should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
+    # WS reference so _hang_up_after_grace can close the connection
+    # server-side. Closing the WS ends Twilio's <Connect>; with no
+    # further TwiML the call hangs up. Avoids the Twilio REST
+    # Calls.update endpoint which 404s on <Connect>-state calls.
+    websocket: "WebSocket | None" = None
 
 
 async def _open_deepgram_connection(
@@ -604,25 +562,6 @@ async def voice(request: Request) -> Response:
         twiml.hangup()
         return Response(content=str(twiml), media_type="application/xml")
 
-    # Start the recording synchronously before returning TwiML. The REST
-    # call must land before Twilio reads our <Connect><Stream> response —
-    # once the call enters <Connect> state, the Recordings API returns
-    # 404. The 2s ceiling caps how long /voice can block: Twilio drops a
-    # voice webhook at ~15s, so even a hung Twilio API can never strand
-    # the caller. Recording is non-essential to call flow; on timeout we
-    # log and continue.
-    if call_sid:
-        try:
-            await asyncio.wait_for(
-                asyncio.to_thread(_start_recording_sync, call_sid, restaurant.id),
-                timeout=2.0,
-            )
-        except asyncio.TimeoutError:
-            logger.warning(
-                "recording: start timed out (>2s) call_sid=%s — answering call without recording",
-                call_sid,
-            )
-
     host = request.headers.get("host", "localhost:8000")
     connect = Connect()
     stream = connect.stream(url=f"wss://{host}/media-stream", tracks="both_tracks")
@@ -642,7 +581,7 @@ async def media_stream(websocket: WebSocket) -> None:
       stop       — call ended; persists completed orders to Firestore
     """
     await websocket.accept()
-    state = _CallState()
+    state = _CallState(websocket=websocket)
     dg_conn = None
 
     async def on_final(text: str) -> None:
@@ -835,87 +774,3 @@ async def media_stream(websocket: WebSocket) -> None:
             await dg_conn.finish()
 
 
-# The recording URL Twilio sends in the callback must live under this
-# host. Anything else is rejected before being persisted, so a forged
-# (or legacy-data) URL can never become an SSRF target when the dashboard
-# proxies it through GET /calls/{call_sid}/recording.
-_TWILIO_RECORDING_URL_PREFIX = "https://api.twilio.com/"
-
-
-@router.post("/recording-status/{restaurant_id}/{call_sid}")
-async def recording_status(
-    restaurant_id: str, call_sid: str, request: Request
-) -> Response:
-    """Twilio recording status callback.
-
-    Twilio POSTs here when a recording finishes processing. The
-    ``restaurant_id`` and ``call_sid`` are encoded in the URL (set when
-    the recording was started in ``_start_recording_sync``) so no
-    additional Firestore lookup is needed to find the right tenant path.
-
-    Authenticity is enforced via Twilio's ``X-Twilio-Signature`` header
-    (HMAC-SHA1 of the request URL + sorted form fields, keyed by the
-    account auth token). Without this check the endpoint would let any
-    unauthenticated POST inject an arbitrary ``RecordingUrl`` into the
-    tenant's call session.
-
-    On ``completed``, stores the recording URL on the call session doc
-    and emits a ``recording_ready`` event so the live dashboard can show
-    the audio player.
-    """
-    auth_token = settings.twilio_auth_token
-    base = (settings.public_base_url or "").rstrip("/")
-    if not auth_token or not base:
-        logger.error(
-            "recording-status: server not configured for signature validation "
-            "(twilio_auth_token=%s, public_base_url=%s)",
-            bool(auth_token),
-            bool(base),
-        )
-        return Response(content="", status_code=503)
-
-    form = await request.form()
-    form_dict = {k: v for k, v in form.items()}
-    signature = request.headers.get("X-Twilio-Signature", "")
-    full_url = f"{base}/recording-status/{restaurant_id}/{call_sid}"
-    validator = RequestValidator(auth_token)
-    if not validator.validate(full_url, form_dict, signature):
-        logger.warning(
-            "recording-status: invalid Twilio signature call_sid=%s", call_sid
-        )
-        return Response(content="", status_code=403)
-
-    status = (form.get("RecordingStatus") or "").lower()
-    recording_url = (form.get("RecordingUrl") or "").strip()
-    recording_sid = (form.get("RecordingSid") or "").strip()
-    try:
-        duration_seconds = int(form.get("RecordingDuration") or 0)
-    except ValueError:
-        duration_seconds = 0
-
-    logger.info(
-        "recording-status call_sid=%s status=%s recording_sid=%s duration=%ss",
-        call_sid,
-        status,
-        recording_sid,
-        duration_seconds,
-    )
-
-    if status == "completed" and recording_url and recording_sid:
-        if not recording_url.startswith(_TWILIO_RECORDING_URL_PREFIX):
-            logger.warning(
-                "recording-status: rejecting non-Twilio RecordingUrl call_sid=%s url=%r",
-                call_sid,
-                recording_url,
-            )
-            return Response(content="", status_code=400)
-        await asyncio.to_thread(
-            call_sessions.mark_recording_ready,
-            call_sid,
-            restaurant_id,
-            recording_url=recording_url,
-            recording_sid=recording_sid,
-            duration_seconds=duration_seconds,
-        )
-
-    return Response(content="", status_code=204)

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -805,8 +805,7 @@ async def media_stream(websocket: WebSocket) -> None:
         rid_for_close = _state_rid(state)
         if state.call_sid and rid_for_close:
             try:
-                await asyncio.to_thread(
-                    call_sessions.mark_call_ended,
+                call_sessions.mark_call_ended(
                     state.call_sid,
                     rid_for_close,
                     confirmed=order_confirmed,
@@ -814,6 +813,22 @@ async def media_stream(websocket: WebSocket) -> None:
             except Exception:
                 logger.exception(
                     "call_sessions: mark_call_ended scheduling failed call_sid=%s",
+                    state.call_sid,
+                )
+        if state.recording_session is not None and rid_for_close:
+            try:
+                gs_url, duration = recordings.finalize_recording(state.recording_session)
+                if gs_url:
+                    call_sessions.mark_recording_ready(
+                        state.call_sid,
+                        rid_for_close,
+                        recording_url=gs_url,
+                        recording_sid=state.call_sid,
+                        duration_seconds=duration,
+                    )
+            except Exception:
+                logger.exception(
+                    "recording: finalize/mark failed call_sid=%s",
                     state.call_sid,
                 )
         if dg_conn is not None:

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -728,9 +728,23 @@ async def media_stream(websocket: WebSocket) -> None:
                 )
 
             elif event == "media":
-                if dg_conn is not None:
-                    audio = base64.b64decode(msg["media"]["payload"])
-                    await dg_conn.send(audio)
+                payload = base64.b64decode(msg["media"]["payload"])
+                track = msg["media"].get("track")
+                if track == "inbound":
+                    inbound_chunk = payload
+                    outbound_chunk = b""
+                    if dg_conn is not None:
+                        await dg_conn.send(payload)
+                elif track == "outbound":
+                    inbound_chunk = b""
+                    outbound_chunk = payload
+                else:
+                    inbound_chunk = b""
+                    outbound_chunk = b""
+                if state.recording_session is not None:
+                    recordings.append_chunks(
+                        state.recording_session, inbound_chunk, outbound_chunk
+                    )
 
             elif event == "mark":
                 # Twilio echoes our outgoing marks once the audio queued

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -622,7 +622,7 @@ async def voice(request: Request) -> Response:
 
     host = request.headers.get("host", "localhost:8000")
     connect = Connect()
-    stream = connect.stream(url=f"wss://{host}/media-stream")
+    stream = connect.stream(url=f"wss://{host}/media-stream", tracks="both_tracks")
     stream.parameter(name="restaurant_id", value=restaurant.id)
     twiml.append(connect)
     return Response(content=str(twiml), media_type="application/xml")

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -34,7 +34,8 @@ from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
 from app.orders.models import Order, OrderStatus
 from app.restaurants.models import Restaurant
-from app.storage import call_sessions, restaurants as restaurants_storage
+from app.storage import call_sessions, recordings, restaurants as restaurants_storage
+from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
 from app.tts.client import speak
 
 router = APIRouter()
@@ -298,6 +299,8 @@ class _CallState:
     hangup_task:       asyncio.Task | None = None   # pending auto-hangup (#78)
     mark_timeout_task: asyncio.Task | None = None   # mark-echo fallback (#114)
     pending_hangup: bool           = False     # set when goodbye mark sent (#78)
+    recording_session: "RecordingUploadSession | None" = None
+    should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
 
 
 async def _open_deepgram_connection(

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -675,6 +675,18 @@ async def media_stream(websocket: WebSocket) -> None:
                         rid or restaurants_storage.DEMO_RID
                     )
                 state.system_prompt = build_system_prompt(state.restaurant)
+                try:
+                    state.recording_session = recordings.begin_recording(
+                        call_sid=state.call_sid or "unknown",
+                        restaurant_id=state.restaurant.id,
+                        retention_days=state.restaurant.recording_retention_days,
+                    )
+                except Exception:
+                    logger.exception(
+                        "recording: begin_recording failed call_sid=%s — call continues without recording",
+                        state.call_sid,
+                    )
+                    state.recording_session = None
                 state.order = Order(
                     call_sid=state.call_sid or "unknown",
                     restaurant_id=state.restaurant.id,

--- a/docs/superpowers/plans/2026-04-30-ws-recording.md
+++ b/docs/superpowers/plans/2026-04-30-ws-recording.md
@@ -1,0 +1,2451 @@
+# WebSocket-side call recording — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Twilio's REST-driven call recording (broken on `<Connect><Stream>` calls) with a self-hosted pipeline that captures audio from the existing WebSocket, encodes to MP3 mid-call via resumable GCS upload, and serves playback through signed URLs. Adds delete + per-tenant retention + WS-close auto-hangup as a bundle.
+
+**Architecture:** A new `app/storage/recordings.py` module exposes `begin_recording` / `append_chunks` / `finalize_recording` / `delete_recording` / `generate_signed_url`. The existing `/media-stream` WS handler holds a `RecordingUploadSession` per call, decodes μ-law to stereo PCM per `media` event, encodes incrementally with `lameenc`, and PUTs 256 KB chunks to a GCS resumable session as the buffer fills. At call end, `finalize_recording` flushes the encoder, sends the final chunk with a known total length, and writes `recording_url=gs://...` into Firestore. Playback proxy returns 302 to a 30-min signed URL. Auto-hangup is now a `should_hangup` `asyncio.Event` watched by the WS loop.
+
+**Tech Stack:** Python 3.12 (FastAPI, asyncio, stdlib `audioop` + `wave`), `lameenc>=1.6` (pure-Python LAME), `google-cloud-storage>=2.0`, GCS resumable upload (Content-Range PUT), GCS lifecycle with `customTime`, Cloud Run runtime SA + `iam.serviceAccountTokenCreator` for V4 URL signing.
+
+**Spec:** See `docs/superpowers/specs/2026-04-30-ws-recording-design.md`. All decisions and error-handling tables already locked there; this plan implements them.
+
+**File map:**
+- Create: `app/storage/recordings.py`, `tests/test_recordings_storage.py`, `tests/test_calls_route.py`, `scripts/setup-recordings-bucket.sh`
+- Modify: `app/config.py`, `app/restaurants/models.py`, `app/storage/call_sessions.py`, `app/telephony/router.py`, `app/main.py`, `tests/test_telephony.py`, `requirements.txt`
+
+---
+
+### Task 1: Add `lameenc` + `google-cloud-storage` to `requirements.txt`
+
+**Files:**
+- Modify: `requirements.txt`
+
+- [ ] **Step 1: Add the two deps**
+
+Open `requirements.txt`, add at the bottom (after `twilio>=9.0,<10.0`):
+
+```
+google-cloud-storage>=2.0,<3.0
+lameenc>=1.6,<2.0
+```
+
+- [ ] **Step 2: Install locally**
+
+Run: `pip install -r requirements.txt`
+Expected: `Successfully installed lameenc-... google-cloud-storage-...`
+
+- [ ] **Step 3: Smoke test the imports**
+
+Run: `python -c "import lameenc, google.cloud.storage; print('ok')"`
+Expected: `ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add requirements.txt
+git commit -m "Add lameenc + google-cloud-storage for WS-side recording"
+```
+
+---
+
+### Task 2: Add config fields for recordings bucket + default retention
+
+**Files:**
+- Modify: `app/config.py`
+
+- [ ] **Step 1: Add the two settings**
+
+In `app/config.py`, inside the `Settings` class (after the existing `public_base_url` field), add:
+
+```python
+    # Recordings bucket. Phase 2 default; can be overridden via env if we
+    # ever split prod/dev/staging buckets.
+    recordings_bucket: str = "niko-recordings"
+
+    # Default retention applied at upload time when a Restaurant doc
+    # doesn't carry its own ``recording_retention_days`` field. The bucket
+    # lifecycle rule deletes blobs whose ``custom_time`` has passed.
+    recording_default_retention_days: int = 90
+```
+
+- [ ] **Step 2: Confirm import still works**
+
+Run: `python -c "from app.config import settings; print(settings.recordings_bucket, settings.recording_default_retention_days)"`
+Expected: `niko-recordings 90`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/config.py
+git commit -m "Add recordings_bucket + retention default to settings"
+```
+
+---
+
+### Task 3: Create the bucket-bootstrap script
+
+**Files:**
+- Create: `scripts/setup-recordings-bucket.sh`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/setup-recordings-bucket.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Bootstrap GCS bucket + IAM for WS-side call recordings (#82).
+# Idempotent enough for one-shot bootstrap; re-running on an existing
+# bucket fails cleanly at create-bucket and the rest are upserts.
+set -euo pipefail
+
+PROJECT="${PROJECT:-niko-tsuki}"
+BUCKET="${BUCKET:-niko-recordings}"
+REGION="${REGION:-us-central1}"
+SA="${SA:-347262010229-compute@developer.gserviceaccount.com}"
+
+echo "Creating bucket gs://${BUCKET} in ${REGION}..."
+gcloud storage buckets create "gs://${BUCKET}" \
+  --project="${PROJECT}" \
+  --location="${REGION}" \
+  --uniform-bucket-level-access || echo "(bucket may already exist; continuing)"
+
+echo "Setting per-blob lifecycle (delete when daysSinceCustomTime >= 0)..."
+TMP_LIFECYCLE="$(mktemp)"
+cat > "${TMP_LIFECYCLE}" <<'EOF'
+{"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"daysSinceCustomTime":0}}]}}
+EOF
+gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file="${TMP_LIFECYCLE}"
+rm -f "${TMP_LIFECYCLE}"
+
+echo "Granting Cloud Run runtime SA roles/storage.objectAdmin on bucket..."
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
+  --member="serviceAccount:${SA}" \
+  --role="roles/storage.objectAdmin"
+
+echo "Granting SA serviceAccountTokenCreator on itself (for V4 signed URLs)..."
+gcloud iam service-accounts add-iam-policy-binding "${SA}" \
+  --member="serviceAccount:${SA}" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --project="${PROJECT}"
+
+echo "Done. Bucket gs://${BUCKET} is ready for recordings."
+```
+
+- [ ] **Step 2: Mark executable**
+
+Run: `chmod +x scripts/setup-recordings-bucket.sh`
+
+- [ ] **Step 3: Validate script syntax (without running it)**
+
+Run: `bash -n scripts/setup-recordings-bucket.sh`
+Expected: no output (no syntax errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/setup-recordings-bucket.sh
+git commit -m "Add scripts/setup-recordings-bucket.sh"
+```
+
+*(The script will be run once in Task 25, just before deploying the new code.)*
+
+---
+
+### Task 4: Add `recording_retention_days` to the `Restaurant` model
+
+**Files:**
+- Modify: `app/restaurants/models.py`
+- Modify: `tests/test_restaurants_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_restaurants_storage.py`:
+
+```python
+def test_restaurant_recording_retention_default_is_90():
+    from app.restaurants.models import Restaurant
+
+    r = Restaurant(
+        id="x", name="X", display_phone="+1", twilio_phone="+1",
+        address="a", hours="h", menu={"pizzas": [], "sides": [], "drinks": []},
+    )
+    assert r.recording_retention_days == 90
+
+
+def test_restaurant_recording_retention_accepts_override():
+    from app.restaurants.models import Restaurant
+
+    r = Restaurant(
+        id="x", name="X", display_phone="+1", twilio_phone="+1",
+        address="a", hours="h",
+        menu={"pizzas": [], "sides": [], "drinks": []},
+        recording_retention_days=30,
+    )
+    assert r.recording_retention_days == 30
+
+
+def test_restaurant_recording_retention_rejects_zero_or_negative():
+    import pytest
+    from pydantic import ValidationError
+    from app.restaurants.models import Restaurant
+
+    with pytest.raises(ValidationError):
+        Restaurant(
+            id="x", name="X", display_phone="+1", twilio_phone="+1",
+            address="a", hours="h",
+            menu={"pizzas": [], "sides": [], "drinks": []},
+            recording_retention_days=0,
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_restaurants_storage.py::test_restaurant_recording_retention_default_is_90 -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'recording_retention_days'` (or Pydantic field-not-found).
+
+- [ ] **Step 3: Add the field to the model**
+
+In `app/restaurants/models.py`, on the `Restaurant` Pydantic model, add (next to other primitive fields):
+
+```python
+    recording_retention_days: int = Field(default=90, ge=1, le=3650)
+```
+
+If the file doesn't already import `Field`, change `from pydantic import BaseModel` to `from pydantic import BaseModel, Field`.
+
+- [ ] **Step 4: Run the three tests to verify they pass**
+
+Run: `pytest tests/test_restaurants_storage.py -k recording_retention -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/restaurants/models.py tests/test_restaurants_storage.py
+git commit -m "Restaurant: add recording_retention_days (default 90)"
+```
+
+---
+
+### Task 5: Add `mark_recording_deleted` to the call-sessions storage module
+
+**Files:**
+- Modify: `app/storage/call_sessions.py`
+- Modify: `tests/test_call_sessions_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_call_sessions_storage.py`:
+
+```python
+def test_mark_recording_deleted_clears_url_and_emits_event(monkeypatch):
+    from app.storage import call_sessions
+
+    patches: list[dict] = []
+    events: list[dict] = []
+
+    class FakeDoc:
+        def __init__(self):
+            self._collection = FakeCollection(events)
+        def update(self, patch):
+            patches.append(patch)
+        def collection(self, _name):
+            return self._collection
+
+    class FakeCollection:
+        def __init__(self, events):
+            self._events = events
+        def add(self, payload):
+            self._events.append(payload)
+
+    fake_legacy = FakeDoc()
+    fake_nested = FakeDoc()
+
+    monkeypatch.setattr(call_sessions, "_get_client", lambda: object())
+    monkeypatch.setattr(call_sessions, "_legacy_parent", lambda _c, _sid: fake_legacy)
+    monkeypatch.setattr(call_sessions, "_nested_parent", lambda _c, _rid, _sid: fake_nested)
+
+    call_sessions.mark_recording_deleted("CAtest", "rid1")
+
+    # Both parents are cleared
+    for p in patches:
+        assert p.get("recording_url") is None
+        assert p.get("recording_sid") is None
+        assert p.get("recording_duration_seconds") is None
+
+    # An event was appended on each side
+    assert len(events) == 2
+    for ev in events:
+        assert ev["kind"] == "recording_deleted"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_call_sessions_storage.py::test_mark_recording_deleted_clears_url_and_emits_event -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'mark_recording_deleted'`.
+
+- [ ] **Step 3: Implement `mark_recording_deleted`**
+
+In `app/storage/call_sessions.py`, after the existing `mark_recording_ready` function, add:
+
+```python
+def mark_recording_deleted(call_sid: str, restaurant_id: str) -> None:
+    """Clear recording metadata from the call session doc and emit a
+    ``recording_deleted`` event so the dashboard's onSnapshot can hide
+    the audio player.
+
+    Mirrors the dual-write shape of ``mark_recording_ready`` —
+    patches both legacy flat and nested call-session docs and appends
+    a matching event on each. Idempotent: calling it twice on the
+    same call is a no-op for the dashboard (the second clear writes
+    the same Nones; the second event row is harmless).
+    """
+    ts = _now()
+    patch: dict[str, Any] = {
+        "recording_url": None,
+        "recording_sid": None,
+        "recording_duration_seconds": None,
+        "last_event_at": ts,
+    }
+    event_payload = {
+        "timestamp": ts,
+        "kind": "recording_deleted",
+        "text": "",
+        "detail": {},
+    }
+    try:
+        client = _get_client()
+        legacy = _legacy_parent(client, call_sid)
+        legacy.update(patch)
+        legacy.collection(_EVENTS_SUBCOLLECTION).add(event_payload)
+
+        nested = _nested_parent(client, restaurant_id, call_sid)
+        nested.update(patch)
+        nested.collection(_EVENTS_SUBCOLLECTION).add(event_payload)
+    except Exception:
+        logger.exception(
+            "call_sessions: mark_recording_deleted failed call_sid=%s", call_sid
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_call_sessions_storage.py::test_mark_recording_deleted_clears_url_and_emits_event -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/call_sessions.py tests/test_call_sessions_storage.py
+git commit -m "call_sessions: add mark_recording_deleted (Firestore + event)"
+```
+
+---
+
+### Task 6: Implement `_compute_pcm_pair` (decode + interleave + pad)
+
+**Files:**
+- Create: `app/storage/recordings.py`
+- Create: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_recordings_storage.py`:
+
+```python
+"""Unit tests for app.storage.recordings.
+
+Hot-path helpers (decode + interleave) are pure and need no mocking.
+Resumable-upload + signed-URL tests live further down and use mocks
+for google.cloud.storage.
+"""
+
+import audioop
+
+
+def test_compute_pcm_pair_interleaves_lr():
+    from app.storage.recordings import _compute_pcm_pair
+
+    # 2 μ-law samples per side. μ-law 0xFF = silence ≈ 0 PCM; 0x00 = max negative.
+    inbound = b"\xff\xff"
+    outbound = b"\x00\x00"
+    out = _compute_pcm_pair(inbound, outbound)
+
+    # 2 samples × 2 channels × 2 bytes = 8 bytes, L then R per sample.
+    assert len(out) == 8
+    inbound_pcm = audioop.ulaw2lin(inbound, 2)
+    outbound_pcm = audioop.ulaw2lin(outbound, 2)
+    # Sample 0: L = inbound[0:2], R = outbound[0:2]
+    assert out[0:2] == inbound_pcm[0:2]
+    assert out[2:4] == outbound_pcm[0:2]
+    # Sample 1: L = inbound[2:4], R = outbound[2:4]
+    assert out[4:6] == inbound_pcm[2:4]
+    assert out[6:8] == outbound_pcm[2:4]
+
+
+def test_compute_pcm_pair_pads_shorter_side_with_silence():
+    from app.storage.recordings import _compute_pcm_pair
+
+    inbound = b"\xff" * 100   # 100 μ-law samples
+    outbound = b"\x00" * 500  # 500 μ-law samples
+    out = _compute_pcm_pair(inbound, outbound)
+
+    # 500 samples × 2 channels × 2 bytes
+    assert len(out) == 500 * 2 * 2
+    # Past the inbound's 100-sample mark, the L channel is PCM silence (\x00\x00).
+    for i in range(100, 500):
+        l_offset = i * 4
+        assert out[l_offset:l_offset + 2] == b"\x00\x00", (
+            f"L sample {i} not silent"
+        )
+
+
+def test_compute_pcm_pair_handles_empty_chunks():
+    from app.storage.recordings import _compute_pcm_pair
+
+    assert _compute_pcm_pair(b"", b"") == b""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_recordings_storage.py -v`
+Expected: 3 FAIL — `ModuleNotFoundError: No module named 'app.storage.recordings'`.
+
+- [ ] **Step 3: Create the module skeleton + implement `_compute_pcm_pair`**
+
+Create `app/storage/recordings.py`:
+
+```python
+"""WS-side call recording: encode + resumable GCS upload + signed URLs.
+
+The /media-stream WS hands raw μ-law payloads (per Twilio media event) to
+``append_chunks``. We decode each side to 16-bit linear PCM, interleave
+L=caller / R=agent, encode incrementally to MP3 via lameenc, and PUT
+~256 KB chunks to a GCS resumable upload session held on a per-call
+``RecordingUploadSession`` object.
+
+Replaces the broken Twilio-REST recording approach (PRs #127, #132, #133).
+See ``docs/superpowers/specs/2026-04-30-ws-recording-design.md``.
+"""
+
+from __future__ import annotations
+
+import audioop
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _compute_pcm_pair(inbound_mu_law: bytes, outbound_mu_law: bytes) -> bytes:
+    """Decode each μ-law track to 16-bit PCM, pad the shorter side with
+    PCM silence, and interleave L=inbound / R=outbound. Returns stereo
+    16-bit little-endian PCM ready to feed the MP3 encoder.
+
+    Pure function; no I/O. Keeps the hot-path math testable in isolation.
+    """
+    if not inbound_mu_law and not outbound_mu_law:
+        return b""
+
+    inbound_pcm = audioop.ulaw2lin(inbound_mu_law, 2)
+    outbound_pcm = audioop.ulaw2lin(outbound_mu_law, 2)
+
+    n_in = len(inbound_pcm) // 2
+    n_out = len(outbound_pcm) // 2
+    n = max(n_in, n_out)
+
+    # Pad each side with PCM silence (0x0000) up to ``n`` samples.
+    inbound_pcm = inbound_pcm + b"\x00\x00" * (n - n_in)
+    outbound_pcm = outbound_pcm + b"\x00\x00" * (n - n_out)
+
+    # Interleave L0 R0 L1 R1 ...
+    out = bytearray(n * 4)
+    for i in range(n):
+        out[i * 4 : i * 4 + 2] = inbound_pcm[i * 2 : i * 2 + 2]
+        out[i * 4 + 2 : i * 4 + 4] = outbound_pcm[i * 2 : i * 2 + 2]
+    return bytes(out)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_recordings_storage.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/recordings.py tests/test_recordings_storage.py
+git commit -m "recordings: add _compute_pcm_pair (μ-law→stereo PCM)"
+```
+
+---
+
+### Task 7: MP3 encode round-trip test + lameenc helper
+
+**Files:**
+- Modify: `app/storage/recordings.py`
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_make_encoder_returns_lame_encoder_at_32kbps():
+    from app.storage.recordings import _make_encoder
+
+    enc = _make_encoder()
+    # Encode 1 second of stereo PCM silence — 16000 samples × 2 channels × 2 bytes.
+    pcm = b"\x00" * (16000 * 2 * 2)
+    mp3 = enc.encode(pcm)
+    mp3 += enc.flush()
+
+    # Output must contain at least one MP3 frame sync (0xFFE/0xFFF prefix).
+    assert b"\xff\xfb" in mp3 or b"\xff\xfa" in mp3 or b"\xff\xf3" in mp3, (
+        f"no MP3 frame sync found in {mp3[:32]!r}"
+    )
+    # 1s of 32 kbps mono ≈ 4 KB; allow a wide range to keep the test stable.
+    assert 1000 < len(mp3) < 10000
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_recordings_storage.py::test_make_encoder_returns_lame_encoder_at_32kbps -v`
+Expected: FAIL — `ImportError: cannot import name '_make_encoder'`.
+
+- [ ] **Step 3: Add `_make_encoder` to the module**
+
+Append to `app/storage/recordings.py`:
+
+```python
+import lameenc
+
+
+# Encoder constants. LAME quality levels are 0-9 (0 best, 9 worst).
+# 2 is the standard "good" preset and runs faster than 0 with no audible
+# difference at 32 kbps on phone audio.
+_MP3_BITRATE_KBPS = 32
+_MP3_QUALITY = 2
+_PCM_SAMPLE_RATE = 8000  # Twilio media is 8 kHz μ-law
+_PCM_CHANNELS = 2        # we encode the stereo (caller=L, agent=R) mix
+
+
+def _make_encoder() -> "lameenc.Encoder":
+    """Build a lameenc.Encoder configured for our telephony pipeline.
+
+    Bound per-call (each RecordingUploadSession owns its own encoder
+    instance; encoders are not safe to share across calls because they
+    carry internal state).
+    """
+    enc = lameenc.Encoder()
+    enc.set_bit_rate(_MP3_BITRATE_KBPS)
+    enc.set_in_sample_rate(_PCM_SAMPLE_RATE)
+    enc.set_channels(_PCM_CHANNELS)
+    enc.set_quality(_MP3_QUALITY)
+    return enc
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_recordings_storage.py::test_make_encoder_returns_lame_encoder_at_32kbps -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/recordings.py tests/test_recordings_storage.py
+git commit -m "recordings: add _make_encoder (lameenc, 32 kbps stereo)"
+```
+
+---
+
+### Task 8: `RecordingUploadSession` dataclass + `begin_recording`
+
+**Files:**
+- Modify: `app/storage/recordings.py`
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_begin_recording_creates_session_and_sets_custom_time(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+    from app.storage import recordings
+
+    fake_blob = type("FakeBlob", (), {})()
+    fake_blob.create_resumable_upload_session = lambda content_type: (
+        "https://storage.googleapis.com/upload/session/fake"
+    )
+    fake_blob.custom_time = None
+
+    fake_bucket = type("FakeBucket", (), {})()
+    fake_bucket.blob = lambda name: fake_blob
+
+    fake_client = type("FakeClient", (), {})()
+    fake_client.bucket = lambda name: fake_bucket
+
+    monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
+
+    before = datetime.now(timezone.utc)
+    session = recordings.begin_recording(
+        call_sid="CAtest", restaurant_id="rid1", retention_days=7
+    )
+    after = datetime.now(timezone.utc)
+
+    assert session.call_sid == "CAtest"
+    assert session.restaurant_id == "rid1"
+    assert session.blob_name == "rid1/CAtest.mp3"
+    assert session.upload_url == "https://storage.googleapis.com/upload/session/fake"
+    assert session.total_bytes_uploaded == 0
+    assert session.broken is False
+    # custom_time must be 7 days from now (within the test's clock window)
+    assert before + timedelta(days=7) - timedelta(seconds=2) <= fake_blob.custom_time <= after + timedelta(days=7)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_recordings_storage.py::test_begin_recording_creates_session_and_sets_custom_time -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'begin_recording'`.
+
+- [ ] **Step 3: Add the dataclass + `begin_recording`**
+
+Append to `app/storage/recordings.py`:
+
+```python
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+from google.cloud import storage as gcs
+
+from app.config import settings
+
+
+@dataclass
+class RecordingUploadSession:
+    """Per-call state for a resumable GCS upload of an MP3 stream."""
+    call_sid: str
+    restaurant_id: str
+    blob_name: str
+    upload_url: str
+    encoder: "lameenc.Encoder"
+    pending_mp3: bytearray = field(default_factory=bytearray)
+    total_bytes_uploaded: int = 0
+    total_pcm_samples: int = 0  # per-channel sample count; drives duration
+    broken: bool = False
+
+
+# 256 KB — minimum non-final chunk size for GCS resumable uploads.
+_GCS_CHUNK_BYTES = 256 * 1024
+
+
+_storage_client_singleton: gcs.Client | None = None
+
+
+def _get_storage_client() -> gcs.Client:
+    """Lazy singleton. Cloud Run's runtime SA picks up ambient creds."""
+    global _storage_client_singleton
+    if _storage_client_singleton is None:
+        _storage_client_singleton = gcs.Client()
+    return _storage_client_singleton
+
+
+def begin_recording(
+    *, call_sid: str, restaurant_id: str, retention_days: int
+) -> RecordingUploadSession:
+    """Create a new GCS resumable upload session for this call.
+
+    Sets the blob's ``custom_time`` to ``now() + retention_days`` so the
+    bucket lifecycle rule (``daysSinceCustomTime: 0``) deletes the blob
+    on its scheduled date — per-tenant retention without per-tenant
+    bucket rules.
+    """
+    blob_name = f"{restaurant_id}/{call_sid}.mp3"
+    bucket = _get_storage_client().bucket(settings.recordings_bucket)
+    blob = bucket.blob(blob_name)
+    upload_url = blob.create_resumable_upload_session(content_type="audio/mpeg")
+    blob.custom_time = datetime.now(timezone.utc) + timedelta(days=retention_days)
+
+    return RecordingUploadSession(
+        call_sid=call_sid,
+        restaurant_id=restaurant_id,
+        blob_name=blob_name,
+        upload_url=upload_url,
+        encoder=_make_encoder(),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_recordings_storage.py::test_begin_recording_creates_session_and_sets_custom_time -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/recordings.py tests/test_recordings_storage.py
+git commit -m "recordings: RecordingUploadSession + begin_recording"
+```
+
+---
+
+### Task 9: `append_chunks` — buffer accumulation, no flush yet
+
+**Files:**
+- Modify: `app/storage/recordings.py`
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_append_chunks_buffers_below_threshold(monkeypatch):
+    from app.storage import recordings
+
+    # PUT counter — must remain 0 since we never cross the threshold.
+    put_count = {"n": 0}
+
+    def fake_put(session, chunk_bytes, *, is_final, total):
+        put_count["n"] += 1
+
+    monkeypatch.setattr(recordings, "_put_chunk", fake_put)
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    # 50 ms of audio per side, repeated 10 times — well under 256 KB MP3.
+    inbound = b"\xff" * 400  # 50 ms at 8 kHz
+    outbound = b"\x00" * 400
+    for _ in range(10):
+        recordings.append_chunks(session, inbound, outbound)
+
+    assert put_count["n"] == 0
+    assert session.total_bytes_uploaded == 0
+    assert session.total_pcm_samples == 400 * 10
+    assert len(session.pending_mp3) > 0  # encoder produced *some* output
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_recordings_storage.py::test_append_chunks_buffers_below_threshold -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'append_chunks'`.
+
+- [ ] **Step 3: Implement `append_chunks` + `_put_chunk` stub**
+
+Append to `app/storage/recordings.py`:
+
+```python
+def append_chunks(
+    session: RecordingUploadSession,
+    inbound_mu_law: bytes,
+    outbound_mu_law: bytes,
+) -> None:
+    """Decode + interleave + encode + buffer; flush a chunk when the
+    pending MP3 buffer reaches the 256 KB GCS-minimum.
+
+    No-op once ``session.broken`` is True (set by `_put_chunk` after two
+    consecutive failures).
+    """
+    if session.broken:
+        return
+
+    pcm = _compute_pcm_pair(inbound_mu_law, outbound_mu_law)
+    if not pcm:
+        return
+
+    # Track per-channel sample count for duration calc.
+    # Stereo PCM-16 = 4 bytes per (per-channel) sample-pair.
+    session.total_pcm_samples += len(pcm) // 4
+
+    mp3 = session.encoder.encode(pcm)
+    if mp3:
+        session.pending_mp3.extend(mp3)
+
+    while len(session.pending_mp3) >= _GCS_CHUNK_BYTES:
+        n = (len(session.pending_mp3) // _GCS_CHUNK_BYTES) * _GCS_CHUNK_BYTES
+        chunk = bytes(session.pending_mp3[:n])
+        del session.pending_mp3[:n]
+        _put_chunk(session, chunk, is_final=False, total=None)
+
+
+def _put_chunk(
+    session: RecordingUploadSession,
+    chunk: bytes,
+    *,
+    is_final: bool,
+    total: int | None,
+) -> None:
+    """PUT one resumable-upload chunk to the session URL.
+
+    Stub for Task 9 — implemented in Task 10. Kept in module scope so
+    tests can monkeypatch it.
+    """
+    raise NotImplementedError
+```
+
+*(The stub raises so Task 10's tests will be the first to exercise it.)*
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_recordings_storage.py::test_append_chunks_buffers_below_threshold -v`
+Expected: PASS (test monkeypatches `_put_chunk`, so the stub never runs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/recordings.py tests/test_recordings_storage.py
+git commit -m "recordings: append_chunks (buffer accumulation, pre-flush)"
+```
+
+---
+
+### Task 10: `_put_chunk` — real PUT with `Content-Range`, 1-retry
+
+**Files:**
+- Modify: `app/storage/recordings.py`
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_put_chunk_sends_content_range_open_for_non_final(monkeypatch):
+    from app.storage import recordings
+
+    calls: list[dict] = []
+
+    def fake_put(url, data, headers, timeout):
+        calls.append({"url": url, "data_len": len(data), "headers": headers})
+        return type("R", (), {"status_code": 200, "text": ""})()
+
+    monkeypatch.setattr(recordings.requests, "put", fake_put)
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    chunk = b"x" * 256 * 1024
+    recordings._put_chunk(session, chunk, is_final=False, total=None)
+
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://fake"
+    assert calls[0]["data_len"] == 256 * 1024
+    assert calls[0]["headers"]["Content-Range"] == "bytes 0-262143/*"
+    assert session.total_bytes_uploaded == 256 * 1024
+
+
+def test_put_chunk_retries_once_on_5xx(monkeypatch):
+    from app.storage import recordings
+
+    responses = iter([
+        type("R", (), {"status_code": 503, "text": "transient"})(),
+        type("R", (), {"status_code": 200, "text": ""})(),
+    ])
+    sleeps: list[float] = []
+    monkeypatch.setattr(recordings.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(recordings.requests, "put", lambda *a, **kw: next(responses))
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    recordings._put_chunk(session, b"x" * 256 * 1024, is_final=False, total=None)
+
+    assert sleeps == [0.5]
+    assert session.broken is False
+    assert session.total_bytes_uploaded == 256 * 1024
+
+
+def test_put_chunk_marks_broken_after_two_5xx(monkeypatch):
+    from app.storage import recordings
+
+    monkeypatch.setattr(recordings.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        recordings.requests, "put",
+        lambda *a, **kw: type("R", (), {"status_code": 503, "text": "fail"})(),
+    )
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    recordings._put_chunk(session, b"x" * 256 * 1024, is_final=False, total=None)
+    assert session.broken is True
+    assert session.total_bytes_uploaded == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_recordings_storage.py -k put_chunk -v`
+Expected: 3 FAIL — currently `_put_chunk` raises NotImplementedError; tests don't get past it.
+
+- [ ] **Step 3: Replace the `_put_chunk` stub with the real impl**
+
+In `app/storage/recordings.py`, add `import requests` and `import time` at the top of the imports, then **replace** the existing `_put_chunk` stub with:
+
+```python
+def _put_chunk(
+    session: RecordingUploadSession,
+    chunk: bytes,
+    *,
+    is_final: bool,
+    total: int | None,
+) -> None:
+    """PUT one resumable-upload chunk to the session URL.
+
+    Builds the ``Content-Range`` header from the session's current
+    ``total_bytes_uploaded``. Retries once on 5xx with a 0.5s pause; on
+    second failure, marks the session broken and stops further uploads.
+    """
+    start = session.total_bytes_uploaded
+    end = start + len(chunk) - 1
+    total_str = str(total) if (is_final and total is not None) else "*"
+    headers = {"Content-Range": f"bytes {start}-{end}/{total_str}"}
+
+    for attempt in range(2):
+        try:
+            resp = requests.put(
+                session.upload_url, data=chunk, headers=headers, timeout=30.0
+            )
+        except Exception:
+            logger.exception(
+                "recording: chunk PUT raised call_sid=%s attempt=%d",
+                session.call_sid, attempt,
+            )
+            resp = None
+
+        # GCS returns 308 ("Resume Incomplete") for a successful non-final
+        # chunk, 200/201 for the final, 5xx on transient failure.
+        ok = resp is not None and (
+            resp.status_code in (200, 201, 308)
+            or (is_final and resp.status_code == 200)
+        )
+        if ok:
+            session.total_bytes_uploaded += len(chunk)
+            return
+        if attempt == 0:
+            time.sleep(0.5)
+            continue
+        # Second failure
+        session.broken = True
+        logger.error(
+            "recording: chunk PUT failed twice — session broken call_sid=%s status=%s",
+            session.call_sid,
+            resp.status_code if resp else "(no response)",
+        )
+        return
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_recordings_storage.py -k put_chunk -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/recordings.py tests/test_recordings_storage.py
+git commit -m "recordings: _put_chunk with Content-Range + 1-retry on 5xx"
+```
+
+---
+
+### Task 11: `append_chunks` — chunk threshold actually fires
+
+**Files:**
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_append_chunks_flushes_one_chunk_when_threshold_hit(monkeypatch):
+    from app.storage import recordings
+
+    chunks: list[tuple[int, bool]] = []
+
+    def fake_put(session, chunk, *, is_final, total):
+        chunks.append((len(chunk), is_final))
+        session.total_bytes_uploaded += len(chunk)
+
+    monkeypatch.setattr(recordings, "_put_chunk", fake_put)
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    # Force the pending buffer to cross 256 KB by pre-loading it; then a
+    # single small append triggers the flush loop.
+    session.pending_mp3.extend(b"x" * (256 * 1024 + 100))
+    recordings.append_chunks(session, b"\xff" * 8, b"\x00" * 8)
+
+    # Exactly one chunk of size 256 KB must have been PUT.
+    assert chunks == [(256 * 1024, False)]
+    # Leftover (>100 bytes from the prefill + the encoder's output for 8
+    # μ-law samples) stays in pending_mp3.
+    assert len(session.pending_mp3) > 0
+```
+
+- [ ] **Step 2: Run test to verify it passes already (the loop in append_chunks already exists)**
+
+Run: `pytest tests/test_recordings_storage.py::test_append_chunks_flushes_one_chunk_when_threshold_hit -v`
+Expected: PASS — Task 9's `append_chunks` already had the threshold loop; this test just exercises it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_recordings_storage.py
+git commit -m "recordings: regression test for chunk-threshold flush"
+```
+
+---
+
+### Task 12: `finalize_recording` — happy path with total length
+
+**Files:**
+- Modify: `app/storage/recordings.py`
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_finalize_recording_sends_final_chunk_with_total_and_returns_url(monkeypatch):
+    from app.storage import recordings
+
+    captured: list[dict] = []
+
+    def fake_put(session, chunk, *, is_final, total):
+        captured.append({"len": len(chunk), "is_final": is_final, "total": total})
+        session.total_bytes_uploaded += len(chunk)
+
+    monkeypatch.setattr(recordings, "_put_chunk", fake_put)
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    # Simulate one prior chunk already uploaded.
+    session.total_bytes_uploaded = 256 * 1024
+    # Simulate 2 seconds of stereo audio captured.
+    session.total_pcm_samples = 2 * 8000
+    # Some bytes still pending for the final flush.
+    session.pending_mp3.extend(b"x" * 1234)
+
+    url, duration = recordings.finalize_recording(session)
+
+    # One final PUT was made, with the encoder's flush() tail appended.
+    assert len(captured) == 1
+    final = captured[0]
+    assert final["is_final"] is True
+    assert final["total"] is not None
+    # Duration is total_pcm_samples / 8000 = 2 seconds.
+    assert duration == 2
+    assert url == "gs://niko-recordings/rid/CAt.mp3"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_recordings_storage.py::test_finalize_recording_sends_final_chunk_with_total_and_returns_url -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'finalize_recording'`.
+
+- [ ] **Step 3: Implement `finalize_recording`**
+
+Append to `app/storage/recordings.py`:
+
+```python
+import requests as _requests_unused  # keep linter happy if `requests` already imported
+
+def finalize_recording(
+    session: RecordingUploadSession,
+) -> tuple[str, int]:
+    """Flush the encoder + send the final chunk with a known total length.
+
+    Returns ``(gs:// URL, duration_seconds)``. If the session never had
+    any audio (zero PCM samples), DELETEs the resumable session URL and
+    returns ``("", 0)`` so the caller can skip the Firestore write.
+    Returns ``("", 0)`` on a broken session too.
+    """
+    if session.broken:
+        return ("", 0)
+
+    if session.total_pcm_samples == 0:
+        # No data — cancel the resumable session so GCS doesn't keep an
+        # orphan around for 7 days.
+        try:
+            requests.delete(session.upload_url, timeout=10.0)
+        except Exception:
+            logger.exception(
+                "recording: failed to cancel empty session call_sid=%s",
+                session.call_sid,
+            )
+        return ("", 0)
+
+    # Flush the encoder tail.
+    tail = session.encoder.flush()
+    if tail:
+        session.pending_mp3.extend(tail)
+
+    final_chunk = bytes(session.pending_mp3)
+    session.pending_mp3.clear()
+    total = session.total_bytes_uploaded + len(final_chunk)
+
+    _put_chunk(session, final_chunk, is_final=True, total=total)
+    if session.broken:
+        return ("", 0)
+
+    duration_seconds = session.total_pcm_samples // _PCM_SAMPLE_RATE
+    return (
+        f"gs://{settings.recordings_bucket}/{session.blob_name}",
+        duration_seconds,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_recordings_storage.py::test_finalize_recording_sends_final_chunk_with_total_and_returns_url -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/recordings.py tests/test_recordings_storage.py
+git commit -m "recordings: finalize_recording (final PUT + duration)"
+```
+
+---
+
+### Task 13: `finalize_recording` — empty session DELETEs the upload URL
+
+**Files:**
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_finalize_recording_with_zero_pcm_cancels_session(monkeypatch):
+    from app.storage import recordings
+
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        recordings.requests, "delete",
+        lambda url, timeout: deleted.append(url) or type("R", (), {"status_code": 204})(),
+    )
+    # _put_chunk should NOT be called.
+    monkeypatch.setattr(
+        recordings, "_put_chunk",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("must not PUT on empty session")),
+    )
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3",
+        upload_url="https://upload.googleapis.com/session/abc",
+        encoder=recordings._make_encoder(),
+    )
+
+    url, duration = recordings.finalize_recording(session)
+
+    assert url == ""
+    assert duration == 0
+    assert deleted == ["https://upload.googleapis.com/session/abc"]
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `pytest tests/test_recordings_storage.py::test_finalize_recording_with_zero_pcm_cancels_session -v`
+Expected: PASS — Task 12 implementation already handles this branch.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_recordings_storage.py
+git commit -m "recordings: regression test for empty-session DELETE"
+```
+
+---
+
+### Task 14: `delete_recording` — idempotent blob delete
+
+**Files:**
+- Modify: `app/storage/recordings.py`
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_delete_recording_calls_blob_delete(monkeypatch):
+    from app.storage import recordings
+
+    deleted: list[str] = []
+
+    fake_blob = type("FakeBlob", (), {})()
+    fake_blob.delete = lambda: deleted.append("called")
+
+    fake_bucket = type("FakeBucket", (), {})()
+    fake_bucket.blob = lambda name: (deleted.append(name) or fake_blob)
+
+    fake_client = type("FakeClient", (), {})()
+    fake_client.bucket = lambda name: fake_bucket
+
+    monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
+
+    recordings.delete_recording(call_sid="CAt", restaurant_id="rid")
+
+    assert deleted == ["rid/CAt.mp3", "called"]
+
+
+def test_delete_recording_idempotent_on_404(monkeypatch):
+    from google.api_core.exceptions import NotFound
+    from app.storage import recordings
+
+    fake_blob = type("FakeBlob", (), {})()
+    def raise_notfound():
+        raise NotFound("gone")
+    fake_blob.delete = raise_notfound
+
+    fake_bucket = type("FakeBucket", (), {})()
+    fake_bucket.blob = lambda name: fake_blob
+
+    fake_client = type("FakeClient", (), {})()
+    fake_client.bucket = lambda name: fake_bucket
+
+    monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
+
+    # Should NOT raise.
+    recordings.delete_recording(call_sid="CAt", restaurant_id="rid")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_recordings_storage.py -k delete_recording -v`
+Expected: 2 FAIL — `AttributeError: module ... has no attribute 'delete_recording'`.
+
+- [ ] **Step 3: Implement `delete_recording`**
+
+Append to `app/storage/recordings.py`:
+
+```python
+from google.api_core.exceptions import NotFound
+
+
+def delete_recording(*, call_sid: str, restaurant_id: str) -> None:
+    """Delete the recording blob for one call. Idempotent: if the blob
+    is already gone, return cleanly. All other errors propagate so the
+    HTTP handler can decide how to surface them."""
+    blob_name = f"{restaurant_id}/{call_sid}.mp3"
+    bucket = _get_storage_client().bucket(settings.recordings_bucket)
+    blob = bucket.blob(blob_name)
+    try:
+        blob.delete()
+    except NotFound:
+        logger.info(
+            "recording: delete on missing blob (idempotent) call_sid=%s", call_sid
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_recordings_storage.py -k delete_recording -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/recordings.py tests/test_recordings_storage.py
+git commit -m "recordings: delete_recording (idempotent blob delete)"
+```
+
+---
+
+### Task 15: `generate_signed_url` — V4 GET, 30 min TTL
+
+**Files:**
+- Modify: `app/storage/recordings.py`
+- Modify: `tests/test_recordings_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_recordings_storage.py`:
+
+```python
+def test_generate_signed_url_uses_v4_get_30min(monkeypatch):
+    from datetime import timedelta
+    from app.storage import recordings
+
+    captured: dict = {}
+
+    fake_blob = type("FakeBlob", (), {})()
+    def fake_signed(*, version, method, expiration):
+        captured["version"] = version
+        captured["method"] = method
+        captured["expiration"] = expiration
+        return "https://signed.googleapis.com/?sig=fake"
+    fake_blob.generate_signed_url = fake_signed
+
+    fake_bucket = type("FakeBucket", (), {})()
+    fake_bucket.blob = lambda name: (captured.setdefault("blob_name", name), fake_blob)[1]
+
+    fake_client = type("FakeClient", (), {})()
+    fake_client.bucket = lambda name: fake_bucket
+
+    monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
+
+    url = recordings.generate_signed_url(call_sid="CAt", restaurant_id="rid")
+
+    assert url == "https://signed.googleapis.com/?sig=fake"
+    assert captured["blob_name"] == "rid/CAt.mp3"
+    assert captured["version"] == "v4"
+    assert captured["method"] == "GET"
+    assert captured["expiration"] == timedelta(minutes=30)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_recordings_storage.py::test_generate_signed_url_uses_v4_get_30min -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'generate_signed_url'`.
+
+- [ ] **Step 3: Implement `generate_signed_url`**
+
+Append to `app/storage/recordings.py`:
+
+```python
+def generate_signed_url(
+    *, call_sid: str, restaurant_id: str, ttl_minutes: int = 30
+) -> str:
+    """Return a V4 signed GET URL for the recording blob. TTL defaults
+    to 30 minutes — long enough for a typical playback session, short
+    enough that a leaked URL ages out fast.
+
+    Cloud Run's runtime SA can sign V4 URLs without a private key file
+    by using the IAM ``signBlob`` API; the SA must hold
+    ``roles/iam.serviceAccountTokenCreator`` on itself. See
+    ``scripts/setup-recordings-bucket.sh``.
+    """
+    blob_name = f"{restaurant_id}/{call_sid}.mp3"
+    bucket = _get_storage_client().bucket(settings.recordings_bucket)
+    blob = bucket.blob(blob_name)
+    return blob.generate_signed_url(
+        version="v4",
+        method="GET",
+        expiration=timedelta(minutes=ttl_minutes),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_recordings_storage.py::test_generate_signed_url_uses_v4_get_30min -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/recordings.py tests/test_recordings_storage.py
+git commit -m "recordings: generate_signed_url (V4 GET, 30min)"
+```
+
+---
+
+### Task 16: `voice()` — emit `tracks="both_tracks"` on the Stream
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_telephony.py`, after `test_voice_passes_restaurant_id_as_stream_parameter`, add:
+
+```python
+def test_voice_stream_requests_both_tracks(monkeypatch):
+    """Twilio sends both inbound and outbound audio over the same WS
+    only when we ask for ``tracks="both_tracks"`` on the <Stream>. This
+    is the foundation for the WS-side recording pipeline (#82)."""
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
+    response = client.post("/voice", data=_VOICE_FORM)
+    body = response.text
+    assert 'tracks="both_tracks"' in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_telephony.py::test_voice_stream_requests_both_tracks -v`
+Expected: FAIL — `assert 'tracks="both_tracks"' in body` returns False.
+
+- [ ] **Step 3: Add `tracks="both_tracks"` to the Stream**
+
+In `app/telephony/router.py`, find the line in `voice()` that creates the Stream:
+
+```python
+stream = connect.stream(url=f"wss://{host}/media-stream")
+```
+
+Replace with:
+
+```python
+stream = connect.stream(url=f"wss://{host}/media-stream", tracks="both_tracks")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_telephony.py::test_voice_stream_requests_both_tracks -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: request both_tracks on <Stream> for WS-side recording"
+```
+
+---
+
+### Task 17: `_CallState` gains recording session + should-hangup event
+
+**Files:**
+- Modify: `app/telephony/router.py`
+
+- [ ] **Step 1: Add the new fields to `_CallState`**
+
+In `app/telephony/router.py`, find `_CallState`:
+
+```python
+@dataclass
+class _CallState:
+    call_sid:     str | None       = None
+    stream_sid:   str | None       = None
+    order:        Order | None     = None
+    history:      list[dict]       = field(default_factory=list)
+    restaurant:   Restaurant | None = None
+    system_prompt: str             = ""
+    llm_task:     asyncio.Task | None = None
+    silence_task: asyncio.Task | None = None
+    hangup_task:  asyncio.Task | None = None
+    pending_hangup: bool           = False
+```
+
+Add these fields at the bottom of the dataclass (forward-reference the type to avoid a top-level import cycle):
+
+```python
+    recording_session: "RecordingUploadSession | None" = None
+    should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
+```
+
+- [ ] **Step 2: Add the import**
+
+Near the top of `app/telephony/router.py`, with the other `app.storage` imports, add:
+
+```python
+from app.storage import recordings
+```
+
+And forward-type-resolve by adding (near the dataclass or at the top of the file):
+
+```python
+from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
+```
+
+- [ ] **Step 3: Smoke check imports**
+
+Run: `python -c "from app.telephony.router import _CallState; s = _CallState(); print(s.recording_session, s.should_hangup.is_set())"`
+Expected: `None False`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/telephony/router.py
+git commit -m "telephony: _CallState gains recording_session + should_hangup event"
+```
+
+---
+
+### Task 18: WS `start` handler kicks off `begin_recording`
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_telephony.py`, after the existing `test_media_stream_handles_full_call_lifecycle`, add:
+
+```python
+def test_media_stream_begins_recording_on_start(mock_pipeline, monkeypatch):
+    """On WS start, after tenant resolution, begin_recording is called
+    with the resolved restaurant id and the tenant's retention setting."""
+    from app.storage import recordings as recordings_mod
+    from app.restaurants.models import Restaurant
+
+    seeded = Restaurant(
+        id="niko-pizza-kitchen",
+        name="Niko",
+        display_phone="+1", twilio_phone=_DEMO_TO,
+        address="a", hours="h",
+        menu={"pizzas": [], "sides": [], "drinks": []},
+        recording_retention_days=42,
+    )
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant", lambda _rid: seeded
+    )
+    monkeypatch.setattr(
+        restaurants_storage, "load_or_fallback_demo", lambda _rid: seeded
+    )
+
+    captured: list[dict] = []
+
+    def fake_begin(call_sid, restaurant_id, retention_days):
+        captured.append({
+            "call_sid": call_sid,
+            "restaurant_id": restaurant_id,
+            "retention_days": retention_days,
+        })
+        return MagicMock(broken=False)
+
+    # The real signature uses kwargs only — adapt:
+    def fake_begin_kwargs(*, call_sid, restaurant_id, retention_days):
+        return fake_begin(call_sid, restaurant_id, retention_days)
+
+    monkeypatch.setattr(recordings_mod, "begin_recording", fake_begin_kwargs)
+    monkeypatch.setattr(recordings_mod, "append_chunks", lambda *a, **kw: None)
+    monkeypatch.setattr(recordings_mod, "finalize_recording", lambda _s: ("", 0))
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert len(captured) == 1
+    assert captured[0] == {
+        "call_sid": "CAtest123",
+        "restaurant_id": "niko-pizza-kitchen",
+        "retention_days": 42,
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_telephony.py::test_media_stream_begins_recording_on_start -v`
+Expected: FAIL — `begin_recording` is never called by the existing handler.
+
+- [ ] **Step 3: Wire `begin_recording` into the WS `start` handler**
+
+In `app/telephony/router.py`, inside `media_stream()` `elif event == "start":` branch, **after** the existing `state.system_prompt = build_system_prompt(state.restaurant)` line and **before** the `state.order = Order(...)` line, add:
+
+```python
+                try:
+                    state.recording_session = recordings.begin_recording(
+                        call_sid=state.call_sid or "unknown",
+                        restaurant_id=state.restaurant.id,
+                        retention_days=state.restaurant.recording_retention_days,
+                    )
+                except Exception:
+                    logger.exception(
+                        "recording: begin_recording failed call_sid=%s — call continues without recording",
+                        state.call_sid,
+                    )
+                    state.recording_session = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_telephony.py::test_media_stream_begins_recording_on_start -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: begin_recording on WS start"
+```
+
+---
+
+### Task 19: `media` event dispatches audio to `append_chunks`
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_telephony.py`:
+
+```python
+def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
+    """Each Twilio media event drives append_chunks with the right
+    inbound/outbound payloads."""
+    from base64 import b64encode
+    from app.storage import recordings as recordings_mod
+
+    fake_session = MagicMock(broken=False)
+    captured: list[tuple[bytes, bytes]] = []
+
+    monkeypatch.setattr(
+        recordings_mod, "begin_recording",
+        lambda *, call_sid, restaurant_id, retention_days: fake_session,
+    )
+    monkeypatch.setattr(
+        recordings_mod, "append_chunks",
+        lambda session, inbound_mu_law, outbound_mu_law:
+            captured.append((inbound_mu_law, outbound_mu_law)),
+    )
+    monkeypatch.setattr(
+        recordings_mod, "finalize_recording", lambda _s: ("", 0),
+    )
+
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, restaurant_id, on_final):
+        return fake_dg
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr(
+        "app.telephony.router.stream_reply", _make_fake_stream_reply()
+    )
+    from app.storage import call_sessions
+    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_recording_ready", lambda *a, **kw: None)
+
+    inbound_payload = b64encode(b"\xff" * 8).decode()
+    outbound_payload = b64encode(b"\x00" * 8).decode()
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps({
+            "event": "media",
+            "media": {"track": "inbound", "chunk": "1", "timestamp": "5", "payload": inbound_payload},
+        }))
+        ws.send_text(json.dumps({
+            "event": "media",
+            "media": {"track": "outbound", "chunk": "2", "timestamp": "10", "payload": outbound_payload},
+        }))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert (b"\xff" * 8, b"") in captured
+    assert (b"", b"\x00" * 8) in captured
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_telephony.py::test_media_stream_dispatches_audio_to_append_chunks -v`
+Expected: FAIL — `append_chunks` is never called by the existing handler.
+
+- [ ] **Step 3: Update the `media` event branch**
+
+In `app/telephony/router.py`, find:
+
+```python
+            elif event == "media":
+                if dg_conn is not None:
+                    audio = base64.b64decode(msg["media"]["payload"])
+                    await dg_conn.send(audio)
+```
+
+Replace with:
+
+```python
+            elif event == "media":
+                payload = base64.b64decode(msg["media"]["payload"])
+                track = msg["media"].get("track")
+                if track == "inbound":
+                    inbound_chunk = payload
+                    outbound_chunk = b""
+                    if dg_conn is not None:
+                        await dg_conn.send(payload)
+                elif track == "outbound":
+                    inbound_chunk = b""
+                    outbound_chunk = payload
+                else:
+                    inbound_chunk = b""
+                    outbound_chunk = b""
+                if state.recording_session is not None:
+                    recordings.append_chunks(
+                        state.recording_session, inbound_chunk, outbound_chunk
+                    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_telephony.py::test_media_stream_dispatches_audio_to_append_chunks -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: dispatch media events to append_chunks (track-aware)"
+```
+
+---
+
+### Task 20: `finalize_recording` + `mark_recording_ready` in WS finally
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_telephony.py`:
+
+```python
+def test_media_stream_finalizes_recording_on_stop(monkeypatch):
+    """After the call ends, finalize_recording runs and mark_recording_ready
+    writes the resulting gs:// URL to Firestore."""
+    from app.storage import recordings as recordings_mod
+    from app.storage import call_sessions
+
+    fake_session = MagicMock(broken=False)
+    monkeypatch.setattr(
+        recordings_mod, "begin_recording",
+        lambda *, call_sid, restaurant_id, retention_days: fake_session,
+    )
+    monkeypatch.setattr(recordings_mod, "append_chunks", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        recordings_mod, "finalize_recording",
+        lambda session: ("gs://niko-recordings/niko-pizza-kitchen/CAtest123.mp3", 12),
+    )
+
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", lambda *a, **kw: fake_dg)
+    monkeypatch.setattr("app.telephony.router.speak", AsyncMock())
+    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
+
+    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
+
+    captured: list[dict] = []
+    monkeypatch.setattr(
+        call_sessions, "mark_recording_ready",
+        lambda call_sid, rid, **kw: captured.append({"call_sid": call_sid, "rid": rid, **kw}),
+    )
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert len(captured) == 1
+    assert captured[0]["call_sid"] == "CAtest123"
+    assert captured[0]["rid"] == "niko-pizza-kitchen"
+    assert captured[0]["recording_url"] == "gs://niko-recordings/niko-pizza-kitchen/CAtest123.mp3"
+    assert captured[0]["recording_sid"] == "CAtest123"
+    assert captured[0]["duration_seconds"] == 12
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_telephony.py::test_media_stream_finalizes_recording_on_stop -v`
+Expected: FAIL — `mark_recording_ready` was never called.
+
+- [ ] **Step 3: Add the finalize block to the WS `finally`**
+
+In `app/telephony/router.py`, find the existing block in `media_stream()`'s `finally` that calls `call_sessions.mark_call_ended`. Right **after** that block (and before `if dg_conn is not None: await dg_conn.finish()`), add:
+
+```python
+        if state.recording_session is not None and rid_for_close:
+            try:
+                gs_url, duration = await asyncio.to_thread(
+                    recordings.finalize_recording, state.recording_session
+                )
+                if gs_url:
+                    await asyncio.to_thread(
+                        call_sessions.mark_recording_ready,
+                        state.call_sid,
+                        rid_for_close,
+                        recording_url=gs_url,
+                        recording_sid=state.call_sid,
+                        duration_seconds=duration,
+                    )
+            except Exception:
+                logger.exception(
+                    "recording: finalize/mark failed call_sid=%s",
+                    state.call_sid,
+                )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_telephony.py::test_media_stream_finalizes_recording_on_stop -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: finalize_recording + mark_recording_ready on WS stop"
+```
+
+---
+
+### Task 21: Replace REST auto-hangup with `should_hangup` Event
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_telephony.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_hang_up_after_grace_sets_should_hangup_event(monkeypatch):
+    """After the grace window, _hang_up_after_grace sets the WS-loop's
+    should_hangup event. The REST update path is gone."""
+    from app.telephony.router import _CallState, _hang_up_after_grace
+
+    monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
+
+    state = _CallState(call_sid="CAtest", pending_hangup=True)
+    assert not state.should_hangup.is_set()
+
+    await _hang_up_after_grace(state)
+
+    assert state.should_hangup.is_set()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_telephony.py::test_hang_up_after_grace_sets_should_hangup_event -v`
+Expected: FAIL — `_hang_up_after_grace` still calls `_twilio_end_call_sync`.
+
+- [ ] **Step 3: Replace `_hang_up_after_grace` with the event-based version**
+
+In `app/telephony/router.py`, find `_hang_up_after_grace`:
+
+```python
+async def _hang_up_after_grace(state: _CallState) -> None:
+    try:
+        await asyncio.sleep(HANGUP_GRACE_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.pending_hangup or not state.call_sid:
+        return
+    try:
+        await asyncio.to_thread(_twilio_end_call_sync, state.call_sid)
+        logger.info("call ended by server call_sid=%s", state.call_sid)
+    except Exception:
+        logger.exception(
+            "auto-hangup: REST end_call failed call_sid=%s", state.call_sid
+        )
+```
+
+Replace with:
+
+```python
+async def _hang_up_after_grace(state: _CallState) -> None:
+    """Wait HANGUP_GRACE_SECONDS, then signal the WS loop to close.
+
+    Closing our /media-stream WebSocket ends Twilio's <Connect>; with
+    no further TwiML the call hangs up. This avoids the Twilio REST
+    Calls.update endpoint, which returns 404 on calls in <Connect>
+    state (same root cause as the recording bug).
+    """
+    try:
+        await asyncio.sleep(HANGUP_GRACE_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.pending_hangup or not state.call_sid:
+        return
+    state.should_hangup.set()
+    logger.info("call ended by server (WS-close path) call_sid=%s", state.call_sid)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_telephony.py::test_hang_up_after_grace_sets_should_hangup_event -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: auto-hangup via should_hangup event (no REST)"
+```
+
+---
+
+### Task 22: WS loop races `receive_text` against `should_hangup.wait()`
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_telephony.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_media_stream_loop_breaks_on_should_hangup(mock_pipeline, monkeypatch):
+    """Setting state.should_hangup mid-call exits the WS loop and runs
+    the finally block."""
+    from app.storage import recordings as recordings_mod
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        recordings_mod, "begin_recording",
+        lambda **kw: MagicMock(broken=False),
+    )
+    monkeypatch.setattr(recordings_mod, "append_chunks", lambda *a, **kw: None)
+    monkeypatch.setattr(recordings_mod, "finalize_recording", lambda _s: ("", 0))
+    monkeypatch.setattr(call_sessions, "mark_recording_ready", lambda *a, **kw: None)
+
+    # We exercise this through a real WebSocket so the loop's race-wait
+    # logic runs end-to-end. After start, we set should_hangup via a
+    # background task by reaching into module state.
+    import app.telephony.router as router_mod
+
+    captured_state = {}
+
+    real_handler = router_mod.media_stream
+
+    async def patched_handler(websocket):
+        # Capture the _CallState by wrapping the handler.
+        state_holder = {}
+        orig_dataclass = router_mod._CallState
+        def _spy(*a, **kw):
+            s = orig_dataclass(*a, **kw)
+            state_holder["s"] = s
+            return s
+        router_mod._CallState = _spy
+        try:
+            await real_handler(websocket)
+        finally:
+            router_mod._CallState = orig_dataclass
+            captured_state["s"] = state_holder.get("s")
+
+    monkeypatch.setattr(router_mod, "media_stream", patched_handler)
+
+    # Re-register the patched route — easier: just call the handler directly
+    # via TestClient as before, then trigger should_hangup from outside.
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        # Trigger hangup through the captured state.
+        s = captured_state.get("s")
+        assert s is not None, "state was not captured"
+        s.should_hangup.set()
+        # Loop should exit; we shouldn't need to send a stop message.
+        # Read any pending close frames — TestClient handles closure.
+
+    # If we got here without timing out, the loop exited on the event.
+```
+
+*(This test is awkward because TestClient doesn't expose a clean handle on the running coroutine. If the spy approach proves fragile, it's acceptable to delete this test and rely on Task 21's unit test plus manual smoke testing in Task 26 to validate the loop integration.)*
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_telephony.py::test_media_stream_loop_breaks_on_should_hangup -v`
+Expected: FAIL or hang — the existing loop only breaks on a `stop` event, never on the new `should_hangup` event.
+
+If the test hangs, kill it and skip to Step 3 — the loop edit is what makes it pass.
+
+- [ ] **Step 3: Add the race in the WS loop**
+
+In `app/telephony/router.py`, find the `media_stream()` function's main loop:
+
+```python
+        while True:
+            raw = await websocket.receive_text()
+            msg: dict = json.loads(raw)
+            event = msg.get("event")
+            ...
+```
+
+Replace with:
+
+```python
+        while not state.should_hangup.is_set():
+            raw_task = asyncio.create_task(websocket.receive_text())
+            hangup_task = asyncio.create_task(state.should_hangup.wait())
+            done, pending = await asyncio.wait(
+                {raw_task, hangup_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if hangup_task in done:
+                # auto-hangup fired. Cancel the in-flight receive and exit.
+                raw_task.cancel()
+                with contextlib.suppress(BaseException):
+                    await raw_task
+                break
+            # raw_task completed
+            hangup_task.cancel()
+            with contextlib.suppress(BaseException):
+                await hangup_task
+            raw = raw_task.result()
+            msg: dict = json.loads(raw)
+            event = msg.get("event")
+            ...
+```
+
+(The `...` is the existing event-dispatch code; leave it unchanged.)
+
+Add at the top of the file with the other imports:
+
+```python
+import contextlib
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_telephony.py::test_media_stream_loop_breaks_on_should_hangup -v --timeout=10`
+Expected: PASS within 10 seconds. If the test is too brittle, delete it (per the Step 1 note) and re-run the full telephony suite to confirm nothing else broke.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: race receive_text vs should_hangup in WS loop"
+```
+
+---
+
+### Task 23: `app/main.py` — `get_call_recording` returns 302 to signed URL
+
+**Files:**
+- Modify: `app/main.py`
+- Create: `tests/test_calls_route.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_calls_route.py`:
+
+```python
+"""Tests for /calls/{call_sid}/recording — proxy to GCS via signed URL."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import Tenant
+from app.main import app, current_tenant
+
+
+def _override_tenant(rid="rid1", role="owner"):
+    def _dep():
+        return Tenant(uid="u1", email="e@x.com", restaurant_id=rid, role=role)
+    return _dep
+
+
+@pytest.fixture
+def authed_client():
+    app.dependency_overrides[current_tenant] = _override_tenant("rid1", "owner")
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_get_call_recording_returns_302_to_signed_url(authed_client, monkeypatch):
+    from app.storage import call_sessions, recordings
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": "gs://niko-recordings/rid1/CAt.mp3"},
+    )
+    monkeypatch.setattr(
+        recordings, "generate_signed_url",
+        lambda *, call_sid, restaurant_id: "https://signed.example/?sig=fake",
+    )
+
+    r = authed_client.get("/calls/CAt/recording", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["Location"] == "https://signed.example/?sig=fake"
+
+
+def test_get_call_recording_404_when_url_missing(authed_client, monkeypatch):
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": None},
+    )
+
+    r = authed_client.get("/calls/CAt/recording")
+    assert r.status_code == 404
+
+
+def test_get_call_recording_502_when_url_not_gs(authed_client, monkeypatch):
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": "https://api.twilio.com/legacy.mp3"},
+    )
+
+    r = authed_client.get("/calls/CAt/recording")
+    assert r.status_code == 502
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_calls_route.py -v`
+Expected: 3 FAIL — current `get_call_recording` does buffered Twilio fetch, not 302.
+
+- [ ] **Step 3: Replace the proxy with a 302 redirect**
+
+In `app/main.py`:
+
+1. Remove the `import httpx` line (no longer needed — we don't fetch upstream from FastAPI anymore).
+2. Add `from fastapi.responses import RedirectResponse` to the existing FastAPI imports.
+3. Add `from app.storage import recordings` to the existing `app.storage` imports.
+4. Replace the entire body of `get_call_recording(...)`:
+
+```python
+@app.get("/calls/{call_sid}/recording")
+async def get_call_recording(
+    call_sid: str,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """Tenant-authed entry point for playback. Returns a 302 redirect to
+    a 30-min V4 signed URL for the recording blob in GCS. The browser's
+    <audio> element follows the redirect natively. Cloud Run sees zero
+    audio bytes for the playback path."""
+    session = call_sessions.get_session(call_sid, tenant.restaurant_id)
+    if not session or not session.get("recording_url"):
+        raise HTTPException(status_code=404, detail="recording not available yet")
+    if not session["recording_url"].startswith("gs://"):
+        raise HTTPException(status_code=502, detail="invalid recording URL")
+    signed = await asyncio.to_thread(
+        recordings.generate_signed_url,
+        call_sid=call_sid,
+        restaurant_id=tenant.restaurant_id,
+    )
+    return RedirectResponse(url=signed, status_code=302)
+```
+
+5. If `import asyncio` isn't already at the top of the file, add it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_calls_route.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/main.py tests/test_calls_route.py
+git commit -m "main: GET /calls/{sid}/recording returns 302 to signed URL"
+```
+
+---
+
+### Task 24: `app/main.py` — `delete_call_recording` endpoint (owner only)
+
+**Files:**
+- Modify: `app/main.py`
+- Modify: `tests/test_calls_route.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_calls_route.py`:
+
+```python
+def test_delete_call_recording_owner_returns_204(authed_client, monkeypatch):
+    from app.storage import call_sessions, recordings
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": "gs://niko-recordings/rid1/CAt.mp3"},
+    )
+
+    deleted: list[dict] = []
+    cleared: list[dict] = []
+    monkeypatch.setattr(
+        recordings, "delete_recording",
+        lambda *, call_sid, restaurant_id: deleted.append({"sid": call_sid, "rid": restaurant_id}),
+    )
+    monkeypatch.setattr(
+        call_sessions, "mark_recording_deleted",
+        lambda call_sid, rid: cleared.append({"sid": call_sid, "rid": rid}),
+    )
+
+    r = authed_client.delete("/calls/CAt/recording")
+    assert r.status_code == 204
+    assert deleted == [{"sid": "CAt", "rid": "rid1"}]
+    assert cleared == [{"sid": "CAt", "rid": "rid1"}]
+
+
+def test_delete_call_recording_non_owner_returns_403(monkeypatch):
+    app.dependency_overrides[current_tenant] = _override_tenant("rid1", "staff")
+    try:
+        c = TestClient(app)
+        r = c.delete("/calls/CAt/recording")
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_delete_call_recording_idempotent_on_missing_blob(authed_client, monkeypatch):
+    from google.api_core.exceptions import NotFound
+    from app.storage import call_sessions, recordings
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": None},
+    )
+
+    def raise_notfound(**_kw):
+        raise NotFound("gone")
+    monkeypatch.setattr(recordings, "delete_recording", lambda *, call_sid, restaurant_id: None)
+    monkeypatch.setattr(call_sessions, "mark_recording_deleted", lambda *a, **kw: None)
+
+    r = authed_client.delete("/calls/CAt/recording")
+    assert r.status_code == 204
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_calls_route.py -k delete -v`
+Expected: 3 FAIL — endpoint doesn't exist (404 from FastAPI) or 405 method-not-allowed.
+
+- [ ] **Step 3: Add the DELETE endpoint**
+
+In `app/main.py`, immediately after the `get_call_recording` function, add:
+
+```python
+@app.delete("/calls/{call_sid}/recording", status_code=204)
+async def delete_call_recording(
+    call_sid: str,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """Owner-only: delete the recording blob from GCS, clear
+    ``recording_url`` from the call session doc, emit a ``recording_deleted``
+    event. Idempotent: returns 204 even if the blob was already gone or
+    the call had no recording.
+
+    Tenant scoping: the call session must belong to the calling tenant.
+    A non-existent call session (cross-tenant or genuinely missing) is
+    indistinguishable to the caller — both return 404.
+    """
+    if tenant.role != "owner":
+        raise HTTPException(status_code=403, detail="owner role required")
+    session = call_sessions.get_session(call_sid, tenant.restaurant_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="call not found")
+    await asyncio.to_thread(
+        recordings.delete_recording,
+        call_sid=call_sid,
+        restaurant_id=tenant.restaurant_id,
+    )
+    await asyncio.to_thread(
+        call_sessions.mark_recording_deleted,
+        call_sid,
+        tenant.restaurant_id,
+    )
+    return Response(status_code=204)
+```
+
+If `Response` from `fastapi` isn't already imported in this file, add it: `from fastapi import Response`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_calls_route.py -k delete -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/main.py tests/test_calls_route.py
+git commit -m "main: DELETE /calls/{sid}/recording (owner only)"
+```
+
+---
+
+### Task 25: Remove dead code from the Twilio-REST recording era
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Identify the dead symbols**
+
+The following are unused after Tasks 16–22 land:
+
+- `_start_recording_sync(...)` (function)
+- `_twilio_end_call_sync(...)` (function)
+- `recording_status(...)` HTTP endpoint
+- `_TWILIO_RECORDING_URL_PREFIX` constant
+- `RequestValidator` import
+- The `await asyncio.wait_for(asyncio.to_thread(_start_recording_sync, ...))` block in `voice()`
+
+- [ ] **Step 2: Remove them all**
+
+In `app/telephony/router.py`:
+- Delete the `from twilio.request_validator import RequestValidator` import.
+- Delete the `_start_recording_sync` function.
+- Delete the `_twilio_end_call_sync` function.
+- Delete the `_TWILIO_RECORDING_URL_PREFIX` constant.
+- Delete the entire `@router.post("/recording-status/{restaurant_id}/{call_sid}")` block (`recording_status`).
+- In `voice()`, delete the `try: await asyncio.wait_for(asyncio.to_thread(_start_recording_sync, ...)); except asyncio.TimeoutError: ...` block.
+
+- [ ] **Step 3: Remove obsolete tests**
+
+In `tests/test_telephony.py`, delete:
+- `test_recording_status_rejects_invalid_signature`
+- `test_recording_status_returns_503_when_public_base_url_unset`
+- `test_recording_status_writes_firestore_with_valid_signature`
+- `test_recording_status_rejects_non_twilio_recording_url`
+- `_recording_status_env` fixture and `_force_signature_valid` helper (if scoped only to those tests)
+
+- [ ] **Step 4: Run the full telephony test suite**
+
+Run: `pytest tests/test_telephony.py -v`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: remove dead Twilio-REST recording + REST hangup code"
+```
+
+---
+
+### Task 26: Run the full backend test suite + push
+
+**Files:** none
+
+- [ ] **Step 1: Run the full suite**
+
+Run: `pytest -v`
+Expected: all green. If anything red, fix the regression before continuing.
+
+- [ ] **Step 2: Static parse check**
+
+Run:
+```bash
+python -c "import ast; [ast.parse(open(p).read()) for p in [
+  'app/storage/recordings.py',
+  'app/storage/call_sessions.py',
+  'app/restaurants/models.py',
+  'app/telephony/router.py',
+  'app/main.py',
+  'app/config.py',
+]]; print('all parse OK')"
+```
+Expected: `all parse OK`.
+
+- [ ] **Step 3: Push the branch**
+
+Run: `git push -u origin feat/82-ws-side-recording`
+
+- [ ] **Step 4: Open the PR**
+
+Run:
+```bash
+gh pr create --repo tsuki-works/niko \
+  --title "WS-side call recording (replaces Twilio REST recording)" \
+  --body-file docs/superpowers/specs/2026-04-30-ws-recording-design.md
+```
+
+(Or write a fresh body summarising the spec — your choice.)
+
+---
+
+### Task 27: Run the bucket-bootstrap script + deploy
+
+**Files:** none
+
+- [ ] **Step 1: Bootstrap the bucket + IAM (one-shot)**
+
+Run: `bash scripts/setup-recordings-bucket.sh`
+Expected output ends with: `Done. Bucket gs://niko-recordings is ready for recordings.`
+
+- [ ] **Step 2: Verify bucket lifecycle**
+
+Run: `gcloud storage buckets describe gs://niko-recordings --format="value(lifecycle_config)"`
+Expected: contains `daysSinceCustomTime: 0`.
+
+- [ ] **Step 3: Verify IAM grants**
+
+Run: `gcloud storage buckets get-iam-policy gs://niko-recordings | grep storage.objectAdmin`
+Expected: lists `serviceAccount:347262010229-compute@developer.gserviceaccount.com`.
+
+Run: `gcloud iam service-accounts get-iam-policy 347262010229-compute@developer.gserviceaccount.com | grep tokenCreator`
+Expected: lists the SA bound to `roles/iam.serviceAccountTokenCreator`.
+
+- [ ] **Step 4: Merge the PR (admin override; CI is informational)**
+
+Run: `gh pr merge --repo tsuki-works/niko --squash --admin --delete-branch <PR_NUM>`
+
+The push to `master` triggers the existing Cloud Run auto-deploy.
+
+- [ ] **Step 5: Watch the deploy**
+
+Run: `gh run watch --repo tsuki-works/niko $(gh run list --repo tsuki-works/niko --workflow="Deploy to Cloud Run" --limit 1 --json databaseId --jq '.[0].databaseId')`
+Expected: deploy succeeds.
+
+- [ ] **Step 6: Manual smoke test**
+
+Place a call to `+1 647 905 8093`. After hangup:
+
+a. Run: `gcloud logging read 'resource.type=cloud_run_revision AND resource.labels.service_name=niko AND textPayload=~"recording"' --limit 10 --format='value(textPayload)' --order desc`
+   Expected: lines like `recording chunk uploaded …` and (if the call had audio) `recording finalized gs://niko-recordings/.../...mp3`.
+
+b. Open `https://niko-dashboard-ciyyvuq2pq-uc.a.run.app/orders/<call_sid>` and click play. Confirm audio plays. DevTools should show a 302 from `/api/calls/.../recording` to `storage.googleapis.com`.
+
+c. Pan L/R via OS audio controls — confirm caller is on left, agent on right.
+
+d. From the dashboard or via curl with an owner Firebase token: `DELETE /api/calls/<sid>/recording`. Confirm subsequent GET returns 404 and the audio player disappears.
+
+e. Place another call and hang up after the order is confirmed (let the AI deliver the goodbye). Confirm Twilio drops the line within ~3s of the goodbye — auto-hangup is working.
+
+- [ ] **Step 7: If anything is wrong**, tail logs to diagnose; otherwise close out.
+
+---
+
+## Self-Review
+
+(Performed during plan authoring; record findings inline.)
+
+**Spec coverage check:**
+- Decision 1 (`tracks="both_tracks"`) → Task 16 ✓
+- Decision 2 (stereo L=caller R=agent) → Task 6 (`_compute_pcm_pair`) ✓
+- Decision 3 (MP3 32 kbps stereo via lameenc) → Tasks 7, 8 ✓
+- Decision 4 (resumable upload, 256 KB chunks) → Tasks 8–11 ✓
+- Decision 5 (signed URL via 302) → Task 23 ✓
+- Decision 6 (auto-hangup via WS close) → Tasks 21–22 ✓
+- Decision 7 (delete endpoint, owner only) → Task 24 ✓
+- Decision 8 (per-tenant retention via custom_time) → Tasks 4 + 8 ✓
+- Error-handling table → covered case-by-case across the relevant tasks (begin failure: Task 18 try/except; chunk retry: Task 10; finalize failure: Task 20 try/except; empty session: Task 13; broken session: Task 10 + 11; signed URL failure: implicitly returns 502 in Task 23; etc.)
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" remain. One soft area: Task 22's WS-loop test is acknowledged as fragile in the test description and may be deleted if it can't be made deterministic — that's an acceptable note rather than a placeholder.
+
+**Type consistency:** `RecordingUploadSession` field names match across Tasks 8, 9, 10, 12. `begin_recording` / `append_chunks` / `finalize_recording` / `delete_recording` / `generate_signed_url` signatures match across plan and spec.

--- a/docs/superpowers/specs/2026-04-30-ws-recording-design.md
+++ b/docs/superpowers/specs/2026-04-30-ws-recording-design.md
@@ -1,0 +1,232 @@
+# WebSocket-side call recording (replaces Twilio REST recording)
+
+**Date:** 2026-04-30
+**Issue:** #82 (Sprint 2.1 — Call quality optimization). Successor to PRs #127, #132, #133.
+**Status:** Spec — awaiting implementation plan
+
+---
+
+## Context
+
+Sprint 2.4 calls for call recordings playable from the dashboard's call detail page. The first attempt (PR #127) used Twilio's Recordings REST API, started from the WebSocket `start` event. PRs #132 + #133 chased timing fixes. All three approaches got the same `HTTP 404 / "requested resource not found"` from Twilio.
+
+Root cause is documented Twilio behaviour: when a call is in `<Connect>` state, Twilio's voice REST API control is suspended for the duration of the connection. `recordings.create`, `calls.update(status="completed")`, and similar endpoints all return 404 mid-call. The 404 is not a timing race — there is no point in the `<Connect><Stream>` lifecycle when REST recording will work. Direct evidence:
+
+- During an active `<Connect>` call: `POST /Calls/{sid}/Recordings.json` → 404
+- After the same call completes: same POST → 400 / error code 21220 (`not eligible for recording`)
+- `GET /Calls/{sid}.json` always succeeds — auth and resource path are correct
+
+Auto-hangup (`_twilio_end_call_sync`) hits the same root cause; tracked separately.
+
+This spec defines the replacement: capture the audio from the WebSocket Twilio is *already* sending, store it ourselves in GCS, and proxy it back through the existing dashboard contract.
+
+---
+
+## Decisions locked during brainstorming
+
+| # | Question | Decision | Rationale |
+|---|---|---|---|
+| 1 | Caller-only or both tracks? | **Both** (`tracks="both_tracks"` on `<Stream>`) | "We recorded the customer but not what we said back" is a weird artifact for QA / disputes. Twilio sends both via the same WS. |
+| 2 | Storage format? | **WAV + 16-bit PCM (decoded from μ-law via Python stdlib `audioop`)** | Universal browser support, including Safari on iPad (restaurant operator surface). No `ffmpeg`, no third-party encoder. The μ-law→PCM decode is stdlib (single function call), <1 ms for a 5-min call. ~5 MB per 5-min stereo call. *(`audioop` is removed in Python 3.13; we're on 3.12 in prod. When we upgrade, swap in a 256-entry μ-law decode table — ~15 lines, no dep.)* |
+| 3 | Playback URL — proxy or signed URL? | **Keep the existing proxy** | Tenant scoping stays in our FastAPI dep. Egress cost is rounding-error at our call volume. Switch to signed URLs later if it ever matters. |
+| 4 | Mono mix or stereo? | **Stereo (caller=L, agent=R)** | Same code complexity, ~2× file size (still tiny). Restaurant staff can pan L/R for QA when both sides talk simultaneously. |
+| 5 | Buffering pipeline? | **In-memory bytearray per call, upload at `stop`** | Memory footprint trivial at our scale. Streaming/resumable upload is 3× the code for marginal durability gain. /tmp on Cloud Run is tmpfs so spooling there saves nothing. |
+
+---
+
+## Architecture
+
+One new module + targeted edits in three existing files. No new tenant model, no new auth path.
+
+### New: `app/storage/recordings.py`
+
+Single public function:
+
+```python
+def save_call_recording(
+    *,
+    call_sid: str,
+    restaurant_id: str,
+    inbound_audio: bytes,   # raw μ-law 8 kHz mono, caller side
+    outbound_audio: bytes,  # raw μ-law 8 kHz mono, agent side
+) -> tuple[str, int]:       # (gs:// URL, duration_seconds)
+```
+
+Internals:
+1. `audioop.ulaw2lin(b, 2)` decodes each μ-law track to 16-bit linear PCM (Python stdlib).
+2. Pad the shorter PCM track with `b"\x00"` (silence) to match the longer one.
+3. Interleave the two PCM tracks — left=caller, right=agent — sample by sample.
+4. Write a stereo 16-bit PCM @ 8 kHz WAV via the `wave` stdlib into a `BytesIO`.
+5. Upload to `gs://{settings.recordings_bucket}/{restaurant_id}/{call_sid}.wav` via `google-cloud-storage` (`Blob.upload_from_string` of the bytes; content-type `audio/wav`).
+6. Return `(gs_url, duration_seconds)` where duration = `len(longest_pcm) / 2 / 8000`.
+
+Helper `_silent_skip_path()` returns the empty/None decision before calling GCS — keeps the function safe to invoke unconditionally.
+
+### Edits in `app/telephony/router.py`
+
+1. `_CallState` adds two `bytearray` fields:
+   ```python
+   inbound_audio: bytearray = field(default_factory=bytearray)
+   outbound_audio: bytearray = field(default_factory=bytearray)
+   ```
+2. `voice()` passes `tracks="both_tracks"` on the `<Stream>`:
+   ```python
+   stream = connect.stream(url=f"wss://{host}/media-stream", tracks="both_tracks")
+   ```
+3. The `media` event branch dispatches base64-decoded bytes by `msg["media"]["track"]`:
+   ```python
+   payload = base64.b64decode(msg["media"]["payload"])
+   track = msg["media"].get("track")
+   if track == "inbound":
+       state.inbound_audio.extend(payload)
+       if dg_conn is not None:
+           await dg_conn.send(payload)   # existing Deepgram forwarding stays here
+   elif track == "outbound":
+       state.outbound_audio.extend(payload)
+   ```
+   (Other track values are silently ignored — forward-compat.)
+4. The WS `stop`/disconnect `finally` block, after `mark_call_ended`, calls `save_call_recording` via `asyncio.to_thread`, then `mark_recording_ready` with the returned GCS URL.
+5. **Delete dead code** now that we no longer use Twilio's Recordings API:
+   - `_start_recording_sync`
+   - The `await asyncio.wait_for(asyncio.to_thread(_start_recording_sync, …))` block in `voice()`
+   - `recording_status` endpoint and the `_TWILIO_RECORDING_URL_PREFIX` constant
+   - `RequestValidator` import
+
+### Edits in `app/main.py`
+
+`get_call_recording` proxy:
+
+- Reads `recording_url` from the session doc as before — but the value is now `gs://...` not `https://api.twilio.com/...`.
+- Replace the `httpx.AsyncClient.get(...)` + Twilio Basic Auth path with `google.cloud.storage.Client().bucket(name).blob(path).download_as_bytes()` (running in `asyncio.to_thread`).
+- Keep the existing Twilio-host allowlist in spirit by asserting `recording_url.startswith("gs://")` before parsing. Refuse anything else with `HTTPException(502, "invalid recording URL")`.
+- Response media-type changes from `audio/mpeg` to `audio/wav`. Filename in `Content-Disposition` becomes `{call_sid}.wav`.
+
+### Edits in `app/config.py`
+
+```python
+recordings_bucket: str = "niko-recordings"
+```
+
+Centralised so tests can override to a fake bucket name. No new env var; default is fine for prod and dev.
+
+### Infra (one-time)
+
+`scripts/setup-recordings-bucket.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+PROJECT=niko-tsuki
+BUCKET=niko-recordings
+REGION=us-central1
+SA="347262010229-compute@developer.gserviceaccount.com"
+
+gcloud storage buckets create "gs://${BUCKET}" \
+  --project="${PROJECT}" --location="${REGION}" --uniform-bucket-level-access
+
+cat > /tmp/lifecycle.json <<EOF
+{"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":90}}]}}
+EOF
+gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.json
+
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
+  --member="serviceAccount:${SA}" --role="roles/storage.objectAdmin"
+```
+
+Add to `requirements.txt`:
+
+```
+google-cloud-storage>=2.0,<3.0
+```
+
+---
+
+## Data flow
+
+1. Caller dials `+1 647 905 8093`. Twilio POSTs `/voice` with `CallSid=CA…`, `To=+16479058093`.
+2. `voice()` resolves the tenant, returns TwiML:
+   ```xml
+   <Response><Connect><Stream url="wss://niko.../media-stream" tracks="both_tracks">
+     <Parameter name="restaurant_id" value="twilight-family-restaurant"/>
+   </Stream></Connect></Response>
+   ```
+3. Twilio opens the WS to `/media-stream`. `start` event fires; `_CallState` initialises with empty audio bytearrays alongside the existing fields.
+4. Per `media` event: append the base64-decoded payload to the bytearray matching `media.track`. Inbound payloads also continue to be forwarded to Deepgram (existing STT pipeline unchanged).
+5. `stop` event (or WS disconnect):
+   ```python
+   if state.call_sid and rid_for_close and (state.inbound_audio or state.outbound_audio):
+       try:
+           gs_url, duration = await asyncio.to_thread(
+               save_call_recording,
+               call_sid=state.call_sid,
+               restaurant_id=rid_for_close,
+               inbound_audio=bytes(state.inbound_audio),
+               outbound_audio=bytes(state.outbound_audio),
+           )
+           await asyncio.to_thread(
+               call_sessions.mark_recording_ready,
+               state.call_sid, rid_for_close,
+               recording_url=gs_url,
+               recording_sid=state.call_sid,
+               duration_seconds=duration,
+           )
+       except Exception:
+           logger.exception(
+               "recording: save/mark failed call_sid=%s", state.call_sid
+           )
+   ```
+6. `mark_recording_ready` writes `recording_url` and emits a `recording_ready` event onto the call session doc. The dashboard's existing `onSnapshot` picks it up and renders the audio player.
+7. User clicks play → `<audio>` requests `/api/calls/{call_sid}/recording` → Next.js proxies to FastAPI → `get_call_recording` looks up the session via `call_sessions.get_session(call_sid, tenant.restaurant_id)` (existing tenant scoping; cross-tenant returns 404), reads `recording_url`, downloads the blob from GCS via the runtime SA, returns `audio/wav` bytes.
+
+---
+
+## Error handling
+
+| Failure | Behaviour |
+|---|---|
+| WS disconnects before `stop` (caller hangs up abruptly) | Existing `finally` block runs. We have whatever bytes arrived; same upload path executes. Recording is just shorter. |
+| Tenant unresolved at upload time (`rid_for_close is None`) | Skip upload entirely. Same guard already protects `mark_call_ended`. Logged at WARNING. |
+| GCS upload fails (perms, transient network, quota) | `save_call_recording` raises; the wrapping `try/except Exception` logs via `logger.exception(...)` and the call lifecycle still completes cleanly. No `recording_ready` event written; dashboard shows no audio player. |
+| Empty buffers (call dropped on first ring; zero `media` events) | Both bytearrays empty → `if … or …:` guard skips upload; no Firestore write. |
+| `audioop` / `wave` raises mid-encode | Same try/except as above. |
+| Cloud Run instance dies mid-call | Recording for that one call is lost. Documented v1 limitation; instance death during a live WS is rare. |
+| Dashboard proxy hits a missing GCS blob (Firestore says ready but blob 404s) | `get_call_recording` raises `HTTPException(status_code=404, detail="recording not available yet")`. |
+| Two `media` events with the same timestamp on different tracks | Each appends to its own buffer independently. No cross-contamination. |
+| Track-length skew (one side talked more than the other) | `save_call_recording` pads the shorter PCM track with `b"\x00"` (silence) before interleaving. Skew of tens of ms is acceptable for QA-and-disputes use. |
+
+---
+
+## Testing
+
+### Unit — `tests/test_recordings_storage.py` (new)
+
+- `test_save_call_recording_happy_path` — 1 second of inbound (8000 bytes of `0x00`) + 1 second of outbound (8000 bytes of `0x7F`); assert blob path is `twilight/CAtest.wav`, returned URL is `gs://niko-recordings/twilight/CAtest.wav`, duration is `1`. Mocks `google.cloud.storage.Client` so no network.
+- `test_wav_header_is_well_formed` — pull the uploaded bytes off the mock; assert RIFF/WAVE magic, fmt chunk = 16-bit PCM @ 8000 Hz × 2 channels, byte-rate matches, data chunk size matches.
+- `test_track_length_skew_padded_with_silence` — inbound = 100 ms, outbound = 500 ms; assert resulting WAV is 500 ms × 2 ch × 16-bit, the inbound channel after the 100 ms mark is zero-bytes.
+- `test_empty_buffers_skip_upload` — both buffers empty; assert the GCS client was never called and the function returns early.
+- `test_gcs_upload_failure_raises` — mock client raises `GoogleAPIError`; function re-raises so the WS handler can log + skip the Firestore write.
+
+### Integration — extend `tests/test_telephony.py`
+
+- `test_voice_emits_both_tracks_stream_parameter` — POST `/voice`, assert returned TwiML contains `tracks="both_tracks"` on the `<Stream>` verb.
+- `test_media_stream_dispatches_audio_by_track` — drive WS through a fake call: `connected` → `start` → 2× `media` (inbound) → 2× `media` (outbound) → `stop`. Assert `save_call_recording` is called once with `inbound_audio` containing the two inbound payloads concatenated and `outbound_audio` containing the two outbound payloads. Mock `save_call_recording` and `mark_recording_ready` so no GCS / Firestore.
+- `test_recording_skipped_when_buffers_empty` — `start` → `stop` with no `media` events; assert `save_call_recording` was *not* called and no `recording_ready` event was emitted.
+- Existing tests touching `_start_recording_sync`, `recording_status`, signature validation, and host allowlisting are removed (now-dead code).
+
+### Manual — post-deploy
+
+- Place a test call to `+1 647 905 8093`. After hangup:
+  - Cloud Run logs show `recording uploaded gs://niko-recordings/...`
+  - Dashboard `<audio>` plays
+  - Pan L/R independently to confirm caller is on left, agent on right
+
+---
+
+## Out of scope
+
+- **MP3 transcode** — keep WAV/μ-law for v1; revisit when storage cost is real.
+- **Signed-URL playback** — keep proxy until egress costs justify the swap.
+- **Auto-hangup REST fix** — same `<Connect>`-blocks-REST root cause, but distinct mechanism (probably "send a special TwiML mark and let the WS shut the call down by closing"). Separate ticket.
+- **Cross-instance durability** — accept the rare instance-death gap; add resumable upload only if real loss is observed.
+- **Recording deletion when an order is deleted** — Firestore doc lifecycle isn't tied to GCS today; Phase 3 concern.
+- **Per-tenant retention policies** — single 90-day bucket-level rule for v1; tenant-specific rules later if needed.

--- a/docs/superpowers/specs/2026-04-30-ws-recording-design.md
+++ b/docs/superpowers/specs/2026-04-30-ws-recording-design.md
@@ -27,87 +27,181 @@ This spec defines the replacement: capture the audio from the WebSocket Twilio i
 | # | Question | Decision | Rationale |
 |---|---|---|---|
 | 1 | Caller-only or both tracks? | **Both** (`tracks="both_tracks"` on `<Stream>`) | "We recorded the customer but not what we said back" is a weird artifact for QA / disputes. Twilio sends both via the same WS. |
-| 2 | Storage format? | **WAV + 16-bit PCM (decoded from μ-law via Python stdlib `audioop`)** | Universal browser support, including Safari on iPad (restaurant operator surface). No `ffmpeg`, no third-party encoder. The μ-law→PCM decode is stdlib (single function call), <1 ms for a 5-min call. ~5 MB per 5-min stereo call. *(`audioop` is removed in Python 3.13; we're on 3.12 in prod. When we upgrade, swap in a 256-entry μ-law decode table — ~15 lines, no dep.)* |
-| 3 | Playback URL — proxy or signed URL? | **Keep the existing proxy** | Tenant scoping stays in our FastAPI dep. Egress cost is rounding-error at our call volume. Switch to signed URLs later if it ever matters. |
-| 4 | Mono mix or stereo? | **Stereo (caller=L, agent=R)** | Same code complexity, ~2× file size (still tiny). Restaurant staff can pan L/R for QA when both sides talk simultaneously. |
-| 5 | Buffering pipeline? | **In-memory bytearray per call, upload at `stop`** | Memory footprint trivial at our scale. Streaming/resumable upload is 3× the code for marginal durability gain. /tmp on Cloud Run is tmpfs so spooling there saves nothing. |
+| 2 | Mono mix or stereo? | **Stereo (caller=L, agent=R)** | Same code complexity, ~2× file size (still tiny). Restaurant staff can pan L/R for QA when both sides talk simultaneously. |
+| 3 | On-disk format? | **MP3 32 kbps stereo via Python `lameenc`** | 4–5× smaller than WAV (~1.2 MB per 5-min call vs ~5 MB). Pure-Python encoder — no ffmpeg, no system dep added to the Docker image. Universal browser playback (including Safari on iPad). Encodes incrementally so it pairs cleanly with resumable upload. At 8 kHz narrowband telephony, MP3 32 kbps is perceptually identical to source. *(μ-law→PCM decode uses stdlib `audioop`, which is removed in Python 3.13. Prod runs 3.12; when we upgrade, swap in a 256-entry decode table — ~15 lines, no dep.)* |
+| 4 | Buffering & durability? | **Resumable GCS upload, 256 KB MP3 chunks streamed during the call, finalized at `stop`** | Survives Cloud Run pod death between chunks. Worst-case loss is one chunk (~64 s at 32 kbps MP3). Session URL stored on `_CallState`; pod death before *any* chunk uploads loses the recording for that call, which is rare enough to accept. |
+| 5 | Playback URL? | **Signed URL (30 min TTL, V4) via 302 redirect from `/calls/{sid}/recording`** | Existing tenant-authed FastAPI endpoint stays as the entry point — it now issues a 302 to a freshly-signed GCS URL instead of streaming bytes. The dashboard `<audio>` element follows the 302 natively. No public surface (URLs are unguessable + short-lived). Saves ~all playback egress through Cloud Run. Cloud Run runtime SA needs `roles/iam.serviceAccountTokenCreator` on itself to sign V4 URLs without a key file. |
+| 6 | Auto-hangup mechanism? | **Close the WebSocket server-side; let `<Connect>` end the call** | Same `<Connect>`-blocks-REST root cause as the recording bug. When our WS closes, Twilio's `<Connect>` ends; with no further TwiML the call hangs up. Replaces `_twilio_end_call_sync` REST call entirely. |
+| 7 | Recording deletion? | **`DELETE /calls/{call_sid}/recording` endpoint (owner role only)** | Tenant-authed endpoint deletes the GCS blob, clears `recording_url` from the call session doc, emits a `recording_deleted` event. Backend-only in this spec — dashboard UI button is a follow-up frontend ticket once UX is decided. |
+| 8 | Retention policy? | **Per-tenant via `recording_retention_days` field on Restaurant doc + GCS `customTime` per blob** | At upload time, `blob.custom_time = now() + retention_days`. Bucket lifecycle rule `daysSinceCustomTime: 0` deletes blobs whose customTime has passed. Each blob is effectively "scheduled to expire" on its own clock. Default 90 days; per-tenant override is one Firestore field. |
 
 ---
 
 ## Architecture
 
-One new module + targeted edits in three existing files. No new tenant model, no new auth path.
+Two new modules + edits in four existing files. No new tenant model, no new auth path.
 
 ### New: `app/storage/recordings.py`
 
-Single public function:
+Three public functions:
 
 ```python
-def save_call_recording(
-    *,
-    call_sid: str,
-    restaurant_id: str,
-    inbound_audio: bytes,   # raw μ-law 8 kHz mono, caller side
-    outbound_audio: bytes,  # raw μ-law 8 kHz mono, agent side
-) -> tuple[str, int]:       # (gs:// URL, duration_seconds)
+class RecordingUploadSession:
+    """In-memory + GCS-side state for a single call's resumable upload."""
+    call_sid: str
+    restaurant_id: str
+    blob_name: str                  # e.g. "twilight/CAtest.mp3"
+    upload_url: str                 # GCS resumable session URL
+    encoder: lameenc.Encoder        # MP3 encoder bound to this call
+    pending_mp3: bytearray          # encoded MP3 bytes not yet uploaded
+    total_bytes_uploaded: int       # cumulative MP3 bytes PUT to GCS so far
+    total_pcm_samples: int          # cumulative PCM samples per channel — drives duration calc
+    broken: bool                    # set if an upload chunk failed twice; further appends become no-ops
+
+def begin_recording(
+    *, call_sid: str, restaurant_id: str, retention_days: int
+) -> RecordingUploadSession: ...
+
+def append_chunks(
+    session: RecordingUploadSession,
+    inbound_mu_law: bytes,    # raw bytes from Twilio media event (track=inbound)
+    outbound_mu_law: bytes,   # raw bytes from Twilio media event (track=outbound)
+) -> None: ...
+
+def finalize_recording(session: RecordingUploadSession) -> tuple[str, int]: ...
+    # returns (gs:// URL, duration_seconds)
+
+def delete_recording(call_sid: str, restaurant_id: str) -> None: ...
+
+def generate_signed_url(
+    *, call_sid: str, restaurant_id: str, ttl_minutes: int = 30
+) -> str: ...
+    # returns "https://storage.googleapis.com/...?X-Goog-Signature=..."
 ```
 
-Internals:
-1. `audioop.ulaw2lin(b, 2)` decodes each μ-law track to 16-bit linear PCM (Python stdlib).
-2. Pad the shorter PCM track with `b"\x00"` (silence) to match the longer one.
-3. Interleave the two PCM tracks — left=caller, right=agent — sample by sample.
-4. Write a stereo 16-bit PCM @ 8 kHz WAV via the `wave` stdlib into a `BytesIO`.
-5. Upload to `gs://{settings.recordings_bucket}/{restaurant_id}/{call_sid}.wav` via `google-cloud-storage` (`Blob.upload_from_string` of the bytes; content-type `audio/wav`).
-6. Return `(gs_url, duration_seconds)` where duration = `len(longest_pcm) / 2 / 8000`.
+Internals — happy path:
 
-Helper `_silent_skip_path()` returns the empty/None decision before calling GCS — keeps the function safe to invoke unconditionally.
+1. **`begin_recording`**: creates the `lameenc.Encoder` (32 kbps, stereo, 8 kHz input rate); creates a GCS resumable upload session via `Blob.create_resumable_upload_session(content_type="audio/mpeg")`; sets `blob.custom_time = now() + retention_days` (per-tenant retention); stores the upload URL on the session object.
+2. **`append_chunks`**: decodes each μ-law payload to PCM-16 via `audioop.ulaw2lin(_, 2)`, interleaves L/R per-sample into `session.pending_pcm`, and feeds it to `encoder.encode(...)` which produces MP3 bytes. The MP3 bytes accumulate in a separate `pending_mp3` buffer. When `pending_mp3` ≥ 256 KB (the GCS resumable-upload minimum chunk size — about 64 s of 32 kbps stereo audio), the buffer is sliced to a 256 KB-multiple, `PUT` to the resumable session URL with `Content-Range: bytes <start>-<end>/*`, and `total_bytes_uploaded` is advanced. The PUT runs via `asyncio.to_thread` so the call loop never blocks on it. The leftover (< 256 KB) stays in the buffer for the next chunk.
+3. **`finalize_recording`**: appends `encoder.flush()` (the LAME tail) to `pending_mp3`, then PUTs the final chunk with `Content-Range: bytes <start>-<end>/<total>` — now we know the total length so the session closes. If `total_pcm_samples == 0` (no media events arrived), DELETE the resumable session URL and return `("", 0)` so the caller skips the Firestore write. Returns `(gs://{bucket}/{rid}/{sid}.mp3, total_pcm_samples / 8000)` for duration in seconds.
+4. **`delete_recording`**: `Client().bucket(name).blob(f"{rid}/{sid}.mp3").delete()`. Idempotent — non-existent blob is a no-op.
+5. **`generate_signed_url`**: uses `blob.generate_signed_url(version="v4", method="GET", expiration=timedelta(minutes=ttl_minutes))`. Cloud Run's runtime SA can sign URLs without a private key by using the IAM SignBlob workaround — the SA needs `roles/iam.serviceAccountTokenCreator` *on itself*. Granted as part of the bootstrap script.
+
+Helper `_compute_pcm_pair(inbound_mu_law: bytes, outbound_mu_law: bytes) -> bytes` is the pure function at the core of `append_chunks` — it decodes each μ-law track via `audioop.ulaw2lin(_, 2)`, pads the shorter side with PCM silence (`b"\x00\x00"` per missing sample), and interleaves L/R as 16-bit little-endian samples. Returns the stereo PCM-16 byte string ready to feed to `encoder.encode(...)`. Easily unit-tested without GCS.
 
 ### Edits in `app/telephony/router.py`
 
-1. `_CallState` adds two `bytearray` fields:
+1. `_CallState` adds:
    ```python
-   inbound_audio: bytearray = field(default_factory=bytearray)
-   outbound_audio: bytearray = field(default_factory=bytearray)
+   recording_session: RecordingUploadSession | None = None
+   should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
    ```
 2. `voice()` passes `tracks="both_tracks"` on the `<Stream>`:
    ```python
    stream = connect.stream(url=f"wss://{host}/media-stream", tracks="both_tracks")
    ```
-3. The `media` event branch dispatches base64-decoded bytes by `msg["media"]["track"]`:
+3. WS `start` event handler: after the existing tenant resolution, call `recordings.begin_recording(...)` and store the result on `state.recording_session`. The retention days come from `state.restaurant.recording_retention_days` (added below). Wrap in try/except — failure here just disables recording for this call, doesn't break the call loop.
+4. The `media` event branch dispatches by `msg["media"]["track"]`:
    ```python
    payload = base64.b64decode(msg["media"]["payload"])
    track = msg["media"].get("track")
    if track == "inbound":
-       state.inbound_audio.extend(payload)
+       inbound_chunk = payload
+       outbound_chunk = b""
        if dg_conn is not None:
-           await dg_conn.send(payload)   # existing Deepgram forwarding stays here
+           await dg_conn.send(payload)   # existing Deepgram STT forwarding
    elif track == "outbound":
-       state.outbound_audio.extend(payload)
+       inbound_chunk = b""
+       outbound_chunk = payload
+   else:
+       inbound_chunk = outbound_chunk = b""
+   if state.recording_session is not None:
+       recordings.append_chunks(
+           state.recording_session, inbound_chunk, outbound_chunk
+       )  # internal queue + threshold-driven background upload
    ```
-   (Other track values are silently ignored — forward-compat.)
-4. The WS `stop`/disconnect `finally` block, after `mark_call_ended`, calls `save_call_recording` via `asyncio.to_thread`, then `mark_recording_ready` with the returned GCS URL.
-5. **Delete dead code** now that we no longer use Twilio's Recordings API:
+   (Per-call chunk dispatch stays under ~1 ms — no awaits in the hot path; the actual chunk PUT happens in `asyncio.to_thread` inside `append_chunks` once 256 KB has accumulated.)
+5. The WS `stop`/disconnect `finally` block: if `state.recording_session is not None`, call `await asyncio.to_thread(recordings.finalize_recording, state.recording_session)`, then `mark_recording_ready` with the returned GCS URL. Then close the WS (handled below).
+6. **Replace `_twilio_end_call_sync` with WS-close**:
+   - Delete `_twilio_end_call_sync` entirely.
+   - `_hang_up_after_grace` no longer awaits a REST call. Instead, after the grace sleep, it calls `state.should_hangup.set()`. The main WS event loop checks this event after each `receive_text()` and breaks out of the loop, which causes the existing `finally` to run and the WS to close. Twilio's `<Connect>` ends when the WS closes; with no further TwiML the call hangs up.
+   - Concretely the loop becomes:
+     ```python
+     while not state.should_hangup.is_set():
+         raw_task = asyncio.create_task(websocket.receive_text())
+         hangup_task = asyncio.create_task(state.should_hangup.wait())
+         done, _ = await asyncio.wait(
+             [raw_task, hangup_task], return_when=asyncio.FIRST_COMPLETED
+         )
+         if hangup_task in done:
+             raw_task.cancel()
+             break
+         raw = raw_task.result()
+         ...
+     ```
+7. **Delete dead code** now that we no longer use Twilio's Recordings or Calls.update APIs:
    - `_start_recording_sync`
    - The `await asyncio.wait_for(asyncio.to_thread(_start_recording_sync, …))` block in `voice()`
-   - `recording_status` endpoint and the `_TWILIO_RECORDING_URL_PREFIX` constant
-   - `RequestValidator` import
+   - `recording_status` endpoint, `_TWILIO_RECORDING_URL_PREFIX`, `RequestValidator` import
+   - `_twilio_end_call_sync`
 
 ### Edits in `app/main.py`
 
-`get_call_recording` proxy:
+`get_call_recording` becomes a 302 redirect:
+```python
+@app.get("/calls/{call_sid}/recording")
+async def get_call_recording(call_sid: str, tenant: Tenant = Depends(current_tenant)):
+    session = call_sessions.get_session(call_sid, tenant.restaurant_id)
+    if not session or not session.get("recording_url"):
+        raise HTTPException(status_code=404, detail="recording not available yet")
+    if not session["recording_url"].startswith("gs://"):
+        raise HTTPException(status_code=502, detail="invalid recording URL")
+    signed = await asyncio.to_thread(
+        recordings.generate_signed_url,
+        call_sid=call_sid, restaurant_id=tenant.restaurant_id,
+    )
+    return RedirectResponse(url=signed, status_code=302)
+```
 
-- Reads `recording_url` from the session doc as before — but the value is now `gs://...` not `https://api.twilio.com/...`.
-- Replace the `httpx.AsyncClient.get(...)` + Twilio Basic Auth path with `google.cloud.storage.Client().bucket(name).blob(path).download_as_bytes()` (running in `asyncio.to_thread`).
-- Keep the existing Twilio-host allowlist in spirit by asserting `recording_url.startswith("gs://")` before parsing. Refuse anything else with `HTTPException(502, "invalid recording URL")`.
-- Response media-type changes from `audio/mpeg` to `audio/wav`. Filename in `Content-Disposition` becomes `{call_sid}.wav`.
+New `delete_call_recording` endpoint on the same path:
+```python
+@app.delete("/calls/{call_sid}/recording")
+async def delete_call_recording(call_sid: str, tenant: Tenant = Depends(current_tenant)):
+    if tenant.role != "owner":  # mirrors existing role gating
+        raise HTTPException(status_code=403, detail="owner role required")
+    session = call_sessions.get_session(call_sid, tenant.restaurant_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="call not found")
+    await asyncio.to_thread(
+        recordings.delete_recording, call_sid, tenant.restaurant_id
+    )
+    await asyncio.to_thread(
+        call_sessions.mark_recording_deleted, call_sid, tenant.restaurant_id
+    )
+    return Response(status_code=204)
+```
+
+`httpx` import goes away — we no longer fetch upstream from FastAPI; the browser fetches directly from GCS via the signed URL.
+
+### Edits in `app/storage/call_sessions.py`
+
+Add `mark_recording_deleted(call_sid, restaurant_id)`: clears `recording_url`/`recording_sid`/`recording_duration_seconds` from the parent doc and appends a `recording_deleted` event to the events subcollection. Mirrors the shape of `mark_recording_ready`.
+
+### Edits in `app/restaurants/models.py`
+
+Add field to the `Restaurant` model:
+```python
+recording_retention_days: int = Field(default=90, ge=1, le=3650)
+```
+
+`/restaurants/me` already serializes the full doc, so this becomes available to the dashboard for free if we ever build a per-tenant retention UI.
 
 ### Edits in `app/config.py`
 
 ```python
 recordings_bucket: str = "niko-recordings"
+recording_default_retention_days: int = 90  # used only if Restaurant doc lacks the field
 ```
-
-Centralised so tests can override to a fake bucket name. No new env var; default is fine for prod and dev.
 
 ### Infra (one-time)
 
@@ -124,24 +218,35 @@ SA="347262010229-compute@developer.gserviceaccount.com"
 gcloud storage buckets create "gs://${BUCKET}" \
   --project="${PROJECT}" --location="${REGION}" --uniform-bucket-level-access
 
-cat > /tmp/lifecycle.json <<EOF
-{"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":90}}]}}
+# Per-tenant retention via custom_time. Each blob carries its own
+# scheduled-deletion timestamp; this rule deletes blobs whose customTime
+# has passed.
+cat > /tmp/lifecycle.json <<'EOF'
+{"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"daysSinceCustomTime":0}}]}}
 EOF
 gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file=/tmp/lifecycle.json
 
+# Cloud Run runtime SA needs read/write/delete on the bucket
 gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
   --member="serviceAccount:${SA}" --role="roles/storage.objectAdmin"
+
+# Sign V4 URLs without a private-key file: SA must have iam.serviceAccountTokenCreator on itself
+gcloud iam service-accounts add-iam-policy-binding "${SA}" \
+  --member="serviceAccount:${SA}" --role="roles/iam.serviceAccountTokenCreator"
 ```
 
 Add to `requirements.txt`:
 
 ```
 google-cloud-storage>=2.0,<3.0
+lameenc>=1.6,<2.0          # pure-Python LAME wrapper; no system ffmpeg
 ```
 
 ---
 
 ## Data flow
+
+### Capture & upload (during the call)
 
 1. Caller dials `+1 647 905 8093`. Twilio POSTs `/voice` with `CallSid=CA…`, `To=+16479058093`.
 2. `voice()` resolves the tenant, returns TwiML:
@@ -150,18 +255,23 @@ google-cloud-storage>=2.0,<3.0
      <Parameter name="restaurant_id" value="twilight-family-restaurant"/>
    </Stream></Connect></Response>
    ```
-3. Twilio opens the WS to `/media-stream`. `start` event fires; `_CallState` initialises with empty audio bytearrays alongside the existing fields.
-4. Per `media` event: append the base64-decoded payload to the bytearray matching `media.track`. Inbound payloads also continue to be forwarded to Deepgram (existing STT pipeline unchanged).
-5. `stop` event (or WS disconnect):
+3. Twilio opens WS to `/media-stream`. `start` event fires. After tenant resolution, `recordings.begin_recording(call_sid=…, restaurant_id=…, retention_days=state.restaurant.recording_retention_days)` runs:
+   - Creates `lameenc.Encoder` (32 kbps, stereo, 8 kHz input).
+   - Creates a GCS resumable upload session (`Blob.create_resumable_upload_session(content_type="audio/mpeg")`).
+   - Sets `blob.custom_time = now() + timedelta(days=retention_days)`.
+   - Returns a `RecordingUploadSession` stored on `state.recording_session`. On any failure here, log and continue — recording disabled for this call, call itself unaffected.
+4. For each WS `media` event:
+   - μ-law payload → PCM-16 via `audioop.ulaw2lin(_, 2)`.
+   - Two-track interleave: inbound bytes go to L, outbound to R, missing-track padded with silence at the per-chunk level.
+   - PCM appended to `session.pending_pcm`.
+   - Inbound payloads continue to be forwarded to Deepgram (existing STT pipeline unchanged — only the inbound branch sends to dg_conn).
+   - When `pending_pcm` reaches the chunk threshold (~256 KB stereo PCM ≈ ~16 s of audio), the slice is encoded through `encoder.encode(...)` to MP3 bytes and PUT to the resumable session URL via `asyncio.to_thread`. The PUT runs in the background; the call loop is never blocked on its completion.
+5. WS `stop` (or disconnect / `should_hangup` set) → finally block:
    ```python
-   if state.call_sid and rid_for_close and (state.inbound_audio or state.outbound_audio):
+   if state.recording_session is not None:
        try:
            gs_url, duration = await asyncio.to_thread(
-               save_call_recording,
-               call_sid=state.call_sid,
-               restaurant_id=rid_for_close,
-               inbound_audio=bytes(state.inbound_audio),
-               outbound_audio=bytes(state.outbound_audio),
+               recordings.finalize_recording, state.recording_session
            )
            await asyncio.to_thread(
                call_sessions.mark_recording_ready,
@@ -172,11 +282,36 @@ google-cloud-storage>=2.0,<3.0
            )
        except Exception:
            logger.exception(
-               "recording: save/mark failed call_sid=%s", state.call_sid
+               "recording: finalize/mark failed call_sid=%s", state.call_sid
            )
    ```
-6. `mark_recording_ready` writes `recording_url` and emits a `recording_ready` event onto the call session doc. The dashboard's existing `onSnapshot` picks it up and renders the audio player.
-7. User clicks play → `<audio>` requests `/api/calls/{call_sid}/recording` → Next.js proxies to FastAPI → `get_call_recording` looks up the session via `call_sessions.get_session(call_sid, tenant.restaurant_id)` (existing tenant scoping; cross-tenant returns 404), reads `recording_url`, downloads the blob from GCS via the runtime SA, returns `audio/wav` bytes.
+   `finalize_recording` flushes any remaining PCM through the encoder + appends `encoder.flush()` (LAME tail), PUTs the final chunk with `Content-Range: bytes <start>-<end>/<total>` (now we know the total size), closing the resumable session.
+6. `mark_recording_ready` writes `recording_url=gs://...mp3` and emits a `recording_ready` event onto the call session doc. The dashboard's existing `onSnapshot` picks it up and renders the audio player.
+
+### Playback
+
+7. User clicks play → `<audio>` GETs `/api/calls/{call_sid}/recording` → Next.js proxies to FastAPI → `get_call_recording`:
+   - Looks up the session via `call_sessions.get_session(call_sid, tenant.restaurant_id)` (existing tenant scoping; cross-tenant returns 404).
+   - Asserts `recording_url` starts with `gs://`. Refuses anything else.
+   - Calls `recordings.generate_signed_url(...)` (V4, 30-min TTL, GET method, signed via IAM `signBlob`).
+   - Returns `302 Found` with `Location:` set to the signed URL.
+8. Browser follows the 302 to GCS directly, downloads the MP3 bytes, plays them. Cloud Run sees zero audio bytes for the playback path.
+
+### Auto-hangup
+
+9. After order confirmation, `_run_llm_tts_turn` sends the `end_of_call` mark and sets `state.pending_hangup = True`. Twilio echoes the mark when its audio buffer drains; the WS `mark` handler schedules `_hang_up_after_grace`.
+10. After the grace sleep (`HANGUP_GRACE_SECONDS = 3.0`), if `state.pending_hangup` is still set, `_hang_up_after_grace` calls `state.should_hangup.set()`.
+11. The main WS `while not state.should_hangup.is_set()` loop wakes (it's `await`ing a `FIRST_COMPLETED` race between `receive_text` and `should_hangup.wait()`), breaks out, runs the `finally` block, and the WebSocket closes.
+12. Twilio's `<Connect>` ends when our WS closes; with no further TwiML, the inbound call hangs up. Caller hears the line drop ~10–80 ms later.
+
+### Recording deletion
+
+13. Owner clicks "delete recording" → dashboard sends `DELETE /api/calls/{call_sid}/recording` → Next.js proxies → FastAPI's `delete_call_recording`:
+    - `current_tenant` enforces auth + tenant scope; an additional `tenant.role == "owner"` check rejects non-owners with 403.
+    - Calls `recordings.delete_recording(call_sid, tenant.restaurant_id)` (idempotent GCS delete).
+    - Calls `call_sessions.mark_recording_deleted(call_sid, restaurant_id)` to clear `recording_url` and append a `recording_deleted` event.
+    - Returns 204.
+14. The dashboard's existing `onSnapshot` sees `recording_url` cleared and removes the audio player.
 
 ---
 
@@ -184,15 +319,24 @@ google-cloud-storage>=2.0,<3.0
 
 | Failure | Behaviour |
 |---|---|
-| WS disconnects before `stop` (caller hangs up abruptly) | Existing `finally` block runs. We have whatever bytes arrived; same upload path executes. Recording is just shorter. |
-| Tenant unresolved at upload time (`rid_for_close is None`) | Skip upload entirely. Same guard already protects `mark_call_ended`. Logged at WARNING. |
-| GCS upload fails (perms, transient network, quota) | `save_call_recording` raises; the wrapping `try/except Exception` logs via `logger.exception(...)` and the call lifecycle still completes cleanly. No `recording_ready` event written; dashboard shows no audio player. |
-| Empty buffers (call dropped on first ring; zero `media` events) | Both bytearrays empty → `if … or …:` guard skips upload; no Firestore write. |
-| `audioop` / `wave` raises mid-encode | Same try/except as above. |
-| Cloud Run instance dies mid-call | Recording for that one call is lost. Documented v1 limitation; instance death during a live WS is rare. |
-| Dashboard proxy hits a missing GCS blob (Firestore says ready but blob 404s) | `get_call_recording` raises `HTTPException(status_code=404, detail="recording not available yet")`. |
-| Two `media` events with the same timestamp on different tracks | Each appends to its own buffer independently. No cross-contamination. |
-| Track-length skew (one side talked more than the other) | `save_call_recording` pads the shorter PCM track with `b"\x00"` (silence) before interleaving. Skew of tens of ms is acceptable for QA-and-disputes use. |
+| `begin_recording` fails (GCS perms, IAM, transient) at WS `start` | Logged at ERROR; `state.recording_session` stays `None`; call proceeds without recording. |
+| Per-chunk PUT fails (transient) | `append_chunks` retries the PUT once with exponential backoff inside the worker thread; on second failure, marks the session as broken and stops attempting further uploads. The call continues; no `recording_ready` event at end. |
+| Cloud Run pod dies mid-call after some chunks have uploaded | Resumable upload session lives on GCS for ~7 days; the chunks already PUT remain. Without our final PUT (which carries the total length), GCS treats the session as orphaned and reaps it after the TTL. The dashboard never sees a `recording_ready` for that call. Acceptable — much better than losing the entire call as in v1. |
+| Cloud Run pod dies mid-call before any chunks have uploaded | Recording for that call is lost. Same as v1. Rare. |
+| WS disconnects before `stop` (caller hangs up abruptly) | Existing `finally` block runs `finalize_recording`. We have whatever PCM/MP3 has been encoded so far; the recording is just shorter. |
+| `finalize_recording` fails (transient final PUT) | Logged at ERROR; no `recording_ready` written. The chunks are still on GCS as an orphaned session and get reaped after TTL. |
+| Tenant unresolved at upload time (`rid_for_close is None`) | Skip finalize. Same guard already protects `mark_call_ended`. Logged at WARNING. |
+| Empty buffers (call dropped on first ring; zero `media` events) | `state.recording_session` was created with the begin step but no chunks were appended. `finalize_recording` notices `total_bytes_uploaded == 0`, skips the final PUT, and marks the resumable session as cancelled (`DELETE` on the session URL). No Firestore write. |
+| `audioop`/`lameenc`/`wave` raises mid-encode | The chunk worker logs the exception and marks the session broken. Call lifecycle finishes cleanly. |
+| Track-length skew (one side talked more than the other within a chunk) | `_compute_pcm_pair` pads the shorter side with PCM silence per chunk. Skew of tens of ms is acceptable for QA use. |
+| Two `media` events with the same timestamp on different tracks | Each is dispatched to its own track-side buffer independently. No cross-contamination. |
+| `generate_signed_url` fails (IAM SignBlob denied, transient) | `get_call_recording` returns 502 with `detail="failed to generate playback URL"`. Caller can retry. |
+| Dashboard playback hits an expired signed URL | Browser surfaces a load error; user reloads the page, the dashboard re-fetches `/calls/{sid}/recording`, gets a fresh redirect. UX-acceptable; we can shorten the TTL further later if needed. |
+| `delete_call_recording` called with non-owner role | 403. Owner-only operation. |
+| `delete_call_recording` called for a call with no recording | GCS delete is idempotent; `mark_recording_deleted` is idempotent (no-op if `recording_url` already absent). 204 returned either way. |
+| `should_hangup.set()` triggered but WS already disconnected | Main loop already exited. `_hang_up_after_grace`'s `set()` is a no-op on a Set-already-set Event. Idempotent. |
+| Caller speaks during the grace window | `_handle_final_transcript` calls `_abort_pending_hangup`, which clears `state.pending_hangup` and cancels `state.hangup_task`. `should_hangup` is never set; call continues. |
+| `recording_retention_days` field missing from older Restaurant docs | Pydantic default of 90 applies on model load. No migration required. |
 
 ---
 
@@ -200,33 +344,61 @@ google-cloud-storage>=2.0,<3.0
 
 ### Unit — `tests/test_recordings_storage.py` (new)
 
-- `test_save_call_recording_happy_path` — 1 second of inbound (8000 bytes of `0x00`) + 1 second of outbound (8000 bytes of `0x7F`); assert blob path is `twilight/CAtest.wav`, returned URL is `gs://niko-recordings/twilight/CAtest.wav`, duration is `1`. Mocks `google.cloud.storage.Client` so no network.
-- `test_wav_header_is_well_formed` — pull the uploaded bytes off the mock; assert RIFF/WAVE magic, fmt chunk = 16-bit PCM @ 8000 Hz × 2 channels, byte-rate matches, data chunk size matches.
-- `test_track_length_skew_padded_with_silence` — inbound = 100 ms, outbound = 500 ms; assert resulting WAV is 500 ms × 2 ch × 16-bit, the inbound channel after the 100 ms mark is zero-bytes.
-- `test_empty_buffers_skip_upload` — both buffers empty; assert the GCS client was never called and the function returns early.
-- `test_gcs_upload_failure_raises` — mock client raises `GoogleAPIError`; function re-raises so the WS handler can log + skip the Firestore write.
+**Encode + interleave (pure functions, no GCS):**
+- `test_compute_pcm_pair_interleaves_lr` — 1 inbound chunk + 1 outbound chunk of equal length; assert output is sample-interleaved L/R/L/R.
+- `test_compute_pcm_pair_pads_shorter_side` — inbound 100 ms, outbound 500 ms; assert L channel is zero-padded after the 100 ms mark.
+- `test_compute_pcm_pair_handles_empty_chunks` — both empty; returns empty bytes.
+- `test_mp3_encode_produces_decodable_frames` — feed a known sine wave through encode+flush; assert output starts with an MP3 frame sync and decodes (via `pydub` or just header parse) back to a stereo 8 kHz signal of the right length.
 
-### Integration — extend `tests/test_telephony.py`
+**Resumable upload (with mocked `requests.Session` for the PUT calls and mocked `google.cloud.storage.Client`):**
+- `test_begin_recording_creates_session_and_sets_custom_time` — assert `Blob.create_resumable_upload_session` was called with `content_type="audio/mpeg"`, `blob.custom_time` set to `now() + retention_days`, and the returned session has the upload URL stored.
+- `test_append_chunks_buffers_until_threshold` — feed 100 small PCM chunks each well below 256 KB; assert no PUT has fired yet.
+- `test_append_chunks_flushes_when_threshold_hit` — feed enough PCM to cross the threshold; assert one PUT with `Content-Range: bytes 0-<n>/*` and the right MP3 byte content.
+- `test_append_chunks_retries_once_on_transient_error` — mock first PUT returns 503, second 200; assert exactly two attempts and `total_bytes_uploaded` is updated.
+- `test_append_chunks_marks_broken_after_two_failures` — mock both PUTs return 503; assert session marked broken and subsequent appends are no-ops.
+- `test_finalize_recording_sends_total_length` — mock final PUT; assert the `Content-Range` is `bytes <start>-<end>/<total>` (with a concrete total, not `*`), and the returned URL is `gs://...`.
+- `test_finalize_recording_with_zero_chunks_cancels_session` — no appends between begin and finalize; assert `DELETE` on the session URL was called and no Firestore write happened.
 
-- `test_voice_emits_both_tracks_stream_parameter` — POST `/voice`, assert returned TwiML contains `tracks="both_tracks"` on the `<Stream>` verb.
-- `test_media_stream_dispatches_audio_by_track` — drive WS through a fake call: `connected` → `start` → 2× `media` (inbound) → 2× `media` (outbound) → `stop`. Assert `save_call_recording` is called once with `inbound_audio` containing the two inbound payloads concatenated and `outbound_audio` containing the two outbound payloads. Mock `save_call_recording` and `mark_recording_ready` so no GCS / Firestore.
-- `test_recording_skipped_when_buffers_empty` — `start` → `stop` with no `media` events; assert `save_call_recording` was *not* called and no `recording_ready` event was emitted.
-- Existing tests touching `_start_recording_sync`, `recording_status`, signature validation, and host allowlisting are removed (now-dead code).
+**Delete + signed URL:**
+- `test_delete_recording_calls_blob_delete` — mock blob; assert `delete()` called once on `{rid}/{sid}.mp3`.
+- `test_delete_recording_idempotent_on_404` — mock blob raises `NotFound`; function swallows it and returns normally.
+- `test_generate_signed_url_uses_v4_get_30min` — mock `blob.generate_signed_url`; assert call kwargs `version="v4"`, `method="GET"`, `expiration=timedelta(minutes=30)`.
+
+### Integration — `tests/test_telephony.py` (extended)
+
+- `test_voice_emits_both_tracks_stream_parameter` — POST `/voice`, assert returned TwiML contains `tracks="both_tracks"` on the `<Stream>`.
+- `test_media_stream_begins_recording_on_start` — drive WS through `connected` → `start`; assert `recordings.begin_recording` was called with the resolved tenant id and retention from the (mocked) Restaurant doc.
+- `test_media_stream_dispatches_audio_by_track` — drive WS: `start` → 2× `media` (inbound) → 2× `media` (outbound) → `stop`. Assert `recordings.append_chunks` was called four times with the right inbound/outbound payloads, and `recordings.finalize_recording` was called once at the end.
+- `test_media_stream_skips_finalize_when_no_session` — simulate `begin_recording` failure (raises); assert no `append_chunks` calls, no `finalize_recording`, no `mark_recording_ready`. Call still completes cleanly.
+- `test_should_hangup_event_breaks_ws_loop` — start a fake call, externally `state.should_hangup.set()` after a few media events, assert the loop exits, the WS closes, and `finalize_recording` is called in the `finally`.
+- Remove existing tests touching `_start_recording_sync`, `recording_status`, signature validation, host allowlisting, `_twilio_end_call_sync` — all now-dead code.
+
+### Integration — `tests/test_orders_route.py` or new `tests/test_calls_route.py`
+
+- `test_get_call_recording_returns_302_with_signed_url` — mock `recordings.generate_signed_url`; POST as authed tenant; assert 302 and `Location` header equals the mocked signed URL.
+- `test_get_call_recording_404_when_recording_missing` — session has no `recording_url`; assert 404.
+- `test_get_call_recording_502_when_url_not_gs` — Firestore session has a non-`gs://` URL (legacy data); assert 502.
+- `test_get_call_recording_404_cross_tenant` — call_sid belongs to tenant A; tenant B's auth → 404 (existing behaviour, just reasserting it survives the rewrite).
+- `test_delete_call_recording_owner_only_204` — owner-role authed user → 204, `delete_recording` and `mark_recording_deleted` both called.
+- `test_delete_call_recording_non_owner_403` — staff-role user → 403; neither helper called.
+- `test_delete_call_recording_idempotent_on_missing_blob` — call exists, blob already gone → 204.
 
 ### Manual — post-deploy
 
-- Place a test call to `+1 647 905 8093`. After hangup:
-  - Cloud Run logs show `recording uploaded gs://niko-recordings/...`
-  - Dashboard `<audio>` plays
-  - Pan L/R independently to confirm caller is on left, agent on right
+- **Recording capture + playback**: place a test call to `+1 647 905 8093`. After hangup:
+  - Cloud Run logs show `recording chunk uploaded` lines mid-call and `recording finalized gs://niko-recordings/...mp3` at end.
+  - Dashboard `<audio>` plays. DevTools network tab shows 302 from `/api/calls/.../recording` to a `storage.googleapis.com` signed URL.
+  - Pan L/R to confirm caller is on left, agent on right.
+- **Auto-hangup**: place a test call, complete an order, observe Twilio drops the line within ~3 s of order confirmation (no manual hangup needed).
+- **Delete**: from the dashboard (or curl with an owner Firebase ID token), `DELETE /api/calls/{sid}/recording`. Audio player disappears within ~1 s; subsequent GET returns 404.
+- **Per-tenant retention**: update one Restaurant doc to `recording_retention_days: 1`. Place a test call. Verify on GCS console that the resulting blob's `Custom time` is set to ~24 h from now (lifecycle deletion verifiable but not waited-on in this manual test).
 
 ---
 
-## Out of scope
+## Out of scope (genuinely deferred)
 
-- **MP3 transcode** — keep WAV/μ-law for v1; revisit when storage cost is real.
-- **Signed-URL playback** — keep proxy until egress costs justify the swap.
-- **Auto-hangup REST fix** — same `<Connect>`-blocks-REST root cause, but distinct mechanism (probably "send a special TwiML mark and let the WS shut the call down by closing"). Separate ticket.
-- **Cross-instance durability** — accept the rare instance-death gap; add resumable upload only if real loss is observed.
-- **Recording deletion when an order is deleted** — Firestore doc lifecycle isn't tied to GCS today; Phase 3 concern.
-- **Per-tenant retention policies** — single 90-day bucket-level rule for v1; tenant-specific rules later if needed.
+- **Recording-deletion UI in the dashboard** — backend `DELETE` endpoint is in scope; the actual button + confirmation dialog on the call detail page is a separate frontend ticket once we know the exact UX.
+- **Bulk delete** — "delete all recordings for tenant X older than Y" — not modelled. The bucket lifecycle rule + per-blob `customTime` already handles age-based bulk cleanup; one-off bulk operations can be done via gcloud for now.
+- **Recording-deleted notification** — the `recording_deleted` event lands on the events subcollection; no email/SMS is sent. If that's needed later it's a separate ticket.
+- **Custom MP3 bitrate per tenant** — single 32 kbps stereo for all calls. If a tenant later needs higher fidelity (unlikely for telephony narrowband), revisit.
+- **Recording-resume across instance death** (i.e., somehow continuing the same recording session if the WS reconnects on a new pod) — Twilio doesn't reconnect calls across pod restarts, so this isn't physically possible. The resumable upload merely protects already-uploaded chunks, not the unwritten future.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ fastapi==0.115.0
 uvicorn[standard]==0.32.0
 python-multipart>=0.0.9,<1.0
 twilio>=9.0,<10.0
+google-cloud-storage>=2.0,<3.0
+lameenc>=1.6,<2.0
 pydantic-settings>=2.0,<3.0
 anthropic>=0.40,<1.0
 google-cloud-firestore>=2.0,<3.0

--- a/scripts/setup-recordings-bucket.sh
+++ b/scripts/setup-recordings-bucket.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Bootstrap GCS bucket + IAM for WS-side call recordings (#82).
+# Idempotent enough for one-shot bootstrap; re-running on an existing
+# bucket fails cleanly at create-bucket and the rest are upserts.
+set -euo pipefail
+
+PROJECT="${PROJECT:-niko-tsuki}"
+BUCKET="${BUCKET:-niko-recordings}"
+REGION="${REGION:-us-central1}"
+SA="${SA:-347262010229-compute@developer.gserviceaccount.com}"
+
+echo "Creating bucket gs://${BUCKET} in ${REGION}..."
+gcloud storage buckets create "gs://${BUCKET}" \
+  --project="${PROJECT}" \
+  --location="${REGION}" \
+  --uniform-bucket-level-access || echo "(bucket may already exist; continuing)"
+
+echo "Setting per-blob lifecycle (delete when daysSinceCustomTime >= 0)..."
+TMP_LIFECYCLE="$(mktemp)"
+cat > "${TMP_LIFECYCLE}" <<'EOF'
+{"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"daysSinceCustomTime":0}}]}}
+EOF
+gcloud storage buckets update "gs://${BUCKET}" --lifecycle-file="${TMP_LIFECYCLE}"
+rm -f "${TMP_LIFECYCLE}"
+
+echo "Granting Cloud Run runtime SA roles/storage.objectAdmin on bucket..."
+gcloud storage buckets add-iam-policy-binding "gs://${BUCKET}" \
+  --member="serviceAccount:${SA}" \
+  --role="roles/storage.objectAdmin"
+
+echo "Granting SA serviceAccountTokenCreator on itself (for V4 signed URLs)..."
+gcloud iam service-accounts add-iam-policy-binding "${SA}" \
+  --member="serviceAccount:${SA}" \
+  --role="roles/iam.serviceAccountTokenCreator" \
+  --project="${PROJECT}"
+
+echo "Done. Bucket gs://${BUCKET} is ready for recordings."

--- a/tests/test_call_sessions_storage.py
+++ b/tests/test_call_sessions_storage.py
@@ -327,3 +327,45 @@ def test_record_event_swallows_firestore_exceptions(fake_client):
     call_sessions.record_event(
         "CAtest", _DEMO_RID, kind="transcript_final", text="hi"
     )
+
+
+def test_mark_recording_deleted_clears_url_and_emits_event(monkeypatch):
+    from app.storage import call_sessions
+
+    patches: list[dict] = []
+    events: list[dict] = []
+
+    class FakeDoc:
+        def __init__(self):
+            self._collection = FakeCollection(events)
+        def update(self, patch):
+            patches.append(patch)
+        def collection(self, _name):
+            return self._collection
+
+    class FakeCollection:
+        def __init__(self, events):
+            self._events = events
+        def add(self, payload):
+            self._events.append(payload)
+
+    fake_legacy = FakeDoc()
+    fake_nested = FakeDoc()
+
+    monkeypatch.setattr(call_sessions, "_get_client", lambda: object())
+    monkeypatch.setattr(call_sessions, "_legacy_parent", lambda _c, _sid: fake_legacy)
+    monkeypatch.setattr(call_sessions, "_nested_parent", lambda _c, _rid, _sid: fake_nested)
+
+    call_sessions.mark_recording_deleted("CAtest", "rid1")
+
+    # Both parents are cleared
+    assert len(patches) == 2
+    for p in patches:
+        assert p.get("recording_url") is None
+        assert p.get("recording_sid") is None
+        assert p.get("recording_duration_seconds") is None
+
+    # An event was appended on each side
+    assert len(events) == 2
+    for ev in events:
+        assert ev["kind"] == "recording_deleted"

--- a/tests/test_calls_route.py
+++ b/tests/test_calls_route.py
@@ -1,0 +1,140 @@
+"""Tests for /calls/{call_sid}/recording — playback redirect + delete.
+
+The auth boundary is checked through FastAPI's dep override pattern,
+matching ``test_orders_route.py``. GCS and Firestore are stubbed at the
+module level so no network call escapes.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependency import Tenant, current_tenant
+from app.main import app
+
+client = TestClient(app)
+
+_RID = "niko-pizza-kitchen"
+_OWNER = Tenant(uid="u-owner", email="o@x.com", restaurant_id=_RID, role="owner")
+_STAFF = Tenant(uid="u-staff", email="s@x.com", restaurant_id=_RID, role="staff")
+
+
+@pytest.fixture
+def override_owner():
+    app.dependency_overrides[current_tenant] = lambda: _OWNER
+    yield
+    app.dependency_overrides.pop(current_tenant, None)
+
+
+@pytest.fixture
+def override_staff():
+    app.dependency_overrides[current_tenant] = lambda: _STAFF
+    yield
+    app.dependency_overrides.pop(current_tenant, None)
+
+
+# ---------------------------------------------------------------------------
+# GET /calls/{sid}/recording — 302 to signed URL
+# ---------------------------------------------------------------------------
+
+
+def test_get_call_recording_returns_302_to_signed_url(override_owner, monkeypatch):
+    from app.storage import call_sessions, recordings
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": f"gs://niko-recordings/{rid}/CAt.mp3"},
+    )
+    monkeypatch.setattr(
+        recordings, "generate_signed_url",
+        lambda *, call_sid, restaurant_id: "https://signed.example/?sig=fake",
+    )
+
+    r = client.get("/calls/CAt/recording", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["Location"] == "https://signed.example/?sig=fake"
+
+
+def test_get_call_recording_404_when_url_missing(override_owner, monkeypatch):
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": None},
+    )
+    r = client.get("/calls/CAt/recording")
+    assert r.status_code == 404
+
+
+def test_get_call_recording_502_when_url_not_gs(override_owner, monkeypatch):
+    """Legacy Firestore docs that still carry a Twilio URL would have
+    been served via the old proxy. Refuse them now — only ``gs://``."""
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": "https://api.twilio.com/legacy.mp3"},
+    )
+    r = client.get("/calls/CAt/recording", follow_redirects=False)
+    assert r.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# DELETE /calls/{sid}/recording — owner only
+# ---------------------------------------------------------------------------
+
+
+def test_delete_call_recording_owner_returns_204(override_owner, monkeypatch):
+    from app.storage import call_sessions, recordings
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": f"gs://niko-recordings/{rid}/CAt.mp3"},
+    )
+    deleted: list[dict] = []
+    cleared: list[dict] = []
+    monkeypatch.setattr(
+        recordings, "delete_recording",
+        lambda *, call_sid, restaurant_id: deleted.append({"sid": call_sid, "rid": restaurant_id}),
+    )
+    monkeypatch.setattr(
+        call_sessions, "mark_recording_deleted",
+        lambda call_sid, rid: cleared.append({"sid": call_sid, "rid": rid}),
+    )
+
+    r = client.delete("/calls/CAt/recording")
+    assert r.status_code == 204
+    assert deleted == [{"sid": "CAt", "rid": _RID}]
+    assert cleared == [{"sid": "CAt", "rid": _RID}]
+
+
+def test_delete_call_recording_non_owner_returns_403(override_staff):
+    r = client.delete("/calls/CAt/recording")
+    assert r.status_code == 403
+
+
+def test_delete_call_recording_404_when_call_missing(override_owner, monkeypatch):
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions, "get_session", lambda call_sid, rid: None
+    )
+    r = client.delete("/calls/CAt/recording")
+    assert r.status_code == 404
+
+
+def test_delete_call_recording_idempotent_on_no_recording(override_owner, monkeypatch):
+    """Call exists but has no recording. The endpoint still returns 204
+    — both ``delete_recording`` (idempotent on missing blob) and
+    ``mark_recording_deleted`` (idempotent on already-cleared doc)
+    handle this gracefully."""
+    from app.storage import call_sessions, recordings
+
+    monkeypatch.setattr(
+        call_sessions, "get_session",
+        lambda call_sid, rid: {"recording_url": None},
+    )
+    monkeypatch.setattr(recordings, "delete_recording", lambda **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_recording_deleted", lambda *a, **kw: None)
+
+    r = client.delete("/calls/CAt/recording")
+    assert r.status_code == 204

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -103,3 +103,33 @@ def test_begin_recording_creates_session_and_sets_custom_time(monkeypatch):
     assert session.total_bytes_uploaded == 0
     assert session.broken is False
     assert before + timedelta(days=7) - timedelta(seconds=2) <= fake_blob.custom_time <= after + timedelta(days=7)
+
+
+def test_append_chunks_buffers_below_threshold(monkeypatch):
+    from app.storage import recordings
+
+    put_count = {"n": 0}
+
+    def fake_put(session, chunk_bytes, *, is_final, total):
+        put_count["n"] += 1
+
+    monkeypatch.setattr(recordings, "_put_chunk", fake_put)
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    # 50 ms of audio per side, repeated 10 times — well under 256 KB MP3.
+    inbound = b"\xff" * 400  # 50 ms at 8 kHz
+    outbound = b"\x00" * 400
+    for _ in range(10):
+        recordings.append_chunks(session, inbound, outbound)
+
+    assert put_count["n"] == 0
+    assert session.total_bytes_uploaded == 0
+    assert session.total_pcm_samples == 400 * 10
+    # encoder may or may not produce output for short bursts (LAME buffers
+    # internally before emitting frames); accept >= 0.
+    assert len(session.pending_mp3) >= 0

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -133,3 +133,74 @@ def test_append_chunks_buffers_below_threshold(monkeypatch):
     # encoder may or may not produce output for short bursts (LAME buffers
     # internally before emitting frames); accept >= 0.
     assert len(session.pending_mp3) >= 0
+
+
+def test_put_chunk_sends_content_range_open_for_non_final(monkeypatch):
+    from app.storage import recordings
+
+    calls: list[dict] = []
+
+    def fake_put(url, data, headers, timeout):
+        calls.append({"url": url, "data_len": len(data), "headers": headers})
+        return type("R", (), {"status_code": 200, "text": ""})()
+
+    monkeypatch.setattr(recordings.requests, "put", fake_put)
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    chunk = b"x" * 256 * 1024
+    recordings._put_chunk(session, chunk, is_final=False, total=None)
+
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://fake"
+    assert calls[0]["data_len"] == 256 * 1024
+    assert calls[0]["headers"]["Content-Range"] == "bytes 0-262143/*"
+    assert session.total_bytes_uploaded == 256 * 1024
+
+
+def test_put_chunk_retries_once_on_5xx(monkeypatch):
+    from app.storage import recordings
+
+    responses = iter([
+        type("R", (), {"status_code": 503, "text": "transient"})(),
+        type("R", (), {"status_code": 200, "text": ""})(),
+    ])
+    sleeps: list[float] = []
+    monkeypatch.setattr(recordings.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(recordings.requests, "put", lambda *a, **kw: next(responses))
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    recordings._put_chunk(session, b"x" * 256 * 1024, is_final=False, total=None)
+
+    assert sleeps == [0.5]
+    assert session.broken is False
+    assert session.total_bytes_uploaded == 256 * 1024
+
+
+def test_put_chunk_marks_broken_after_two_5xx(monkeypatch):
+    from app.storage import recordings
+
+    monkeypatch.setattr(recordings.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        recordings.requests, "put",
+        lambda *a, **kw: type("R", (), {"status_code": 503, "text": "fail"})(),
+    )
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    recordings._put_chunk(session, b"x" * 256 * 1024, is_final=False, total=None)
+    assert session.broken is True
+    assert session.total_bytes_uploaded == 0

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -231,3 +231,37 @@ def test_append_chunks_flushes_one_chunk_when_threshold_hit(monkeypatch):
     # Exactly one chunk of size 256 KB must have been PUT.
     assert chunks == [(256 * 1024, False)]
     assert len(session.pending_mp3) > 0  # leftover stays for next chunk
+
+
+def test_finalize_recording_sends_final_chunk_with_total_and_returns_url(monkeypatch):
+    from app.storage import recordings
+
+    captured: list[dict] = []
+
+    def fake_put(session, chunk, *, is_final, total):
+        captured.append({"len": len(chunk), "is_final": is_final, "total": total})
+        session.total_bytes_uploaded += len(chunk)
+
+    monkeypatch.setattr(recordings, "_put_chunk", fake_put)
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    # Simulate one prior chunk already uploaded.
+    session.total_bytes_uploaded = 256 * 1024
+    # Simulate 2 seconds of stereo audio captured.
+    session.total_pcm_samples = 2 * 8000
+    # Some bytes still pending for the final flush.
+    session.pending_mp3.extend(b"x" * 1234)
+
+    url, duration = recordings.finalize_recording(session)
+
+    assert len(captured) == 1
+    final = captured[0]
+    assert final["is_final"] is True
+    assert final["total"] is not None
+    assert duration == 2
+    assert url == "gs://niko-recordings/rid/CAt.mp3"

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -337,3 +337,37 @@ def test_delete_recording_idempotent_on_404(monkeypatch):
     recordings.delete_recording(call_sid="CAt", restaurant_id="rid")
 
 
+def test_generate_signed_url_uses_v4_get_30min(monkeypatch):
+    from datetime import timedelta
+    from app.storage import recordings
+
+    captured: dict = {}
+
+    fake_blob = type("FakeBlob", (), {})()
+    def fake_signed(*, version, method, expiration):
+        captured["version"] = version
+        captured["method"] = method
+        captured["expiration"] = expiration
+        return "https://signed.googleapis.com/?sig=fake"
+    fake_blob.generate_signed_url = fake_signed
+
+    fake_bucket = type("FakeBucket", (), {})()
+    def get_blob(name):
+        captured["blob_name"] = name
+        return fake_blob
+    fake_bucket.blob = get_blob
+
+    fake_client = type("FakeClient", (), {})()
+    fake_client.bucket = lambda name: fake_bucket
+
+    monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
+
+    url = recordings.generate_signed_url(call_sid="CAt", restaurant_id="rid")
+
+    assert url == "https://signed.googleapis.com/?sig=fake"
+    assert captured["blob_name"] == "rid/CAt.mp3"
+    assert captured["version"] == "v4"
+    assert captured["method"] == "GET"
+    assert captured["expiration"] == timedelta(minutes=30)
+
+

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -293,3 +293,47 @@ def test_finalize_recording_with_zero_pcm_cancels_session(monkeypatch):
     assert url == ""
     assert duration == 0
     assert deleted == ["https://upload.googleapis.com/session/abc"]
+
+
+def test_delete_recording_calls_blob_delete(monkeypatch):
+    from app.storage import recordings
+
+    deleted: list[str] = []
+
+    fake_blob = type("FakeBlob", (), {})()
+    fake_blob.delete = lambda: deleted.append("called")
+
+    fake_bucket = type("FakeBucket", (), {})()
+    fake_bucket.blob = lambda name: (deleted.append(name) or fake_blob)
+
+    fake_client = type("FakeClient", (), {})()
+    fake_client.bucket = lambda name: fake_bucket
+
+    monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
+
+    recordings.delete_recording(call_sid="CAt", restaurant_id="rid")
+
+    assert deleted == ["rid/CAt.mp3", "called"]
+
+
+def test_delete_recording_idempotent_on_404(monkeypatch):
+    from google.api_core.exceptions import NotFound
+    from app.storage import recordings
+
+    fake_blob = type("FakeBlob", (), {})()
+    def raise_notfound():
+        raise NotFound("gone")
+    fake_blob.delete = raise_notfound
+
+    fake_bucket = type("FakeBucket", (), {})()
+    fake_bucket.blob = lambda name: fake_blob
+
+    fake_client = type("FakeClient", (), {})()
+    fake_client.bucket = lambda name: fake_bucket
+
+    monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
+
+    # Should NOT raise.
+    recordings.delete_recording(call_sid="CAt", restaurant_id="rid")
+
+

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -62,9 +62,12 @@ def test_make_encoder_returns_lame_encoder_at_32kbps():
     mp3 = enc.encode(pcm)
     mp3 += enc.flush()
 
-    # Output must contain at least one MP3 frame sync (0xFFE/0xFFF prefix).
-    assert b"\xff\xfb" in mp3 or b"\xff\xfa" in mp3 or b"\xff\xf3" in mp3, (
-        f"no MP3 frame sync found in {mp3[:32]!r}"
+    # Output must start with an MP3 frame sync word (11-bit 0x7FF sync).
+    # The second byte's top 3 bits must be 110 or 111, so the second byte
+    # is in range 0xE0-0xFF. lameenc may emit MPEG-1 (0xFF 0xFx) or
+    # MPEG-2 (0xFF 0xEx) depending on sample rate; both are valid MP3.
+    assert len(mp3) >= 2 and mp3[0] == 0xFF and (mp3[1] & 0xE0) == 0xE0, (
+        f"no MP3 frame sync found in {bytes(mp3[:32])!r}"
     )
     assert 1000 < len(mp3) < 10000
 

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -265,3 +265,31 @@ def test_finalize_recording_sends_final_chunk_with_total_and_returns_url(monkeyp
     assert final["total"] is not None
     assert duration == 2
     assert url == "gs://niko-recordings/rid/CAt.mp3"
+
+
+def test_finalize_recording_with_zero_pcm_cancels_session(monkeypatch):
+    from app.storage import recordings
+
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        recordings.requests, "delete",
+        lambda url, timeout: deleted.append(url) or type("R", (), {"status_code": 204})(),
+    )
+    # _put_chunk should NOT be called.
+    monkeypatch.setattr(
+        recordings, "_put_chunk",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("must not PUT on empty session")),
+    )
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3",
+        upload_url="https://upload.googleapis.com/session/abc",
+        encoder=recordings._make_encoder(),
+    )
+
+    url, duration = recordings.finalize_recording(session)
+
+    assert url == ""
+    assert duration == 0
+    assert deleted == ["https://upload.googleapis.com/session/abc"]

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -204,3 +204,30 @@ def test_put_chunk_marks_broken_after_two_5xx(monkeypatch):
     recordings._put_chunk(session, b"x" * 256 * 1024, is_final=False, total=None)
     assert session.broken is True
     assert session.total_bytes_uploaded == 0
+
+
+def test_append_chunks_flushes_one_chunk_when_threshold_hit(monkeypatch):
+    from app.storage import recordings
+
+    chunks: list[tuple[int, bool]] = []
+
+    def fake_put(session, chunk, *, is_final, total):
+        chunks.append((len(chunk), is_final))
+        session.total_bytes_uploaded += len(chunk)
+
+    monkeypatch.setattr(recordings, "_put_chunk", fake_put)
+
+    session = recordings.RecordingUploadSession(
+        call_sid="CAt", restaurant_id="rid",
+        blob_name="rid/CAt.mp3", upload_url="https://fake",
+        encoder=recordings._make_encoder(),
+    )
+
+    # Force the pending buffer to cross 256 KB by pre-loading it; then a
+    # single small append triggers the flush loop.
+    session.pending_mp3.extend(b"x" * (256 * 1024 + 100))
+    recordings.append_chunks(session, b"\xff" * 8, b"\x00" * 8)
+
+    # Exactly one chunk of size 256 KB must have been PUT.
+    assert chunks == [(256 * 1024, False)]
+    assert len(session.pending_mp3) > 0  # leftover stays for next chunk

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -1,0 +1,102 @@
+"""Unit tests for app.storage.recordings.
+
+Hot-path helpers (decode + interleave) are pure and need no mocking.
+Resumable-upload + signed-URL tests live further down and use mocks
+for google.cloud.storage.
+
+Note: stdlib ``audioop`` was removed in Python 3.13. Prod targets 3.12;
+locally we run 3.13, so tests use the module's own ``_ulaw2lin_16``
+helper for expected-value assertions instead of ``audioop.ulaw2lin``.
+"""
+
+
+def test_compute_pcm_pair_interleaves_lr():
+    from app.storage.recordings import _compute_pcm_pair, _ulaw2lin_16
+
+    # 2 μ-law samples per side. μ-law 0xFF = silence ≈ 0 PCM; 0x00 = max negative.
+    inbound = b"\xff\xff"
+    outbound = b"\x00\x00"
+    out = _compute_pcm_pair(inbound, outbound)
+
+    # 2 samples × 2 channels × 2 bytes = 8 bytes, L then R per sample.
+    assert len(out) == 8
+    inbound_pcm = _ulaw2lin_16(inbound)
+    outbound_pcm = _ulaw2lin_16(outbound)
+    # Sample 0: L = inbound[0:2], R = outbound[0:2]
+    assert out[0:2] == inbound_pcm[0:2]
+    assert out[2:4] == outbound_pcm[0:2]
+    # Sample 1: L = inbound[2:4], R = outbound[2:4]
+    assert out[4:6] == inbound_pcm[2:4]
+    assert out[6:8] == outbound_pcm[2:4]
+
+
+def test_compute_pcm_pair_pads_shorter_side_with_silence():
+    from app.storage.recordings import _compute_pcm_pair
+
+    inbound = b"\xff" * 100   # 100 μ-law samples
+    outbound = b"\x00" * 500  # 500 μ-law samples
+    out = _compute_pcm_pair(inbound, outbound)
+
+    # 500 samples × 2 channels × 2 bytes
+    assert len(out) == 500 * 2 * 2
+    # Past the inbound's 100-sample mark, the L channel is PCM silence (\x00\x00).
+    for i in range(100, 500):
+        l_offset = i * 4
+        assert out[l_offset:l_offset + 2] == b"\x00\x00", (
+            f"L sample {i} not silent"
+        )
+
+
+def test_compute_pcm_pair_handles_empty_chunks():
+    from app.storage.recordings import _compute_pcm_pair
+
+    assert _compute_pcm_pair(b"", b"") == b""
+
+
+def test_make_encoder_returns_lame_encoder_at_32kbps():
+    from app.storage.recordings import _make_encoder
+
+    enc = _make_encoder()
+    # Encode 1 second of stereo PCM silence — 16000 samples × 2 channels × 2 bytes.
+    pcm = b"\x00" * (16000 * 2 * 2)
+    mp3 = enc.encode(pcm)
+    mp3 += enc.flush()
+
+    # Output must contain at least one MP3 frame sync (0xFFE/0xFFF prefix).
+    assert b"\xff\xfb" in mp3 or b"\xff\xfa" in mp3 or b"\xff\xf3" in mp3, (
+        f"no MP3 frame sync found in {mp3[:32]!r}"
+    )
+    assert 1000 < len(mp3) < 10000
+
+
+def test_begin_recording_creates_session_and_sets_custom_time(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+    from app.storage import recordings
+
+    fake_blob = type("FakeBlob", (), {})()
+    fake_blob.create_resumable_upload_session = lambda content_type: (
+        "https://storage.googleapis.com/upload/session/fake"
+    )
+    fake_blob.custom_time = None
+
+    fake_bucket = type("FakeBucket", (), {})()
+    fake_bucket.blob = lambda name: fake_blob
+
+    fake_client = type("FakeClient", (), {})()
+    fake_client.bucket = lambda name: fake_bucket
+
+    monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
+
+    before = datetime.now(timezone.utc)
+    session = recordings.begin_recording(
+        call_sid="CAtest", restaurant_id="rid1", retention_days=7
+    )
+    after = datetime.now(timezone.utc)
+
+    assert session.call_sid == "CAtest"
+    assert session.restaurant_id == "rid1"
+    assert session.blob_name == "rid1/CAtest.mp3"
+    assert session.upload_url == "https://storage.googleapis.com/upload/session/fake"
+    assert session.total_bytes_uploaded == 0
+    assert session.broken is False
+    assert before + timedelta(days=7) - timedelta(seconds=2) <= fake_blob.custom_time <= after + timedelta(days=7)

--- a/tests/test_restaurants_storage.py
+++ b/tests/test_restaurants_storage.py
@@ -210,3 +210,39 @@ def test_restaurant_offers_delivery_defaults_to_true():
         offers_delivery=False,
     )
     assert r_off.offers_delivery is False
+
+
+def test_restaurant_recording_retention_default_is_90():
+    from app.restaurants.models import Restaurant
+
+    r = Restaurant(
+        id="x", name="X", display_phone="+1", twilio_phone="+1",
+        address="a", hours="h", menu={"pizzas": [], "sides": [], "drinks": []},
+    )
+    assert r.recording_retention_days == 90
+
+
+def test_restaurant_recording_retention_accepts_override():
+    from app.restaurants.models import Restaurant
+
+    r = Restaurant(
+        id="x", name="X", display_phone="+1", twilio_phone="+1",
+        address="a", hours="h",
+        menu={"pizzas": [], "sides": [], "drinks": []},
+        recording_retention_days=30,
+    )
+    assert r.recording_retention_days == 30
+
+
+def test_restaurant_recording_retention_rejects_zero_or_negative():
+    import pytest
+    from pydantic import ValidationError
+    from app.restaurants.models import Restaurant
+
+    with pytest.raises(ValidationError):
+        Restaurant(
+            id="x", name="X", display_phone="+1", twilio_phone="+1",
+            address="a", hours="h",
+            menu={"pizzas": [], "sides": [], "drinks": []},
+            recording_retention_days=0,
+        )

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -144,6 +144,18 @@ def test_voice_passes_restaurant_id_as_stream_parameter(monkeypatch):
     assert 'value="niko-pizza-kitchen"' in body
 
 
+def test_voice_stream_requests_both_tracks(monkeypatch):
+    """Twilio sends both inbound and outbound audio over the same WS
+    only when we ask for ``tracks="both_tracks"`` on the <Stream>. This
+    is the foundation for the WS-side recording pipeline (#82)."""
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
+    )
+    response = client.post("/voice", data=_VOICE_FORM)
+    body = response.text
+    assert 'tracks="both_tracks"' in body
+
+
 def test_voice_uses_firestore_lookup_when_present(monkeypatch):
     """When Firestore has a doc for the dialed number, ``/voice`` uses
     it directly without touching the MENU fallback."""

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -268,6 +268,54 @@ def test_media_stream_handles_full_call_lifecycle(mock_pipeline):
     mock_pipeline.finish.assert_called_once()
 
 
+def test_media_stream_begins_recording_on_start(mock_pipeline, monkeypatch):
+    """On WS start, after tenant resolution, begin_recording is called
+    with the resolved restaurant id and the tenant's retention setting."""
+    from app.storage import recordings as recordings_mod
+    from app.restaurants.models import Restaurant
+
+    seeded = Restaurant(
+        id="niko-pizza-kitchen",
+        name="Niko",
+        display_phone="+1", twilio_phone=_DEMO_TO,
+        address="a", hours="h",
+        menu={"pizzas": [], "sides": [], "drinks": []},
+        recording_retention_days=42,
+    )
+    monkeypatch.setattr(
+        restaurants_storage, "get_restaurant", lambda _rid: seeded
+    )
+    monkeypatch.setattr(
+        restaurants_storage, "load_or_fallback_demo", lambda _rid: seeded
+    )
+
+    captured: list[dict] = []
+
+    def fake_begin(*, call_sid, restaurant_id, retention_days):
+        captured.append({
+            "call_sid": call_sid,
+            "restaurant_id": restaurant_id,
+            "retention_days": retention_days,
+        })
+        return MagicMock(broken=False)
+
+    monkeypatch.setattr(recordings_mod, "begin_recording", fake_begin)
+    monkeypatch.setattr(recordings_mod, "append_chunks", lambda *a, **kw: None)
+    monkeypatch.setattr(recordings_mod, "finalize_recording", lambda _s: ("", 0))
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert len(captured) == 1
+    assert captured[0] == {
+        "call_sid": "CAtest123",
+        "restaurant_id": "niko-pizza-kitchen",
+        "retention_days": 42,
+    }
+
+
 # ---------------------------------------------------------------------------
 # AI greeting
 # ---------------------------------------------------------------------------

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -316,6 +316,69 @@ def test_media_stream_begins_recording_on_start(mock_pipeline, monkeypatch):
     }
 
 
+def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
+    """Each Twilio media event drives append_chunks with the right
+    inbound/outbound payloads."""
+    from base64 import b64encode
+    from app.storage import recordings as recordings_mod
+
+    fake_session = MagicMock(broken=False)
+    captured: list[tuple[bytes, bytes]] = []
+
+    monkeypatch.setattr(
+        recordings_mod, "begin_recording",
+        lambda *, call_sid, restaurant_id, retention_days: fake_session,
+    )
+    monkeypatch.setattr(
+        recordings_mod, "append_chunks",
+        lambda session, inbound_mu_law, outbound_mu_law:
+            captured.append((inbound_mu_law, outbound_mu_law)),
+    )
+    monkeypatch.setattr(
+        recordings_mod, "finalize_recording", lambda _s: ("", 0),
+    )
+
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, restaurant_id, on_final):
+        return fake_dg
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr(
+        "app.telephony.router.stream_reply", _make_fake_stream_reply()
+    )
+    from app.storage import call_sessions
+    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_recording_ready", lambda *a, **kw: None)
+
+    inbound_payload = b64encode(b"\xff" * 8).decode()
+    outbound_payload = b64encode(b"\x00" * 8).decode()
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps({
+            "event": "media",
+            "media": {"track": "inbound", "chunk": "1", "timestamp": "5", "payload": inbound_payload},
+        }))
+        ws.send_text(json.dumps({
+            "event": "media",
+            "media": {"track": "outbound", "chunk": "2", "timestamp": "10", "payload": outbound_payload},
+        }))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert (b"\xff" * 8, b"") in captured
+    assert (b"", b"\x00" * 8) in captured
+
+
 # ---------------------------------------------------------------------------
 # AI greeting
 # ---------------------------------------------------------------------------

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -202,45 +202,6 @@ def test_voice_rejects_unmapped_number(monkeypatch):
     assert "<Connect" not in body
 
 
-def test_voice_schedules_recording_start(monkeypatch):
-    """Recording must be kicked off from /voice — and awaited inline,
-    not fire-and-forget. If we return TwiML before the REST call lands,
-    Twilio routes the call into <Connect> and the Recordings API
-    returns 404 ('not eligible'). Awaiting guarantees the REST call
-    completes before our TwiML response (#82 follow-up)."""
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
-    )
-    captured: list[tuple[str, str]] = []
-    monkeypatch.setattr(
-        "app.telephony.router._start_recording_sync",
-        lambda call_sid, restaurant_id: captured.append((call_sid, restaurant_id)),
-    )
-    response = client.post("/voice", data=_VOICE_FORM)
-    assert response.status_code == 200
-    # Awaited inline — must be populated by the time the response returns.
-    assert captured == [("CAtest", "niko-pizza-kitchen")]
-
-
-def test_voice_skips_recording_when_no_call_sid(monkeypatch):
-    """Defensive: if Twilio's webhook ever lands without a CallSid (test
-    harnesses, future TwiML changes), don't crash trying to start a
-    recording with an empty SID."""
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
-    )
-    called: list = []
-    monkeypatch.setattr(
-        "app.telephony.router._start_recording_sync",
-        lambda *a, **kw: called.append(a),
-    )
-    response = client.post(
-        "/voice", data={"From": "+10000000000", "To": _DEMO_TO}  # no CallSid
-    )
-    assert response.status_code == 200
-    assert called == []
-
-
 # ---------------------------------------------------------------------------
 # WS /media-stream — basic lifecycle
 # ---------------------------------------------------------------------------
@@ -649,41 +610,34 @@ async def test_send_end_of_call_mark_returns_false_when_stream_sid_missing():
 
 
 @pytest.mark.asyncio
-async def test_hang_up_after_grace_calls_twilio_when_pending(monkeypatch):
-    """The grace timer fires the REST hangup when no transcript arrived."""
+async def test_hang_up_after_grace_sets_should_hangup_event(monkeypatch):
+    """After the grace window, _hang_up_after_grace sets the WS-loop's
+    should_hangup event so the loop exits and the WebSocket closes —
+    Twilio's <Connect> ends and the call hangs up. The REST update path
+    is gone (it 404'd on <Connect>-state calls)."""
     from app.telephony.router import (
         HANGUP_GRACE_SECONDS,
         _CallState,
         _hang_up_after_grace,
     )
 
-    ended: list[str] = []
-    monkeypatch.setattr(
-        "app.telephony.router._twilio_end_call_sync",
-        lambda call_sid: ended.append(call_sid),
-    )
-    # Speed the grace timer up so the test runs fast.
     monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
 
     state = _CallState(call_sid="CAtest", pending_hangup=True)
+    assert not state.should_hangup.is_set()
+
     await _hang_up_after_grace(state)
 
-    assert ended == ["CAtest"]
-    # Sanity: original constant unchanged.
+    assert state.should_hangup.is_set()
     assert HANGUP_GRACE_SECONDS == 5.0
 
 
 @pytest.mark.asyncio
 async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
     """If pending_hangup gets cleared during the grace window (caller
-    spoke), the REST hangup MUST NOT fire."""
+    spoke), the should_hangup event MUST NOT fire."""
     from app.telephony.router import _CallState, _hang_up_after_grace
 
-    ended: list[str] = []
-    monkeypatch.setattr(
-        "app.telephony.router._twilio_end_call_sync",
-        lambda call_sid: ended.append(call_sid),
-    )
     monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
 
     state = _CallState(call_sid="CAtest", pending_hangup=True)
@@ -693,7 +647,7 @@ async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
 
     await _hang_up_after_grace(state)
 
-    assert ended == []
+    assert not state.should_hangup.is_set()
 
 
 def test_looks_like_goodbye_excludes_coming_right_up():
@@ -813,111 +767,3 @@ async def test_clear_twilio_audio_swallows_websocket_disconnect():
     await clear_twilio_audio(ws, "MZtest456")
 
 
-# ---------------------------------------------------------------------------
-# POST /recording-status — Twilio signature validation
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def _recording_status_env(monkeypatch):
-    """Configure settings so /recording-status doesn't immediately 503.
-    Tests for the 503 path override the env explicitly."""
-    from app.config import settings
-    from app.telephony import router as telephony_router
-
-    monkeypatch.setattr(settings, "twilio_auth_token", "test_token", raising=False)
-    monkeypatch.setattr(
-        settings, "public_base_url", "http://testserver", raising=False
-    )
-    captured: list[dict] = []
-
-    def _fake_mark(call_sid, restaurant_id, **kw):
-        captured.append({"call_sid": call_sid, "restaurant_id": restaurant_id, **kw})
-
-    monkeypatch.setattr(
-        telephony_router.call_sessions, "mark_recording_ready", _fake_mark
-    )
-    return captured
-
-
-def _force_signature_valid(monkeypatch, valid: bool) -> None:
-    monkeypatch.setattr(
-        "app.telephony.router.RequestValidator.validate",
-        lambda self, url, params, sig: valid,
-    )
-
-
-def test_recording_status_rejects_invalid_signature(
-    _recording_status_env, monkeypatch
-):
-    """No (or wrong) X-Twilio-Signature → 403, no Firestore write.
-    This is the P0 the original PR shipped without."""
-    _force_signature_valid(monkeypatch, False)
-    response = client.post(
-        "/recording-status/niko-pizza-kitchen/CAtest123",
-        data={
-            "RecordingStatus": "completed",
-            "RecordingUrl": "https://api.twilio.com/2010-04-01/Recordings/REabc",
-            "RecordingSid": "REabc",
-            "RecordingDuration": "42",
-        },
-    )
-    assert response.status_code == 403
-    assert _recording_status_env == []
-
-
-def test_recording_status_returns_503_when_public_base_url_unset(monkeypatch):
-    """Without PUBLIC_BASE_URL we cannot reconstruct the signed URL,
-    so the only safe behavior is to refuse all callbacks."""
-    from app.config import settings
-
-    monkeypatch.setattr(settings, "twilio_auth_token", "test_token", raising=False)
-    monkeypatch.setattr(settings, "public_base_url", None, raising=False)
-    response = client.post(
-        "/recording-status/niko-pizza-kitchen/CAtest123",
-        data={"RecordingStatus": "completed"},
-    )
-    assert response.status_code == 503
-
-
-def test_recording_status_writes_firestore_with_valid_signature(
-    _recording_status_env, monkeypatch
-):
-    _force_signature_valid(monkeypatch, True)
-    response = client.post(
-        "/recording-status/niko-pizza-kitchen/CAtest123",
-        data={
-            "RecordingStatus": "completed",
-            "RecordingUrl": "https://api.twilio.com/2010-04-01/Recordings/REabc",
-            "RecordingSid": "REabc",
-            "RecordingDuration": "42",
-        },
-    )
-    assert response.status_code == 204
-    assert len(_recording_status_env) == 1
-    write = _recording_status_env[0]
-    assert write["call_sid"] == "CAtest123"
-    assert write["restaurant_id"] == "niko-pizza-kitchen"
-    assert write["recording_sid"] == "REabc"
-    assert write["duration_seconds"] == 42
-
-
-def test_recording_status_rejects_non_twilio_recording_url(
-    _recording_status_env, monkeypatch
-):
-    """Even with a valid signature, refuse to persist a RecordingUrl
-    that doesn't live on api.twilio.com — defense-in-depth against
-    malformed/spoofed payloads becoming an SSRF vector when the
-    dashboard later proxies the URL."""
-    _force_signature_valid(monkeypatch, True)
-    response = client.post(
-        "/recording-status/niko-pizza-kitchen/CAtest123",
-        data={
-            "RecordingStatus": "completed",
-            "RecordingUrl": "https://attacker.example/evil.mp3",
-            "RecordingSid": "REabc",
-            "RecordingDuration": "42",
-        },
-    )
-    assert response.status_code == 400
-    assert _recording_status_env == []

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -379,6 +379,57 @@ def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
     assert (b"", b"\x00" * 8) in captured
 
 
+def test_media_stream_finalizes_recording_on_stop(monkeypatch):
+    """After the call ends, finalize_recording runs and mark_recording_ready
+    writes the resulting gs:// URL to Firestore."""
+    from app.storage import recordings as recordings_mod
+    from app.storage import call_sessions
+
+    fake_session = MagicMock(broken=False)
+    monkeypatch.setattr(
+        recordings_mod, "begin_recording",
+        lambda *, call_sid, restaurant_id, retention_days: fake_session,
+    )
+    monkeypatch.setattr(recordings_mod, "append_chunks", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        recordings_mod, "finalize_recording",
+        lambda session: ("gs://niko-recordings/niko-pizza-kitchen/CAtest123.mp3", 12),
+    )
+
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, restaurant_id, on_final):
+        return fake_dg
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", AsyncMock())
+    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
+
+    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
+
+    captured: list[dict] = []
+    monkeypatch.setattr(
+        call_sessions, "mark_recording_ready",
+        lambda call_sid, rid, **kw: captured.append({"call_sid": call_sid, "rid": rid, **kw}),
+    )
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert len(captured) == 1
+    assert captured[0]["call_sid"] == "CAtest123"
+    assert captured[0]["rid"] == "niko-pizza-kitchen"
+    assert captured[0]["recording_url"] == "gs://niko-recordings/niko-pizza-kitchen/CAtest123.mp3"
+    assert captured[0]["recording_sid"] == "CAtest123"
+    assert captured[0]["duration_seconds"] == 12
+
+
 # ---------------------------------------------------------------------------
 # AI greeting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces the Twilio-REST recording approach (#127, #132, #133) which 404'd on every prod call. Twilio's REST control APIs (`Recordings.create`, `Calls.update`) return 404 on calls in `<Connect>` state — documented behaviour, no timing fix possible.

This PR captures audio from the existing `/media-stream` WebSocket Twilio is *already* sending us, encodes it incrementally to MP3 via `lameenc`, and PUTs 256 KB chunks to a GCS resumable upload session as the call progresses. Playback is via 302 redirect to a 30-min V4 signed URL — Cloud Run sees zero audio bytes on the playback path.

Bundle of six previously-deferred items, all now in scope:
- Both inbound + outbound tracks (caller=L, agent=R stereo)
- MP3 32 kbps via `lameenc` (no ffmpeg dep)
- Resumable upload (survives Cloud Run pod death between chunks)
- Signed-URL playback (saves Cloud Run egress)
- Auto-hangup via WS-close (replaces the equally-broken `Calls.update`)
- `DELETE /calls/{sid}/recording` (owner-only)
- Per-tenant retention via GCS `customTime` per blob

Spec: `docs/superpowers/specs/2026-04-30-ws-recording-design.md`. Plan: `docs/superpowers/plans/2026-04-30-ws-recording.md`.

## What changed

- **New module** `app/storage/recordings.py` — `begin_recording` / `append_chunks` / `finalize_recording` / `delete_recording` / `generate_signed_url` + `RecordingUploadSession` dataclass + 256-entry μ-law lookup table (replaces `audioop`, removed in Python 3.13).
- **`app/telephony/router.py`** — `/voice` emits `tracks="both_tracks"`. WS `start` calls `begin_recording`, each `media` event dispatches per-track to `append_chunks`, WS `stop`/`finally` runs `finalize_recording` + `mark_recording_ready`. `_hang_up_after_grace` now closes the WebSocket directly (auto-hangup). Dead code removed: `_start_recording_sync`, `_twilio_end_call_sync`, `/recording-status` endpoint, `RequestValidator` import. **Net -209 lines** in this file alone.
- **`app/main.py`** — `GET /calls/{sid}/recording` now returns 302 to a 30-min V4 signed URL. New `DELETE /calls/{sid}/recording` (owner-only). `httpx` dep removed.
- **`app/restaurants/models.py`** — new `recording_retention_days: int` field, default 90, bounded 1-3650.
- **`app/storage/call_sessions.py`** — new `mark_recording_deleted` (mirrors `mark_recording_ready` shape).
- **`app/config.py`** — `recordings_bucket`, `recording_default_retention_days`.
- **`scripts/setup-recordings-bucket.sh`** — one-shot bootstrap. Creates the bucket, configures `daysSinceCustomTime: 0` lifecycle, grants Cloud Run runtime SA `objectAdmin` + `serviceAccountTokenCreator` on itself.
- **deps** — `lameenc>=1.6,<2.0`, `google-cloud-storage>=2.0,<3.0`.

## Test plan

- [x] **Unit + integration suite** — 244 passed, 1 skipped, 0 failed. New `tests/test_recordings_storage.py` (15 tests) covers encoder, interleave/silence-pad, resumable PUT with retry/break, finalize happy + empty, delete idempotency, signed URL kwargs. New `tests/test_calls_route.py` (7 tests) covers GET 302 + 404 + 502 paths and DELETE owner/staff/missing/idempotent paths. Existing telephony tests updated to drop `_start_recording_sync` / `_twilio_end_call_sync` / `recording_status` references.
- [ ] **Run bootstrap script in prod**: `bash scripts/setup-recordings-bucket.sh` (creates `gs://niko-recordings`, applies lifecycle, grants IAM).
- [ ] **Place a real test call**, verify in Cloud Run logs:
  - mid-call: `recording chunk uploaded` lines
  - post-call: `recording finalized gs://niko-recordings/.../...mp3`
- [ ] **Open dashboard call detail page**, click play. DevTools should show 302 → `storage.googleapis.com`. Pan L/R to verify caller=left, agent=right.
- [ ] **Auto-hangup**: complete an order, observe Twilio drops the line ~3-5 s after the goodbye (no manual hangup needed).
- [ ] **DELETE**: from dashboard or curl, `DELETE /api/calls/<sid>/recording`. Audio player disappears within ~1 s; subsequent GET returns 404.

## Migration

- `gs://niko-recordings` does not exist yet. Run `scripts/setup-recordings-bucket.sh` from a workstation with `gcloud` auth on `niko-tsuki` *before* this PR's auto-deploy completes.
- Existing Firestore `recording_url` values (Twilio URLs from prior unsuccessful PRs) won't play — `get_call_recording` now returns 502 for non-`gs://` URLs. Affects only test calls; no real recordings ever landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)