### PR TITLE
dashboard: pin sidebar with sticky position (fixes #135 regression)

### DIFF
--- a/dashboard/components/app-sidebar.tsx
+++ b/dashboard/components/app-sidebar.tsx
@@ -58,14 +58,26 @@ export function AppSidebar({
   const pathname = usePathname();
 
   return (
-    // `collapsible="none"` means the sidebar is always expanded.
-    // The ShadCN primitive gives this variant only `h-full`, which
-    // doesn't resolve when SidebarProvider has only `min-h-svh` (no
+    // `collapsible="none"` keeps the sidebar always-expanded. The
+    // ShadCN primitive applies only `h-full` to this variant, which
+    // doesn't resolve against SidebarProvider's `min-h-svh` (no
     // explicit parent height) — the sidebar collapses to nav content
-    // height. `min-h-svh` here gives it a viewport-height floor; the
-    // parent flex row's default `align-items: stretch` then grows it
-    // with tall pages (e.g. /menu) so the sidebar reaches the bottom.
-    <Sidebar collapsible="none" className="min-h-svh border-r">
+    // size. We bypass the flex-stretch puzzle entirely with sticky
+    // positioning + explicit `h-svh`, giving us the standard "always-
+    // visible sidebar that follows the viewport" pattern (cf. GitHub,
+    // Stripe). `self-start` keeps stretch from interfering. Inline
+    // styles back up the Tailwind classes in case `tailwind-merge`
+    // mishandles `min-h-0` ↔ `min-h-svh` conflicts on Tailwind v4.
+    <Sidebar
+      collapsible="none"
+      className="sticky top-0 h-svh self-start border-r"
+      style={{
+        position: 'sticky',
+        top: 0,
+        height: '100svh',
+        alignSelf: 'flex-start',
+      }}
+    >
       <SidebarHeader>
         <div className="flex items-center gap-2.5 px-2 py-3">
           {/* 48px lines up with the "Niko" + "by Tsuki Works" stack


### PR DESCRIPTION
## Summary
- The sidebar still collapsed to its nav content height after #135 — `min-h-svh` with flex-stretch wasn't doing the work I expected.
- Replaces the height strategy with **sticky positioning + explicit `h-svh` + `self-start`** — the standard always-visible-sidebar pattern (GitHub, Stripe, etc.).
- Inline styles back the Tailwind classes so the height is enforced regardless of any `tailwind-merge` / Tailwind-v4 class-merge quirks.

## What I think actually went wrong with #135
Two things, in order of likelihood:

1. **`h-full` from the primitive prevents stretch.** `align-items: stretch` only applies to flex items whose cross-axis size is `auto`. `h-full` (`height: 100%`) computes to `100%`, not `auto` — so even when 100% can't resolve against an indefinite parent height, browsers don't fall back to stretch. The sidebar collapses to content size.
2. **`tailwind-merge` 3.5 may not be deduping `min-h-0` ↔ `min-h-svh` for Tailwind v4 utilities** — leaving `min-h-0` last in the cascade and clobbering the floor I tried to set.

Either way, this approach sidesteps both: explicit `100svh` height, no reliance on stretch, no class-merge gymnastics.

## Linked issue
Follow-up to #135 (which itself was a follow-up to #134). Confirmed broken on `/menu` in the deployed build (sidebar footer showed SHA `37f82fe` — #135 was live and the bug persisted).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` on `components/app-sidebar.tsx` clean
- [ ] Manual: `/menu` (long content) — sidebar fills viewport top to bottom in light + dark mode
- [ ] Manual: scroll to the bottom of `/menu` — sidebar stays pinned, follows viewport
- [ ] Manual: short pages (`/`, `/calls`, `/settings`) — sidebar still spans the viewport, no regression
- [ ] Manual: window resize — sidebar height tracks viewport correctly

## Notes
With `position: sticky` the sidebar takes its natural width in the flex row but is visually pinned at `top: 0`. As content scrolls past, the sidebar appears to follow. It does NOT grow beyond viewport height — that's intentional and matches established dashboard patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)