### PR TITLE
Route V4 signed URLs through IAM signBlob (fixes audio playback)

### DIFF
--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -332,18 +332,37 @@ def generate_signed_url(
     to 30 minutes — long enough for a typical playback session, short
     enough that a leaked URL ages out fast.
 
-    Cloud Run's runtime SA can sign V4 URLs without a private key file
-    by using the IAM ``signBlob`` API; the SA must hold
-    ``roles/iam.serviceAccountTokenCreator`` on itself. See
+    On Cloud Run the runtime credentials are
+    ``compute_engine.Credentials`` — they only carry an OAuth token, no
+    private key, so V4 signing must be routed through the IAM
+    ``signBlob`` API. We pass ``service_account_email`` and
+    ``access_token`` to ``generate_signed_url``; google-cloud-storage
+    detects them and routes the signing call to ``iam.googleapis.com``.
+    The runtime SA must hold ``roles/iam.serviceAccountTokenCreator``
+    on itself for that to work — granted by
     ``scripts/setup-recordings-bucket.sh``.
+
+    Local dev with an ADC service-account JSON file (which DOES carry a
+    private key) still works: ``ServiceAccountCredentials`` exposes
+    ``service_account_email`` too, and ``generate_signed_url`` prefers
+    local signing when a key is available.
     """
+    import google.auth
+    from google.auth.transport import requests as _gauth_requests
+
     blob_name = f"{restaurant_id}/{call_sid}.mp3"
     bucket = _get_storage_client().bucket(settings.recordings_bucket)
     blob = bucket.blob(blob_name)
+
+    credentials, _project = google.auth.default()
+    credentials.refresh(_gauth_requests.Request())
+
     return blob.generate_signed_url(
         version="v4",
         method="GET",
         expiration=timedelta(minutes=ttl_minutes),
+        service_account_email=getattr(credentials, "service_account_email", None),
+        access_token=getattr(credentials, "token", None),
     )
 
 

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -337,17 +337,21 @@ def test_delete_recording_idempotent_on_404(monkeypatch):
     recordings.delete_recording(call_sid="CAt", restaurant_id="rid")
 
 
-def test_generate_signed_url_uses_v4_get_30min(monkeypatch):
+def test_generate_signed_url_uses_v4_get_30min_and_iam_signblob(monkeypatch):
+    """Cloud Run runtime credentials (compute_engine.Credentials) lack a
+    private key, so V4 signing must route through IAM signBlob. We pass
+    ``service_account_email`` and ``access_token`` to
+    ``generate_signed_url``; google-cloud-storage uses them to call
+    iam.googleapis.com instead of trying to sign locally."""
     from datetime import timedelta
+    from types import SimpleNamespace
     from app.storage import recordings
 
     captured: dict = {}
 
     fake_blob = type("FakeBlob", (), {})()
-    def fake_signed(*, version, method, expiration):
-        captured["version"] = version
-        captured["method"] = method
-        captured["expiration"] = expiration
+    def fake_signed(**kwargs):
+        captured.update(kwargs)
         return "https://signed.googleapis.com/?sig=fake"
     fake_blob.generate_signed_url = fake_signed
 
@@ -362,6 +366,18 @@ def test_generate_signed_url_uses_v4_get_30min(monkeypatch):
 
     monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
 
+    # Stub google.auth.default + transport.requests.Request so the test
+    # never touches the metadata server.
+    fake_creds = SimpleNamespace(
+        service_account_email="runtime-sa@niko-tsuki.iam.gserviceaccount.com",
+        token="oauth-access-token-fake",
+        refresh=lambda _request: None,
+    )
+    import google.auth as gauth_mod
+    monkeypatch.setattr(gauth_mod, "default", lambda: (fake_creds, "niko-tsuki"))
+    from google.auth.transport import requests as _gauth_req
+    monkeypatch.setattr(_gauth_req, "Request", lambda: object())
+
     url = recordings.generate_signed_url(call_sid="CAt", restaurant_id="rid")
 
     assert url == "https://signed.googleapis.com/?sig=fake"
@@ -369,5 +385,8 @@ def test_generate_signed_url_uses_v4_get_30min(monkeypatch):
     assert captured["version"] == "v4"
     assert captured["method"] == "GET"
     assert captured["expiration"] == timedelta(minutes=30)
+    # IAM signBlob path
+    assert captured["service_account_email"] == "runtime-sa@niko-tsuki.iam.gserviceaccount.com"
+    assert captured["access_token"] == "oauth-access-token-fake"
 
 


### PR DESCRIPTION
## Summary

Hotfix to PR #136. Recording capture + GCS upload work — two MP3s landed in `gs://niko-recordings/twilight-family-restaurant/` from prod test calls. Playback was 500ing because `generate_signed_url` tried local signing on Cloud Run's compute-engine credentials (which carry only an OAuth token, no private key):

```
AttributeError: you need a private key to sign credentials.
the credentials you are currently using <class 'google.auth.compute_engine.credentials.Credentials'>
just contains a token.
```

Fix: pass `service_account_email` + `access_token` to `generate_signed_url`. google-cloud-storage detects them and routes signing to `iam.googleapis.com` (signBlob). The runtime SA already holds `roles/iam.serviceAccountTokenCreator` on itself (granted by `scripts/setup-recordings-bucket.sh`).

## Test plan

- [x] Existing `test_generate_signed_url_*` updated to stub `google.auth.default` and assert the new kwargs flow through. 22 storage + route tests pass.
- [ ] After deploy: re-fetch the existing `CAa5349...` recording — same call_sid that 500'd should now redirect 302 to a signed `storage.googleapis.com` URL and play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)