### PR TITLE
Fix <Stream> attribute (track, not tracks) — restores agent audio in recordings

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -564,7 +564,7 @@ async def voice(request: Request) -> Response:
 
     host = request.headers.get("host", "localhost:8000")
     connect = Connect()
-    stream = connect.stream(url=f"wss://{host}/media-stream", tracks="both_tracks")
+    stream = connect.stream(url=f"wss://{host}/media-stream", track="both_tracks")
     stream.parameter(name="restaurant_id", value=restaurant.id)
     twiml.append(connect)
     return Response(content=str(twiml), media_type="application/xml")

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -146,14 +146,19 @@ def test_voice_passes_restaurant_id_as_stream_parameter(monkeypatch):
 
 def test_voice_stream_requests_both_tracks(monkeypatch):
     """Twilio sends both inbound and outbound audio over the same WS
-    only when we ask for ``tracks="both_tracks"`` on the <Stream>. This
-    is the foundation for the WS-side recording pipeline (#82)."""
+    only when we ask for ``track="both_tracks"`` on the <Stream>. The
+    attribute is singular ``track`` per Twilio's TwiML reference;
+    plural ``tracks`` is silently ignored and falls back to inbound
+    only — exactly the bug that left agent audio out of recordings."""
     monkeypatch.setattr(
         restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
     )
     response = client.post("/voice", data=_VOICE_FORM)
     body = response.text
-    assert 'tracks="both_tracks"' in body
+    assert 'track="both_tracks"' in body
+    # Defensive: catch a regression to the plural attribute that
+    # Twilio silently drops.
+    assert 'tracks="both_tracks"' not in body
 
 
 def test_voice_uses_firestore_lookup_when_present(monkeypatch):


### PR DESCRIPTION
Two-character typo. tracks="both_tracks" (plural) is silently ignored by Twilio; the correct attribute is track="both_tracks" (singular per [Twilio's TwiML reference](https://www.twilio.com/docs/voice/twiml/stream)). Result: every recording so far captured caller audio only, no agent.

Test updated; also asserts the plural attribute is NOT present so this can't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)