### PR TITLE
Capture agent TTS in recordings + mix to single mono channel

### DIFF
--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -66,8 +66,14 @@ def _ulaw2lin_16(mu_law_bytes: bytes) -> bytes:
 
 def _compute_pcm_pair(inbound_mu_law: bytes, outbound_mu_law: bytes) -> bytes:
     """Decode each μ-law track to 16-bit PCM, pad the shorter side with
-    PCM silence, and interleave L=inbound / R=outbound. Returns stereo
+    PCM silence, and **mix** to a single mono channel by summing the
+    two streams sample-wise (clipped to int16 range). Returns mono
     16-bit little-endian PCM ready to feed the MP3 encoder.
+
+    Mono mix is what restaurant operators actually want: one playback
+    that "sounds like a normal phone call." Stereo (caller=L, agent=R)
+    sounds disorienting and confuses operators who expect a single
+    speaker waveform. File size is also halved.
 
     Pure function; no I/O. Keeps the hot-path math testable in isolation.
     """
@@ -84,10 +90,19 @@ def _compute_pcm_pair(inbound_mu_law: bytes, outbound_mu_law: bytes) -> bytes:
     inbound_pcm = inbound_pcm + b"\x00\x00" * (n - n_in)
     outbound_pcm = outbound_pcm + b"\x00\x00" * (n - n_out)
 
-    out = bytearray(n * 4)
+    # Sum each pair of int16 samples; clip to the int16 range so we
+    # never wrap around. Both sides talking simultaneously may clip
+    # briefly — acceptable for QA-grade phone audio.
+    out = bytearray(n * 2)
     for i in range(n):
-        out[i * 4 : i * 4 + 2] = inbound_pcm[i * 2 : i * 2 + 2]
-        out[i * 4 + 2 : i * 4 + 4] = outbound_pcm[i * 2 : i * 2 + 2]
+        a = struct.unpack_from("<h", inbound_pcm, i * 2)[0]
+        b = struct.unpack_from("<h", outbound_pcm, i * 2)[0]
+        s = a + b
+        if s > 32767:
+            s = 32767
+        elif s < -32768:
+            s = -32768
+        struct.pack_into("<h", out, i * 2, s)
     return bytes(out)
 
 
@@ -99,7 +114,7 @@ import lameenc
 _MP3_BITRATE_KBPS = 32
 _MP3_QUALITY = 2
 _PCM_SAMPLE_RATE = 8000  # Twilio media is 8 kHz μ-law
-_PCM_CHANNELS = 2        # we encode the stereo (caller=L, agent=R) mix
+_PCM_CHANNELS = 1        # caller + agent summed to mono in _compute_pcm_pair
 
 
 def _make_encoder() -> "lameenc.Encoder":
@@ -200,7 +215,8 @@ def append_chunks(
 
     # Track per-channel sample count for duration calc.
     # Stereo PCM-16 = 4 bytes per (per-channel) sample-pair.
-    session.total_pcm_samples += len(pcm) // 4
+    # Mono PCM-16 = 2 bytes per sample.
+    session.total_pcm_samples += len(pcm) // 2
 
     mp3 = session.encoder.encode(pcm)
     if mp3:

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -330,7 +330,12 @@ async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
         logger.info("silence timeout call_sid=%s", state.call_sid)
         _bg_call_event(state.call_sid, _state_rid(state), kind="silence_timeout")
         if state.stream_sid:
-            await speak(SILENCE_PROMPT, websocket, state.stream_sid)
+            await speak(
+                SILENCE_PROMPT,
+                websocket,
+                state.stream_sid,
+                recording_session=state.recording_session,
+            )
     except asyncio.CancelledError:
         pass
 
@@ -400,7 +405,12 @@ async def _run_llm_tts_turn(
                         if first_speak:
                             _record_first_audio()
                             first_speak = False
-                        await speak(chunk, websocket, state.stream_sid)
+                        await speak(
+                            chunk,
+                            websocket,
+                            state.stream_sid,
+                            recording_session=state.recording_session,
+                        )
 
             elif event.final is not None:
                 remainder = "".join(text_buffer).strip()
@@ -408,7 +418,12 @@ async def _run_llm_tts_turn(
                 if remainder and state.stream_sid:
                     if first_speak:
                         _record_first_audio()
-                    await speak(remainder, websocket, state.stream_sid)
+                    await speak(
+                        remainder,
+                        websocket,
+                        state.stream_sid,
+                        recording_session=state.recording_session,
+                    )
                 state.history = event.final.history
                 state.order = event.final.order
                 full_reply = "".join(full_reply_parts).strip()
@@ -664,6 +679,7 @@ async def media_stream(websocket: WebSocket) -> None:
                         f"Test build {settings.commit_sha[:7]}.",
                         websocket,
                         state.stream_sid,
+                        recording_session=state.recording_session,
                     )
                 state.llm_task = asyncio.create_task(
                     _run_llm_tts_turn(GREETING_TRANSCRIPT, state, websocket)

--- a/app/tts/client.py
+++ b/app/tts/client.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import base64
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import httpx
 from fastapi import WebSocket
@@ -42,6 +42,7 @@ async def speak(
     stream_sid: str,
     *,
     client: Optional[httpx.AsyncClient] = None,
+    recording_session: Optional[Any] = None,
 ) -> None:
     """Stream Deepgram Aura TTS audio back into the Twilio call.
 
@@ -51,10 +52,18 @@ async def speak(
     immediately, keeping latency low.
 
     Args:
-        text:       LLM reply text to synthesize.
-        websocket:  Active Twilio Media Streams WebSocket.
-        stream_sid: Twilio streamSid from the ``start`` event.
-        client:     Optional injected httpx.AsyncClient (for unit tests).
+        text:              LLM reply text to synthesize.
+        websocket:         Active Twilio Media Streams WebSocket.
+        stream_sid:        Twilio streamSid from the ``start`` event.
+        client:            Optional injected httpx.AsyncClient (for unit tests).
+        recording_session: Optional ``RecordingUploadSession`` from
+                           ``app.storage.recordings``. When set, each TTS
+                           chunk is also fed into the recording's
+                           outbound side via ``append_chunks(session, b"",
+                           chunk)``. ``<Connect><Stream>`` only sends us
+                           inbound audio from Twilio, so the only way
+                           to get the agent's voice into the recording is
+                           to capture the bytes we generate ourselves.
     """
     if not text.strip():
         return
@@ -112,6 +121,22 @@ async def speak(
                 except WebSocketDisconnect:
                     logger.info("tts: websocket disconnected mid-stream stream_sid=%s", stream_sid)
                     return
+                # Also feed the chunk into the recording session's outbound
+                # side. Done after the WS send so a recording-pipeline
+                # failure can't delay the audio reaching Twilio. The
+                # storage module short-circuits on a broken session.
+                if recording_session is not None:
+                    try:
+                        from app.storage import recordings as _recordings
+                        _recordings.append_chunks(
+                            recording_session, b"", chunk
+                        )
+                    except Exception:
+                        logger.exception(
+                            "tts: failed to feed chunk into recording session "
+                            "stream_sid=%s",
+                            stream_sid,
+                        )
     finally:
         if created_client:
             await _client.aclose()

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -10,41 +10,62 @@ helper for expected-value assertions instead of ``audioop.ulaw2lin``.
 """
 
 
-def test_compute_pcm_pair_interleaves_lr():
+def test_compute_pcm_pair_sums_to_mono():
+    """Both sides are summed sample-wise into a single mono channel.
+    Output length = max(in, out) samples × 2 bytes per sample."""
+    import struct
     from app.storage.recordings import _compute_pcm_pair, _ulaw2lin_16
 
-    # 2 μ-law samples per side. μ-law 0xFF = silence ≈ 0 PCM; 0x00 = max negative.
-    inbound = b"\xff\xff"
-    outbound = b"\x00\x00"
+    inbound = b"\xff\xff"   # μ-law 0xFF ≈ silence (~0 PCM)
+    outbound = b"\x80\x80"  # mid-positive PCM
     out = _compute_pcm_pair(inbound, outbound)
 
-    # 2 samples × 2 channels × 2 bytes = 8 bytes, L then R per sample.
-    assert len(out) == 8
+    # 2 samples × 2 bytes (mono)
+    assert len(out) == 4
     inbound_pcm = _ulaw2lin_16(inbound)
     outbound_pcm = _ulaw2lin_16(outbound)
-    # Sample 0: L = inbound[0:2], R = outbound[0:2]
-    assert out[0:2] == inbound_pcm[0:2]
-    assert out[2:4] == outbound_pcm[0:2]
-    # Sample 1: L = inbound[2:4], R = outbound[2:4]
-    assert out[4:6] == inbound_pcm[2:4]
-    assert out[6:8] == outbound_pcm[2:4]
+    for i in range(2):
+        a = struct.unpack_from("<h", inbound_pcm, i * 2)[0]
+        b = struct.unpack_from("<h", outbound_pcm, i * 2)[0]
+        expected = max(-32768, min(32767, a + b))
+        actual = struct.unpack_from("<h", out, i * 2)[0]
+        assert actual == expected, f"sample {i}: expected {expected}, got {actual}"
+
+
+def test_compute_pcm_pair_clips_on_overflow():
+    """When summed PCM overflows int16, the result clips at the boundary
+    instead of wrapping around (which would produce a nasty pop)."""
+    import struct
+    from app.storage.recordings import _compute_pcm_pair
+
+    # μ-law 0x80 decodes to a large positive PCM value; summing two of
+    # them overflows int16 → must clip at +32767.
+    inbound = b"\x80"
+    outbound = b"\x80"
+    out = _compute_pcm_pair(inbound, outbound)
+    assert len(out) == 2
+    sample = struct.unpack_from("<h", out, 0)[0]
+    assert sample == 32767
 
 
 def test_compute_pcm_pair_pads_shorter_side_with_silence():
-    from app.storage.recordings import _compute_pcm_pair
+    """Track-length skew: missing samples on one side become PCM silence
+    (zero) before the sum, so the longer side is preserved unchanged."""
+    import struct
+    from app.storage.recordings import _compute_pcm_pair, _ulaw2lin_16
 
-    inbound = b"\xff" * 100   # 100 μ-law samples
-    outbound = b"\x00" * 500  # 500 μ-law samples
+    inbound = b"\xff" * 100    # 100 samples on caller side
+    outbound = b"\x40" * 500   # 500 samples on agent side, non-zero PCM
     out = _compute_pcm_pair(inbound, outbound)
 
-    # 500 samples × 2 channels × 2 bytes
-    assert len(out) == 500 * 2 * 2
-    # Past the inbound's 100-sample mark, the L channel is PCM silence (\x00\x00).
+    # Mono PCM-16: 500 samples × 2 bytes
+    assert len(out) == 500 * 2
+    # Past the 100-sample mark, output is just outbound (caller padded with 0).
+    outbound_pcm = _ulaw2lin_16(outbound)
     for i in range(100, 500):
-        l_offset = i * 4
-        assert out[l_offset:l_offset + 2] == b"\x00\x00", (
-            f"L sample {i} not silent"
-        )
+        expected = struct.unpack_from("<h", outbound_pcm, i * 2)[0]
+        actual = struct.unpack_from("<h", out, i * 2)[0]
+        assert actual == expected, f"sample {i}: expected outbound={expected}, got {actual}"
 
 
 def test_compute_pcm_pair_handles_empty_chunks():
@@ -53,23 +74,23 @@ def test_compute_pcm_pair_handles_empty_chunks():
     assert _compute_pcm_pair(b"", b"") == b""
 
 
-def test_make_encoder_returns_lame_encoder_at_32kbps():
+def test_make_encoder_is_mono():
+    """Encoder is configured for mono input — the mix produced by
+    ``_compute_pcm_pair`` is a single channel."""
     from app.storage.recordings import _make_encoder
 
     enc = _make_encoder()
-    # Encode 1 second of stereo PCM silence — 16000 samples × 2 channels × 2 bytes.
-    pcm = b"\x00" * (16000 * 2 * 2)
+    # 1 second of mono PCM silence: 8000 samples × 1 channel × 2 bytes
+    pcm = b"\x00" * (8000 * 2)
     mp3 = enc.encode(pcm)
     mp3 += enc.flush()
 
-    # Output must start with an MP3 frame sync word (11-bit 0x7FF sync).
-    # The second byte's top 3 bits must be 110 or 111, so the second byte
-    # is in range 0xE0-0xFF. lameenc may emit MPEG-1 (0xFF 0xFx) or
-    # MPEG-2 (0xFF 0xEx) depending on sample rate; both are valid MP3.
+    # Valid MP3 frame sync (11-bit 0x7FF). Second byte top 3 bits = 110/111.
     assert len(mp3) >= 2 and mp3[0] == 0xFF and (mp3[1] & 0xE0) == 0xE0, (
         f"no MP3 frame sync found in {bytes(mp3[:32])!r}"
     )
-    assert 1000 < len(mp3) < 10000
+    # 1 s at 32 kbps mono ≈ 4 KB; allow a wide range to keep stable.
+    assert 500 < len(mp3) < 10000
 
 
 def test_begin_recording_creates_session_and_sets_custom_time(monkeypatch):

--- a/tests/test_tts_client.py
+++ b/tests/test_tts_client.py
@@ -158,3 +158,59 @@ async def test_speak_uses_configured_model_and_mulaw_format():
     assert kwargs["params"]["container"] == "none"
     assert kwargs["headers"]["Authorization"] == "Token test-key"
     assert kwargs["json"] == {"text": "Hello"}
+
+
+@pytest.mark.asyncio
+async def test_speak_feeds_recording_session_each_chunk(monkeypatch):
+    """When ``recording_session`` is passed, each TTS chunk is also fed
+    into the recording's outbound side via ``append_chunks``. This is
+    how the agent's voice gets into the recording — Twilio's
+    ``<Connect><Stream>`` only sends us inbound audio, so we capture
+    the bytes we generate ourselves."""
+    chunks = [b"\xab\xcd", b"\xef\x01\x02", b"\x03"]
+    client = make_mock_client(chunks)
+    ws = make_mock_websocket()
+    fake_session = MagicMock(broken=False)
+
+    captured: list[tuple] = []
+
+    def fake_append(session, inbound, outbound):
+        captured.append((session, inbound, outbound))
+
+    monkeypatch.setattr("app.storage.recordings.append_chunks", fake_append)
+
+    await speak(
+        "Hello",
+        ws,
+        stream_sid="MZ123",
+        client=client,
+        recording_session=fake_session,
+    )
+
+    # One append_chunks call per TTS chunk. inbound side is always
+    # empty (caller side is captured separately by the WS handler).
+    assert len(captured) == 3
+    for (session, inbound, outbound), expected_chunk in zip(captured, chunks):
+        assert session is fake_session
+        assert inbound == b""
+        assert outbound == expected_chunk
+
+
+@pytest.mark.asyncio
+async def test_speak_without_recording_session_skips_append(monkeypatch):
+    """If no recording session is passed, append_chunks is never called.
+    Defensive: the storage module's import should not be required when
+    recording is disabled or unavailable."""
+    chunks = [b"\xab", b"\xcd"]
+    client = make_mock_client(chunks)
+    ws = make_mock_websocket()
+
+    called: list = []
+    monkeypatch.setattr(
+        "app.storage.recordings.append_chunks",
+        lambda *a, **kw: called.append(a),
+    )
+
+    await speak("Hello", ws, stream_sid="MZ123", client=client)
+
+    assert called == []


### PR DESCRIPTION
Finishes the recording pipeline so playback contains both sides of the call.

**Agent audio capture.** Twilio's <Connect><Stream> only sends us caller audio over the WS — we can't ask for outbound_track without breaking the call. Instead, intercept the TTS bytes we generate ourselves: speak() takes a new recording_session kwarg and feeds each chunk into recordings.append_chunks(session, b"", chunk) after the send. All four speak() call sites in the WS handler pass state.recording_session.

**Mono mix replaces stereo interleave.** Restaurant operators expect a single phone-call waveform, not a stereo split. _compute_pcm_pair now sums both sides per sample and clips at int16 boundaries; _make_encoder switched to mono; duration math updated. Bonus: file size halved.

247 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)