### PR TITLE
Cast lameenc bytearray to bytes before GCS upload

### DIFF
--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -238,7 +238,9 @@ def finalize_recording(
             return ("", 0)
 
         encoder = _make_encoder()
-        mp3 = encoder.encode(mixed) + encoder.flush()
+        # lameenc returns bytearray; upload_from_string rejects bytearray
+        # ("could not be converted to bytes"), so cast explicitly.
+        mp3 = bytes(encoder.encode(mixed) + encoder.flush())
 
         _upload_blob(
             blob_name=session.blob_name,

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -238,6 +238,11 @@ def test_finalize_recording_mixes_encodes_and_uploads(monkeypatch):
     assert duration == 1
     assert captured["blob_name"] == "rid/CAt.mp3"
     assert captured["content_type"] == "audio/mpeg"
+    # google-cloud-storage's upload_from_string rejects bytearray
+    # ("could not be converted to bytes") so finalize MUST cast to bytes
+    # before handing off. Catching that here would have prevented the
+    # bug shipped in the first cut of this PR.
+    assert isinstance(captured["data"], bytes)
     # Output is real MP3 bytes
     assert captured["data"][0] == 0xFF and (captured["data"][1] & 0xE0) == 0xE0
     # custom_time is set to now() + retention_days


### PR DESCRIPTION
Hotfix to PR #142. Finalize crashed in prod with TypeError: bytearray(...) could not be converted to bytes. lameenc.Encoder returns bytearrays; upload_from_string rejects them. One-line cast. Test strengthened to assert the upload arg is bytes so this can't regress.