### PR TITLE
Rescope Sprint 2.3 from Square POS integration to Stripe payments (#6)

### DIFF
--- a/docs/superpowers/specs/2026-05-01-sprint-2.3-payments-rescope-design.md
+++ b/docs/superpowers/specs/2026-05-01-sprint-2.3-payments-rescope-design.md
@@ -1,0 +1,175 @@
+# Sprint 2.3 rescope: Payments vendor (not POS integration)
+
+**Date:** 2026-05-01
+**Issue:** #6 (Sprint 2.3 — currently titled "First POS Integration (Square)")
+**Status:** Spec — queued. Not active work; Sprint 2.1 stabilization and Sprint 2.4 dashboard precede this.
+
+---
+
+## Context
+
+The roadmap (`docs/02-product-roadmap.md`) framed Sprint 2.3 as **"First POS Integration (Square)"** — menu sync, order push, availability sync, webhook system, sandbox certification. That framing was set in Phase 0 before we had Sprint 2.2 in hand. Two facts on the ground now invalidate it:
+
+1. **niko already runs the order lifecycle end-to-end on its own.** Sprint 2.2 shipped order statuses (#107), tablet alert UX (#109), and the kitchen workflow UI (#111). The kitchen sees the order, accepts it, marks it ready, all on the niko tablet. There is no second screen the order needs to land on.
+
+2. **Our target restaurant doesn't have a cloud POS.** Loman.ai (the closest competitor — see `docs/loman-ai-disection.md` §6) treats POS integration as their "primary moat" precisely because their target customer already runs Toast/Square/Clover with a KDS the kitchen trusts. niko's target — small independent restaurants whose "POS" is a payment terminal that prints tickets (Dejavoo, PAX, Verifone, Clover Mini used standalone) — has no such system. Pushing orders into a Square account they don't have is solving a problem they don't have.
+
+What these restaurants do need that we haven't shipped: **a way to take payment when the customer isn't physically at the counter** — i.e., delivery, and optionally pickup pre-pay to reduce no-shows. That's a payment vendor problem, not a POS problem.
+
+Loman's own MVP path confirms this: their canonical order ticket fires with `"payment": "in_person"` and "Customer pays at counter via existing POS terminal. No new hardware, no new payment workflow" (loman dissection §4 step 8). They only invoke phone payment (Twilio DTMF + Stripe) when the in-person flow doesn't apply.
+
+This spec rescopes Sprint 2.3 around that reality.
+
+---
+
+## What changes
+
+### Original scope (drop)
+
+- ~~Square POS menu sync~~ — restaurants enter their menu in niko's editor (Sprint 2.4 deliverable). Restaurants without Square have nothing to sync from.
+- ~~Square POS order push~~ — niko's tablet IS the kitchen ticket display. Sprint 2.2 already ships this.
+- ~~Square item availability sync~~ — same reasoning. Availability lives in niko.
+- ~~Square sandbox certification~~ — no Square integration to certify.
+
+POS integrations move to **Phase 5 / Growth**, gated on real customer demand from a restaurant that already runs Toast/Square/Clover and asks for two-way sync. Until that demand surfaces, every dev-week spent on POS connectors is a dev-week not spent winning the no-POS independent segment.
+
+### New scope (in)
+
+Sprint 2.3 becomes **"Payment Vendor — Stripe (SMS Checkout link)"**:
+
+- **Stripe Connect onboarding** per tenant. Restaurant owner completes Stripe's hosted onboarding flow once during tenant setup; payouts land in their bank account directly. niko never touches funds.
+- **SMS Stripe Checkout link** as the phone-payment mechanism. After order confirmation, AI says "I'll text you a payment link." niko sends an SMS with a Stripe Checkout URL scoped to the order. Customer taps, pays in their browser, Stripe webhook flips the order to `paid`.
+- **"Payment moment" routing**:
+  - **Pickup orders** → default `payment_mode: "in_person"`. No SMS link sent. Tablet shows a "Mark paid" toggle for staff to flip when the customer pays at counter.
+  - **Delivery orders** → `payment_mode: "sms_link"`. SMS sent automatically after AI confirms order. Order does NOT advance past `received` until the Stripe webhook lands; if it doesn't land within a configurable window (default 10 min), order is auto-cancelled and the customer is notified by SMS.
+  - **Restaurant-level setting** `requires_prepay_for_pickup: bool` (default off). When on, pickup orders also use the SMS-link path.
+- **Refund flow (basic)**: tablet shows a "Refund" button on `paid` orders. Owner role only. Hits Stripe's refund API. Idempotent.
+- **Stripe webhook receiver** (`/webhooks/stripe`) that handles `checkout.session.completed`, `checkout.session.expired`, and `charge.refunded`. Tenant scoping via Stripe Connect's `account` field on the event.
+- **Outbound SMS infrastructure** — niko already uses Twilio for inbound voice; reuse the same Twilio account for outbound SMS (Messaging Service or per-tenant 10DLC number, decide during planning). This piece overlaps with Sprint 2.4's "Outbound SMS for order confirmations" deliverable; we should consolidate the two into one SMS module.
+
+### What's NOT in this rescope
+
+- **Card-over-phone via Twilio `<Pay>` / DTMF capture.** Loman uses this; we considered it (Option C in brainstorming). Skipped for MVP because (a) SMS link is simpler to implement and PCI-isolate, (b) we have no evidence callers prefer keypad entry to tapping a link on the same phone, (c) Twilio Pay setup requires a separate PCI-compliant PSP wiring step that SMS link sidesteps. Re-evaluate post-pilot if a real restaurant tells us their callers won't tap links.
+- **Reservations.** Phase 3.1 originally bundled "Payments & Reservations." Reservations stay in 3.1; this rescope only touches the payments half.
+- **Stripe Terminal / in-person card readers.** niko is not replacing the restaurant's existing payment terminal for walk-in customers. The restaurant's terminal continues to handle in-person payment unchanged.
+
+---
+
+## Architectural sketch
+
+Three new pieces; the rest is config + new fields on existing docs.
+
+### `app/payments/` (new module)
+
+```
+app/payments/
+  stripe_client.py     # thin wrapper: create_checkout_session, refund, retrieve
+  webhooks.py          # FastAPI router: /webhooks/stripe (signature-verified)
+  payment_modes.py     # routing logic: order → payment_mode based on type + tenant setting
+```
+
+### `app/sms/` (new module — shared with Sprint 2.4 outbound SMS)
+
+```
+app/sms/
+  client.py            # Twilio SMS send wrapper (idempotency-keyed)
+  templates.py         # payment_link, order_confirmation, payment_expired templates
+```
+
+### Firestore schema additions
+
+- **`restaurants/{rid}`** new fields:
+  - `stripe_account_id: string` — set after Connect onboarding completes
+  - `requires_prepay_for_pickup: bool` (default `false`)
+  - `payment_link_expiry_minutes: int` (default `10`)
+- **`orders/{oid}`** new fields:
+  - `payment_mode: "in_person" | "sms_link"`
+  - `payment_status: "pending" | "paid" | "expired" | "refunded"`
+  - `stripe_checkout_session_id: string | null`
+  - `stripe_payment_intent_id: string | null`
+
+Order status state machine gains a guard: delivery orders cannot transition past `received` until `payment_status == "paid"`.
+
+### Surfaces
+
+- **Tablet UI (existing kitchen workflow)** gains a "Mark paid" toggle for `in_person` orders and a "Refund" button on `paid` orders. Both behind the owner role gate.
+- **Dashboard onboarding flow** gains a Stripe Connect step (link out → return URL → status check). This is part of restaurant onboarding; the existing `/onboard-restaurant` skill is updated to optionally trigger Stripe onboarding.
+- **No customer-facing UI from us** — Stripe hosts Checkout. The SMS message body is the only customer touchpoint we own.
+
+---
+
+## Sprint 2.3 deliverables (rewritten)
+
+The Sprint 2.3 issue (#6) checklist becomes:
+
+- [ ] Stripe Connect onboarding: per-tenant account creation + dashboard link-out + return-handler
+- [ ] `/webhooks/stripe` receiver with signature verification + tenant scoping via Connect `account` field
+- [ ] `app/payments/` module: create_checkout_session, refund, retrieve
+- [ ] `app/sms/` module: Twilio SMS send wrapper (also unblocks Sprint 2.4 SMS confirmations)
+- [ ] Order schema migration: `payment_mode`, `payment_status`, Stripe ID fields
+- [ ] Payment-moment routing: pickup defaults in_person; delivery defaults sms_link; tenant-level prepay-for-pickup toggle
+- [ ] Order state-machine guard: delivery `received → preparing` blocked until `payment_status == paid`
+- [ ] Auto-cancel job: orders with `payment_mode=sms_link` and `payment_status=pending` past `payment_link_expiry_minutes` flip to `cancelled` + SMS notification
+- [ ] Tablet UI: "Mark paid" on in-person orders, "Refund" on paid orders (owner role)
+- [ ] Stripe sandbox integration tests (using `stripe-mock` or Stripe's hosted test mode)
+- [ ] Update `docs/02-product-roadmap.md` Sprint 2.3 section + MVP exit criteria
+
+### MVP exit criterion change
+
+Roadmap line 127 currently reads:
+> Orders flowing from phone → AI → Square POS reliably
+
+Becomes:
+> Orders flowing from phone → AI → kitchen tablet reliably; delivery orders pre-paid via SMS link before reaching the kitchen
+
+---
+
+## Why we're queuing this, not building it
+
+Three things must come first before Sprint 2.3 is the right work to start:
+
+1. **Sprint 2.1 must finish.** Eleven open issues (#82, #83, #115–122, #146) on call quality, error recovery, and latency. None of payments matters if the call drops or mishears the order.
+2. **Sprint 2.4 dashboard pieces must ship.** The menu editor, hours editor, and call history are what allow a real restaurant owner to self-manage the system. Without those, we can't onboard a pilot — payments or no payments.
+3. **First 2-3 pickup-only pilots must run.** Loman's `"payment": "in_person"` model means we can pilot with pickup-only restaurants without ANY payment vendor work. We learn whether the AI takes orders cleanly, whether the tablet workflow holds up in a real kitchen, and whether owners trust the system — all without Stripe in the picture. Only when a pilot restaurant says "we want to add delivery" does Sprint 2.3 become the critical path.
+
+This sequencing also means by the time we pick this up, we'll have real pilot feedback that may further refine the spec — particularly around the `payment_link_expiry_minutes` default, whether owners want prepay-for-pickup, and whether SMS link conversion is high enough or we need a fallback.
+
+---
+
+## Risks and open questions
+
+| # | Risk / Question | Mitigation / Where decided |
+|---|---|---|
+| 1 | SMS link tap-through rate may be too low for delivery (customer doesn't tap, food sits) | Auto-cancel + SMS notification at `payment_link_expiry_minutes`. Re-evaluate threshold after first 50 delivery orders. If conversion is bad, re-introduce DTMF capture as fallback. |
+| 2 | Stripe Connect onboarding adds friction to restaurant signup | Make it optional during onboarding (pickup-only restaurants don't need it). Trigger only when delivery is enabled or `requires_prepay_for_pickup` is turned on. |
+| 3 | Twilio outbound SMS requires 10DLC registration in the US (now mandatory) | Use a Messaging Service with shared 10DLC pool, or per-tenant brand registration during onboarding. Decide during implementation planning; not a blocker for this rescope. |
+| 4 | Refund flow needs an audit trail | Log every refund as a `refund_issued` event on the order doc with actor (Firebase user UID), timestamp, amount, and Stripe refund ID. Consistent with Sprint 2.2's order-event pattern. |
+| 5 | Restaurants on Square (non-target segment) want their daily sales in Square reports | Out of scope. Document the gap; revisit if/when a restaurant explicitly asks for it as a deal-blocker. POS integrations move to Phase 5. |
+| 6 | What if a customer pays via the SMS link AND at the counter (double-charge)? | "Mark paid" toggle is disabled when `payment_mode == "sms_link"`. The two paths are mutually exclusive at the order level. |
+
+---
+
+## Action items
+
+### Now (this rescope PR)
+
+- [x] Write spec (this doc).
+- [ ] Update issue #6 body on the GitHub project to reflect the new scope and link this spec.
+
+### Deferred — do when Sprint 2.3 actually becomes active
+
+These are intentionally NOT done now to avoid a doc/issue mismatch while the spec is queued:
+
+- [ ] Update `docs/02-product-roadmap.md` Sprint 2.3 section + MVP exit criterion to match this spec.
+- [ ] Add a line to the roadmap's Phase 5 / Growth section: "Optional POS integrations (Toast, Square, Clover) — gated on customer demand."
+- [ ] Reconcile with issue #8 (Sprint 3.1 Payments & Reservations) — strip the payments deliverables, leave the reservation work.
+
+---
+
+## References
+
+- `docs/02-product-roadmap.md` — current Sprint 2.3 / 3.1 framing being rescoped
+- `docs/loman-ai-disection.md` §4 step 8, §6, §9 — Loman's pickup-pays-at-counter default and DTMF-vs-SMS payment options
+- Issue #6 — Sprint 2.3 placeholder being rewritten
+- Issue #8 — Sprint 3.1 Payments & Reservations (reservations remain; payments fold up into 2.3 per this rescope)
+- Sprint 2.2 issues #107 (lifecycle statuses), #109 (tablet alerts), #111 (kitchen workflow UI) — establish niko-as-KDS


### PR DESCRIPTION
## Summary

- Rescopes Sprint 2.3 from "First POS Integration (Square)" to "Payment vendor (Stripe + SMS Checkout link)".
- Rationale: Sprint 2.2 already shipped the kitchen tablet workflow (#107/#109/#111) — niko's tablet IS the KDS. Our target segment (small independents whose "POS" is a payment terminal that prints tickets) doesn't have a cloud POS to integrate with. Pushing orders into Square is the wrong moat for this segment; payment-when-customer-isn't-at-the-counter is the real gap.
- Spec follows Loman.ai's MVP pattern (\`payment: "in_person"\` for pickup, customer pays at counter) with one deliberate improvement: SMS Stripe Checkout link instead of Twilio DTMF for phone payment — simpler wiring, lower PCI surface, modern UX.

## Linked issue

Relates to #6. Issue body is being updated separately to reflect the new scope and link this spec.

## What's changing

Spec only — no code yet. Sprint 2.3 status remains queued; Sprint 2.1 stabilization (11 open issues) and Sprint 2.4 dashboard pieces precede it. Pilot pickup-only restaurants validate the approach before payments become critical path.

POS integrations (Toast/Square/Clover) move to Phase 5 / Growth, gated on real customer demand.

## Test plan

- [ ] Reviewer reads \`docs/superpowers/specs/2026-05-01-sprint-2.3-payments-rescope-design.md\` end-to-end
- [ ] Confirm the in/out scope split makes sense for our target segment
- [ ] Sanity-check the deferred action items (roadmap update, issue #8 reconciliation) — these are intentionally NOT done now to avoid doc/issue mismatch while the spec is queued

## Notes

- Branch is docs-only. No application code touched.
- Outbound SMS module proposed here (\`app/sms/\`) also unblocks Sprint 2.4's "outbound SMS for order confirmations" deliverable; consolidating both under one module.
- One intentional divergence from Loman flagged in the spec: SMS Checkout link vs Loman's DTMF capture. Re-evaluate post-pilot if SMS-link tap-through is poor.