### PR TITLE
Sprint 2.4 design spec + 3 implementation plans (#7)

### DIFF
--- a/docs/superpowers/plans/2026-05-01-sprint-2.4-dashboard.md
+++ b/docs/superpowers/plans/2026-05-01-sprint-2.4-dashboard.md
@@ -1,0 +1,4136 @@
+# Sprint 2.4 — Track 1: Dashboard implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the dashboard's `ComingSoon` settings stub with a working settings page (info + hours + `fallback_phone`), turn the read-only menu view into a CRUD editor, ship a basic analytics page, and polish the call transcript display. Every change keeps the existing patterns: server-first RSC, Zod-via-converter, Server Actions for mutations, OKLCH tokens.
+
+**Architecture:** Backend changes are confined to `app/restaurants/models.py`, `app/main.py` (new endpoints), and a new `app/storage/analytics.py`. Dashboard changes stay inside `dashboard/` — new pages under `app/(dashboard)/`, new sections under `components/settings/`, `components/menu/`, `components/analytics/`. Mutations route through Server Actions that call the backend's new PATCH/POST/DELETE endpoints. The hours field is **additive** — `hours: str` (free-form, LLM-readable) stays for the prompt builder; a new `hours_structured: HoursStructured | None` carries the dashboard's editable form. The save action regenerates `hours: str` from `hours_structured` so the LLM keeps reading the same text.
+
+**Tech Stack:** FastAPI + Pydantic v2 (backend), Next.js 16 RSC + React 19 + Zod + Tailwind v4 + ShadCN (dashboard), pytest + vitest.
+
+**Spec deviation — menu item identity:** Spec wrote `PATCH /restaurants/me/menu/items/{item_id}`. Items don't currently carry stable IDs. Rather than running a UUID migration, this plan uses **composite keys** in the URL: `PATCH /restaurants/me/menu/items/{category}/{name}` with `name` URL-encoded. Trade-off: renaming changes the URL (a non-issue for admin ops). The path stable-ID restructure stays in the Phase 2+ deferred list (`dashboard/CLAUDE.md`).
+
+**Phase split — each phase is its own PR:**
+- Phase A + B → PR "Sprint 2.4 — settings page + hours editor (#7)"
+- Phase C + D → PR "Sprint 2.4 — menu editor (#7)"
+- Phase E → PR "Sprint 2.4 — analytics page (#7)"
+- Phase F → PR "Sprint 2.4 — transcript polish on /calls (#7)"
+
+---
+
+## Phase A — Backend: Restaurant schema additions + PATCH endpoint
+
+### Task 1: Add `HoursStructured` and `fallback_phone` to the Restaurant model (TDD)
+
+**Files:**
+- Modify: `app/restaurants/models.py`
+- Test: `tests/test_restaurants_storage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `tests/test_restaurants_storage.py`. Add at the end:
+
+```python
+def test_restaurant_has_optional_hours_structured_and_fallback_phone():
+    """New optional fields land additively — old Firestore docs without
+    them must still validate."""
+    from app.restaurants.models import (
+        DayHours,
+        HoursStructured,
+        Restaurant,
+    )
+
+    legacy_doc = {
+        "id": "demo",
+        "name": "Demo",
+        "display_phone": "+15551234567",
+        "twilio_phone": "+15551234567",
+        "address": "123 Main",
+        "hours": "Mon-Sun 11-22",
+    }
+    legacy = Restaurant.model_validate(legacy_doc)
+    assert legacy.hours_structured is None
+    assert legacy.fallback_phone is None
+
+    structured = HoursStructured(
+        mon=DayHours(open="11:00", close="22:00", closed=False),
+        tue=DayHours(open="11:00", close="22:00", closed=False),
+        wed=DayHours(open="11:00", close="22:00", closed=False),
+        thu=DayHours(open="11:00", close="22:00", closed=False),
+        fri=DayHours(open="11:00", close="23:00", closed=False),
+        sat=DayHours(open="11:00", close="23:00", closed=False),
+        sun=DayHours(open="11:00", close="22:00", closed=True),
+    )
+    full = Restaurant.model_validate(
+        {**legacy_doc, "hours_structured": structured.model_dump(), "fallback_phone": "+15559999999"},
+    )
+    assert full.hours_structured is not None
+    assert full.hours_structured.sun.closed is True
+    assert full.fallback_phone == "+15559999999"
+
+
+def test_day_hours_rejects_invalid_time_format():
+    from app.restaurants.models import DayHours
+
+    import pytest
+
+    with pytest.raises(Exception):
+        DayHours(open="11", close="22:00", closed=False)
+    with pytest.raises(Exception):
+        DayHours(open="25:00", close="22:00", closed=False)
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `pytest tests/test_restaurants_storage.py -v -k "hours_structured or day_hours"`
+Expected: 2 errors — `ImportError`.
+
+- [ ] **Step 3: Implement the new models**
+
+Open `app/restaurants/models.py`. After the imports, add:
+
+```python
+import re
+
+_HHMM = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+def _validate_hhmm(value: str) -> str:
+    if not _HHMM.match(value):
+        raise ValueError(f"time must be HH:MM (24-hour), got {value!r}")
+    return value
+```
+
+Then add the new model classes AFTER the existing imports and BEFORE the `Restaurant` class:
+
+```python
+class DayHours(BaseModel):
+    """Open/close pair for a single day. Times are local to the
+    restaurant's timezone (Phase 1: America/Toronto for everyone;
+    multi-tz arrives with multi-location, deferred per
+    dashboard/CLAUDE.md)."""
+
+    open: str = Field(description="Local opening time, HH:MM 24-hour")
+    close: str = Field(description="Local closing time, HH:MM 24-hour")
+    closed: bool = False
+
+    @field_validator("open", "close")
+    @classmethod
+    def _check_format(cls, v: str) -> str:
+        return _validate_hhmm(v)
+
+
+class HoursStructured(BaseModel):
+    """Per-day open/close ranges. The dashboard's hours editor writes
+    this; the prompt builder reads ``Restaurant.hours`` (the str
+    rendering) so changing this without regenerating ``hours`` would
+    drift the LLM. ``RestaurantUpdate`` regenerates ``hours`` on save."""
+
+    mon: DayHours
+    tue: DayHours
+    wed: DayHours
+    thu: DayHours
+    fri: DayHours
+    sat: DayHours
+    sun: DayHours
+```
+
+Add `field_validator` to the imports at the top of the file:
+
+```python
+from pydantic import BaseModel, Field, field_validator
+```
+
+Then in the `Restaurant` class, after `recording_retention_days` and before `created_at`, add:
+
+```python
+    hours_structured: Optional[HoursStructured] = None
+    # Used by Sprint 2.4 Track 2 (call transfer). E.164. None means
+    # the call falls through to voicemail without an attempted dial.
+    fallback_phone: Optional[str] = None
+```
+
+You'll also need `Optional` in the imports — check the existing import line at the top.
+
+- [ ] **Step 4: Run the tests — should pass**
+
+Run: `pytest tests/test_restaurants_storage.py -v -k "hours_structured or day_hours"`
+Expected: 2 passes.
+
+- [ ] **Step 5: Run the full backend test suite to confirm nothing broke**
+
+Run: `pytest tests/ -x`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/restaurants/models.py tests/test_restaurants_storage.py
+git commit -m "restaurants: add HoursStructured and fallback_phone fields (additive)"
+```
+
+---
+
+### Task 2: Add `PATCH /restaurants/me` endpoint with hours regeneration (TDD)
+
+**Files:**
+- Modify: `app/main.py`
+- Test: `tests/test_restaurants_api.py` (NEW)
+- Helper: `app/restaurants/hours.py` (NEW — `render_hours_text`)
+
+The PATCH body accepts a `RestaurantUpdate` with optional fields. The handler:
+1. Loads the current restaurant.
+2. Applies the patch (only owner-editable fields: `name`, `address`, `hours_structured`, `fallback_phone`, `display_phone`, `offers_delivery`).
+3. If `hours_structured` was patched, regenerates `hours: str` from it.
+4. Calls `save_restaurant`.
+5. Returns the updated doc.
+
+- [ ] **Step 1: Write the helper test (failing)**
+
+Create `tests/test_restaurants_hours.py`:
+
+```python
+"""Unit tests for app.restaurants.hours.render_hours_text."""
+
+from app.restaurants.hours import render_hours_text
+from app.restaurants.models import DayHours, HoursStructured
+
+
+def _all_days(open_t: str, close_t: str, closed: bool = False) -> HoursStructured:
+    payload = DayHours(open=open_t, close=close_t, closed=closed)
+    return HoursStructured(
+        mon=payload,
+        tue=payload,
+        wed=payload,
+        thu=payload,
+        fri=payload,
+        sat=payload,
+        sun=payload,
+    )
+
+
+def test_render_hours_text_collapses_uniform_week():
+    """All seven days identical → "Mon-Sun 11:00-22:00"."""
+    text = render_hours_text(_all_days("11:00", "22:00"))
+    assert text == "Mon-Sun 11:00-22:00"
+
+
+def test_render_hours_text_handles_per_day_when_mixed():
+    h = HoursStructured(
+        mon=DayHours(open="11:00", close="22:00", closed=False),
+        tue=DayHours(open="11:00", close="22:00", closed=False),
+        wed=DayHours(open="11:00", close="22:00", closed=False),
+        thu=DayHours(open="11:00", close="22:00", closed=False),
+        fri=DayHours(open="11:00", close="23:00", closed=False),
+        sat=DayHours(open="11:00", close="23:00", closed=False),
+        sun=DayHours(open="00:00", close="00:00", closed=True),
+    )
+    text = render_hours_text(h)
+    assert "Mon" in text and "11:00-22:00" in text
+    assert "Fri" in text and "11:00-23:00" in text
+    assert "Sun: closed" in text
+
+
+def test_render_hours_text_marks_all_closed_day_as_closed():
+    h = HoursStructured(
+        mon=DayHours(open="00:00", close="00:00", closed=True),
+        tue=DayHours(open="11:00", close="22:00", closed=False),
+        wed=DayHours(open="11:00", close="22:00", closed=False),
+        thu=DayHours(open="11:00", close="22:00", closed=False),
+        fri=DayHours(open="11:00", close="22:00", closed=False),
+        sat=DayHours(open="11:00", close="22:00", closed=False),
+        sun=DayHours(open="11:00", close="22:00", closed=False),
+    )
+    text = render_hours_text(h)
+    assert "Mon: closed" in text
+    assert "Tue-Sun 11:00-22:00" in text
+```
+
+- [ ] **Step 2: Run the failing helper tests**
+
+Run: `pytest tests/test_restaurants_hours.py -v`
+Expected: 3 errors — `ModuleNotFoundError: No module named 'app.restaurants.hours'`.
+
+- [ ] **Step 3: Implement `render_hours_text`**
+
+Create `app/restaurants/hours.py`:
+
+```python
+"""Render an ``HoursStructured`` value to the LLM-readable ``hours: str``
+the prompt builder consumes. The renderer collapses contiguous runs of
+identical days (Mon-Wed 11:00-22:00) and inlines closed-day notes
+(Sun: closed) so the rendered text stays compact."""
+
+from __future__ import annotations
+
+from app.restaurants.models import DayHours, HoursStructured
+
+_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+_LABELS = {
+    "mon": "Mon",
+    "tue": "Tue",
+    "wed": "Wed",
+    "thu": "Thu",
+    "fri": "Fri",
+    "sat": "Sat",
+    "sun": "Sun",
+}
+
+
+def _key(d: DayHours) -> tuple[bool, str, str]:
+    return (d.closed, d.open, d.close)
+
+
+def render_hours_text(hours: HoursStructured) -> str:
+    """Collapse contiguous runs of identical days into ranges; mark
+    closed days inline. Returns a compact one-line description suitable
+    for the system prompt."""
+    days = [(d, getattr(hours, d)) for d in _DAYS]
+
+    parts: list[str] = []
+    i = 0
+    while i < len(days):
+        start_key = _key(days[i][1])
+        j = i
+        while j + 1 < len(days) and _key(days[j + 1][1]) == start_key:
+            j += 1
+
+        first_label = _LABELS[days[i][0]]
+        last_label = _LABELS[days[j][0]]
+        span = first_label if i == j else f"{first_label}-{last_label}"
+
+        spec = days[i][1]
+        if spec.closed:
+            parts.append(f"{span}: closed")
+        else:
+            parts.append(f"{span} {spec.open}-{spec.close}")
+
+        i = j + 1
+
+    return ", ".join(parts)
+```
+
+- [ ] **Step 4: Run the helper tests — should pass**
+
+Run: `pytest tests/test_restaurants_hours.py -v`
+Expected: 3 passes.
+
+- [ ] **Step 5: Write the failing endpoint test**
+
+Create `tests/test_restaurants_api.py`:
+
+```python
+"""Integration tests for the dashboard-facing restaurants endpoints
+(``GET /restaurants/me`` already exists; this file covers the new
+``PATCH /restaurants/me``)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependency import current_tenant
+from app.auth.firebase import Tenant
+from app.main import app
+from app.restaurants import models as r_models
+from app.storage import restaurants as r_storage
+
+
+@pytest.fixture
+def fake_tenant():
+    return Tenant(
+        uid="user-1",
+        email="owner@niko.test",
+        restaurant_id="niko-pizza-kitchen",
+        role="owner",
+    )
+
+
+@pytest.fixture
+def client(fake_tenant: Tenant):
+    app.dependency_overrides[current_tenant] = lambda: fake_tenant
+    yield TestClient(app)
+    app.dependency_overrides.pop(current_tenant, None)
+
+
+@pytest.fixture(autouse=True)
+def reset_storage():
+    yield
+    r_storage.set_client(None)
+    r_storage.clear_cache()
+
+
+def _existing_doc() -> dict:
+    return {
+        "id": "niko-pizza-kitchen",
+        "name": "Niko Pizza Kitchen",
+        "display_phone": "+15551234567",
+        "twilio_phone": "+16479058093",
+        "address": "123 Main",
+        "hours": "Mon-Sun 11-22",
+        "menu": {},
+    }
+
+
+def _wire_storage(existing: dict) -> MagicMock:
+    fs = MagicMock()
+    r_storage.set_client(fs)
+    snap = MagicMock()
+    snap.exists = True
+    snap.to_dict.return_value = existing
+    fs.collection.return_value.document.return_value.get.return_value = snap
+    return fs
+
+
+def test_patch_restaurant_updates_name_and_address(client: TestClient):
+    fs = _wire_storage(_existing_doc())
+
+    resp = client.patch(
+        "/restaurants/me",
+        json={"name": "Niko Pizza Kitchen 2.0", "address": "456 New Street"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Niko Pizza Kitchen 2.0"
+    assert body["address"] == "456 New Street"
+    fs.collection.return_value.document.return_value.set.assert_called_once()
+
+
+def test_patch_restaurant_regenerates_hours_text_when_structured_changes(
+    client: TestClient,
+):
+    _wire_storage(_existing_doc())
+
+    structured = {
+        "mon": {"open": "11:00", "close": "22:00", "closed": False},
+        "tue": {"open": "11:00", "close": "22:00", "closed": False},
+        "wed": {"open": "11:00", "close": "22:00", "closed": False},
+        "thu": {"open": "11:00", "close": "22:00", "closed": False},
+        "fri": {"open": "11:00", "close": "23:00", "closed": False},
+        "sat": {"open": "11:00", "close": "23:00", "closed": False},
+        "sun": {"open": "00:00", "close": "00:00", "closed": True},
+    }
+    resp = client.patch(
+        "/restaurants/me",
+        json={"hours_structured": structured},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["hours_structured"] == structured
+    # Regenerated ``hours`` text should reflect the structured input
+    assert "Mon-Thu 11:00-22:00" in body["hours"]
+    assert "Sun: closed" in body["hours"]
+
+
+def test_patch_restaurant_rejects_unknown_fields(client: TestClient):
+    _wire_storage(_existing_doc())
+
+    resp = client.patch(
+        "/restaurants/me",
+        json={"id": "different-id", "twilio_phone": "+15550000000"},
+    )
+
+    # Pydantic strict-extra → 422
+    assert resp.status_code == 422
+
+
+def test_patch_restaurant_404_when_doc_missing(client: TestClient):
+    fs = MagicMock()
+    r_storage.set_client(fs)
+    snap = MagicMock()
+    snap.exists = False
+    fs.collection.return_value.document.return_value.get.return_value = snap
+
+    resp = client.patch("/restaurants/me", json={"name": "X"})
+    assert resp.status_code == 404
+
+
+def test_patch_restaurant_validates_fallback_phone_format(client: TestClient):
+    _wire_storage(_existing_doc())
+
+    # Loose validation: any non-empty E.164-like string is fine; "abc"
+    # rejected.
+    resp = client.patch("/restaurants/me", json={"fallback_phone": "abc"})
+    assert resp.status_code == 422
+```
+
+- [ ] **Step 6: Run the failing endpoint tests**
+
+Run: `pytest tests/test_restaurants_api.py -v`
+Expected: 5 errors — endpoint not registered.
+
+- [ ] **Step 7: Implement the endpoint**
+
+Open `app/main.py`. Add to the imports near the top:
+
+```python
+import re as _re
+
+from app.restaurants.hours import render_hours_text
+from app.restaurants.models import HoursStructured
+
+_E164 = _re.compile(r"^\+\d{8,15}$")
+```
+
+Add a body model below the `restaurants_me` handler:
+
+```python
+from pydantic import BaseModel, Field, field_validator
+
+
+class RestaurantUpdate(BaseModel):
+    """Owner-editable fields for PATCH /restaurants/me. Strict-extra so
+    typos and security-sensitive fields (id, twilio_phone) are rejected
+    rather than silently dropped."""
+
+    model_config = {"extra": "forbid"}
+
+    name: Optional[str] = None
+    display_phone: Optional[str] = None
+    address: Optional[str] = None
+    hours_structured: Optional[HoursStructured] = None
+    fallback_phone: Optional[str] = None
+    offers_delivery: Optional[bool] = None
+
+    @field_validator("fallback_phone")
+    @classmethod
+    def _check_e164(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or v == "":
+            return v
+        if not _E164.match(v):
+            raise ValueError(
+                f"fallback_phone must be E.164 (+1...), got {v!r}"
+            )
+        return v
+```
+
+Add `Optional` to the typing import at the top of `app/main.py` if it's not already imported.
+
+Then add the handler:
+
+```python
+@app.patch("/restaurants/me")
+def patch_restaurant(
+    update: RestaurantUpdate,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """Apply an owner-driven update to the calling tenant's Restaurant
+    doc. Owner-editable fields only — id and twilio_phone are not
+    patchable here (provisioning concerns)."""
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+
+    patch = update.model_dump(exclude_unset=True, exclude_none=False)
+
+    # Pydantic v2 model_copy with update-dict
+    updated = restaurant.model_copy(update=patch)
+
+    # If hours_structured was set, regenerate hours text so the prompt
+    # builder reflects the new schedule on the next call.
+    if update.hours_structured is not None:
+        updated = updated.model_copy(
+            update={"hours": render_hours_text(update.hours_structured)},
+        )
+
+    restaurants_storage.save_restaurant(updated)
+    restaurants_storage.clear_cache()
+    return updated.model_dump(mode="json")
+```
+
+- [ ] **Step 8: Run the endpoint tests**
+
+Run: `pytest tests/test_restaurants_api.py -v`
+Expected: 5 passes.
+
+- [ ] **Step 9: Run the full test suite**
+
+Run: `pytest tests/ -x`
+Expected: all green.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add app/main.py app/restaurants/hours.py tests/test_restaurants_api.py tests/test_restaurants_hours.py
+git commit -m "restaurants: add PATCH /restaurants/me with hours-text regeneration"
+```
+
+---
+
+## Phase B — Dashboard: settings page
+
+### Task 3: Update dashboard `RestaurantSchema` to include the new fields
+
+**Files:**
+- Modify: `dashboard/lib/schemas/restaurant.ts`
+- Test: `dashboard/tests/restaurant-schema.test.ts` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/tests/restaurant-schema.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+
+import { RestaurantSchema } from '@/lib/schemas/restaurant';
+
+const BASE = {
+  id: 'r1',
+  name: 'R',
+  display_phone: '+15551234567',
+  twilio_phone: '+15551234567',
+  address: '1 Main',
+  hours: 'Mon-Sun 11-22',
+};
+
+describe('RestaurantSchema', () => {
+  it('accepts a doc without hours_structured or fallback_phone', () => {
+    const parsed = RestaurantSchema.safeParse(BASE);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.hours_structured).toBeNull();
+      expect(parsed.data.fallback_phone).toBeNull();
+    }
+  });
+
+  it('accepts hours_structured with all seven days', () => {
+    const day = { open: '11:00', close: '22:00', closed: false };
+    const parsed = RestaurantSchema.safeParse({
+      ...BASE,
+      hours_structured: {
+        mon: day,
+        tue: day,
+        wed: day,
+        thu: day,
+        fri: day,
+        sat: day,
+        sun: { open: '00:00', close: '00:00', closed: true },
+      },
+      fallback_phone: '+15559999999',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects malformed hour times', () => {
+    const parsed = RestaurantSchema.safeParse({
+      ...BASE,
+      hours_structured: {
+        mon: { open: '99', close: '22:00', closed: false },
+        tue: { open: '11:00', close: '22:00', closed: false },
+        wed: { open: '11:00', close: '22:00', closed: false },
+        thu: { open: '11:00', close: '22:00', closed: false },
+        fri: { open: '11:00', close: '22:00', closed: false },
+        sat: { open: '11:00', close: '22:00', closed: false },
+        sun: { open: '11:00', close: '22:00', closed: false },
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `cd dashboard && pnpm vitest run tests/restaurant-schema.test.ts`
+Expected: failures (test 2 + 3 fail because `hours_structured` is rejected as unknown).
+
+- [ ] **Step 3: Update the schema**
+
+Open `dashboard/lib/schemas/restaurant.ts`. Replace the `RestaurantSchema` definition with:
+
+```typescript
+const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export const DayHoursSchema = z.object({
+  open: z.string().regex(HHMM, 'must be HH:MM (24-hour)'),
+  close: z.string().regex(HHMM, 'must be HH:MM (24-hour)'),
+  closed: z.boolean(),
+});
+export type DayHours = z.infer<typeof DayHoursSchema>;
+
+export const HoursStructuredSchema = z.object({
+  mon: DayHoursSchema,
+  tue: DayHoursSchema,
+  wed: DayHoursSchema,
+  thu: DayHoursSchema,
+  fri: DayHoursSchema,
+  sat: DayHoursSchema,
+  sun: DayHoursSchema,
+});
+export type HoursStructured = z.infer<typeof HoursStructuredSchema>;
+
+export const RestaurantSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  display_phone: z.string(),
+  twilio_phone: z.string(),
+  address: z.string(),
+  hours: z.string(),
+  hours_structured: HoursStructuredSchema.nullable().default(null),
+  fallback_phone: z
+    .string()
+    .regex(/^\+\d{8,15}$/, 'must be E.164')
+    .nullable()
+    .default(null),
+  offers_delivery: z.boolean().default(true),
+  menu: z.record(z.string(), z.unknown()).default({}),
+  prompt_overrides: z.record(z.string(), z.string()).default({}),
+  forwarding_mode: z.enum(['always', 'busy', 'noanswer']).default('always'),
+});
+
+export type Restaurant = z.infer<typeof RestaurantSchema>;
+```
+
+- [ ] **Step 4: Run the tests — should pass**
+
+Run: `cd dashboard && pnpm vitest run tests/restaurant-schema.test.ts`
+Expected: 3 passes.
+
+- [ ] **Step 5: Run typecheck + full vitest suite**
+
+Run: `cd dashboard && pnpm typecheck && pnpm vitest run`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/lib/schemas/restaurant.ts dashboard/tests/restaurant-schema.test.ts
+git commit -m "dashboard: add hours_structured + fallback_phone to RestaurantSchema"
+```
+
+---
+
+### Task 4: Add `updateRestaurant` API helper
+
+**Files:**
+- Modify: `dashboard/lib/api/restaurant.ts`
+- Test: `dashboard/tests/restaurant-api.test.ts` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/tests/restaurant-api.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from 'vitest';
+
+import { updateRestaurant } from '@/lib/api/restaurant';
+
+vi.mock('@/lib/api/http', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/lib/api/http';
+
+describe('updateRestaurant', () => {
+  it('PATCHes /restaurants/me with the patch body and parses the response', async () => {
+    const updated = {
+      id: 'r1',
+      name: 'New Name',
+      display_phone: '+15551234567',
+      twilio_phone: '+15551234567',
+      address: '1 Main',
+      hours: 'Mon-Sun 11-22',
+      hours_structured: null,
+      fallback_phone: null,
+      offers_delivery: true,
+      menu: {},
+      prompt_overrides: {},
+      forwarding_mode: 'always',
+    };
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => updated,
+    });
+
+    const result = await updateRestaurant({ name: 'New Name' });
+
+    expect(apiFetch).toHaveBeenCalledWith('/restaurants/me', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'New Name' }),
+    });
+    expect(result.name).toBe('New Name');
+  });
+
+  it('throws when the response is not ok', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable',
+    });
+    await expect(updateRestaurant({ name: 'X' })).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `cd dashboard && pnpm vitest run tests/restaurant-api.test.ts`
+Expected: error — `updateRestaurant` not exported.
+
+- [ ] **Step 3: Implement `updateRestaurant`**
+
+Open `dashboard/lib/api/restaurant.ts`. Append:
+
+```typescript
+export type RestaurantUpdate = Partial<{
+  name: string;
+  display_phone: string;
+  address: string;
+  hours_structured: import('@/lib/schemas/restaurant').HoursStructured;
+  fallback_phone: string | null;
+  offers_delivery: boolean;
+}>;
+
+export async function updateRestaurant(
+  update: RestaurantUpdate,
+): Promise<Restaurant> {
+  const res = await apiFetch('/restaurants/me', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(update),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `PATCH /restaurants/me failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  const body = (await res.json()) as unknown;
+  const parsed = RestaurantSchema.safeParse(body);
+  if (!parsed.success) {
+    console.error(
+      '[lib/api/restaurant] PATCH response failed validation',
+      parsed.error.flatten(),
+    );
+    throw new Error('updated restaurant payload failed schema validation');
+  }
+  return parsed.data;
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd dashboard && pnpm vitest run tests/restaurant-api.test.ts`
+Expected: 2 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/lib/api/restaurant.ts dashboard/tests/restaurant-api.test.ts
+git commit -m "dashboard: add updateRestaurant API helper"
+```
+
+---
+
+### Task 5: Settings page server component + section scaffold
+
+**Files:**
+- Replace: `dashboard/app/(dashboard)/settings/page.tsx`
+- Create: `dashboard/components/settings/settings-shell.tsx`
+
+- [ ] **Step 1: Replace the page contents**
+
+Open `dashboard/app/(dashboard)/settings/page.tsx`. Replace contents with:
+
+```tsx
+import { redirect } from 'next/navigation';
+
+import { SettingsShell } from '@/components/settings/settings-shell';
+import { getMyRestaurant } from '@/lib/api/restaurant';
+import { getServerSession } from '@/lib/auth/session';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SettingsPage() {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
+  let restaurant;
+  try {
+    restaurant = await getMyRestaurant();
+  } catch (err) {
+    console.error('[settings page] /restaurants/me fetch failed', err);
+    return (
+      <section className="flex flex-1 flex-col gap-3 p-6 lg:p-10">
+        <h2 className="text-3xl font-medium tracking-tight">Settings</h2>
+        <p className="text-sm text-muted-foreground">
+          Could not reach the backend to load your restaurant configuration.
+        </p>
+      </section>
+    );
+  }
+
+  return <SettingsShell restaurant={restaurant} />;
+}
+```
+
+- [ ] **Step 2: Create the shell component**
+
+Create `dashboard/components/settings/settings-shell.tsx`:
+
+```tsx
+import type { Restaurant } from '@/lib/schemas/restaurant';
+
+import { HoursEditor } from '@/components/settings/hours-editor';
+import { RestaurantInfoForm } from '@/components/settings/restaurant-info-form';
+
+export function SettingsShell({ restaurant }: { restaurant: Restaurant }) {
+  return (
+    <section className="flex flex-1 flex-col gap-10 p-6 lg:p-10">
+      <header className="flex max-w-3xl flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-3xl font-medium tracking-tight">Settings</h2>
+          <span aria-hidden className="h-px flex-1 translate-y-[-0.5rem] bg-border" />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Restaurant info, hours, and call-handling fallbacks. Changes take
+          effect on the next call.
+        </p>
+      </header>
+
+      <div className="flex max-w-3xl flex-col gap-12">
+        <RestaurantInfoForm restaurant={restaurant} />
+        <HoursEditor restaurant={restaurant} />
+
+        <section className="flex flex-col gap-2 rounded-lg border border-dashed border-border p-6">
+          <h3 className="text-base font-medium">Stripe Connect</h3>
+          <p className="text-xs text-muted-foreground">
+            Configured during onboarding when delivery or prepay-for-pickup is
+            enabled. Lands in Sprint 2.3.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-2 rounded-lg border border-dashed border-border p-6">
+          <h3 className="text-base font-medium">SMS preferences</h3>
+          <p className="text-xs text-muted-foreground">
+            Order confirmations send by default. Opt-out toggles arrive
+            post-pilot.
+          </p>
+        </section>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Verify typecheck (forms don't exist yet — page won't render)**
+
+Run: `cd dashboard && pnpm typecheck`
+Expected: errors about `@/components/settings/restaurant-info-form` and `@/components/settings/hours-editor` not found. That's expected — Tasks 6 + 7 land them.
+
+- [ ] **Step 4: Commit (broken state is OK; next two tasks fix it)**
+
+```bash
+git add dashboard/app/\(dashboard\)/settings/page.tsx dashboard/components/settings/settings-shell.tsx
+git commit -m "dashboard: settings page scaffold + shell (forms in next tasks)"
+```
+
+---
+
+### Task 6: Restaurant info form + Server Action
+
+**Files:**
+- Create: `dashboard/components/settings/restaurant-info-form.tsx`
+- Create: `dashboard/app/actions/update-restaurant.ts`
+- Test: `dashboard/tests/restaurant-info-form.test.tsx` (NEW)
+
+- [ ] **Step 1: Create the Server Action**
+
+Create `dashboard/app/actions/update-restaurant.ts`:
+
+```typescript
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import {
+  updateRestaurant,
+  type RestaurantUpdate,
+} from '@/lib/api/restaurant';
+
+export type UpdateRestaurantResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export async function updateRestaurantAction(
+  patch: RestaurantUpdate,
+): Promise<UpdateRestaurantResult> {
+  try {
+    await updateRestaurant(patch);
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    };
+  }
+  revalidatePath('/settings');
+  return { success: true };
+}
+```
+
+- [ ] **Step 2: Write the failing form test**
+
+Create `dashboard/tests/restaurant-info-form.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RestaurantInfoForm } from '@/components/settings/restaurant-info-form';
+
+vi.mock('@/app/actions/update-restaurant', () => ({
+  updateRestaurantAction: vi.fn().mockResolvedValue({ success: true }),
+}));
+import { updateRestaurantAction } from '@/app/actions/update-restaurant';
+
+const BASE = {
+  id: 'r1',
+  name: 'Niko Pizza Kitchen',
+  display_phone: '+15551234567',
+  twilio_phone: '+16479058093',
+  address: '123 Main',
+  hours: 'Mon-Sun 11-22',
+  hours_structured: null,
+  fallback_phone: null,
+  offers_delivery: true,
+  menu: {},
+  prompt_overrides: {},
+  forwarding_mode: 'always' as const,
+};
+
+describe('RestaurantInfoForm', () => {
+  it('submits a patch with edited fields only', async () => {
+    render(<RestaurantInfoForm restaurant={BASE} />);
+
+    const nameInput = screen.getByLabelText(/restaurant name/i);
+    fireEvent.change(nameInput, { target: { value: 'New Name' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(updateRestaurantAction).toHaveBeenCalledWith({
+        name: 'New Name',
+      }),
+    );
+  });
+
+  it('shows the twilio_phone read-only', () => {
+    render(<RestaurantInfoForm restaurant={BASE} />);
+    const twilio = screen.getByLabelText(/twilio number/i);
+    expect(twilio).toHaveAttribute('readOnly');
+    expect(twilio).toHaveValue('+16479058093');
+  });
+
+  it('validates fallback_phone format on submit', async () => {
+    render(<RestaurantInfoForm restaurant={BASE} />);
+    const fallback = screen.getByLabelText(/fallback number/i);
+    fireEvent.change(fallback, { target: { value: 'abc' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await screen.findByText(/E\.164/i);
+    expect(updateRestaurantAction).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: Run the failing test**
+
+Run: `cd dashboard && pnpm vitest run tests/restaurant-info-form.test.tsx`
+Expected: error — component not found.
+
+- [ ] **Step 4: Implement the form**
+
+Create `dashboard/components/settings/restaurant-info-form.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { updateRestaurantAction } from '@/app/actions/update-restaurant';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { Restaurant } from '@/lib/schemas/restaurant';
+
+const E164 = /^\+\d{8,15}$/;
+
+export function RestaurantInfoForm({ restaurant }: { restaurant: Restaurant }) {
+  const [name, setName] = useState(restaurant.name);
+  const [address, setAddress] = useState(restaurant.address);
+  const [displayPhone, setDisplayPhone] = useState(restaurant.display_phone);
+  const [fallbackPhone, setFallbackPhone] = useState(
+    restaurant.fallback_phone ?? '',
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function buildPatch() {
+    const patch: Record<string, unknown> = {};
+    if (name !== restaurant.name) patch.name = name;
+    if (address !== restaurant.address) patch.address = address;
+    if (displayPhone !== restaurant.display_phone)
+      patch.display_phone = displayPhone;
+    const trimmedFallback = fallbackPhone.trim();
+    const restaurantFallback = restaurant.fallback_phone ?? '';
+    if (trimmedFallback !== restaurantFallback) {
+      patch.fallback_phone = trimmedFallback === '' ? null : trimmedFallback;
+    }
+    return patch;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedFallback = fallbackPhone.trim();
+    if (trimmedFallback !== '' && !E164.test(trimmedFallback)) {
+      setError('Fallback number must be in E.164 format (e.g. +15551234567).');
+      return;
+    }
+
+    const patch = buildPatch();
+    if (Object.keys(patch).length === 0) {
+      toast.info('Nothing to save.');
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await updateRestaurantAction(patch);
+      if (!result.success) {
+        setError(result.error);
+        toast.error('Save failed.');
+        return;
+      }
+      toast.success('Saved.');
+    });
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h3 className="text-base font-medium">Restaurant info</h3>
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="restaurant-name">Restaurant name</Label>
+          <Input
+            id="restaurant-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="address">Address</Label>
+          <Input
+            id="address"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="display-phone">Display number</Label>
+          <Input
+            id="display-phone"
+            value={displayPhone}
+            onChange={(e) => setDisplayPhone(e.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            What customers dial. Forwards into Niko via your carrier.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="twilio-phone">Twilio number</Label>
+          <Input
+            id="twilio-phone"
+            value={restaurant.twilio_phone || '(awaiting)'}
+            readOnly
+            className="bg-muted"
+          />
+          <p className="text-xs text-muted-foreground">
+            Provisioned by Niko — not editable from here.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="fallback-phone">Fallback number</Label>
+          <Input
+            id="fallback-phone"
+            value={fallbackPhone}
+            placeholder="+15551234567"
+            onChange={(e) => setFallbackPhone(e.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            Niko transfers callers here when the AI hits a snag or the caller
+            asks for a human. Leave blank to skip the transfer attempt and go
+            straight to voicemail.
+          </p>
+        </div>
+
+        {error ? (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={pending}>
+            {pending ? 'Saving…' : 'Save info'}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 5: Run the form tests**
+
+Run: `cd dashboard && pnpm vitest run tests/restaurant-info-form.test.tsx`
+Expected: 3 passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/app/actions/update-restaurant.ts dashboard/components/settings/restaurant-info-form.tsx dashboard/tests/restaurant-info-form.test.tsx
+git commit -m "dashboard: settings — restaurant info form + Server Action"
+```
+
+---
+
+### Task 7: Hours editor
+
+**Files:**
+- Create: `dashboard/components/settings/hours-editor.tsx`
+- Test: `dashboard/tests/hours-editor.test.tsx` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `dashboard/tests/hours-editor.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HoursEditor } from '@/components/settings/hours-editor';
+
+vi.mock('@/app/actions/update-restaurant', () => ({
+  updateRestaurantAction: vi.fn().mockResolvedValue({ success: true }),
+}));
+import { updateRestaurantAction } from '@/app/actions/update-restaurant';
+
+const day = { open: '11:00', close: '22:00', closed: false };
+const BASE = {
+  id: 'r1',
+  name: 'R',
+  display_phone: '+15551234567',
+  twilio_phone: '+15551234567',
+  address: '1 Main',
+  hours: 'Mon-Sun 11-22',
+  hours_structured: {
+    mon: day,
+    tue: day,
+    wed: day,
+    thu: day,
+    fri: day,
+    sat: day,
+    sun: day,
+  },
+  fallback_phone: null,
+  offers_delivery: true,
+  menu: {},
+  prompt_overrides: {},
+  forwarding_mode: 'always' as const,
+};
+
+describe('HoursEditor', () => {
+  it('renders seven day rows', () => {
+    render(<HoursEditor restaurant={BASE} />);
+    expect(screen.getAllByRole('row')).toHaveLength(7 + 1); // 7 days + header
+  });
+
+  it('seeds from hours_structured when present', () => {
+    render(<HoursEditor restaurant={BASE} />);
+    const opens = screen.getAllByLabelText(/open time/i);
+    expect(opens[0]).toHaveValue('11:00');
+  });
+
+  it('seeds with default 11:00-22:00 when hours_structured is null', () => {
+    render(<HoursEditor restaurant={{ ...BASE, hours_structured: null }} />);
+    const opens = screen.getAllByLabelText(/open time/i);
+    expect(opens[0]).toHaveValue('11:00');
+  });
+
+  it('disables open/close inputs when the day is marked closed', () => {
+    render(<HoursEditor restaurant={BASE} />);
+    const monClosed = screen.getByLabelText(/monday closed/i);
+    fireEvent.click(monClosed);
+    const opens = screen.getAllByLabelText(/open time/i);
+    expect(opens[0]).toBeDisabled();
+  });
+
+  it('submits hours_structured when saved', async () => {
+    render(<HoursEditor restaurant={BASE} />);
+    const monClosed = screen.getByLabelText(/monday closed/i);
+    fireEvent.click(monClosed);
+    fireEvent.click(screen.getByRole('button', { name: /save hours/i }));
+
+    await waitFor(() => {
+      expect(updateRestaurantAction).toHaveBeenCalled();
+      const call = (updateRestaurantAction as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(call.hours_structured.mon.closed).toBe(true);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `cd dashboard && pnpm vitest run tests/hours-editor.test.tsx`
+Expected: error — component not found.
+
+- [ ] **Step 3: Implement the editor**
+
+Create `dashboard/components/settings/hours-editor.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { updateRestaurantAction } from '@/app/actions/update-restaurant';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { DayHours, HoursStructured, Restaurant } from '@/lib/schemas/restaurant';
+
+const DAYS: { key: keyof HoursStructured; label: string }[] = [
+  { key: 'mon', label: 'Monday' },
+  { key: 'tue', label: 'Tuesday' },
+  { key: 'wed', label: 'Wednesday' },
+  { key: 'thu', label: 'Thursday' },
+  { key: 'fri', label: 'Friday' },
+  { key: 'sat', label: 'Saturday' },
+  { key: 'sun', label: 'Sunday' },
+];
+
+const DEFAULT_DAY: DayHours = { open: '11:00', close: '22:00', closed: false };
+
+function seedHours(r: Restaurant): HoursStructured {
+  if (r.hours_structured) return r.hours_structured;
+  return {
+    mon: { ...DEFAULT_DAY },
+    tue: { ...DEFAULT_DAY },
+    wed: { ...DEFAULT_DAY },
+    thu: { ...DEFAULT_DAY },
+    fri: { ...DEFAULT_DAY },
+    sat: { ...DEFAULT_DAY },
+    sun: { ...DEFAULT_DAY },
+  };
+}
+
+export function HoursEditor({ restaurant }: { restaurant: Restaurant }) {
+  const [hours, setHours] = useState<HoursStructured>(seedHours(restaurant));
+  const [pending, startTransition] = useTransition();
+
+  function update(day: keyof HoursStructured, patch: Partial<DayHours>) {
+    setHours((prev) => ({
+      ...prev,
+      [day]: { ...prev[day], ...patch },
+    }));
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await updateRestaurantAction({ hours_structured: hours });
+      if (!result.success) {
+        toast.error(`Save failed: ${result.error}`);
+        return;
+      }
+      toast.success('Hours saved.');
+    });
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h3 className="text-base font-medium">Hours</h3>
+      <p className="text-xs text-muted-foreground">
+        Times are local to the restaurant. Use 24-hour format. Niko reads
+        these to callers and routes after-hours calls to voicemail.
+      </p>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Day</TableHead>
+            <TableHead>Open</TableHead>
+            <TableHead>Close</TableHead>
+            <TableHead>Closed</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {DAYS.map(({ key, label }) => {
+            const day = hours[key];
+            return (
+              <TableRow key={key}>
+                <TableCell className="font-medium">{label}</TableCell>
+                <TableCell>
+                  <Label htmlFor={`open-${key}`} className="sr-only">
+                    {label} open time
+                  </Label>
+                  <Input
+                    id={`open-${key}`}
+                    type="time"
+                    value={day.open}
+                    disabled={day.closed}
+                    onChange={(e) => update(key, { open: e.target.value })}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Label htmlFor={`close-${key}`} className="sr-only">
+                    {label} close time
+                  </Label>
+                  <Input
+                    id={`close-${key}`}
+                    type="time"
+                    value={day.close}
+                    disabled={day.closed}
+                    onChange={(e) => update(key, { close: e.target.value })}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Label htmlFor={`closed-${key}`} className="sr-only">
+                    {label} closed
+                  </Label>
+                  <input
+                    id={`closed-${key}`}
+                    type="checkbox"
+                    checked={day.closed}
+                    onChange={(e) => update(key, { closed: e.target.checked })}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      <div className="flex justify-end">
+        <Button type="button" onClick={handleSave} disabled={pending}>
+          {pending ? 'Saving…' : 'Save hours'}
+        </Button>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd dashboard && pnpm vitest run tests/hours-editor.test.tsx`
+Expected: 5 passes.
+
+- [ ] **Step 5: Manual smoke**
+
+Run: `cd dashboard && pnpm dev`
+Open `/settings`, edit a day's hours, mark Sunday closed, click Save. Reload — values persist.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/components/settings/hours-editor.tsx dashboard/tests/hours-editor.test.tsx
+git commit -m "dashboard: settings — hours editor with per-day open/close + closed toggle"
+```
+
+---
+
+### Task 8: Open Phase A+B PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin <branch>
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "Sprint 2.4 — settings page + hours editor (#7)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds `HoursStructured` and `fallback_phone` to `Restaurant` (additive — old docs unaffected).
+- Adds `PATCH /restaurants/me` with strict-extra validation; regenerates `hours: str` from `hours_structured` so the LLM prompt builder reflects the new schedule.
+- Replaces the dashboard's `ComingSoon` settings stub with `RestaurantInfoForm` + `HoursEditor`. Save uses a Server Action that calls the new PATCH endpoint.
+- Lays placeholder cards for Stripe Connect (Sprint 2.3) and SMS preferences (post-pilot).
+
+## Test plan
+
+- [ ] `pytest tests/test_restaurants_api.py tests/test_restaurants_hours.py tests/test_restaurants_storage.py -v`
+- [ ] `cd dashboard && pnpm vitest run tests/restaurant-schema.test.ts tests/restaurant-api.test.ts tests/restaurant-info-form.test.tsx tests/hours-editor.test.tsx`
+- [ ] `cd dashboard && pnpm typecheck`
+- [ ] Manual: edit name/address/fallback_phone on `/settings`, save, reload — values persist.
+- [ ] Manual: mark Sunday closed in hours editor, save, reload — Sunday stays closed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Phase C — Backend: menu CRUD endpoints
+
+### Task 9: Update menu schema with `available` field + helpers (TDD)
+
+**Files:**
+- Modify: `app/restaurants/models.py` — add `MenuItemUpdate` + `MenuItemCreate` Pydantic models
+- Test: `tests/test_menu_models.py` (NEW)
+
+The granular endpoints accept Pydantic-validated bodies rather than free-form dicts. Items in storage stay as flexible dicts (no migration), but writes go through validation that enforces shape: `name` required, exactly one of `price` or `sizes`, `available` defaults true.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_menu_models.py`:
+
+```python
+"""Unit tests for the granular-menu request bodies."""
+
+import pytest
+
+from app.restaurants.models import MenuItemCreate, MenuItemUpdate
+
+
+def test_menu_item_create_accepts_single_price():
+    item = MenuItemCreate(category="pizzas", name="Margherita", price=12.99)
+    assert item.available is True
+    assert item.sizes is None
+    assert item.price == 12.99
+
+
+def test_menu_item_create_accepts_sizes():
+    item = MenuItemCreate(
+        category="pizzas",
+        name="Pepperoni",
+        sizes={"small": 12.99, "large": 18.99},
+    )
+    assert item.price is None
+    assert item.sizes == {"small": 12.99, "large": 18.99}
+
+
+def test_menu_item_create_rejects_both_price_and_sizes():
+    with pytest.raises(ValueError):
+        MenuItemCreate(
+            category="pizzas",
+            name="X",
+            price=10.00,
+            sizes={"small": 8.00},
+        )
+
+
+def test_menu_item_create_rejects_neither_price_nor_sizes():
+    with pytest.raises(ValueError):
+        MenuItemCreate(category="pizzas", name="X")
+
+
+def test_menu_item_create_rejects_negative_price():
+    with pytest.raises(ValueError):
+        MenuItemCreate(category="pizzas", name="X", price=-1.00)
+
+
+def test_menu_item_update_allows_partial_fields():
+    upd = MenuItemUpdate(price=14.99)
+    assert upd.model_dump(exclude_unset=True) == {"price": 14.99}
+
+
+def test_menu_item_update_rejects_both_price_and_sizes_together():
+    with pytest.raises(ValueError):
+        MenuItemUpdate(price=10.00, sizes={"small": 8.00})
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `pytest tests/test_menu_models.py -v`
+Expected: 7 errors — models don't exist.
+
+- [ ] **Step 3: Implement the models**
+
+Open `app/restaurants/models.py`. Append at the end:
+
+```python
+from pydantic import model_validator
+
+
+class MenuItemCreate(BaseModel):
+    """Body for POST /restaurants/me/menu/items. Exactly one of
+    ``price`` or ``sizes`` is required."""
+
+    model_config = {"extra": "forbid"}
+
+    category: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    description: Optional[str] = None
+    price: Optional[float] = Field(default=None, ge=0)
+    sizes: Optional[dict[str, float]] = None
+    available: bool = True
+
+    @model_validator(mode="after")
+    def _exactly_one_price(self):
+        has_price = self.price is not None
+        has_sizes = self.sizes is not None and len(self.sizes) > 0
+        if has_price and has_sizes:
+            raise ValueError("specify exactly one of price or sizes, not both")
+        if not has_price and not has_sizes:
+            raise ValueError("specify either price or sizes")
+        if has_sizes:
+            for size_name, price in (self.sizes or {}).items():
+                if price < 0:
+                    raise ValueError(
+                        f"size {size_name!r} price must be non-negative"
+                    )
+        return self
+
+
+class MenuItemUpdate(BaseModel):
+    """Body for PATCH /restaurants/me/menu/items/{category}/{name}.
+    All fields optional. Specifying both ``price`` and ``sizes``
+    together is an error; specifying one clears the other on save."""
+
+    model_config = {"extra": "forbid"}
+
+    new_name: Optional[str] = Field(default=None, min_length=1)
+    new_category: Optional[str] = Field(default=None, min_length=1)
+    description: Optional[str] = None
+    price: Optional[float] = Field(default=None, ge=0)
+    sizes: Optional[dict[str, float]] = None
+    available: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def _not_both_price_and_sizes(self):
+        if self.price is not None and self.sizes is not None:
+            raise ValueError("specify at most one of price or sizes")
+        return self
+
+
+class CategoryCreate(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(min_length=1, pattern=r"^[a-z0-9_]+$")
+```
+
+You may need to add `model_validator` to your existing pydantic imports.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pytest tests/test_menu_models.py -v`
+Expected: 7 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/restaurants/models.py tests/test_menu_models.py
+git commit -m "menu: add MenuItemCreate/Update/CategoryCreate validation models"
+```
+
+---
+
+### Task 10: Implement menu storage helpers (TDD)
+
+**Files:**
+- Create: `app/restaurants/menu_writes.py`
+- Test: `tests/test_menu_writes.py` (NEW)
+
+Pure functions that take a `Restaurant`, apply a change, and return a new `Restaurant`. No Firestore I/O — endpoints orchestrate storage. Keeps the logic unit-testable without mocking Firestore.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_menu_writes.py`:
+
+```python
+"""Unit tests for app.restaurants.menu_writes — pure-function menu
+mutations on a Restaurant.menu dict."""
+
+import pytest
+
+from app.restaurants.menu_writes import (
+    DuplicateMenuItem,
+    MenuItemNotFound,
+    add_category,
+    add_menu_item,
+    delete_menu_item,
+    update_menu_item,
+)
+from app.restaurants.models import (
+    CategoryCreate,
+    MenuItemCreate,
+    MenuItemUpdate,
+    Restaurant,
+)
+
+
+def _r() -> Restaurant:
+    return Restaurant(
+        id="r1",
+        name="R",
+        display_phone="+15551234567",
+        twilio_phone="+15551234567",
+        address="1 Main",
+        hours="11-22",
+        menu={
+            "pizzas": [
+                {"name": "Margherita", "price": 12.99, "available": True},
+            ],
+            "sides": [],
+        },
+    )
+
+
+def test_add_menu_item_appends_to_existing_category():
+    r = _r()
+    out = add_menu_item(
+        r,
+        MenuItemCreate(category="pizzas", name="Pepperoni", price=15.99),
+    )
+    items = out.menu["pizzas"]
+    assert len(items) == 2
+    assert items[1]["name"] == "Pepperoni"
+    assert items[1]["available"] is True
+
+
+def test_add_menu_item_creates_category_if_missing():
+    r = _r()
+    out = add_menu_item(
+        r,
+        MenuItemCreate(category="drinks", name="Coke", price=2.50),
+    )
+    assert out.menu["drinks"][0]["name"] == "Coke"
+
+
+def test_add_menu_item_rejects_duplicate_name_in_category():
+    r = _r()
+    with pytest.raises(DuplicateMenuItem):
+        add_menu_item(
+            r,
+            MenuItemCreate(category="pizzas", name="Margherita", price=10.00),
+        )
+
+
+def test_update_menu_item_modifies_price_in_place():
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(price=14.99),
+    )
+    assert out.menu["pizzas"][0]["price"] == 14.99
+
+
+def test_update_menu_item_renames_when_new_name_set():
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(new_name="Margherita DOP"),
+    )
+    assert out.menu["pizzas"][0]["name"] == "Margherita DOP"
+
+
+def test_update_menu_item_moves_category_when_new_category_set():
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(new_category="sides"),
+    )
+    assert out.menu["pizzas"] == []
+    assert any(i["name"] == "Margherita" for i in out.menu["sides"])
+
+
+def test_update_menu_item_swaps_price_for_sizes():
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(sizes={"small": 10.00, "large": 16.00}),
+    )
+    item = out.menu["pizzas"][0]
+    assert "price" not in item
+    assert item["sizes"] == {"small": 10.00, "large": 16.00}
+
+
+def test_update_menu_item_404_when_not_found():
+    r = _r()
+    with pytest.raises(MenuItemNotFound):
+        update_menu_item(
+            r,
+            category="pizzas",
+            name="NonExistent",
+            update=MenuItemUpdate(price=10.00),
+        )
+
+
+def test_delete_menu_item_removes_from_category():
+    r = _r()
+    out = delete_menu_item(r, category="pizzas", name="Margherita")
+    assert out.menu["pizzas"] == []
+
+
+def test_delete_menu_item_404_when_not_found():
+    r = _r()
+    with pytest.raises(MenuItemNotFound):
+        delete_menu_item(r, category="pizzas", name="NonExistent")
+
+
+def test_add_category_creates_empty_array():
+    r = _r()
+    out = add_category(r, CategoryCreate(key="drinks"))
+    assert out.menu["drinks"] == []
+
+
+def test_add_category_rejects_duplicate():
+    r = _r()
+    with pytest.raises(DuplicateMenuItem):
+        add_category(r, CategoryCreate(key="pizzas"))
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `pytest tests/test_menu_writes.py -v`
+Expected: 12 errors — `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `app/restaurants/menu_writes.py`:
+
+```python
+"""Pure-function menu mutations on a Restaurant.menu dict.
+
+The dashboard's editor sends granular create/update/delete operations
+against this module's functions; the FastAPI handler reads the
+restaurant doc, calls the helper, writes the new doc back. Keeping the
+logic free of Firestore I/O lets us unit-test mutations without mocks.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from app.restaurants.models import (
+    CategoryCreate,
+    MenuItemCreate,
+    MenuItemUpdate,
+    Restaurant,
+)
+
+
+class MenuItemNotFound(KeyError):
+    """The (category, name) pair didn't match any item."""
+
+
+class DuplicateMenuItem(ValueError):
+    """An item with this name already exists in the target category,
+    or the target category already exists."""
+
+
+_RESERVED_KEYS = {"_category_order"}
+
+
+def _menu_copy(r: Restaurant) -> dict[str, Any]:
+    return deepcopy(r.menu)
+
+
+def add_menu_item(r: Restaurant, item: MenuItemCreate) -> Restaurant:
+    menu = _menu_copy(r)
+    cat = menu.setdefault(item.category, [])
+    if any(existing.get("name") == item.name for existing in cat):
+        raise DuplicateMenuItem(
+            f"item {item.name!r} already exists in category {item.category!r}"
+        )
+
+    payload: dict[str, Any] = {
+        "name": item.name,
+        "available": item.available,
+    }
+    if item.description:
+        payload["description"] = item.description
+    if item.price is not None:
+        payload["price"] = item.price
+    if item.sizes is not None:
+        payload["sizes"] = dict(item.sizes)
+
+    cat.append(payload)
+    return r.model_copy(update={"menu": menu})
+
+
+def _find_item(menu: dict[str, Any], category: str, name: str) -> int:
+    items = menu.get(category)
+    if not isinstance(items, list):
+        raise MenuItemNotFound(f"category {category!r} not found")
+    for idx, item in enumerate(items):
+        if isinstance(item, dict) and item.get("name") == name:
+            return idx
+    raise MenuItemNotFound(
+        f"item {name!r} not found in category {category!r}"
+    )
+
+
+def update_menu_item(
+    r: Restaurant,
+    *,
+    category: str,
+    name: str,
+    update: MenuItemUpdate,
+) -> Restaurant:
+    menu = _menu_copy(r)
+    idx = _find_item(menu, category, name)
+    item = dict(menu[category][idx])
+
+    if update.new_name is not None:
+        # Reject rename collision in the same (or new) category.
+        target_cat = update.new_category or category
+        target_items = menu.get(target_cat, []) if target_cat != category else menu[category]
+        if any(
+            (i.get("name") == update.new_name)
+            and not (
+                target_cat == category and target_items[idx] is i
+            )
+            for i in target_items
+            if isinstance(i, dict)
+        ):
+            raise DuplicateMenuItem(
+                f"item {update.new_name!r} already exists in {target_cat!r}"
+            )
+        item["name"] = update.new_name
+    if update.description is not None:
+        item["description"] = update.description
+    if update.available is not None:
+        item["available"] = update.available
+    if update.price is not None:
+        item["price"] = update.price
+        item.pop("sizes", None)
+    if update.sizes is not None:
+        item["sizes"] = dict(update.sizes)
+        item.pop("price", None)
+
+    if update.new_category is not None and update.new_category != category:
+        menu[category].pop(idx)
+        menu.setdefault(update.new_category, []).append(item)
+    else:
+        menu[category][idx] = item
+
+    return r.model_copy(update={"menu": menu})
+
+
+def delete_menu_item(
+    r: Restaurant, *, category: str, name: str
+) -> Restaurant:
+    menu = _menu_copy(r)
+    idx = _find_item(menu, category, name)
+    menu[category].pop(idx)
+    return r.model_copy(update={"menu": menu})
+
+
+def add_category(r: Restaurant, category: CategoryCreate) -> Restaurant:
+    menu = _menu_copy(r)
+    if category.key in _RESERVED_KEYS or category.key in menu:
+        raise DuplicateMenuItem(
+            f"category {category.key!r} already exists"
+        )
+    menu[category.key] = []
+    return r.model_copy(update={"menu": menu})
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pytest tests/test_menu_writes.py -v`
+Expected: 12 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/restaurants/menu_writes.py tests/test_menu_writes.py
+git commit -m "menu: add pure-function menu mutations (add/update/delete + category)"
+```
+
+---
+
+### Task 11: Wire the four menu endpoints (TDD)
+
+**Files:**
+- Modify: `app/main.py` — add four handlers
+- Test: `tests/test_menu_api.py` (NEW)
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+Create `tests/test_menu_api.py`:
+
+```python
+"""Integration tests for the granular menu endpoints."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependency import current_tenant
+from app.auth.firebase import Tenant
+from app.main import app
+from app.storage import restaurants as r_storage
+
+
+@pytest.fixture
+def fake_tenant():
+    return Tenant(
+        uid="user-1",
+        email="owner@niko.test",
+        restaurant_id="r1",
+        role="owner",
+    )
+
+
+@pytest.fixture
+def client(fake_tenant: Tenant):
+    app.dependency_overrides[current_tenant] = lambda: fake_tenant
+    yield TestClient(app)
+    app.dependency_overrides.pop(current_tenant, None)
+
+
+@pytest.fixture(autouse=True)
+def reset_storage():
+    yield
+    r_storage.set_client(None)
+    r_storage.clear_cache()
+
+
+def _wire(menu: dict) -> MagicMock:
+    fs = MagicMock()
+    r_storage.set_client(fs)
+    snap = MagicMock()
+    snap.exists = True
+    snap.to_dict.return_value = {
+        "id": "r1",
+        "name": "R",
+        "display_phone": "+15551234567",
+        "twilio_phone": "+15551234567",
+        "address": "1 Main",
+        "hours": "11-22",
+        "menu": menu,
+    }
+    fs.collection.return_value.document.return_value.get.return_value = snap
+    return fs
+
+
+def test_post_menu_item_appends(client: TestClient):
+    fs = _wire({"pizzas": [{"name": "Margherita", "price": 12.99, "available": True}]})
+    resp = client.post(
+        "/restaurants/me/menu/items",
+        json={"category": "pizzas", "name": "Pepperoni", "price": 15.99},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert any(i["name"] == "Pepperoni" for i in body["menu"]["pizzas"])
+    fs.collection.return_value.document.return_value.set.assert_called_once()
+
+
+def test_post_menu_item_409_on_duplicate(client: TestClient):
+    _wire({"pizzas": [{"name": "Margherita", "price": 12.99, "available": True}]})
+    resp = client.post(
+        "/restaurants/me/menu/items",
+        json={"category": "pizzas", "name": "Margherita", "price": 99.00},
+    )
+    assert resp.status_code == 409
+
+
+def test_patch_menu_item_updates_price(client: TestClient):
+    _wire({"pizzas": [{"name": "Margherita", "price": 12.99, "available": True}]})
+    resp = client.patch(
+        "/restaurants/me/menu/items/pizzas/Margherita",
+        json={"price": 14.99},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    item = body["menu"]["pizzas"][0]
+    assert item["price"] == 14.99
+
+
+def test_patch_menu_item_404_when_not_found(client: TestClient):
+    _wire({"pizzas": []})
+    resp = client.patch(
+        "/restaurants/me/menu/items/pizzas/NotThere",
+        json={"price": 10.00},
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_menu_item_removes(client: TestClient):
+    _wire({"pizzas": [{"name": "Margherita", "price": 12.99}]})
+    resp = client.delete(
+        "/restaurants/me/menu/items/pizzas/Margherita",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["menu"]["pizzas"] == []
+
+
+def test_post_category_creates_empty(client: TestClient):
+    _wire({"pizzas": []})
+    resp = client.post(
+        "/restaurants/me/menu/categories",
+        json={"key": "drinks"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["menu"]["drinks"] == []
+
+
+def test_post_category_409_on_duplicate(client: TestClient):
+    _wire({"pizzas": []})
+    resp = client.post(
+        "/restaurants/me/menu/categories",
+        json={"key": "pizzas"},
+    )
+    assert resp.status_code == 409
+
+
+def test_post_category_rejects_underscore_prefix(client: TestClient):
+    _wire({"pizzas": []})
+    resp = client.post(
+        "/restaurants/me/menu/categories",
+        json={"key": "_secret"},
+    )
+    # underscore prefix violates the regex pattern
+    assert resp.status_code == 422
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `pytest tests/test_menu_api.py -v`
+Expected: 8 errors — endpoints don't exist.
+
+- [ ] **Step 3: Implement the endpoints**
+
+Open `app/main.py`. Add to imports:
+
+```python
+from urllib.parse import unquote
+
+from app.restaurants.menu_writes import (
+    DuplicateMenuItem,
+    MenuItemNotFound,
+    add_category,
+    add_menu_item,
+    delete_menu_item,
+    update_menu_item,
+)
+from app.restaurants.models import (
+    CategoryCreate,
+    MenuItemCreate,
+    MenuItemUpdate,
+)
+```
+
+Add these handlers (anywhere after the existing `patch_restaurant`):
+
+```python
+@app.post("/restaurants/me/menu/items", status_code=201)
+def post_menu_item(
+    item: MenuItemCreate,
+    tenant: Tenant = Depends(current_tenant),
+):
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+    try:
+        updated = add_menu_item(restaurant, item)
+    except DuplicateMenuItem as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    restaurants_storage.save_restaurant(updated)
+    restaurants_storage.clear_cache()
+    return updated.model_dump(mode="json")
+
+
+@app.patch("/restaurants/me/menu/items/{category}/{name}")
+def patch_menu_item(
+    category: str,
+    name: str,
+    update: MenuItemUpdate,
+    tenant: Tenant = Depends(current_tenant),
+):
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+    try:
+        updated = update_menu_item(
+            restaurant,
+            category=unquote(category),
+            name=unquote(name),
+            update=update,
+        )
+    except MenuItemNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except DuplicateMenuItem as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    restaurants_storage.save_restaurant(updated)
+    restaurants_storage.clear_cache()
+    return updated.model_dump(mode="json")
+
+
+@app.delete("/restaurants/me/menu/items/{category}/{name}")
+def delete_menu_item_endpoint(
+    category: str,
+    name: str,
+    tenant: Tenant = Depends(current_tenant),
+):
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+    try:
+        updated = delete_menu_item(
+            restaurant,
+            category=unquote(category),
+            name=unquote(name),
+        )
+    except MenuItemNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    restaurants_storage.save_restaurant(updated)
+    restaurants_storage.clear_cache()
+    return updated.model_dump(mode="json")
+
+
+@app.post("/restaurants/me/menu/categories", status_code=201)
+def post_menu_category(
+    category: CategoryCreate,
+    tenant: Tenant = Depends(current_tenant),
+):
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+    try:
+        updated = add_category(restaurant, category)
+    except DuplicateMenuItem as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    restaurants_storage.save_restaurant(updated)
+    restaurants_storage.clear_cache()
+    return updated.model_dump(mode="json")
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pytest tests/test_menu_api.py -v`
+Expected: 8 passes.
+
+- [ ] **Step 5: Run the full backend suite**
+
+Run: `pytest tests/ -x`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/main.py tests/test_menu_api.py
+git commit -m "menu: add granular CRUD endpoints (item POST/PATCH/DELETE + category POST)"
+```
+
+---
+
+## Phase D — Dashboard: menu editor
+
+### Task 12: Menu API helpers + schema additions
+
+**Files:**
+- Modify: `dashboard/lib/schemas/menu.ts` — add `available` to item schemas
+- Create: `dashboard/lib/api/menu.ts`
+- Test: `dashboard/tests/menu-api.test.ts` (NEW)
+
+- [ ] **Step 1: Update menu schema with optional `available`**
+
+Open `dashboard/lib/schemas/menu.ts`. Modify both `SizedItemSchema` and `SinglePriceItemSchema` to add an optional `available: boolean` field with default `true`:
+
+```typescript
+export const SizedItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  available: z.boolean().default(true),
+  sizes: z
+    .record(z.string().min(1), z.number().nonnegative())
+    .refine((s) => Object.keys(s).length > 0, {
+      message: 'sizes must contain at least one entry',
+    }),
+});
+export type SizedItem = z.infer<typeof SizedItemSchema>;
+
+export const SinglePriceItemSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  available: z.boolean().default(true),
+  price: z.number().nonnegative(),
+});
+export type SinglePriceItem = z.infer<typeof SinglePriceItemSchema>;
+```
+
+- [ ] **Step 2: Write failing API helper tests**
+
+Create `dashboard/tests/menu-api.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createMenuItem,
+  createMenuCategory,
+  deleteMenuItem,
+  updateMenuItem,
+} from '@/lib/api/menu';
+
+vi.mock('@/lib/api/http', () => ({
+  apiFetch: vi.fn(),
+}));
+import { apiFetch } from '@/lib/api/http';
+
+const okJson = (body: unknown) =>
+  ({ ok: true, json: async () => body }) as Response;
+
+const FAKE_RESTAURANT = {
+  id: 'r1',
+  name: 'R',
+  display_phone: '+15551234567',
+  twilio_phone: '+15551234567',
+  address: '1 Main',
+  hours: '11-22',
+  hours_structured: null,
+  fallback_phone: null,
+  offers_delivery: true,
+  menu: {
+    pizzas: [{ name: 'Margherita', price: 12.99, available: true }],
+  },
+  prompt_overrides: {},
+  forwarding_mode: 'always',
+};
+
+describe('menu api helpers', () => {
+  it('createMenuItem POSTs and returns parsed restaurant', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      okJson(FAKE_RESTAURANT),
+    );
+    const r = await createMenuItem({
+      category: 'pizzas',
+      name: 'Pepperoni',
+      price: 15.99,
+    });
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/restaurants/me/menu/items',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(r.id).toBe('r1');
+  });
+
+  it('updateMenuItem PATCHes with URL-encoded names', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      okJson(FAKE_RESTAURANT),
+    );
+    await updateMenuItem({
+      category: 'pizzas',
+      name: 'Marg & Cheese',
+      patch: { price: 14.99 },
+    });
+    const url = (apiFetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(url).toBe('/restaurants/me/menu/items/pizzas/Marg%20%26%20Cheese');
+  });
+
+  it('deleteMenuItem DELETEs', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      okJson(FAKE_RESTAURANT),
+    );
+    await deleteMenuItem({ category: 'pizzas', name: 'Margherita' });
+    const init = (apiFetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('createMenuCategory POSTs the key', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      okJson(FAKE_RESTAURANT),
+    );
+    await createMenuCategory({ key: 'drinks' });
+    const init = (apiFetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(init.body).toBe(JSON.stringify({ key: 'drinks' }));
+  });
+});
+```
+
+- [ ] **Step 3: Run failing tests**
+
+Run: `cd dashboard && pnpm vitest run tests/menu-api.test.ts`
+Expected: errors — module missing.
+
+- [ ] **Step 4: Implement `lib/api/menu.ts`**
+
+Create `dashboard/lib/api/menu.ts`:
+
+```typescript
+import 'server-only';
+
+import { apiFetch } from '@/lib/api/http';
+import { RestaurantSchema, type Restaurant } from '@/lib/schemas/restaurant';
+
+export type CreateMenuItem = {
+  category: string;
+  name: string;
+  description?: string;
+  available?: boolean;
+  price?: number;
+  sizes?: Record<string, number>;
+};
+
+export type UpdateMenuItem = {
+  new_name?: string;
+  new_category?: string;
+  description?: string;
+  price?: number;
+  sizes?: Record<string, number>;
+  available?: boolean;
+};
+
+async function parseRestaurant(res: Response, what: string): Promise<Restaurant> {
+  if (!res.ok) {
+    throw new Error(`${what} failed: ${res.status} ${res.statusText}`);
+  }
+  const body = (await res.json()) as unknown;
+  const parsed = RestaurantSchema.safeParse(body);
+  if (!parsed.success) {
+    console.error(`[lib/api/menu] ${what} response failed validation`);
+    throw new Error(`${what} response failed schema validation`);
+  }
+  return parsed.data;
+}
+
+export async function createMenuItem(
+  payload: CreateMenuItem,
+): Promise<Restaurant> {
+  const res = await apiFetch('/restaurants/me/menu/items', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return parseRestaurant(res, 'POST /menu/items');
+}
+
+export async function updateMenuItem(args: {
+  category: string;
+  name: string;
+  patch: UpdateMenuItem;
+}): Promise<Restaurant> {
+  const url = `/restaurants/me/menu/items/${encodeURIComponent(args.category)}/${encodeURIComponent(args.name)}`;
+  const res = await apiFetch(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(args.patch),
+  });
+  return parseRestaurant(res, 'PATCH /menu/items');
+}
+
+export async function deleteMenuItem(args: {
+  category: string;
+  name: string;
+}): Promise<Restaurant> {
+  const url = `/restaurants/me/menu/items/${encodeURIComponent(args.category)}/${encodeURIComponent(args.name)}`;
+  const res = await apiFetch(url, { method: 'DELETE' });
+  return parseRestaurant(res, 'DELETE /menu/items');
+}
+
+export async function createMenuCategory(payload: {
+  key: string;
+}): Promise<Restaurant> {
+  const res = await apiFetch('/restaurants/me/menu/categories', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return parseRestaurant(res, 'POST /menu/categories');
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd dashboard && pnpm vitest run tests/menu-api.test.ts`
+Expected: 4 passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/lib/schemas/menu.ts dashboard/lib/api/menu.ts dashboard/tests/menu-api.test.ts
+git commit -m "dashboard: menu API helpers + available field on schema"
+```
+
+---
+
+### Task 13: Server Actions for menu mutations
+
+**Files:**
+- Create: `dashboard/app/actions/edit-menu.ts`
+
+- [ ] **Step 1: Create the actions file**
+
+Create `dashboard/app/actions/edit-menu.ts`:
+
+```typescript
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import {
+  createMenuCategory,
+  createMenuItem,
+  deleteMenuItem,
+  updateMenuItem,
+  type CreateMenuItem,
+  type UpdateMenuItem,
+} from '@/lib/api/menu';
+
+export type ActionResult =
+  | { success: true }
+  | { success: false; error: string };
+
+function wrap<T>(work: () => Promise<T>): Promise<ActionResult> {
+  return work()
+    .then(() => ({ success: true as const }))
+    .catch((err) => ({
+      success: false as const,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    }));
+}
+
+export async function createMenuItemAction(
+  payload: CreateMenuItem,
+): Promise<ActionResult> {
+  const result = await wrap(() => createMenuItem(payload));
+  revalidatePath('/menu');
+  return result;
+}
+
+export async function updateMenuItemAction(args: {
+  category: string;
+  name: string;
+  patch: UpdateMenuItem;
+}): Promise<ActionResult> {
+  const result = await wrap(() => updateMenuItem(args));
+  revalidatePath('/menu');
+  return result;
+}
+
+export async function deleteMenuItemAction(args: {
+  category: string;
+  name: string;
+}): Promise<ActionResult> {
+  const result = await wrap(() => deleteMenuItem(args));
+  revalidatePath('/menu');
+  return result;
+}
+
+export async function createCategoryAction(payload: {
+  key: string;
+}): Promise<ActionResult> {
+  const result = await wrap(() => createMenuCategory(payload));
+  revalidatePath('/menu');
+  return result;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add dashboard/app/actions/edit-menu.ts
+git commit -m "dashboard: Server Actions for menu mutations"
+```
+
+---
+
+### Task 14: Menu editor UI replaces read-only view
+
+**Files:**
+- Replace: `dashboard/app/(dashboard)/menu/page.tsx`
+- Create: `dashboard/components/menu/menu-editor.tsx`
+- Create: `dashboard/components/menu/item-edit-dialog.tsx`
+- Create: `dashboard/components/menu/add-item-dialog.tsx`
+- Create: `dashboard/components/menu/add-category-dialog.tsx`
+- Test: `dashboard/tests/menu-editor.test.tsx` (NEW)
+
+This is the largest single file in the plan. The editor reuses `MenuView`'s editorial layout but adds inline edit/delete affordances and dialog-based add/edit forms.
+
+- [ ] **Step 1: Replace the menu page to render the editor**
+
+Open `dashboard/app/(dashboard)/menu/page.tsx`. Replace contents:
+
+```tsx
+import { redirect } from 'next/navigation';
+
+import { MenuEditor } from '@/components/menu/menu-editor';
+import { MenuEmptyState } from '@/components/menu/menu-empty-state';
+import { MenuParseError } from '@/components/menu/menu-parse-error';
+import { getMyRestaurant } from '@/lib/api/restaurant';
+import { getServerSession } from '@/lib/auth/session';
+import { humanizeRestaurantId } from '@/lib/formatters/restaurant';
+import { parseMenu } from '@/lib/schemas/menu';
+
+export const dynamic = 'force-dynamic';
+
+export default async function MenuPage() {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
+  let restaurantName = humanizeRestaurantId(session.restaurantId);
+  let rawMenu: Record<string, unknown> = {};
+
+  try {
+    const restaurant = await getMyRestaurant();
+    restaurantName = restaurant.name || restaurantName;
+    rawMenu = restaurant.menu;
+  } catch (err) {
+    console.error('[menu page] /restaurants/me fetch failed', err);
+    return (
+      <MenuParseError reason="Could not reach the backend to load the restaurant configuration." />
+    );
+  }
+
+  const hasCategories = Object.keys(rawMenu).some((k) => !k.startsWith('_'));
+  if (!hasCategories) {
+    return <MenuEmptyState restaurantName={restaurantName} />;
+  }
+
+  const result = parseMenu(rawMenu);
+  if ('error' in result) {
+    return <MenuParseError reason={result.error} />;
+  }
+
+  return (
+    <MenuEditor
+      categories={result.categories}
+      itemCount={result.itemCount}
+      restaurantName={restaurantName}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Implement `MenuEditor` (re-uses MenuView's layout)**
+
+Create `dashboard/components/menu/menu-editor.tsx`:
+
+```tsx
+'use client';
+
+import { Fragment, useState } from 'react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { AddCategoryDialog } from '@/components/menu/add-category-dialog';
+import { AddItemDialog } from '@/components/menu/add-item-dialog';
+import { ItemEditDialog } from '@/components/menu/item-edit-dialog';
+import { Button } from '@/components/ui/button';
+import { deleteMenuItemAction } from '@/app/actions/edit-menu';
+import { formatCAD } from '@/lib/formatters/money';
+import {
+  type Category,
+  type MenuItem,
+  humanizeCategoryKey,
+  isSizedItem,
+} from '@/lib/schemas/menu';
+
+type Props = {
+  categories: Category[];
+  itemCount: number;
+  restaurantName: string;
+};
+
+export function MenuEditor({
+  categories,
+  itemCount,
+  restaurantName,
+}: Props) {
+  const [editing, setEditing] = useState<{
+    category: string;
+    item: MenuItem;
+  } | null>(null);
+  const [addingTo, setAddingTo] = useState<string | null>(null);
+  const [addingCategory, setAddingCategory] = useState(false);
+
+  async function handleDelete(category: string, name: string) {
+    if (!confirm(`Delete "${name}" from ${humanizeCategoryKey(category)}?`)) {
+      return;
+    }
+    const result = await deleteMenuItemAction({ category, name });
+    if (!result.success) {
+      toast.error(`Delete failed: ${result.error}`);
+      return;
+    }
+    toast.success('Item deleted.');
+  }
+
+  return (
+    <section className="flex flex-1 flex-col gap-10 p-6 lg:p-10">
+      <header className="flex max-w-3xl flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-3xl font-medium tracking-tight">Menu</h2>
+          <span aria-hidden className="h-px flex-1 translate-y-[-0.5rem] bg-border" />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => setAddingCategory(true)}
+          >
+            <Plus className="h-4 w-4" /> Add category
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {restaurantName}
+          <span className="mx-2 text-muted-foreground/40">·</span>
+          <span className="tabular-nums">{categories.length}</span>{' '}
+          {categories.length === 1 ? 'category' : 'categories'}
+          <span className="mx-2 text-muted-foreground/40">·</span>
+          <span className="tabular-nums">{itemCount}</span>{' '}
+          {itemCount === 1 ? 'item' : 'items'}
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-14">
+        {categories.map((c) => (
+          <section
+            key={c.key}
+            id={`category-${c.key}`}
+            className="scroll-mt-8"
+          >
+            <header className="mb-6 flex items-baseline gap-4 border-b border-border pb-3">
+              <h3 className="text-xl font-medium tracking-tight">
+                {humanizeCategoryKey(c.key)}
+              </h3>
+              <span aria-hidden className="h-px flex-1 bg-border/60" />
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setAddingTo(c.key)}
+              >
+                <Plus className="h-4 w-4" /> Add item
+              </Button>
+            </header>
+
+            <ul className="grid gap-x-12 gap-y-6 sm:grid-cols-2">
+              {c.items.map((item, idx) => (
+                <li key={`${c.key}-${idx}-${item.name}`}>
+                  <article className="flex flex-col gap-1.5">
+                    <div className="flex items-baseline gap-3">
+                      <h4
+                        className={`font-medium leading-snug ${
+                          item.available === false
+                            ? 'text-muted-foreground line-through'
+                            : 'text-foreground'
+                        }`}
+                      >
+                        {item.name}
+                        {item.available === false ? (
+                          <span className="ml-2 rounded-md bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                            unavailable
+                          </span>
+                        ) : null}
+                      </h4>
+                      <span
+                        aria-hidden
+                        className="min-w-4 flex-1 translate-y-[-0.25rem] border-b border-dotted border-border"
+                      />
+                      <span className="font-mono text-sm tabular-nums text-foreground">
+                        {isSizedItem(item)
+                          ? Object.entries(item.sizes)
+                              .map(
+                                ([size, price]) =>
+                                  `${size} ${formatCAD(price)}`,
+                              )
+                              .join(' · ')
+                          : formatCAD(item.price)}
+                      </span>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        aria-label={`Edit ${item.name}`}
+                        onClick={() =>
+                          setEditing({ category: c.key, item })
+                        }
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        aria-label={`Delete ${item.name}`}
+                        onClick={() => handleDelete(c.key, item.name)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    {item.description ? (
+                      <p className="text-xs leading-relaxed text-muted-foreground">
+                        {item.description}
+                      </p>
+                    ) : null}
+                  </article>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      {editing ? (
+        <ItemEditDialog
+          category={editing.category}
+          item={editing.item}
+          onClose={() => setEditing(null)}
+        />
+      ) : null}
+      {addingTo ? (
+        <AddItemDialog
+          category={addingTo}
+          onClose={() => setAddingTo(null)}
+        />
+      ) : null}
+      {addingCategory ? (
+        <AddCategoryDialog onClose={() => setAddingCategory(false)} />
+      ) : null}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Implement `AddItemDialog`**
+
+Create `dashboard/components/menu/add-item-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { createMenuItemAction } from '@/app/actions/edit-menu';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export function AddItemDialog({
+  category,
+  onClose,
+}: {
+  category: string;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [price, setPrice] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function submit() {
+    setError(null);
+    if (!name.trim()) {
+      setError('Name is required.');
+      return;
+    }
+    const priceNum = Number(price);
+    if (!Number.isFinite(priceNum) || priceNum < 0) {
+      setError('Price must be a non-negative number.');
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await createMenuItemAction({
+        category,
+        name: name.trim(),
+        price: priceNum,
+        description: description.trim() || undefined,
+      });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      toast.success(`${name} added.`);
+      onClose();
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (!open ? onClose() : null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add item to {category}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="item-name">Name</Label>
+            <Input
+              id="item-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="item-price">Price (CAD)</Label>
+            <Input
+              id="item-price"
+              type="number"
+              min="0"
+              step="0.01"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="item-desc">Description (optional)</Label>
+            <Input
+              id="item-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={pending} type="button">
+            {pending ? 'Adding…' : 'Add item'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Implement `ItemEditDialog`**
+
+Create `dashboard/components/menu/item-edit-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { updateMenuItemAction } from '@/app/actions/edit-menu';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { type MenuItem, isSizedItem } from '@/lib/schemas/menu';
+
+export function ItemEditDialog({
+  category,
+  item,
+  onClose,
+}: {
+  category: string;
+  item: MenuItem;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState(item.name);
+  const [price, setPrice] = useState(
+    isSizedItem(item) ? '' : String(item.price),
+  );
+  const [description, setDescription] = useState(item.description ?? '');
+  const [available, setAvailable] = useState(item.available !== false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function submit() {
+    setError(null);
+    const patch: Record<string, unknown> = {};
+    if (name.trim() !== item.name) patch.new_name = name.trim();
+    if (description.trim() !== (item.description ?? '')) {
+      patch.description = description.trim();
+    }
+    if (available !== (item.available !== false)) {
+      patch.available = available;
+    }
+    if (!isSizedItem(item)) {
+      const priceNum = Number(price);
+      if (!Number.isFinite(priceNum) || priceNum < 0) {
+        setError('Price must be a non-negative number.');
+        return;
+      }
+      if (priceNum !== item.price) patch.price = priceNum;
+    }
+
+    if (Object.keys(patch).length === 0) {
+      onClose();
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await updateMenuItemAction({
+        category,
+        name: item.name,
+        patch,
+      });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      toast.success(`${item.name} updated.`);
+      onClose();
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (!open ? onClose() : null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit {item.name}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-name">Name</Label>
+            <Input
+              id="edit-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          {isSizedItem(item) ? (
+            <p className="text-xs text-muted-foreground">
+              This item has size variants. Editing size prices isn't yet
+              supported in the dashboard — contact support to update.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-price">Price (CAD)</Label>
+              <Input
+                id="edit-price"
+                type="number"
+                min="0"
+                step="0.01"
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+              />
+            </div>
+          )}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-desc">Description</Label>
+            <Input
+              id="edit-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              id="edit-available"
+              type="checkbox"
+              checked={available}
+              onChange={(e) => setAvailable(e.target.checked)}
+            />
+            <Label htmlFor="edit-available">Available right now</Label>
+          </div>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={pending} type="button">
+            {pending ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 5: Implement `AddCategoryDialog`**
+
+Create `dashboard/components/menu/add-category-dialog.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { createCategoryAction } from '@/app/actions/edit-menu';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export function AddCategoryDialog({ onClose }: { onClose: () => void }) {
+  const [key, setKey] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function submit() {
+    setError(null);
+    const cleaned = key.trim().toLowerCase().replace(/\s+/g, '_');
+    if (!/^[a-z0-9_]+$/.test(cleaned)) {
+      setError('Use letters, numbers, and underscores only.');
+      return;
+    }
+    startTransition(async () => {
+      const result = await createCategoryAction({ key: cleaned });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      toast.success(`Category ${cleaned} added.`);
+      onClose();
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (!open ? onClose() : null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add category</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="cat-key">Key</Label>
+          <Input
+            id="cat-key"
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            placeholder="e.g. drinks or caribbean_appetizers"
+            autoFocus
+          />
+          <p className="text-xs text-muted-foreground">
+            Lowercase, underscores instead of spaces. Display name is
+            generated automatically.
+          </p>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={pending} type="button">
+            {pending ? 'Adding…' : 'Add category'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 6: Smoke test the editor**
+
+Run: `cd dashboard && pnpm dev`
+Open `/menu`, add a category, add an item, edit its price, mark unavailable, delete an item. Reload — changes persist.
+
+- [ ] **Step 7: Vitest smoke for the editor presence**
+
+Create `dashboard/tests/menu-editor.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MenuEditor } from '@/components/menu/menu-editor';
+
+describe('MenuEditor', () => {
+  it('renders edit/delete affordances on each item row', () => {
+    render(
+      <MenuEditor
+        restaurantName="Niko"
+        itemCount={1}
+        categories={[
+          {
+            key: 'pizzas',
+            items: [
+              { name: 'Margherita', price: 12.99, available: true },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByLabelText(/edit margherita/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/delete margherita/i)).toBeInTheDocument();
+  });
+
+  it('shows "unavailable" badge on items where available is false', () => {
+    render(
+      <MenuEditor
+        restaurantName="Niko"
+        itemCount={1}
+        categories={[
+          {
+            key: 'pizzas',
+            items: [
+              { name: 'Margherita', price: 12.99, available: false },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/unavailable/i)).toBeInTheDocument();
+  });
+
+  it('shows "Add item" buttons per category and a global "Add category"', () => {
+    render(
+      <MenuEditor
+        restaurantName="Niko"
+        itemCount={0}
+        categories={[
+          { key: 'pizzas', items: [] },
+          { key: 'drinks', items: [] },
+        ]}
+      />,
+    );
+    expect(screen.getAllByRole('button', { name: /add item/i })).toHaveLength(2);
+    expect(screen.getByRole('button', { name: /add category/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 8: Run vitest**
+
+Run: `cd dashboard && pnpm vitest run tests/menu-editor.test.tsx`
+Expected: 3 passes.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add dashboard/app/\(dashboard\)/menu/page.tsx dashboard/components/menu/menu-editor.tsx dashboard/components/menu/item-edit-dialog.tsx dashboard/components/menu/add-item-dialog.tsx dashboard/components/menu/add-category-dialog.tsx dashboard/tests/menu-editor.test.tsx
+git commit -m "dashboard: replace read-only menu with editor (add/edit/delete + categories)"
+```
+
+---
+
+### Task 15: Open Phase C+D PR
+
+- [ ] **Step 1: Push and open PR**
+
+```bash
+git push origin <branch>
+gh pr create --title "Sprint 2.4 — menu editor (#7)" --body "$(cat <<'EOF'
+## Summary
+
+- Backend: granular menu endpoints — POST/PATCH/DELETE `/restaurants/me/menu/items/...` + POST `/restaurants/me/menu/categories`. Pydantic validation rejects mixing price + sizes; conflicts → 409, unknown items → 404.
+- Backend: pure-function mutations in `app/restaurants/menu_writes.py` keep the endpoint handlers narrow.
+- Dashboard: `MenuEditor` replaces read-only `MenuView`. Items get edit/delete affordances + an "unavailable" badge; per-category "Add item"; global "Add category".
+- Dashboard: `available: bool` lands on the menu schema; LLM consumers (Sprint 2.1+) can later filter unavailable items from the prompt.
+
+## Spec deviation
+
+Spec wrote `PATCH /menu/items/{item_id}`. Implemented as `{category}/{name}` composite-key URLs since items don't carry stable IDs. Item ID restructure stays in the deferred list.
+
+## Test plan
+
+- [ ] `pytest tests/test_menu_models.py tests/test_menu_writes.py tests/test_menu_api.py -v`
+- [ ] `cd dashboard && pnpm vitest run tests/menu-api.test.ts tests/menu-editor.test.tsx`
+- [ ] Manual: add a new category, add a new item, edit its price, toggle unavailable, delete it. Reload — persists.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Phase E — Analytics
+
+### Task 16: Backend analytics aggregation (TDD)
+
+**Files:**
+- Create: `app/storage/analytics.py`
+- Test: `tests/test_storage_analytics.py` (NEW)
+
+Computes the 4 tile metrics from existing `orders` and `call_sessions` data. No new collections.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_storage_analytics.py`:
+
+```python
+"""Unit tests for app.storage.analytics aggregations."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderStatus,
+    OrderType,
+)
+from app.storage import analytics, firestore as order_storage
+
+
+@pytest.fixture(autouse=True)
+def reset_storage():
+    yield
+    order_storage.set_client(None)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _wire_orders(orders: list[Order]) -> None:
+    fs = MagicMock()
+    order_storage.set_client(fs)
+    snapshots = []
+    for o in orders:
+        snap = MagicMock()
+        snap.to_dict.return_value = o.model_dump(mode="python")
+        snapshots.append(snap)
+    (
+        fs.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .where.return_value
+        .stream
+    ).return_value = iter(snapshots)
+
+
+def _confirmed(call_sid: str, total: float, age_days: float = 0) -> Order:
+    return Order(
+        call_sid=call_sid,
+        items=[
+            LineItem(
+                name="P",
+                category=ItemCategory.PIZZA,
+                quantity=1,
+                unit_price=total,
+            ),
+        ],
+        order_type=OrderType.PICKUP,
+        status=OrderStatus.CONFIRMED,
+        created_at=_now() - timedelta(days=age_days),
+        confirmed_at=_now() - timedelta(days=age_days),
+    )
+
+
+def _completed(call_sid: str, total: float, age_days: float = 0) -> Order:
+    base = _confirmed(call_sid, total, age_days=age_days)
+    return base.model_copy(update={"status": OrderStatus.COMPLETED})
+
+
+def test_summarize_orders_counts_today_and_seven_day_window():
+    _wire_orders(
+        [
+            _confirmed("CA1", 20.00, age_days=0),
+            _confirmed("CA2", 30.00, age_days=2),
+            _confirmed("CA3", 50.00, age_days=8),  # outside 7d window
+        ],
+    )
+    s = analytics.summarize_orders(restaurant_id="r1")
+    assert s.today_count == 1
+    assert s.seven_day_count == 2  # CA1 + CA2; CA3 too old
+
+
+def test_summarize_orders_average_order_value_uses_seven_day_window():
+    _wire_orders(
+        [
+            _confirmed("CA1", 20.00, age_days=0),
+            _confirmed("CA2", 30.00, age_days=2),
+        ],
+    )
+    s = analytics.summarize_orders(restaurant_id="r1")
+    assert s.average_order_value_7d == 25.00
+
+
+def test_summarize_orders_completion_rate_seven_day():
+    _wire_orders(
+        [
+            _completed("CA1", 20.00, age_days=0),
+            _completed("CA2", 30.00, age_days=2),
+            _confirmed("CA3", 40.00, age_days=3),  # not yet completed
+        ],
+    )
+    s = analytics.summarize_orders(restaurant_id="r1")
+    # 2 completed of 3 confirmed-or-later in window
+    assert s.completion_rate_7d == pytest.approx(2 / 3, rel=1e-3)
+
+
+def test_summarize_orders_handles_empty():
+    _wire_orders([])
+    s = analytics.summarize_orders(restaurant_id="r1")
+    assert s.today_count == 0
+    assert s.seven_day_count == 0
+    assert s.average_order_value_7d == 0.0
+    assert s.completion_rate_7d == 0.0
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/test_storage_analytics.py -v`
+Expected: 4 errors — module missing.
+
+- [ ] **Step 3: Implement aggregations**
+
+Create `app/storage/analytics.py`:
+
+```python
+"""Analytics aggregations on Firestore order data.
+
+Computes the four tile metrics (today_count, seven_day_count,
+average_order_value_7d, completion_rate_7d) the dashboard's analytics
+page renders. No new collections — reads from
+``restaurants/{rid}/orders``.
+
+Streams the past 7 days into memory; for pilot scale this is fine
+(<200 orders/day per restaurant). When restaurants get to 1k orders/
+day we'll move to scheduled aggregations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from pydantic import BaseModel
+
+from app.orders.models import Order, OrderStatus
+from app.storage import firestore as order_storage
+
+
+@dataclass(frozen=True)
+class _Window:
+    today_start: datetime
+    seven_days_ago: datetime
+
+
+def _window(now: datetime | None = None) -> _Window:
+    now = now or datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    return _Window(
+        today_start=today_start,
+        seven_days_ago=now - timedelta(days=7),
+    )
+
+
+class OrderSummary(BaseModel):
+    today_count: int
+    seven_day_count: int
+    average_order_value_7d: float
+    completion_rate_7d: float
+
+
+def _stream_recent_orders(restaurant_id: str, since: datetime) -> list[Order]:
+    """Read orders newer than ``since`` for one tenant. Uses the
+    restaurants/{rid}/orders subcollection that
+    ``app.storage.firestore`` writes to."""
+    client = order_storage._get_client()
+    coll = (
+        client.collection("restaurants")
+        .document(restaurant_id)
+        .collection("orders")
+        .where("created_at", ">=", since)
+    )
+    return [Order.model_validate(snap.to_dict()) for snap in coll.stream()]
+
+
+def summarize_orders(*, restaurant_id: str) -> OrderSummary:
+    win = _window()
+    orders = _stream_recent_orders(restaurant_id, win.seven_days_ago)
+
+    today: list[Order] = []
+    seven_day: list[Order] = []
+    for o in orders:
+        if o.created_at >= win.today_start:
+            today.append(o)
+        if o.created_at >= win.seven_days_ago:
+            seven_day.append(o)
+
+    if seven_day:
+        aov = round(sum(o.subtotal for o in seven_day) / len(seven_day), 2)
+        completed = sum(
+            1 for o in seven_day if o.status is OrderStatus.COMPLETED
+        )
+        # Denominator: orders that reached confirmed (or beyond) — i.e.
+        # excluding still-in-progress and cancelled-before-confirm.
+        confirmed_or_later = sum(
+            1
+            for o in seven_day
+            if o.status
+            in {
+                OrderStatus.CONFIRMED,
+                OrderStatus.PREPARING,
+                OrderStatus.READY,
+                OrderStatus.COMPLETED,
+            }
+        )
+        completion_rate = (
+            completed / confirmed_or_later if confirmed_or_later else 0.0
+        )
+    else:
+        aov = 0.0
+        completion_rate = 0.0
+
+    return OrderSummary(
+        today_count=len(today),
+        seven_day_count=len(seven_day),
+        average_order_value_7d=aov,
+        completion_rate_7d=completion_rate,
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_storage_analytics.py -v`
+Expected: 4 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/analytics.py tests/test_storage_analytics.py
+git commit -m "analytics: add orders summary aggregation (today/7d/AOV/completion)"
+```
+
+---
+
+### Task 17: `GET /analytics/summary` endpoint (TDD)
+
+**Files:**
+- Modify: `app/main.py`
+- Test: `tests/test_analytics_api.py` (NEW)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/test_analytics_api.py`:
+
+```python
+"""Integration test for GET /analytics/summary."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependency import current_tenant
+from app.auth.firebase import Tenant
+from app.main import app
+from app.storage import analytics, firestore as order_storage
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[current_tenant] = lambda: Tenant(
+        uid="u1",
+        email="o@niko.test",
+        restaurant_id="r1",
+        role="owner",
+    )
+    yield TestClient(app)
+    app.dependency_overrides.pop(current_tenant, None)
+
+
+@pytest.fixture(autouse=True)
+def reset_storage():
+    yield
+    order_storage.set_client(None)
+
+
+def test_get_analytics_summary_returns_metrics(client: TestClient):
+    fake = analytics.OrderSummary(
+        today_count=3,
+        seven_day_count=21,
+        average_order_value_7d=24.50,
+        completion_rate_7d=0.92,
+    )
+    with patch(
+        "app.main.analytics.summarize_orders",
+        return_value=fake,
+    ):
+        resp = client.get("/analytics/summary")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["today_count"] == 3
+    assert body["seven_day_count"] == 21
+    assert body["average_order_value_7d"] == 24.50
+    assert body["completion_rate_7d"] == 0.92
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `pytest tests/test_analytics_api.py -v`
+Expected: error — endpoint not registered.
+
+- [ ] **Step 3: Implement endpoint**
+
+Open `app/main.py`. Add to imports:
+
+```python
+from app.storage import analytics
+```
+
+Add the handler:
+
+```python
+@app.get("/analytics/summary")
+def get_analytics_summary(tenant: Tenant = Depends(current_tenant)):
+    """Tile metrics for the dashboard's /analytics page."""
+    return analytics.summarize_orders(
+        restaurant_id=tenant.restaurant_id,
+    ).model_dump()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_analytics_api.py -v`
+Expected: 1 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/main.py tests/test_analytics_api.py
+git commit -m "analytics: add GET /analytics/summary endpoint"
+```
+
+---
+
+### Task 18: Dashboard analytics page + tile components
+
+**Files:**
+- Create: `dashboard/lib/api/analytics.ts`
+- Create: `dashboard/lib/schemas/analytics.ts`
+- Create: `dashboard/app/(dashboard)/analytics/page.tsx`
+- Create: `dashboard/components/analytics/tile.tsx`
+- Test: `dashboard/tests/analytics-tile.test.tsx` (NEW)
+
+- [ ] **Step 1: Schema + API helper**
+
+Create `dashboard/lib/schemas/analytics.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const OrderSummarySchema = z.object({
+  today_count: z.number().int().nonnegative(),
+  seven_day_count: z.number().int().nonnegative(),
+  average_order_value_7d: z.number().nonnegative(),
+  completion_rate_7d: z.number().min(0).max(1),
+});
+
+export type OrderSummary = z.infer<typeof OrderSummarySchema>;
+```
+
+Create `dashboard/lib/api/analytics.ts`:
+
+```typescript
+import 'server-only';
+
+import { apiFetch } from '@/lib/api/http';
+import {
+  OrderSummarySchema,
+  type OrderSummary,
+} from '@/lib/schemas/analytics';
+
+export async function getOrderSummary(): Promise<OrderSummary> {
+  const res = await apiFetch('/analytics/summary');
+  if (!res.ok) {
+    throw new Error(
+      `GET /analytics/summary failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  const body = (await res.json()) as unknown;
+  const parsed = OrderSummarySchema.safeParse(body);
+  if (!parsed.success) {
+    console.error(
+      '[lib/api/analytics] /analytics/summary failed validation',
+      parsed.error.flatten(),
+    );
+    throw new Error('analytics summary failed schema validation');
+  }
+  return parsed.data;
+}
+```
+
+- [ ] **Step 2: Write failing tile test**
+
+Create `dashboard/tests/analytics-tile.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Tile } from '@/components/analytics/tile';
+
+describe('analytics Tile', () => {
+  it('renders label, value, and unit', () => {
+    render(<Tile label="Calls today" value="3" unit="calls" />);
+    expect(screen.getByText('Calls today')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('calls')).toBeInTheDocument();
+  });
+
+  it('omits unit when not provided', () => {
+    render(<Tile label="x" value="5" />);
+    expect(screen.queryByText(/calls/)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Implement `Tile`**
+
+Create `dashboard/components/analytics/tile.tsx`:
+
+```tsx
+export function Tile({
+  label,
+  value,
+  unit,
+  hint,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+  hint?: string;
+}) {
+  return (
+    <article className="flex flex-col gap-2 rounded-lg border border-border p-6">
+      <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex items-baseline gap-2">
+        <span className="text-3xl font-medium tabular-nums tracking-tight">
+          {value}
+        </span>
+        {unit ? (
+          <span className="text-sm text-muted-foreground">{unit}</span>
+        ) : null}
+      </div>
+      {hint ? (
+        <p className="text-xs text-muted-foreground">{hint}</p>
+      ) : null}
+    </article>
+  );
+}
+```
+
+- [ ] **Step 4: Implement the page**
+
+Create `dashboard/app/(dashboard)/analytics/page.tsx`:
+
+```tsx
+import { redirect } from 'next/navigation';
+
+import { Tile } from '@/components/analytics/tile';
+import { getOrderSummary } from '@/lib/api/analytics';
+import { getServerSession } from '@/lib/auth/session';
+import { formatCAD } from '@/lib/formatters/money';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AnalyticsPage() {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
+  let summary;
+  try {
+    summary = await getOrderSummary();
+  } catch (err) {
+    console.error('[analytics page] /analytics/summary fetch failed', err);
+    return (
+      <section className="flex flex-1 flex-col gap-3 p-6 lg:p-10">
+        <h2 className="text-3xl font-medium tracking-tight">Analytics</h2>
+        <p className="text-sm text-muted-foreground">
+          Could not load metrics. Try again in a moment.
+        </p>
+      </section>
+    );
+  }
+
+  const empty = summary.seven_day_count === 0;
+
+  return (
+    <section className="flex flex-1 flex-col gap-10 p-6 lg:p-10">
+      <header className="flex max-w-3xl flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-3xl font-medium tracking-tight">Analytics</h2>
+          <span aria-hidden className="h-px flex-1 translate-y-[-0.5rem] bg-border" />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Today and the past seven days.
+        </p>
+      </header>
+
+      {empty ? (
+        <p className="rounded-lg border border-dashed border-border p-6 text-sm text-muted-foreground">
+          No orders in the last seven days yet. Make a test call to your
+          Niko number — the metrics will populate automatically.
+        </p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <Tile
+            label="Orders today"
+            value={String(summary.today_count)}
+            unit={summary.today_count === 1 ? 'order' : 'orders'}
+          />
+          <Tile
+            label="Orders this week"
+            value={String(summary.seven_day_count)}
+            unit={summary.seven_day_count === 1 ? 'order' : 'orders'}
+            hint="rolling 7 days"
+          />
+          <Tile
+            label="Avg order value"
+            value={formatCAD(summary.average_order_value_7d)}
+            hint="rolling 7 days"
+          />
+          <Tile
+            label="Completion rate"
+            value={`${Math.round(summary.completion_rate_7d * 100)}%`}
+            hint="of orders confirmed → completed"
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 5: Add `/analytics` to the sidebar nav**
+
+Open `dashboard/components/app-sidebar.tsx`. Import the icon and add the entry:
+
+```typescript
+import { BarChart3, ListOrdered, Menu, Phone, Settings } from 'lucide-react';
+```
+
+In the `NAV` array, add between `Menu` and `Settings`:
+
+```typescript
+  { label: 'Analytics', href: '/analytics', icon: BarChart3 },
+```
+
+- [ ] **Step 6: Run tests + smoke**
+
+Run: `cd dashboard && pnpm vitest run tests/analytics-tile.test.tsx && pnpm typecheck`
+Expected: green.
+
+Manual: `pnpm dev` → `/analytics` renders 4 tiles (or empty state if no orders in 7 days).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/lib/schemas/analytics.ts dashboard/lib/api/analytics.ts dashboard/components/analytics/tile.tsx dashboard/app/\(dashboard\)/analytics/page.tsx dashboard/components/app-sidebar.tsx dashboard/tests/analytics-tile.test.tsx
+git commit -m "dashboard: add /analytics page with 4 tiles + sparse-data empty state"
+```
+
+- [ ] **Step 8: Open PR**
+
+```bash
+git push origin <branch>
+gh pr create --title "Sprint 2.4 — analytics page (#7)" --body "$(cat <<'EOF'
+## Summary
+
+- Backend: `app/storage/analytics.py` aggregations + `GET /analytics/summary` endpoint.
+- Dashboard: `/analytics` page with 4 tiles (today, 7-day, AOV, completion rate). Sparse-data empty state when no orders in 7 days.
+- Sidebar gains an Analytics entry.
+
+## Test plan
+
+- [ ] `pytest tests/test_storage_analytics.py tests/test_analytics_api.py -v`
+- [ ] `cd dashboard && pnpm vitest run tests/analytics-tile.test.tsx`
+- [ ] Manual: with no orders, `/analytics` shows empty state. With at least one order in the last 7 days, tiles populate.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Phase F — Transcript polish
+
+### Task 19: Audit current transcript display
+
+Before changing code, identify what already exists.
+
+- [ ] **Step 1: Read the current call-detail page**
+
+Read these files end-to-end (no edits yet):
+- `dashboard/app/(dashboard)/calls/[call_sid]/page.tsx`
+- `dashboard/components/calls/call-timeline.tsx`
+- `dashboard/components/calls/call-timeline-live.tsx`
+- `dashboard/components/calls/timeline-export.tsx`
+
+- [ ] **Step 2: Note what's missing**
+
+Capture in a scratchpad (not committed):
+- Does each transcript turn have a stable timestamp visible?
+- Is there a way to copy a single turn without selecting + Ctrl-C?
+- If audio is present, can clicking a turn seek the audio to that turn's timestamp?
+- Are turns keyboard-focusable?
+
+The polish task addresses gaps. If all four already work, mark task complete and move on.
+
+---
+
+### Task 20: Make transcript turns copyable
+
+**Files:**
+- Modify: `dashboard/components/calls/call-timeline.tsx`
+- Test: `dashboard/tests/call-timeline.test.tsx` (NEW or extend)
+
+- [ ] **Step 1: Write failing test for the copy-button**
+
+Append to (or create) `dashboard/tests/call-timeline.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CallTimeline } from '@/components/calls/call-timeline';
+
+describe('CallTimeline copy turn', () => {
+  it('copies the turn text to the clipboard when the copy button is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    render(
+      <CallTimeline
+        events={[
+          {
+            kind: 'transcript',
+            role: 'agent',
+            text: 'Hi, what can I get you?',
+            at: new Date('2026-05-01T18:00:01Z'),
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /copy turn/i }));
+    expect(writeText).toHaveBeenCalledWith('Hi, what can I get you?');
+  });
+});
+```
+
+(The exact prop shape of `CallTimeline` may differ — adjust the test fixture to match the actual interface. The point is: per turn, render a button with accessible name "Copy turn" that calls `navigator.clipboard.writeText` with the turn's text.)
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd dashboard && pnpm vitest run tests/call-timeline.test.tsx`
+Expected: error — copy button not present.
+
+- [ ] **Step 3: Add the copy button**
+
+In `call-timeline.tsx`, on each turn's row, add (next to or after the turn text):
+
+```tsx
+<Button
+  size="icon"
+  variant="ghost"
+  aria-label="Copy turn"
+  onClick={() => navigator.clipboard.writeText(turn.text)}
+>
+  <Copy className="h-4 w-4" />
+</Button>
+```
+
+Import `Copy` from `lucide-react` and `Button` from `@/components/ui/button` if not already imported.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd dashboard && pnpm vitest run tests/call-timeline.test.tsx`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/components/calls/call-timeline.tsx dashboard/tests/call-timeline.test.tsx
+git commit -m "calls: add per-turn copy button on transcript"
+```
+
+---
+
+### Task 21: Audio-seek when clicking a turn
+
+This requires the audio player and the timeline to share a ref or callback. The simplest approach: pass an `onSeek(seconds: number)` prop to `CallTimeline`; clicking a turn invokes it. The page component owns the audio element and wires `onSeek` to set `audio.currentTime`.
+
+- [ ] **Step 1: Confirm the audio player component name**
+
+Grep the codebase: `Grep "audio" type "tsx" path "dashboard/components/calls"`. Identify the component that renders `<audio>` (likely added in PR #127).
+
+- [ ] **Step 2: Add `onSeek` prop to `CallTimeline`**
+
+Open `dashboard/components/calls/call-timeline.tsx`. Add `onSeek?: (seconds: number) => void` to the props. On each turn, when the row is clicked (and `onSeek` is defined and the turn has a numeric offset relative to call start), call `onSeek(offsetSeconds)`.
+
+If the turn data carries an absolute timestamp but not a call-relative offset, compute the offset from the call's `started_at`.
+
+```tsx
+const callStart = events[0]?.at ?? new Date();
+// per turn:
+const offset = (turn.at.getTime() - callStart.getTime()) / 1000;
+
+<button
+  type="button"
+  className="flex w-full items-start gap-2 text-left hover:bg-muted/50"
+  onClick={() => onSeek?.(offset)}
+>
+  {/* turn body */}
+</button>
+```
+
+(Wrap each turn in a `<button>` rather than a clickable `<div>` for keyboard accessibility.)
+
+- [ ] **Step 3: Wire `onSeek` from the page**
+
+In `dashboard/app/(dashboard)/calls/[call_sid]/page.tsx` (or wherever the audio + timeline are co-located), use a ref:
+
+```tsx
+'use client';
+import { useRef } from 'react';
+
+const audioRef = useRef<HTMLAudioElement>(null);
+
+function handleSeek(seconds: number) {
+  if (!audioRef.current) return;
+  audioRef.current.currentTime = seconds;
+  audioRef.current.play().catch(() => {});
+}
+```
+
+If the page is a Server Component, push the audio + timeline into a Client Component that handles this together.
+
+- [ ] **Step 4: Add a vitest covering the seek wiring**
+
+Append to `tests/call-timeline.test.tsx`:
+
+```tsx
+it('calls onSeek with the turn offset when a turn is clicked', () => {
+  const onSeek = vi.fn();
+  render(
+    <CallTimeline
+      events={[
+        {
+          kind: 'transcript',
+          role: 'agent',
+          text: 'Hello',
+          at: new Date('2026-05-01T18:00:00Z'),
+        },
+        {
+          kind: 'transcript',
+          role: 'caller',
+          text: 'Hi',
+          at: new Date('2026-05-01T18:00:05Z'),
+        },
+      ]}
+      onSeek={onSeek}
+    />,
+  );
+  fireEvent.click(screen.getByRole('button', { name: /Hi/ }));
+  expect(onSeek).toHaveBeenCalledWith(5);
+});
+```
+
+- [ ] **Step 5: Run tests + smoke**
+
+Run: `cd dashboard && pnpm vitest run tests/call-timeline.test.tsx`
+Expected: green.
+
+Manual: open a call detail page, click a turn — audio jumps to that point.
+
+- [ ] **Step 6: Commit + PR**
+
+```bash
+git add dashboard/components/calls/call-timeline.tsx dashboard/tests/call-timeline.test.tsx dashboard/app/\(dashboard\)/calls/\[call_sid\]/page.tsx
+git commit -m "calls: click-to-seek on transcript turns"
+git push origin <branch>
+
+gh pr create --title "Sprint 2.4 — transcript polish on /calls (#7)" --body "$(cat <<'EOF'
+## Summary
+
+- Per-turn copy button on the call timeline.
+- Click-to-seek: clicking a turn jumps the audio player to that point in the recording.
+- Each turn is now a focusable `<button>` for keyboard accessibility.
+
+## Test plan
+
+- [ ] `cd dashboard && pnpm vitest run tests/call-timeline.test.tsx`
+- [ ] Manual: open a call with a recording; click an early turn → audio plays from there.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- 1a Settings page — Phases A + B (Tasks 1–8). ✓
+- 1b Menu editor — Phases C + D (Tasks 9–15). ✓
+- 1c Analytics — Phase E (Tasks 16–18). ✓
+- 1d Transcript polish — Phase F (Tasks 19–21). ✓
+
+**Cross-track outputs:**
+- `restaurants/{rid}.fallback_phone` — produced in Task 1 (backend model) and Task 6 (dashboard form). Track 2 consumes from day 3 of the sprint.
+- `restaurants/{rid}.hours_structured` — produced in Task 1 + Task 7 (hours editor). Track 2 (voicemail after-hours trigger) consumes day 7.
+
+**Spec deviations recorded:**
+- `send_sms` async → sync (Track 3 plan).
+- Menu item URL: `/menu/items/{item_id}` → `/menu/items/{category}/{name}` composite key. Stable ID restructure deferred.
+
+**Open follow-ups (do NOT do in this plan):**
+- Structured menu modifiers (price deltas, modifier groups) — Phase 2+ per `dashboard/CLAUDE.md`.
+- SMS preferences toggle (skip confirmation per restaurant) — settings page placeholder card lands; wiring is post-pilot.
+- Stripe Connect onboarding — Sprint 2.3.
+- Per-tenant 10DLC brand registration — defer to pilot ramp.
+- Sized-item editing in the dashboard — current edit dialog rejects with a "contact support" hint; full sized-edit UI is a follow-up.
+- Connection-state live indicator on `/calls` — separate Sprint 2.4 sub-project, not in scope here.

--- a/docs/superpowers/plans/2026-05-01-sprint-2.4-sms-infra.md
+++ b/docs/superpowers/plans/2026-05-01-sprint-2.4-sms-infra.md
@@ -1,0 +1,997 @@
+# Sprint 2.4 — Track 3: SMS infra implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `app/sms/` module (Twilio outbound SMS wrapper, idempotency, templates) and wire `order_confirmation` SMS to fire when an order transitions to `confirmed`. Module is shared with the queued Sprint 2.3 payments work.
+
+**Architecture:** New `app/sms/` package — `client.py` wraps the Twilio REST SDK, `templates.py` renders order data into SMS body strings, `exceptions.py` carries failure types. Idempotency lives at our layer: each `(call_sid, template_name)` pair writes a record to `restaurants/{rid}/orders/{call_sid}.sms_sent[template_name]` before send and confirms on success. The `lifecycle.persist_on_confirm` hook calls `send_sms` after the Firestore write so a failed SMS can't roll back a confirmed order.
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic v2, Twilio Python SDK (sync), `google.cloud.firestore` (sync). pytest with `unittest.mock.MagicMock` for Twilio + Firestore.
+
+**Spec deviation:** The spec contract shows `async def send_sms`. Implemented as **sync** because (1) `twilio.rest.Client` is sync, (2) the existing storage layer (`firestore.save_order`, `lifecycle.persist_on_confirm`) is sync, (3) async wrapping adds no concurrency benefit for a one-shot HTTP call. Async callers wrap with `asyncio.to_thread(send_sms, ...)` — same pattern the orchestrator already uses for `persist_on_confirm`. Spec contract will be updated at sprint end.
+
+**Spec path correction:** Spec wrote `orders/{oid}.sms_sent`. Real Firestore path per `app/storage/firestore.py` is `restaurants/{rid}/orders/{call_sid}.sms_sent`. The plan uses the real path.
+
+---
+
+### Task 1: Add Twilio Messaging Service config
+
+**Files:**
+- Modify: `app/config.py`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add the setting to `app/config.py`**
+
+Open `app/config.py`. After the existing `twilio_phone_number` line, add:
+
+```python
+    # Twilio Messaging Service SID for outbound SMS. Shared 10DLC pool
+    # for pilot; per-tenant brand registration deferred until pilot ramp.
+    # Required when wiring outbound SMS in Sprint 2.4 (#7) — None elsewhere
+    # so importing this module doesn't crash environments that don't
+    # send SMS yet.
+    twilio_messaging_service_sid: Optional[str] = None
+```
+
+- [ ] **Step 2: Document the var in `.env.example`**
+
+Append to `.env.example`:
+
+```
+# Twilio Messaging Service SID — used by app/sms/ for outbound SMS.
+# Get from https://console.twilio.com → Messaging → Services → your service.
+TWILIO_MESSAGING_SERVICE_SID=
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/config.py .env.example
+git commit -m "config: add TWILIO_MESSAGING_SERVICE_SID for app/sms/"
+```
+
+---
+
+### Task 2: Create `app/sms/` package skeleton
+
+**Files:**
+- Create: `app/sms/__init__.py`
+- Create: `app/sms/exceptions.py`
+
+- [ ] **Step 1: Create the exceptions module**
+
+Create `app/sms/exceptions.py`:
+
+```python
+"""Exception types raised by app.sms."""
+
+from __future__ import annotations
+
+
+class SmsError(Exception):
+    """Outbound SMS failed. Caller decides whether to retry or surface
+    the failure. The lifecycle hook treats this as best-effort and
+    does not roll back the order on failure."""
+```
+
+- [ ] **Step 2: Create the package init with exports**
+
+Create `app/sms/__init__.py`:
+
+```python
+"""Outbound SMS — Twilio Messaging Service wrapper, idempotency-keyed.
+
+Shared with Sprint 2.3 payments work (which adds payment_link and
+payment_expired templates without touching the client).
+"""
+
+from app.sms.exceptions import SmsError
+
+__all__ = ["SmsError"]
+```
+
+- [ ] **Step 3: Verify import works**
+
+Run: `python -c "from app.sms import SmsError; print(SmsError)"`
+Expected: `<class 'app.sms.exceptions.SmsError'>`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/sms/__init__.py app/sms/exceptions.py
+git commit -m "sms: scaffold app/sms/ package with SmsError"
+```
+
+---
+
+### Task 3: Add `sms_sent` field to Order model (TDD)
+
+**Files:**
+- Modify: `app/orders/models.py`
+- Test: `tests/test_order_models.py`
+
+The idempotency layer needs a place on the order doc to record successful sends. Adding `sms_sent: dict[str, SmsSentRecord]` keeps it inline with the order — no separate collection, no joins.
+
+- [ ] **Step 1: Write the failing test**
+
+Open `tests/test_order_models.py`. Add at the end:
+
+```python
+def test_order_has_sms_sent_field_defaulting_to_empty_dict():
+    """Order model carries an sms_sent record map, default empty.
+
+    Used by app.sms for idempotency: keys are template names
+    (e.g. "order_confirmation"), values record {sid, sent_at}.
+    """
+    from app.orders.models import Order, SmsSentRecord
+
+    order = Order(call_sid="CAtest")
+    assert order.sms_sent == {}
+
+
+def test_order_sms_sent_record_round_trips():
+    from datetime import datetime, timezone
+    from app.orders.models import Order, SmsSentRecord
+
+    sent_at = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+    record = SmsSentRecord(sid="SMabc123", sent_at=sent_at)
+    order = Order(call_sid="CAtest", sms_sent={"order_confirmation": record})
+
+    dumped = order.model_dump(mode="python")
+    restored = Order.model_validate(dumped)
+    assert restored.sms_sent["order_confirmation"].sid == "SMabc123"
+    assert restored.sms_sent["order_confirmation"].sent_at == sent_at
+
+
+def test_order_sms_sent_back_compat_for_docs_without_field():
+    """Existing Firestore docs predate sms_sent — model_validate must
+    not blow up when the field is absent."""
+    from app.orders.models import Order
+
+    legacy_doc = {
+        "call_sid": "CAlegacy",
+        "items": [],
+        "status": "in_progress",
+    }
+    order = Order.model_validate(legacy_doc)
+    assert order.sms_sent == {}
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `pytest tests/test_order_models.py -v -k sms_sent`
+Expected: 3 failures with `ImportError: cannot import name 'SmsSentRecord'`
+
+- [ ] **Step 3: Add `SmsSentRecord` and the `sms_sent` field**
+
+Open `app/orders/models.py`. After the `LineItem` class (around line 80) and before `class Order`, add:
+
+```python
+class SmsSentRecord(BaseModel):
+    """Idempotency record for an outbound SMS — written to
+    ``orders/{call_sid}.sms_sent[template_name]`` after a successful
+    Twilio send. Presence of a record short-circuits future sends with
+    the same key (e.g. on persist_on_confirm retry)."""
+
+    sid: str  # Twilio Message SID, e.g. "SM..."
+    sent_at: datetime
+```
+
+Then in the `Order` class, after `cancelled_at: Optional[datetime] = None` (around line 100), add:
+
+```python
+    # Idempotency record map for outbound SMS. Keys are template names
+    # (e.g. "order_confirmation"); values are SmsSentRecord. Populated
+    # by app.sms.send_sms after each successful Twilio send. Default
+    # empty so legacy docs (pre-#7) and partially-built orders parse.
+    sms_sent: dict[str, SmsSentRecord] = Field(default_factory=dict)
+```
+
+- [ ] **Step 4: Run the tests — they should pass**
+
+Run: `pytest tests/test_order_models.py -v -k sms_sent`
+Expected: 3 passes.
+
+- [ ] **Step 5: Run the full test suite to confirm nothing else broke**
+
+Run: `pytest tests/ -x`
+Expected: all green. The `Order(call_sid=...)` constructor still works because `sms_sent` defaults to `{}`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/orders/models.py tests/test_order_models.py
+git commit -m "orders: add sms_sent record map for SMS idempotency"
+```
+
+---
+
+### Task 4: Build `order_confirmation` template (TDD)
+
+**Files:**
+- Create: `app/sms/templates.py`
+- Create: `tests/test_sms_templates.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_sms_templates.py`:
+
+```python
+"""Unit tests for app.sms.templates."""
+
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderType,
+)
+from app.sms.templates import order_confirmation
+
+
+def _sample_pickup_order() -> Order:
+    return Order(
+        call_sid="CAabc",
+        caller_phone="+15551234567",
+        items=[
+            LineItem(
+                name="Pepperoni",
+                category=ItemCategory.PIZZA,
+                size="large",
+                quantity=1,
+                unit_price=18.99,
+            ),
+        ],
+        order_type=OrderType.PICKUP,
+    )
+
+
+def _sample_delivery_order() -> Order:
+    return Order(
+        call_sid="CAdef",
+        caller_phone="+15551234567",
+        items=[
+            LineItem(
+                name="Margherita",
+                category=ItemCategory.PIZZA,
+                quantity=2,
+                unit_price=15.00,
+            ),
+        ],
+        order_type=OrderType.DELIVERY,
+        delivery_address="123 Main Street",
+    )
+
+
+def test_order_confirmation_includes_total_and_summary_for_pickup():
+    body = order_confirmation(_sample_pickup_order())
+    assert "$18.99" in body
+    assert "Pepperoni" in body
+    assert "pickup" in body.lower()
+
+
+def test_order_confirmation_includes_delivery_address_for_delivery():
+    body = order_confirmation(_sample_delivery_order())
+    assert "$30.00" in body
+    assert "Margherita" in body
+    assert "123 Main Street" in body
+
+
+def test_order_confirmation_handles_multi_item_orders():
+    order = _sample_pickup_order()
+    order.items.append(
+        LineItem(
+            name="Garlic Knots",
+            category=ItemCategory.SIDE,
+            quantity=1,
+            unit_price=5.00,
+        ),
+    )
+    body = order_confirmation(order)
+    assert "Pepperoni" in body
+    assert "Garlic Knots" in body
+    assert "$23.99" in body  # 18.99 + 5.00
+
+
+def test_order_confirmation_under_sms_segment_limit():
+    """Single-segment SMS is 160 GSM-7 chars. Two-segment is 306. We aim
+    for one segment for typical orders so the per-pilot SMS cost stays
+    predictable. Tolerance: 320 chars accommodates edge cases without
+    blowing past two segments."""
+    body = order_confirmation(_sample_pickup_order())
+    assert len(body) <= 320
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `pytest tests/test_sms_templates.py -v`
+Expected: 4 errors, `ModuleNotFoundError: No module named 'app.sms.templates'`
+
+- [ ] **Step 3: Implement the template**
+
+Create `app/sms/templates.py`:
+
+```python
+"""SMS body templates rendered from order data.
+
+Each function takes the data it needs and returns a plain string — no
+Twilio dependency, no I/O. Templates are intentionally short to fit a
+single 160-char SMS segment for typical orders; multi-item delivery
+orders may spill into a second segment, accepted.
+"""
+
+from __future__ import annotations
+
+from app.orders.models import Order, OrderType
+
+
+def order_confirmation(order: Order) -> str:
+    """Body for the post-confirmation SMS. Format:
+
+        Niko: order confirmed.
+        1x Pepperoni (large)
+        Total: $18.99
+        Pickup at the restaurant.
+
+    For delivery orders, the last line carries the delivery address.
+    """
+    lines = ["Niko: order confirmed."]
+
+    for item in order.items:
+        size_part = f" ({item.size})" if item.size else ""
+        lines.append(f"{item.quantity}x {item.name}{size_part}")
+
+    lines.append(f"Total: ${order.subtotal:.2f}")
+
+    if order.order_type is OrderType.DELIVERY:
+        lines.append(f"Delivery to {order.delivery_address}.")
+    else:
+        lines.append("Pickup at the restaurant.")
+
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pytest tests/test_sms_templates.py -v`
+Expected: 4 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/sms/templates.py tests/test_sms_templates.py
+git commit -m "sms: add order_confirmation template"
+```
+
+---
+
+### Task 5: Build `send_sms` client with idempotency (TDD)
+
+**Files:**
+- Create: `app/sms/client.py`
+- Create: `tests/test_sms_client.py`
+
+The function flow:
+1. Parse `idempotency_key = f"{call_sid}:{template_name}"` to extract `call_sid` and `template_name`.
+2. Read the order doc from Firestore at `restaurants/{tenant_id}/orders/{call_sid}`.
+3. If `order.sms_sent[template_name]` exists, return that record (short-circuit).
+4. Send the SMS via Twilio.
+5. Write `order.sms_sent[template_name] = SmsSentRecord(...)` back to Firestore.
+6. Return the result.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_sms_client.py`:
+
+```python
+"""Unit tests for app.sms.client.send_sms.
+
+Mocks Twilio's REST client and Firestore, mirroring
+test_orders_lifecycle.py's MagicMock pattern.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderType,
+    SmsSentRecord,
+)
+from app.sms.client import SmsResult, send_sms
+from app.sms.exceptions import SmsError
+from app.storage import firestore as storage
+
+
+@pytest.fixture(autouse=True)
+def reset_storage_client():
+    yield
+    storage.set_client(None)
+
+
+def _fake_storage(order: Order | None) -> MagicMock:
+    """Wire the firestore module to return ``order`` for the
+    restaurants/{rid}/orders/{call_sid} read."""
+    client = MagicMock()
+    storage.set_client(client)
+    snapshot = MagicMock()
+    if order is None:
+        snapshot.exists = False
+    else:
+        snapshot.exists = True
+        snapshot.to_dict.return_value = order.model_dump(mode="python")
+    (
+        client.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .get
+        .return_value
+    ) = snapshot
+    return client
+
+
+def _ready_order() -> Order:
+    return Order(
+        call_sid="CAabc",
+        caller_phone="+15551234567",
+        restaurant_id="niko-pizza-kitchen",
+        items=[
+            LineItem(
+                name="Pepperoni",
+                category=ItemCategory.PIZZA,
+                size="large",
+                quantity=1,
+                unit_price=18.99,
+            ),
+        ],
+        order_type=OrderType.PICKUP,
+    )
+
+
+def test_send_sms_calls_twilio_with_messaging_service():
+    order = _ready_order()
+    _fake_storage(order)
+    fake_message = MagicMock(sid="SM123")
+
+    with patch("app.sms.client._twilio_client") as twilio_factory:
+        twilio_factory.return_value.messages.create.return_value = fake_message
+        result = send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="CAabc:order_confirmation",
+            tenant_id="niko-pizza-kitchen",
+        )
+
+    twilio_factory.return_value.messages.create.assert_called_once()
+    kwargs = twilio_factory.return_value.messages.create.call_args.kwargs
+    assert kwargs["to"] == "+15551234567"
+    assert kwargs["body"] == "hello"
+    assert "messaging_service_sid" in kwargs
+    assert isinstance(result, SmsResult)
+    assert result.sid == "SM123"
+
+
+def test_send_sms_short_circuits_when_record_already_exists():
+    """If sms_sent[template] already has a record, return it without
+    calling Twilio."""
+    existing = SmsSentRecord(
+        sid="SMexisting",
+        sent_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    order = _ready_order()
+    order.sms_sent["order_confirmation"] = existing
+    _fake_storage(order)
+
+    with patch("app.sms.client._twilio_client") as twilio_factory:
+        result = send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="CAabc:order_confirmation",
+            tenant_id="niko-pizza-kitchen",
+        )
+
+    twilio_factory.return_value.messages.create.assert_not_called()
+    assert result.sid == "SMexisting"
+
+
+def test_send_sms_writes_record_back_to_firestore_on_success():
+    order = _ready_order()
+    client = _fake_storage(order)
+
+    with patch("app.sms.client._twilio_client") as twilio_factory:
+        twilio_factory.return_value.messages.create.return_value = MagicMock(
+            sid="SMnew",
+        )
+        send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="CAabc:order_confirmation",
+            tenant_id="niko-pizza-kitchen",
+        )
+
+    # Confirm the doc was set with the new record under sms_sent
+    set_call = (
+        client.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .set
+    )
+    set_call.assert_called_once()
+    payload = set_call.call_args.args[0]
+    assert "order_confirmation" in payload["sms_sent"]
+    assert payload["sms_sent"]["order_confirmation"]["sid"] == "SMnew"
+
+
+def test_send_sms_raises_sms_error_when_twilio_fails():
+    order = _ready_order()
+    _fake_storage(order)
+
+    with patch("app.sms.client._twilio_client") as twilio_factory:
+        twilio_factory.return_value.messages.create.side_effect = Exception(
+            "twilio is sad",
+        )
+        with pytest.raises(SmsError) as exc:
+            send_sms(
+                to="+15551234567",
+                body="hello",
+                idempotency_key="CAabc:order_confirmation",
+                tenant_id="niko-pizza-kitchen",
+            )
+        assert "twilio is sad" in str(exc.value)
+
+
+def test_send_sms_raises_sms_error_when_order_not_found():
+    _fake_storage(None)
+
+    with pytest.raises(SmsError) as exc:
+        send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="CAmissing:order_confirmation",
+            tenant_id="niko-pizza-kitchen",
+        )
+    assert "not found" in str(exc.value).lower()
+
+
+def test_send_sms_rejects_malformed_idempotency_key():
+    with pytest.raises(SmsError):
+        send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="no-colon-here",
+            tenant_id="niko-pizza-kitchen",
+        )
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `pytest tests/test_sms_client.py -v`
+Expected: 6 errors, `ModuleNotFoundError` on `app.sms.client`.
+
+- [ ] **Step 3: Implement `send_sms` and `SmsResult`**
+
+Create `app/sms/client.py`:
+
+```python
+"""Outbound SMS client — Twilio REST wrapper with idempotency.
+
+The function flow:
+
+1. Parse the idempotency key into (call_sid, template_name).
+2. Read the order doc from Firestore.
+3. If sms_sent[template_name] already exists, short-circuit — the
+   original record is the source of truth.
+4. Otherwise, send via Twilio's Messaging Service.
+5. Write sms_sent[template_name] back to the order doc.
+
+Sync — Twilio's SDK is sync, the storage layer is sync, async callers
+wrap with asyncio.to_thread.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel
+from twilio.rest import Client as TwilioClient
+
+from app.config import settings
+from app.orders.models import SmsSentRecord
+from app.sms.exceptions import SmsError
+from app.storage import firestore as order_storage
+
+
+class SmsResult(BaseModel):
+    sid: str
+    sent_at: datetime
+
+
+def _twilio_client() -> TwilioClient:
+    """Construct a Twilio client at call time so tests can patch this."""
+    if not settings.twilio_account_sid or not settings.twilio_auth_token:
+        raise SmsError(
+            "Twilio credentials missing — set TWILIO_ACCOUNT_SID and "
+            "TWILIO_AUTH_TOKEN."
+        )
+    return TwilioClient(settings.twilio_account_sid, settings.twilio_auth_token)
+
+
+def send_sms(
+    to: str,
+    body: str,
+    *,
+    idempotency_key: str,
+    tenant_id: str,
+) -> SmsResult:
+    """Send a single SMS, idempotent on (call_sid, template_name).
+
+    ``idempotency_key`` is ``f"{call_sid}:{template_name}"``. The split
+    is the contract — callers form keys this way and ``send_sms`` parses
+    back. Returns the existing record if one is already present for the
+    key. Raises ``SmsError`` on Twilio failure or missing order.
+    """
+    if ":" not in idempotency_key:
+        raise SmsError(
+            f"idempotency_key must be 'call_sid:template_name', "
+            f"got {idempotency_key!r}"
+        )
+    call_sid, template_name = idempotency_key.split(":", 1)
+
+    order = order_storage.get_order(call_sid, tenant_id)
+    if order is None:
+        raise SmsError(
+            f"order {call_sid!r} not found under tenant {tenant_id!r} — "
+            "cannot record SMS idempotency without the order doc"
+        )
+
+    existing = order.sms_sent.get(template_name)
+    if existing is not None:
+        return SmsResult(sid=existing.sid, sent_at=existing.sent_at)
+
+    if not settings.twilio_messaging_service_sid:
+        raise SmsError(
+            "TWILIO_MESSAGING_SERVICE_SID not configured — outbound SMS "
+            "requires a Messaging Service for 10DLC compliance."
+        )
+
+    try:
+        message = _twilio_client().messages.create(
+            to=to,
+            body=body,
+            messaging_service_sid=settings.twilio_messaging_service_sid,
+        )
+    except Exception as exc:  # twilio raises various subclasses
+        raise SmsError(f"Twilio send failed: {exc}") from exc
+
+    sent_at = datetime.now(timezone.utc)
+    record = SmsSentRecord(sid=message.sid, sent_at=sent_at)
+    updated = order.model_copy(
+        update={"sms_sent": {**order.sms_sent, template_name: record}},
+    )
+    order_storage.save_order(updated)
+    return SmsResult(sid=message.sid, sent_at=sent_at)
+```
+
+- [ ] **Step 4: Add the export to `app/sms/__init__.py`**
+
+Open `app/sms/__init__.py`, replace contents with:
+
+```python
+"""Outbound SMS — Twilio Messaging Service wrapper, idempotency-keyed.
+
+Shared with Sprint 2.3 payments work (which adds payment_link and
+payment_expired templates without touching the client).
+"""
+
+from app.sms.client import SmsResult, send_sms
+from app.sms.exceptions import SmsError
+
+__all__ = ["SmsError", "SmsResult", "send_sms"]
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pytest tests/test_sms_client.py -v`
+Expected: 6 passes.
+
+If a test fails on the Twilio import (e.g. `twilio` not installed locally), confirm `requirements.txt` includes `twilio`. The repo already uses Twilio for inbound voice (`app/telephony/router.py`), so it should be there. If not, add it and re-run `pip install -r requirements.txt`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/sms/client.py app/sms/__init__.py tests/test_sms_client.py
+git commit -m "sms: add send_sms client with Firestore-backed idempotency"
+```
+
+---
+
+### Task 6: Wire `order_confirmation` into `lifecycle.persist_on_confirm` (TDD)
+
+**Files:**
+- Modify: `app/orders/lifecycle.py`
+- Modify: `tests/test_orders_lifecycle.py`
+
+`persist_on_confirm` already writes the confirmed order to Firestore. After that write succeeds, fire the `order_confirmation` SMS. Failure is best-effort: log it and let the order stay confirmed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `tests/test_orders_lifecycle.py`. Add at the end:
+
+```python
+def test_persist_on_confirm_sends_order_confirmation_sms():
+    """After Firestore write, persist_on_confirm fires the SMS."""
+    from unittest.mock import patch
+    _fake_client()
+    order = _ready_pickup_order(caller_phone="+15551234567")
+
+    with patch("app.orders.lifecycle.send_sms") as fake_send:
+        persist_on_confirm(order)
+
+    fake_send.assert_called_once()
+    kwargs = fake_send.call_args.kwargs
+    assert kwargs["to"] == "+15551234567"
+    assert kwargs["idempotency_key"] == f"{order.call_sid}:order_confirmation"
+    assert kwargs["tenant_id"] == order.restaurant_id
+    assert "Pepperoni" in kwargs["body"]
+
+
+def test_persist_on_confirm_skips_sms_when_no_caller_phone():
+    """An order without caller_phone (rare — the call had bad caller ID)
+    is still confirmable; we just don't send a confirmation SMS."""
+    from unittest.mock import patch
+    _fake_client()
+    order = _ready_pickup_order(caller_phone=None)
+
+    with patch("app.orders.lifecycle.send_sms") as fake_send:
+        persist_on_confirm(order)
+
+    fake_send.assert_not_called()
+
+
+def test_persist_on_confirm_swallows_sms_errors():
+    """SMS is best-effort: a Twilio failure must not block the order
+    from persisting as confirmed."""
+    from unittest.mock import patch
+    from app.sms.exceptions import SmsError
+    _fake_client()
+    order = _ready_pickup_order(caller_phone="+15551234567")
+
+    with patch("app.orders.lifecycle.send_sms", side_effect=SmsError("boom")):
+        confirmed = persist_on_confirm(order)
+
+    assert confirmed.status is OrderStatus.CONFIRMED
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `pytest tests/test_orders_lifecycle.py -v -k sms`
+Expected: 3 failures — `send_sms` not yet imported in `lifecycle.py`.
+
+- [ ] **Step 3: Add the SMS hook**
+
+Open `app/orders/lifecycle.py`. Add to the imports near the top:
+
+```python
+import logging
+
+from app.sms import SmsError, send_sms
+from app.sms.templates import order_confirmation as render_order_confirmation
+
+_log = logging.getLogger(__name__)
+```
+
+Then in `persist_on_confirm`, after `order_storage.save_order(confirmed_order)` and before `return confirmed_order`, add:
+
+```python
+    if confirmed_order.caller_phone:
+        try:
+            send_sms(
+                to=confirmed_order.caller_phone,
+                body=render_order_confirmation(confirmed_order),
+                idempotency_key=f"{confirmed_order.call_sid}:order_confirmation",
+                tenant_id=confirmed_order.restaurant_id,
+            )
+        except SmsError as exc:
+            # Best-effort: SMS failure must not roll back the order.
+            # Tablet UX still shows the order; owner can resend manually
+            # post-pilot if it matters.
+            _log.warning(
+                "order_confirmation SMS failed for %s: %s",
+                confirmed_order.call_sid,
+                exc,
+            )
+
+    return confirmed_order
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pytest tests/test_orders_lifecycle.py -v`
+Expected: all green (existing tests + 3 new SMS tests).
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `pytest tests/ -x`
+Expected: all green. The existing `test_telephony.py::test_persist_on_confirm_*` tests use `monkeypatch` on `app.telephony.router.persist_on_confirm` so they're unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/orders/lifecycle.py tests/test_orders_lifecycle.py
+git commit -m "orders: fire order_confirmation SMS on confirm transition"
+```
+
+---
+
+### Task 7: End-to-end smoke test with mocked Twilio
+
+**Files:**
+- Create: `tests/test_sms_e2e.py`
+
+Verifies the whole path: `Order` → `persist_on_confirm` → Firestore write → SMS render → Twilio call → idempotency record write — with one mock at the Twilio boundary.
+
+- [ ] **Step 1: Write the e2e test**
+
+Create `tests/test_sms_e2e.py`:
+
+```python
+"""End-to-end test: Order confirmation triggers SMS through the full
+lifecycle path with only Twilio mocked at the boundary."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.orders.lifecycle import persist_on_confirm
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderType,
+)
+from app.storage import firestore as storage
+
+
+@pytest.fixture(autouse=True)
+def reset_storage_client():
+    yield
+    storage.set_client(None)
+
+
+def test_confirm_to_sms_full_path():
+    fs_client = MagicMock()
+    storage.set_client(fs_client)
+
+    # Wire get_order to return an order without sms_sent populated, so
+    # the idempotency check passes through to Twilio.
+    order = Order(
+        call_sid="CAfull",
+        caller_phone="+15551234567",
+        restaurant_id="niko-pizza-kitchen",
+        items=[
+            LineItem(
+                name="Pepperoni",
+                category=ItemCategory.PIZZA,
+                size="medium",
+                quantity=1,
+                unit_price=17.99,
+            ),
+        ],
+        order_type=OrderType.PICKUP,
+    )
+
+    snapshot = MagicMock()
+    snapshot.exists = True
+    # First save_order writes the confirmed order; later get_order reads
+    # it back. Stub get to return the confirmed order.
+    confirmed_dump = order.model_copy(
+        update={"status": "confirmed"},
+    ).model_dump(mode="python")
+    snapshot.to_dict.return_value = confirmed_dump
+    (
+        fs_client.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .get
+        .return_value
+    ) = snapshot
+
+    with (
+        patch("app.sms.client._twilio_client") as twilio_factory,
+        patch(
+            "app.config.settings.twilio_messaging_service_sid",
+            "MGfake",
+        ),
+        patch("app.config.settings.twilio_account_sid", "ACfake"),
+        patch("app.config.settings.twilio_auth_token", "tokenfake"),
+    ):
+        twilio_factory.return_value.messages.create.return_value = MagicMock(
+            sid="SMend2end",
+        )
+        confirmed = persist_on_confirm(order)
+
+    twilio_factory.return_value.messages.create.assert_called_once()
+    body = twilio_factory.return_value.messages.create.call_args.kwargs["body"]
+    assert "Pepperoni" in body
+    assert "$17.99" in body
+    assert confirmed.status.value == "confirmed"
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `pytest tests/test_sms_e2e.py -v`
+Expected: 1 pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_sms_e2e.py
+git commit -m "tests: end-to-end SMS confirmation path with mocked Twilio"
+```
+
+---
+
+### Task 8: Open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin <branch-name>
+```
+
+- [ ] **Step 2: Open PR**
+
+Title: `Sprint 2.4 — app/sms/ module + order confirmation SMS (#7)`
+
+Body:
+
+```markdown
+## Summary
+
+- Adds `app/sms/` module: Twilio Messaging Service wrapper, `SmsError`, `SmsResult`, `order_confirmation` template.
+- Wires `order_confirmation` SMS to fire from `lifecycle.persist_on_confirm` after the Firestore write. Best-effort — Twilio failure does not roll back the order.
+- Adds `Order.sms_sent: dict[str, SmsSentRecord]` for our-layer idempotency on `(call_sid, template_name)`.
+- Adds `TWILIO_MESSAGING_SERVICE_SID` config + `.env.example` entry.
+
+Module is shared with the queued Sprint 2.3 payments work — the `send_sms` contract is the one pinned in `docs/superpowers/specs/2026-05-01-sprint-2.4-design.md`. Sprint 2.3 will add `payment_link` and `payment_expired` templates without touching the client.
+
+## Spec deviation
+
+`send_sms` is sync, not async as the spec contract showed — Twilio's SDK is sync and the existing storage layer is sync. Async callers wrap with `asyncio.to_thread`. Spec to be updated at sprint end.
+
+## Test plan
+
+- [ ] `pytest tests/test_sms_client.py -v` — 6 passes
+- [ ] `pytest tests/test_sms_templates.py -v` — 4 passes
+- [ ] `pytest tests/test_orders_lifecycle.py -v` — all green including 3 new SMS tests
+- [ ] `pytest tests/test_sms_e2e.py -v` — 1 pass
+- [ ] `pytest tests/ -x` — full suite green
+- [ ] Manual: set `TWILIO_MESSAGING_SERVICE_SID` to a real test Messaging Service, confirm an order via `POST /dev/seed-order` + status transition, verify SMS lands on a real phone.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+- [ ] **Step 3: Update issue #7 checklist**
+
+After PR opens, edit issue #7 body to mark `3a` and `3b` checked, with PR link.
+
+---
+
+## Self-review notes
+
+**Spec coverage:** Track 3 deliverables 3a (`app/sms/` module) and 3b (order confirmation wiring) → fully covered by Tasks 2–7.
+
+**Cross-track dependencies:**
+- Track 3 has no inputs from other tracks — runs independently.
+- Track 3 outputs the `app/sms/` interface that Sprint 2.3 consumes unchanged. Pinned in Task 5's `send_sms` signature.
+
+**Open follow-ups for later sprints (do NOT do in this plan):**
+- Per-tenant Messaging Service / 10DLC brand registration → defer to pilot ramp.
+- Owner-facing SMS toggle in `/settings` (skip confirmation per restaurant) → settings page (Track 1) lands the placeholder card; wiring is post-2.4 work.
+- Payment-side templates (`payment_link`, `payment_expired`) → Sprint 2.3.

--- a/docs/superpowers/plans/2026-05-01-sprint-2.4-telephony.md
+++ b/docs/superpowers/plans/2026-05-01-sprint-2.4-telephony.md
@@ -1,0 +1,1649 @@
+# Sprint 2.4 — Track 2: Telephony (call transfer + voicemail) implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the AI hits a failure condition, transfer the caller to a per-restaurant fallback number; when no one answers (or it's after hours), drop into voicemail with Twilio transcription. Surface both on the dashboard's `/calls` page.
+
+**Architecture:** The AI flow runs over Twilio's `<Connect><Stream>`. Transfer cannot interrupt that stream mid-call via the REST API (404s on calls in `<Connect>` state). Instead: the WebSocket handler sets a `transfer_requested` flag on `_CallState` when a trigger fires, then closes the WebSocket. Twilio hits `<Connect>`'s `action` URL → `/voice/stream-ended` returns either an empty TwiML (normal end) or `<Dial>` TwiML (transfer). `<Dial>`'s `action` is `/voice/transfer-result`, which cascades into voicemail on no-answer / busy / failed. Voicemail uses Twilio's `<Record transcribeCallback>`; recording uploads through the existing GCS pipeline (PRs #136–144); transcript writes to the call session.
+
+**Tech Stack:** Python 3.12, FastAPI, Twilio TwiML helpers (`Connect`, `Dial`, `Record`, `VoiceResponse`), Deepgram (existing), pytest with FastAPI TestClient.
+
+**Cross-track inputs:**
+- `restaurants/{rid}.fallback_phone` — produced by Track 1 Phase A. Track 2 stubs a hardcoded constant for days 1–2; Task 8 swaps to the real field once Track 1 lands.
+- `restaurants/{rid}.hours_structured` — produced by Track 1 Phase A + B. Track 2 stubs "always open" until day 7; Task 11 swaps to the real field.
+
+**Spec deviation — "I want a human" detection:** Spec implies LLM-classified intent. Implemented as a regex match on caller transcripts (`/talk to a (human|person|someone)|let me speak to|real person/i`) — fast, deterministic, easy to tune at sprint-end if false positives are noisy. LLM-based intent classification is a Phase 3 follow-up.
+
+**Phase split — each phase is its own PR:**
+- Phase A → "Sprint 2.4 — call_session schema for transfer + voicemail (#7)"
+- Phase B + C → "Sprint 2.4 — call transfer to fallback number (#7)"
+- Phase D → "Sprint 2.4 — voicemail flow (#7)"
+- Phase E → "Sprint 2.4 — voicemail surface on /calls (#7)"
+
+---
+
+## Phase A — Schema + helpers
+
+### Task 1: Extend `call_sessions` storage with transfer + voicemail fields
+
+**Files:**
+- Modify: `app/storage/call_sessions.py` — add `mark_transfer_attempted` + `mark_voicemail_left` helpers
+- Test: `tests/test_call_sessions_storage.py`
+
+The fields land via `record_event` + parent-doc patches, mirroring `mark_recording_ready`'s shape. Both helpers are idempotent — re-calling for the same `call_sid` overwrites the latest state.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_call_sessions_storage.py`:
+
+```python
+def test_mark_transfer_attempted_writes_status_to_both_paths():
+    """Transfer status patches the call session and emits an event."""
+    fs = MagicMock()
+    call_sessions.set_client(fs)
+
+    call_sessions.mark_transfer_attempted(
+        "CAxfer",
+        "r1",
+        status="answered",
+        fallback_phone="+15551234567",
+    )
+
+    # Two updates: legacy + nested
+    legacy_update = fs.collection.return_value.document.return_value.update
+    nested_update = (
+        fs.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .update
+    )
+    assert legacy_update.called
+    assert nested_update.called
+    payload = legacy_update.call_args.args[0]
+    assert payload["transfer_attempted"] is True
+    assert payload["transfer_status"] == "answered"
+
+
+def test_mark_voicemail_left_sets_recording_url_and_transcript():
+    fs = MagicMock()
+    call_sessions.set_client(fs)
+
+    call_sessions.mark_voicemail_left(
+        "CAvm",
+        "r1",
+        recording_url="gs://bucket/path.mp3",
+        recording_sid="REabc",
+        duration_seconds=42,
+        transcript=None,
+    )
+
+    nested_update = (
+        fs.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .update
+    )
+    payload = nested_update.call_args.args[0]
+    assert payload["voicemail_recording_url"] == "gs://bucket/path.mp3"
+    assert payload["voicemail_recording_sid"] == "REabc"
+    assert payload["voicemail_duration_seconds"] == 42
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/test_call_sessions_storage.py -v -k "transfer or voicemail"`
+Expected: 2 errors — helpers missing.
+
+- [ ] **Step 3: Implement helpers**
+
+Open `app/storage/call_sessions.py`. Append:
+
+```python
+def mark_transfer_attempted(
+    call_sid: str,
+    restaurant_id: str,
+    *,
+    status: str,  # "answered" | "no_answer" | "busy" | "failed" | "skipped"
+    fallback_phone: Optional[str] = None,
+) -> None:
+    """Stamp the call session with transfer outcome + emit a
+    ``transfer_attempted`` event. Mirrors mark_recording_ready's
+    dual-write shape."""
+    ts = _now()
+    patch = {
+        "transfer_attempted": True,
+        "transfer_status": status,
+        "transfer_initiated_at": ts,
+        "last_event_at": ts,
+    }
+    event = {
+        "timestamp": ts,
+        "kind": "transfer_attempted",
+        "text": "",
+        "detail": {"status": status, "fallback_phone": fallback_phone},
+    }
+    try:
+        client = _get_client()
+        legacy = _legacy_parent(client, call_sid)
+        legacy.update(patch)
+        legacy.collection(_EVENTS_SUBCOLLECTION).add(event)
+
+        nested = _nested_parent(client, restaurant_id, call_sid)
+        nested.update(patch)
+        nested.collection(_EVENTS_SUBCOLLECTION).add(event)
+    except Exception:
+        logger.exception(
+            "call_sessions: mark_transfer_attempted failed call_sid=%s",
+            call_sid,
+        )
+
+
+def mark_voicemail_left(
+    call_sid: str,
+    restaurant_id: str,
+    *,
+    recording_url: str,
+    recording_sid: str,
+    duration_seconds: int,
+    transcript: Optional[str],
+) -> None:
+    """Stamp the call session with voicemail recording metadata + emit
+    a ``voicemail_left`` event."""
+    ts = _now()
+    patch = {
+        "voicemail_recording_url": recording_url,
+        "voicemail_recording_sid": recording_sid,
+        "voicemail_duration_seconds": duration_seconds,
+        "voicemail_transcript": transcript,
+        "voicemail_recorded_at": ts,
+        "last_event_at": ts,
+    }
+    event = {
+        "timestamp": ts,
+        "kind": "voicemail_left",
+        "text": transcript or "",
+        "detail": {
+            "recording_sid": recording_sid,
+            "duration_seconds": duration_seconds,
+        },
+    }
+    try:
+        client = _get_client()
+        legacy = _legacy_parent(client, call_sid)
+        legacy.update(patch)
+        legacy.collection(_EVENTS_SUBCOLLECTION).add(event)
+
+        nested = _nested_parent(client, restaurant_id, call_sid)
+        nested.update(patch)
+        nested.collection(_EVENTS_SUBCOLLECTION).add(event)
+    except Exception:
+        logger.exception(
+            "call_sessions: mark_voicemail_left failed call_sid=%s",
+            call_sid,
+        )
+
+
+def update_voicemail_transcript(
+    call_sid: str,
+    restaurant_id: str,
+    *,
+    transcript: str,
+) -> None:
+    """Patch the voicemail transcript after Twilio's transcribeCallback
+    fires (out-of-band from the recording-ready callback)."""
+    ts = _now()
+    patch = {
+        "voicemail_transcript": transcript,
+        "last_event_at": ts,
+    }
+    try:
+        client = _get_client()
+        _legacy_parent(client, call_sid).update(patch)
+        _nested_parent(client, restaurant_id, call_sid).update(patch)
+    except Exception:
+        logger.exception(
+            "call_sessions: update_voicemail_transcript failed call_sid=%s",
+            call_sid,
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_call_sessions_storage.py -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/storage/call_sessions.py tests/test_call_sessions_storage.py
+git commit -m "call_sessions: add transfer + voicemail mutation helpers"
+```
+
+---
+
+### Task 2: `is_open_now` helper using `hours_structured` (TDD)
+
+**Files:**
+- Create: `app/restaurants/open_check.py`
+- Test: `tests/test_open_check.py`
+
+Pure function. Takes a `Restaurant` and a `datetime` (UTC); returns `True` if the restaurant is currently open. Falls back to `True` (always open) when `hours_structured` is None — pre-pilot tenants without configured hours don't suddenly start sending callers to voicemail.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_open_check.py`:
+
+```python
+"""Unit tests for app.restaurants.open_check.is_open_now."""
+
+from datetime import datetime, timezone, timedelta
+import pytest
+
+from app.restaurants.models import DayHours, HoursStructured, Restaurant
+from app.restaurants.open_check import is_open_now
+
+
+def _r(hours: HoursStructured | None) -> Restaurant:
+    return Restaurant(
+        id="r1",
+        name="R",
+        display_phone="+15551234567",
+        twilio_phone="+15551234567",
+        address="1 Main",
+        hours="11-22",
+        hours_structured=hours,
+    )
+
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    """Build a UTC datetime. Caller is responsible for accounting for
+    America/Toronto offset (the helper interprets times in the
+    restaurant's tz, hardcoded to America/Toronto for Phase 1)."""
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def test_is_open_now_returns_true_when_hours_structured_is_none():
+    """No configured hours → assume always open. Conservative default
+    so existing tenants don't suddenly land in voicemail."""
+    assert is_open_now(_r(None), _utc(2026, 5, 1, 18)) is True
+
+
+def test_is_open_now_returns_true_within_open_window():
+    day = DayHours(open="11:00", close="22:00", closed=False)
+    h = HoursStructured(mon=day, tue=day, wed=day, thu=day, fri=day, sat=day, sun=day)
+    # 2026-05-01 is a Friday. America/Toronto is UTC-4 (EDT in May).
+    # 18:00 UTC = 14:00 local — well within 11-22 window.
+    assert is_open_now(_r(h), _utc(2026, 5, 1, 18)) is True
+
+
+def test_is_open_now_returns_false_outside_open_window():
+    day = DayHours(open="11:00", close="22:00", closed=False)
+    h = HoursStructured(mon=day, tue=day, wed=day, thu=day, fri=day, sat=day, sun=day)
+    # 06:00 UTC = 02:00 local Friday — closed.
+    assert is_open_now(_r(h), _utc(2026, 5, 1, 6)) is False
+
+
+def test_is_open_now_returns_false_on_closed_day():
+    open_day = DayHours(open="11:00", close="22:00", closed=False)
+    closed_day = DayHours(open="00:00", close="00:00", closed=True)
+    h = HoursStructured(
+        mon=open_day,
+        tue=open_day,
+        wed=open_day,
+        thu=open_day,
+        fri=open_day,
+        sat=open_day,
+        sun=closed_day,
+    )
+    # 2026-05-03 is a Sunday. 18:00 UTC = 14:00 local Sunday.
+    assert is_open_now(_r(h), _utc(2026, 5, 3, 18)) is False
+
+
+def test_is_open_now_handles_late_night_close():
+    """A close time of 23:00 includes 22:59 local; excludes 23:01."""
+    day = DayHours(open="11:00", close="23:00", closed=False)
+    h = HoursStructured(mon=day, tue=day, wed=day, thu=day, fri=day, sat=day, sun=day)
+    # 2026-05-02 03:00 UTC = 23:00 local Friday → at the close edge,
+    # treat as closed.
+    assert is_open_now(_r(h), _utc(2026, 5, 2, 3)) is False
+    # 02:59 UTC = 22:59 local Friday → still open.
+    assert is_open_now(_r(h), _utc(2026, 5, 2, 2, 59)) is True
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/test_open_check.py -v`
+Expected: errors — module missing.
+
+- [ ] **Step 3: Implement**
+
+Create `app/restaurants/open_check.py`:
+
+```python
+"""Is-the-restaurant-open-right-now check.
+
+Phase 1 hardcodes the timezone to America/Toronto (matches the
+dashboard's <LocalTime /> default). Multi-tz support arrives with
+multi-location, deferred per dashboard/CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from app.restaurants.models import DayHours, HoursStructured, Restaurant
+
+_TZ = ZoneInfo("America/Toronto")
+_DAY_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+
+
+def _parse_hhmm(value: str) -> time:
+    hour, minute = value.split(":")
+    return time(int(hour), int(minute))
+
+
+def _day_for(dt_local: datetime) -> str:
+    # Python: Monday == 0, Sunday == 6. Map to our day keys.
+    return _DAY_KEYS[dt_local.weekday()]
+
+
+def is_open_now(
+    restaurant: Restaurant,
+    now_utc: Optional[datetime] = None,
+) -> bool:
+    """Return True if the restaurant is currently open in its local
+    timezone. Falls back to True when ``hours_structured`` is None —
+    don't silently route callers to voicemail just because hours
+    haven't been configured yet."""
+    if restaurant.hours_structured is None:
+        return True
+
+    now = now_utc or datetime.now(_TZ)
+    local = now.astimezone(_TZ)
+    day_key = _day_for(local)
+    day: DayHours = getattr(restaurant.hours_structured, day_key)
+
+    if day.closed:
+        return False
+
+    open_t = _parse_hhmm(day.open)
+    close_t = _parse_hhmm(day.close)
+    current = local.time()
+    return open_t <= current < close_t
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_open_check.py -v`
+Expected: 5 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/restaurants/open_check.py tests/test_open_check.py
+git commit -m "restaurants: add is_open_now helper using hours_structured"
+```
+
+---
+
+## Phase B — Trigger detection inside the WebSocket loop
+
+### Task 3: Add transfer-trigger fields to `_CallState` + a pure detector (TDD)
+
+**Files:**
+- Modify: `app/telephony/router.py` — extend `_CallState`
+- Create: `app/telephony/transfer_triggers.py` — pure detection logic
+- Test: `tests/test_transfer_triggers.py`
+
+Keeping the detector in its own module (rather than inline in the router) makes it testable without standing up the WebSocket harness.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_transfer_triggers.py`:
+
+```python
+"""Unit tests for app.telephony.transfer_triggers.
+
+Each function is a pure check that returns True if its trigger condition
+is met for a given snapshot of call state."""
+
+from app.telephony.transfer_triggers import (
+    detect_human_intent_in_text,
+    should_trigger_transfer,
+    TransferReason,
+)
+
+
+def test_detect_human_intent_matches_common_phrases():
+    cases = [
+        "let me talk to a human please",
+        "can I speak to a person",
+        "I want to talk to someone",
+        "give me a real person",
+    ]
+    for text in cases:
+        assert detect_human_intent_in_text(text), text
+
+
+def test_detect_human_intent_does_not_match_unrelated():
+    cases = [
+        "I want a pepperoni pizza",
+        "talk dirty to me",
+        "person of interest is a great show",
+    ]
+    for text in cases:
+        assert not detect_human_intent_in_text(text), text
+
+
+def test_detect_human_intent_handles_punctuation_and_case():
+    assert detect_human_intent_in_text("Let me SPEAK to a Person!")
+
+
+def test_should_trigger_transfer_after_three_misheard_turns():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=3,
+        last_transcript="any",
+        llm_error_occurred=False,
+    )
+    assert reason is TransferReason.MISHEARD_TURNS
+
+
+def test_should_trigger_transfer_on_llm_error():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=0,
+        last_transcript="any",
+        llm_error_occurred=True,
+    )
+    assert reason is TransferReason.LLM_ERROR
+
+
+def test_should_trigger_transfer_on_human_intent():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=0,
+        last_transcript="please let me talk to a human",
+        llm_error_occurred=False,
+    )
+    assert reason is TransferReason.HUMAN_INTENT
+
+
+def test_should_trigger_transfer_returns_none_below_threshold():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=2,
+        last_transcript="my pizza order",
+        llm_error_occurred=False,
+    )
+    assert reason is None
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/test_transfer_triggers.py -v`
+Expected: errors — module missing.
+
+- [ ] **Step 3: Implement**
+
+Create `app/telephony/transfer_triggers.py`:
+
+```python
+"""Pure-function checks that decide whether the AI loop should transfer
+the caller to a human. Kept free of WebSocket / Twilio dependencies so
+they can be unit-tested independently of the call harness."""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Optional
+
+# Threshold above which we assume the ASR is fundamentally not
+# picking the caller up. Tunable post-pilot.
+MISHEARD_THRESHOLD = 3
+
+_HUMAN_INTENT = re.compile(
+    r"\b("
+    r"(let\s+me|i\s+(want\s+to|need\s+to|wanna))\s+"
+    r"(speak|talk)\s+to\s+(a\s+)?(human|person|someone|real\s+person)"
+    r"|"
+    r"can\s+i\s+(speak|talk)\s+to\s+(a\s+)?(human|person|someone)"
+    r"|"
+    r"give\s+me\s+a\s+(real\s+)?(human|person)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+class TransferReason(str, Enum):
+    MISHEARD_TURNS = "misheard_turns"
+    LLM_ERROR = "llm_error"
+    HUMAN_INTENT = "human_intent"
+
+
+def detect_human_intent_in_text(text: str) -> bool:
+    """True if the caller's transcript reads as a request for a human.
+    Conservative regex; tune at sprint-end if false positives are noisy.
+    Future: replace with LLM-based intent classification."""
+    if not text:
+        return False
+    return _HUMAN_INTENT.search(text) is not None
+
+
+def should_trigger_transfer(
+    *,
+    consecutive_low_confidence_turns: int,
+    last_transcript: str,
+    llm_error_occurred: bool,
+) -> Optional[TransferReason]:
+    """Return the first matching transfer reason, or None.
+
+    The order matters — LLM error and human intent dominate the
+    misheard threshold (a hard error or an explicit ask for a human is
+    more important than a noisy mic count).
+    """
+    if llm_error_occurred:
+        return TransferReason.LLM_ERROR
+    if detect_human_intent_in_text(last_transcript):
+        return TransferReason.HUMAN_INTENT
+    if consecutive_low_confidence_turns >= MISHEARD_THRESHOLD:
+        return TransferReason.MISHEARD_TURNS
+    return None
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_transfer_triggers.py -v`
+Expected: 7 passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/transfer_triggers.py tests/test_transfer_triggers.py
+git commit -m "telephony: add transfer-trigger detector (misheard + LLM error + human intent)"
+```
+
+---
+
+### Task 4: Wire trigger detection into the WebSocket loop
+
+**Files:**
+- Modify: `app/telephony/router.py` — extend `_CallState`, accumulate signals, decide on transfer at end-of-stream
+
+The cleanest hook point: track signals inside `_CallState` as transcripts and LLM errors flow through the existing handlers, but only DECIDE whether to transfer when the WebSocket closes (so we don't fight the running barge-in / silence-watchdog logic mid-call). The decision is then carried into the `<Connect>` action callback by writing it to the call session doc.
+
+- [ ] **Step 1: Extend `_CallState` with trigger signals**
+
+Open `app/telephony/router.py`. Find the `@dataclass class _CallState` definition. Add fields:
+
+```python
+    # Transfer trigger accumulators (#7 Sprint 2.4 Track 2). Set by
+    # transcript / LLM-error handlers; read in the finally block to
+    # decide whether to write a transfer flag to the call session.
+    consecutive_low_confidence_turns: int = 0
+    last_caller_transcript: str = ""
+    llm_error_occurred: bool = False
+```
+
+- [ ] **Step 2: Increment the misheard counter**
+
+Find the transcript-handling code (around the Deepgram `LiveTranscriptionEvents.Transcript` handler). When a `transcript_final` is processed, check the confidence:
+
+```python
+# After the existing transcript_final handling, before the LLM call:
+confidence = result.channel.alternatives[0].confidence  # Deepgram-side
+if confidence < 0.5:
+    state.consecutive_low_confidence_turns += 1
+else:
+    state.consecutive_low_confidence_turns = 0
+state.last_caller_transcript = transcript_text
+```
+
+(The exact attribute path depends on the Deepgram event — adapt if it differs. The intent is: increment when confidence < 0.5, reset on a clear turn.)
+
+- [ ] **Step 3: Set the LLM-error flag**
+
+Find the `try/except` around the LLM call (`stream_reply`). In the except branch, after the existing logging, add:
+
+```python
+state.llm_error_occurred = True
+```
+
+- [ ] **Step 4: Decide on transfer at end-of-stream + persist**
+
+Open `app/telephony/router.py`. In the `finally` block of the media-stream handler (around lines 740–797 — after `mark_call_ended` writes), insert before the recording-finalize block:
+
+```python
+        from app.telephony.transfer_triggers import (
+            TransferReason,
+            should_trigger_transfer,
+        )
+
+        if state.call_sid and rid_for_close:
+            transfer_reason = should_trigger_transfer(
+                consecutive_low_confidence_turns=state.consecutive_low_confidence_turns,
+                last_transcript=state.last_caller_transcript,
+                llm_error_occurred=state.llm_error_occurred,
+            )
+            if transfer_reason is not None:
+                # Stash the reason on the call session so the
+                # /voice/stream-ended action callback can read it and
+                # return the appropriate TwiML.
+                try:
+                    call_sessions.record_event(
+                        state.call_sid,
+                        rid_for_close,
+                        kind="transfer_requested",
+                        text=transfer_reason.value,
+                    )
+                except Exception:
+                    logger.exception(
+                        "call_sessions: transfer_requested write failed call_sid=%s",
+                        state.call_sid,
+                    )
+```
+
+Move the `from ... import` to the top of the file.
+
+- [ ] **Step 5: Add an `action` URL to the `<Connect>`**
+
+Find where `<Connect><Stream>` is rendered in the `/voice` handler. Modify the TwiML:
+
+```python
+response = VoiceResponse()
+connect = Connect(action="/voice/stream-ended", method="POST")
+connect.stream(url=stream_url)
+response.append(connect)
+```
+
+(If the existing code uses a slightly different shape — e.g., `response.connect()` chained — adapt to add `action="/voice/stream-ended"`.)
+
+- [ ] **Step 6: Run the existing telephony tests to confirm no regression**
+
+Run: `pytest tests/test_telephony.py -v`
+Expected: all green. The new fields default to harmless values; no existing test should break. If any do, the failure is likely the new fields being missing from a test fixture — add them with their defaults.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/telephony/router.py
+git commit -m "telephony: accumulate transfer-trigger signals + persist on stream end"
+```
+
+---
+
+## Phase C — Call transfer
+
+### Task 5: `/voice/stream-ended` action endpoint (TDD)
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Test: `tests/test_telephony.py`
+
+When Twilio's `<Connect>` finishes, it POSTs to this URL with the `CallSid` form field. The handler reads the latest call-session events for that SID. If the most recent event is `transfer_requested` AND the restaurant has a `fallback_phone`, it returns `<Dial>` TwiML with an `action` callback to `/voice/transfer-result`. Otherwise: empty TwiML (call ends).
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_telephony.py`:
+
+```python
+def test_stream_ended_returns_empty_twiml_when_no_transfer_requested(
+    client, monkeypatch,
+):
+    """No transfer_requested event → no Dial — Twilio hangs up."""
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_events",
+        lambda sid, rid: [
+            {"kind": "transcript_final", "timestamp": ..., "text": "hi"},
+        ],
+    )
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session",
+        lambda sid, rid: {"restaurant_id": "r1"},
+    )
+
+    resp = client.post("/voice/stream-ended", data={"CallSid": "CAtest"})
+    assert resp.status_code == 200
+    body = resp.text
+    # Empty <Response/> means hang up.
+    assert "<Dial" not in body
+
+
+def test_stream_ended_returns_dial_when_transfer_requested(
+    client, monkeypatch,
+):
+    """transfer_requested + fallback_phone present → <Dial>."""
+    from app.restaurants.models import Restaurant
+    from app.storage import call_sessions, restaurants as r_storage
+
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_events",
+        lambda sid, rid: [
+            {"kind": "transfer_requested", "timestamp": ..., "text": "human_intent"},
+        ],
+    )
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session",
+        lambda sid, rid: {"restaurant_id": "r1"},
+    )
+    monkeypatch.setattr(
+        r_storage,
+        "get_restaurant",
+        lambda rid: Restaurant(
+            id="r1",
+            name="R",
+            display_phone="+15551234567",
+            twilio_phone="+16479058093",
+            address="1 Main",
+            hours="11-22",
+            fallback_phone="+15559999999",
+        ),
+    )
+
+    resp = client.post("/voice/stream-ended", data={"CallSid": "CAtest"})
+    assert resp.status_code == 200
+    body = resp.text
+    assert "<Dial" in body
+    assert "+15559999999" in body
+    assert "/voice/transfer-result" in body
+
+
+def test_stream_ended_skips_dial_when_no_fallback_phone(
+    client, monkeypatch,
+):
+    from app.restaurants.models import Restaurant
+    from app.storage import call_sessions, restaurants as r_storage
+
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_events",
+        lambda sid, rid: [
+            {"kind": "transfer_requested", "timestamp": ..., "text": "llm_error"},
+        ],
+    )
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session",
+        lambda sid, rid: {"restaurant_id": "r1"},
+    )
+    monkeypatch.setattr(
+        r_storage,
+        "get_restaurant",
+        lambda rid: Restaurant(
+            id="r1",
+            name="R",
+            display_phone="+15551234567",
+            twilio_phone="+16479058093",
+            address="1 Main",
+            hours="11-22",
+            fallback_phone=None,
+        ),
+    )
+
+    resp = client.post("/voice/stream-ended", data={"CallSid": "CAtest"})
+    assert resp.status_code == 200
+    # No fallback configured → fall through to voicemail directly.
+    assert "<Dial" not in resp.text
+    assert "<Record" in resp.text
+```
+
+(`client` fixture matches the existing pattern in `test_telephony.py` — adapt if the test file's harness differs.)
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/test_telephony.py -v -k stream_ended`
+Expected: errors — endpoint missing.
+
+- [ ] **Step 3: Implement the handler**
+
+Open `app/telephony/router.py`. Add after the `/voice` handler:
+
+```python
+from twilio.twiml.voice_response import Dial, Record
+
+from app.telephony.voicemail_twiml import voicemail_response
+
+
+@router.post("/voice/stream-ended")
+async def stream_ended(request: Request):
+    """Twilio's <Connect> action callback. Decides what happens after
+    the AI flow ends: empty (hang up), transfer to fallback, or
+    drop to voicemail."""
+    form = await request.form()
+    call_sid = form.get("CallSid")
+
+    if not call_sid:
+        # Twilio always sends CallSid; if it's missing, just hang up.
+        return Response(content=str(VoiceResponse()), media_type="text/xml")
+
+    # Resolve the tenant by reading the call session doc — written by
+    # the WebSocket handler at start time.
+    session = call_sessions.get_session(call_sid, restaurant_id="")  # type: ignore[arg-type]
+    # The session may be at the legacy flat path; try both reads. The
+    # nested path takes restaurant_id; we don't know it yet without
+    # loading the session. Two reads keep the wiring clean.
+    rid: Optional[str] = None
+    if session and isinstance(session, dict):
+        rid = session.get("restaurant_id")
+    if rid is None:
+        # Fall through: no rid, no transfer.
+        return Response(content=str(VoiceResponse()), media_type="text/xml")
+
+    events = call_sessions.get_session_events(call_sid, rid) or []
+    last = events[-1] if events else {}
+    transfer_requested = last.get("kind") == "transfer_requested"
+
+    if not transfer_requested:
+        # Normal end of call — no further action.
+        return Response(content=str(VoiceResponse()), media_type="text/xml")
+
+    restaurant = restaurants_storage.get_restaurant(rid)
+    if restaurant is None or not restaurant.fallback_phone:
+        # Transfer requested but no number to dial → skip transfer,
+        # land on voicemail directly.
+        call_sessions.mark_transfer_attempted(
+            call_sid, rid, status="skipped", fallback_phone=None,
+        )
+        return Response(
+            content=str(voicemail_response(call_sid, rid)),
+            media_type="text/xml",
+        )
+
+    # Transfer attempt: <Dial> with action callback for no-answer.
+    twiml = VoiceResponse()
+    dial = Dial(
+        action=f"/voice/transfer-result?call_sid={call_sid}&rid={rid}",
+        method="POST",
+        timeout=20,  # seconds; Twilio default is 30
+    )
+    dial.number(restaurant.fallback_phone)
+    twiml.append(dial)
+    return Response(content=str(twiml), media_type="text/xml")
+```
+
+(Get `Optional` from `typing` if it's not already imported.)
+
+- [ ] **Step 4: Implement the voicemail TwiML helper (Task 6 dependency, write minimal stub for now)**
+
+Create `app/telephony/voicemail_twiml.py`:
+
+```python
+"""Voicemail TwiML rendering. Stub for Phase B; Phase D fills out the
+recording + transcription wiring."""
+
+from __future__ import annotations
+
+from twilio.twiml.voice_response import Record, VoiceResponse
+
+
+def voicemail_response(call_sid: str, restaurant_id: str) -> VoiceResponse:
+    twiml = VoiceResponse()
+    twiml.say(
+        "We weren't able to take your call. Please leave a message after "
+        "the tone, and we'll get back to you.",
+        voice="alice",
+    )
+    twiml.record(
+        max_length=90,
+        action=f"/voice/voicemail-recorded?call_sid={call_sid}&rid={restaurant_id}",
+        transcribe=True,
+        transcribe_callback=(
+            f"/voice/voicemail-transcription?call_sid={call_sid}&rid={restaurant_id}"
+        ),
+        method="POST",
+    )
+    twiml.hangup()
+    return twiml
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `pytest tests/test_telephony.py -v -k stream_ended`
+Expected: 3 passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/telephony/router.py app/telephony/voicemail_twiml.py tests/test_telephony.py
+git commit -m "telephony: /voice/stream-ended dispatches to transfer or voicemail"
+```
+
+---
+
+### Task 6: `/voice/transfer-result` cascades to voicemail on no-answer (TDD)
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Test: `tests/test_telephony.py`
+
+Twilio POSTs `DialCallStatus` (= `completed | no-answer | busy | failed | canceled`). On `completed`, the call ended successfully — nothing to do. On any other status, drop to voicemail.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_telephony.py`:
+
+```python
+def test_transfer_result_completed_returns_empty(client, monkeypatch):
+    from app.storage import call_sessions
+    monkeypatch.setattr(call_sessions, "mark_transfer_attempted", lambda *a, **k: None)
+
+    resp = client.post(
+        "/voice/transfer-result",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={"DialCallStatus": "completed"},
+    )
+    assert resp.status_code == 200
+    assert "<Record" not in resp.text
+
+
+def test_transfer_result_no_answer_drops_to_voicemail(client, monkeypatch):
+    from app.storage import call_sessions
+    monkeypatch.setattr(call_sessions, "mark_transfer_attempted", lambda *a, **k: None)
+
+    resp = client.post(
+        "/voice/transfer-result",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={"DialCallStatus": "no-answer"},
+    )
+    assert resp.status_code == 200
+    assert "<Record" in resp.text
+
+
+def test_transfer_result_busy_drops_to_voicemail(client, monkeypatch):
+    from app.storage import call_sessions
+    monkeypatch.setattr(call_sessions, "mark_transfer_attempted", lambda *a, **k: None)
+
+    resp = client.post(
+        "/voice/transfer-result",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={"DialCallStatus": "busy"},
+    )
+    assert resp.status_code == 200
+    assert "<Record" in resp.text
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/test_telephony.py -v -k transfer_result`
+Expected: errors.
+
+- [ ] **Step 3: Implement**
+
+Open `app/telephony/router.py`. Add after `stream_ended`:
+
+```python
+@router.post("/voice/transfer-result")
+async def transfer_result(
+    request: Request,
+    call_sid: str,
+    rid: str,
+):
+    form = await request.form()
+    status = form.get("DialCallStatus", "failed")
+
+    # Map Twilio status → our internal vocabulary.
+    status_map = {
+        "completed": "answered",
+        "no-answer": "no_answer",
+        "busy": "busy",
+        "failed": "failed",
+        "canceled": "failed",
+    }
+    internal_status = status_map.get(status, "failed")
+
+    call_sessions.mark_transfer_attempted(
+        call_sid,
+        rid,
+        status=internal_status,
+        fallback_phone=None,
+    )
+
+    if internal_status == "answered":
+        # Call connected; nothing more to do.
+        return Response(content=str(VoiceResponse()), media_type="text/xml")
+
+    # Cascade to voicemail.
+    return Response(
+        content=str(voicemail_response(call_sid, rid)),
+        media_type="text/xml",
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/test_telephony.py -v -k transfer_result`
+Expected: 3 passes.
+
+- [ ] **Step 5: Commit + push + open Phase B+C PR**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: /voice/transfer-result cascades to voicemail on no-answer"
+git push origin <branch>
+gh pr create --title "Sprint 2.4 — call transfer to fallback number (#7)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds transfer triggers (3 misheard turns / LLM error / "talk to a human" regex) detected during the call and persisted on stream end.
+- `/voice/stream-ended` reads the latest call-session events and returns either empty TwiML (normal end), `<Dial>` to the restaurant's `fallback_phone`, or voicemail (when no fallback configured).
+- `/voice/transfer-result` cascades to voicemail when the dial fails (no-answer / busy / failed).
+- Voicemail TwiML helper landed as a stub; Phase D wires recording + transcription persistence.
+
+## Spec deviation
+
+"I want a human" intent uses a regex matcher (deterministic, fast). LLM-based intent classification is a Phase 3 follow-up if false positives are a problem.
+
+## Test plan
+
+- [ ] `pytest tests/test_transfer_triggers.py tests/test_open_check.py tests/test_call_sessions_storage.py tests/test_telephony.py -v`
+- [ ] Manual via test number: trigger "let me talk to a human" mid-call → call dials the configured fallback. Don't answer → voicemail prompt plays.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Phase D — Voicemail recording + transcription
+
+### Task 7: `/voice/voicemail-recorded` webhook persists to GCS (TDD)
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Modify: `app/storage/recordings.py` — add `upload_voicemail` helper if needed (the existing `RecordingUploadSession` is for live streams; voicemail comes from Twilio's REST recording URL, so a different upload path applies)
+- Test: `tests/test_telephony.py`
+
+Twilio POSTs `RecordingUrl`, `RecordingSid`, `RecordingDuration` to this URL. The handler:
+1. Downloads the audio from `RecordingUrl` (Twilio-hosted; auth via account SID + auth token).
+2. Uploads to the existing GCS recordings bucket under `voicemail/{call_sid}.mp3`.
+3. Calls `call_sessions.mark_voicemail_left` with the GS URL.
+4. Returns empty TwiML (Twilio already hung up).
+
+- [ ] **Step 1: Add the GCS uploader for voicemail**
+
+Append to `app/storage/recordings.py`:
+
+```python
+def upload_voicemail_from_twilio(
+    *,
+    call_sid: str,
+    restaurant_id: str,
+    twilio_recording_url: str,
+    auth: tuple[str, str],
+) -> str:
+    """Download a voicemail recording from Twilio and upload to GCS.
+    Returns the gs:// URL. Reuses the same bucket as call recordings.
+
+    ``auth`` is (account_sid, auth_token) — Twilio basic-auths the
+    recording URL.
+    """
+    import requests
+    from google.cloud import storage as gcs
+
+    resp = requests.get(twilio_recording_url + ".mp3", auth=auth, timeout=30)
+    resp.raise_for_status()
+
+    client = gcs.Client()
+    bucket = client.bucket(settings.recordings_bucket)
+    blob_name = f"voicemail/{restaurant_id}/{call_sid}.mp3"
+    blob = bucket.blob(blob_name)
+    blob.upload_from_string(resp.content, content_type="audio/mpeg")
+    return f"gs://{settings.recordings_bucket}/{blob_name}"
+```
+
+- [ ] **Step 2: Write failing endpoint test**
+
+Append to `tests/test_telephony.py`:
+
+```python
+def test_voicemail_recorded_uploads_and_marks_session(client, monkeypatch):
+    from app.storage import call_sessions, recordings
+
+    upload_calls: list[dict] = []
+
+    def fake_upload(**kwargs):
+        upload_calls.append(kwargs)
+        return f"gs://test/voicemail/{kwargs['call_sid']}.mp3"
+
+    monkeypatch.setattr(
+        recordings, "upload_voicemail_from_twilio", fake_upload,
+    )
+
+    mark_calls: list[dict] = []
+    monkeypatch.setattr(
+        call_sessions,
+        "mark_voicemail_left",
+        lambda *a, **kw: mark_calls.append(kw),
+    )
+
+    resp = client.post(
+        "/voice/voicemail-recorded",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={
+            "RecordingUrl": "https://api.twilio.com/2010-04-01/Recordings/REabc",
+            "RecordingSid": "REabc",
+            "RecordingDuration": "42",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert len(upload_calls) == 1
+    assert upload_calls[0]["call_sid"] == "CAtest"
+    assert len(mark_calls) == 1
+    assert mark_calls[0]["recording_url"].startswith("gs://test/voicemail/")
+    assert mark_calls[0]["duration_seconds"] == 42
+```
+
+- [ ] **Step 3: Run failing test**
+
+Run: `pytest tests/test_telephony.py -v -k voicemail_recorded`
+Expected: error.
+
+- [ ] **Step 4: Implement endpoint**
+
+Open `app/telephony/router.py`. Add after `transfer_result`:
+
+```python
+@router.post("/voice/voicemail-recorded")
+async def voicemail_recorded(
+    request: Request,
+    call_sid: str,
+    rid: str,
+):
+    form = await request.form()
+    recording_url = form.get("RecordingUrl", "")
+    recording_sid = form.get("RecordingSid", "")
+    duration_raw = form.get("RecordingDuration", "0")
+    try:
+        duration = int(duration_raw)
+    except (TypeError, ValueError):
+        duration = 0
+
+    if not recording_url or not recording_sid:
+        # Defensive: malformed callback. Empty TwiML hangs up.
+        return Response(content=str(VoiceResponse()), media_type="text/xml")
+
+    if not settings.twilio_account_sid or not settings.twilio_auth_token:
+        logger.error(
+            "voicemail upload: twilio creds missing call_sid=%s",
+            call_sid,
+        )
+        return Response(content=str(VoiceResponse()), media_type="text/xml")
+
+    try:
+        gs_url = recordings.upload_voicemail_from_twilio(
+            call_sid=call_sid,
+            restaurant_id=rid,
+            twilio_recording_url=recording_url,
+            auth=(settings.twilio_account_sid, settings.twilio_auth_token),
+        )
+    except Exception:
+        logger.exception(
+            "voicemail upload failed call_sid=%s sid=%s",
+            call_sid,
+            recording_sid,
+        )
+        return Response(content=str(VoiceResponse()), media_type="text/xml")
+
+    call_sessions.mark_voicemail_left(
+        call_sid,
+        rid,
+        recording_url=gs_url,
+        recording_sid=recording_sid,
+        duration_seconds=duration,
+        transcript=None,  # Filled in by /voice/voicemail-transcription
+    )
+
+    return Response(content=str(VoiceResponse()), media_type="text/xml")
+```
+
+- [ ] **Step 5: Run test**
+
+Run: `pytest tests/test_telephony.py -v -k voicemail_recorded`
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/telephony/router.py app/storage/recordings.py tests/test_telephony.py
+git commit -m "telephony: /voice/voicemail-recorded uploads to GCS + marks session"
+```
+
+---
+
+### Task 8: `/voice/voicemail-transcription` patches the transcript (TDD)
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Test: `tests/test_telephony.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_telephony.py`:
+
+```python
+def test_voicemail_transcription_patches_call_session(client, monkeypatch):
+    from app.storage import call_sessions
+
+    patches: list[dict] = []
+    monkeypatch.setattr(
+        call_sessions,
+        "update_voicemail_transcript",
+        lambda *a, **kw: patches.append(kw),
+    )
+
+    resp = client.post(
+        "/voice/voicemail-transcription",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={"TranscriptionText": "Hi, please call me back."},
+    )
+
+    assert resp.status_code == 200
+    assert patches == [{"transcript": "Hi, please call me back."}]
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `pytest tests/test_telephony.py -v -k voicemail_transcription`
+Expected: error.
+
+- [ ] **Step 3: Implement**
+
+Open `app/telephony/router.py`. Add:
+
+```python
+@router.post("/voice/voicemail-transcription")
+async def voicemail_transcription(
+    request: Request,
+    call_sid: str,
+    rid: str,
+):
+    form = await request.form()
+    transcript = form.get("TranscriptionText", "")
+    if transcript:
+        call_sessions.update_voicemail_transcript(
+            call_sid, rid, transcript=transcript,
+        )
+    return Response(content="", media_type="text/plain")
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `pytest tests/test_telephony.py -v -k voicemail_transcription`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: /voice/voicemail-transcription patches call session"
+```
+
+---
+
+### Task 9: After-hours call routes directly to voicemail
+
+**Files:**
+- Modify: `app/telephony/router.py` — `/voice` handler
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_telephony.py`:
+
+```python
+def test_voice_routes_to_voicemail_when_after_hours(client, monkeypatch):
+    """When the restaurant is closed, /voice returns voicemail TwiML
+    instead of opening a media stream."""
+    from app.restaurants.models import (
+        DayHours,
+        HoursStructured,
+        Restaurant,
+    )
+    from app.storage import restaurants as r_storage
+    from app.restaurants import open_check
+
+    closed_day = DayHours(open="00:00", close="00:00", closed=True)
+    open_day = DayHours(open="11:00", close="22:00", closed=False)
+    h = HoursStructured(
+        mon=closed_day,
+        tue=closed_day,
+        wed=closed_day,
+        thu=closed_day,
+        fri=closed_day,
+        sat=closed_day,
+        sun=closed_day,
+    )
+
+    monkeypatch.setattr(
+        r_storage,
+        "get_restaurant_by_twilio_phone",
+        lambda phone: Restaurant(
+            id="r1",
+            name="R",
+            display_phone="+15551234567",
+            twilio_phone="+16479058093",
+            address="1 Main",
+            hours="closed always for test",
+            hours_structured=h,
+        ),
+    )
+
+    # Force is_open_now to return False regardless of clock
+    monkeypatch.setattr(open_check, "is_open_now", lambda r, now=None: False)
+
+    resp = client.post("/voice", data={"To": "+16479058093", "CallSid": "CAtest"})
+    assert resp.status_code == 200
+    assert "<Record" in resp.text
+    assert "<Connect" not in resp.text
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `pytest tests/test_telephony.py -v -k after_hours`
+Expected: error — `/voice` doesn't yet branch on hours.
+
+- [ ] **Step 3: Modify `/voice` to branch on `is_open_now`**
+
+In `app/telephony/router.py`, find the `/voice` handler. After the restaurant is resolved (call to `get_restaurant_by_twilio_phone` or similar) and BEFORE the TwiML response is built, add:
+
+```python
+from app.restaurants.open_check import is_open_now
+from app.telephony.voicemail_twiml import voicemail_response
+
+if restaurant is not None and not is_open_now(restaurant):
+    # After-hours: skip the AI flow entirely, drop to voicemail.
+    # Initialize the call session so the dashboard sees it; the
+    # voicemail event will follow when /voice/voicemail-recorded fires.
+    call_sessions.init_call_session(call_sid, restaurant.id)
+    return Response(
+        content=str(voicemail_response(call_sid, restaurant.id)),
+        media_type="text/xml",
+    )
+```
+
+(Place the imports at the top of the file with the other module-level imports.)
+
+- [ ] **Step 4: Run the test**
+
+Run: `pytest tests/test_telephony.py -v -k after_hours`
+Expected: pass.
+
+- [ ] **Step 5: Run the full telephony suite**
+
+Run: `pytest tests/test_telephony.py -v`
+Expected: all green.
+
+- [ ] **Step 6: Commit + push + open Phase D PR**
+
+```bash
+git add app/telephony/router.py tests/test_telephony.py
+git commit -m "telephony: voicemail flow — record, transcribe, after-hours routing"
+git push origin <branch>
+gh pr create --title "Sprint 2.4 — voicemail flow (#7)" --body "$(cat <<'EOF'
+## Summary
+
+- After-hours calls (per `restaurants/{rid}.hours_structured`) skip the AI flow and drop to voicemail directly.
+- `<Record maxLength=90>` with `transcribeCallback` hands recordings off to `/voice/voicemail-recorded` (uploads to GCS) and `/voice/voicemail-transcription` (patches the transcript).
+- Recording lands at `gs://niko-recordings/voicemail/{rid}/{call_sid}.mp3`; metadata writes through `call_sessions.mark_voicemail_left`.
+
+## Test plan
+
+- [ ] `pytest tests/test_telephony.py -v`
+- [ ] Manual: call the test number outside configured hours → "leave a message" prompt → leave message → recording lands in GCS, transcript populates after Twilio's transcription job (~30s).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Phase E — Dashboard surface
+
+### Task 10: Voicemail + transfer event types on call timeline
+
+**Files:**
+- Modify: `dashboard/lib/schemas/call.ts` — extend event-kind enum
+- Modify: `dashboard/lib/formatters/call-timeline.ts` — render labels for new event types
+- Modify: `dashboard/components/calls/call-timeline.tsx` — render the new event types
+- Test: `dashboard/tests/call-timeline.test.tsx`
+
+- [ ] **Step 1: Add event kinds to schema**
+
+Open `dashboard/lib/schemas/call.ts`. Find the event-kind enum (likely `CallEventKindSchema` or similar). Add `'transfer_attempted'` and `'voicemail_left'`.
+
+- [ ] **Step 2: Add labels in the formatter**
+
+Open `dashboard/lib/formatters/call-timeline.ts`. Add cases:
+
+```typescript
+case 'transfer_attempted':
+  return 'Transfer attempted';
+case 'voicemail_left':
+  return 'Voicemail left';
+```
+
+- [ ] **Step 3: Render voicemail audio + transcript inline**
+
+Open `dashboard/components/calls/call-timeline.tsx`. When an event has `kind === 'voicemail_left'`, render the audio player (same component used for call recordings) plus the transcript text.
+
+```tsx
+if (event.kind === 'voicemail_left') {
+  return (
+    <article className="flex flex-col gap-2 rounded-lg border border-border bg-muted/30 p-3">
+      <div className="flex items-center gap-2">
+        <Voicemail className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium">Voicemail</span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {event.detail?.duration_seconds ?? 0}s
+        </span>
+      </div>
+      <RecordingPlayer recordingUrl={event.recording_url} />
+      {event.text ? (
+        <p className="text-sm text-foreground">{event.text}</p>
+      ) : (
+        <p className="text-xs italic text-muted-foreground">
+          Transcript pending…
+        </p>
+      )}
+    </article>
+  );
+}
+```
+
+(Adapt `RecordingPlayer` to whatever the existing recording-playback component is named — found via Grep on `dashboard/components/calls/`. Import `Voicemail` from `lucide-react`.)
+
+- [ ] **Step 4: Vitest**
+
+Append to `tests/call-timeline.test.tsx`:
+
+```tsx
+it('renders a voicemail block with audio + transcript when present', () => {
+  render(
+    <CallTimeline
+      events={[
+        {
+          kind: 'voicemail_left',
+          at: new Date(),
+          text: 'Hi please call back',
+          recording_url: 'https://example.com/vm.mp3',
+          detail: { duration_seconds: 18 },
+        },
+      ]}
+    />,
+  );
+  expect(screen.getByText('Voicemail')).toBeInTheDocument();
+  expect(screen.getByText(/Hi please call back/)).toBeInTheDocument();
+  expect(screen.getByText('18s')).toBeInTheDocument();
+});
+
+it('shows "Transcript pending" when voicemail has no transcript yet', () => {
+  render(
+    <CallTimeline
+      events={[
+        {
+          kind: 'voicemail_left',
+          at: new Date(),
+          text: '',
+          recording_url: 'https://example.com/vm.mp3',
+          detail: { duration_seconds: 18 },
+        },
+      ]}
+    />,
+  );
+  expect(screen.getByText(/Transcript pending/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd dashboard && pnpm vitest run tests/call-timeline.test.tsx`
+Expected: all pass (existing + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/lib/schemas/call.ts dashboard/lib/formatters/call-timeline.ts dashboard/components/calls/call-timeline.tsx dashboard/tests/call-timeline.test.tsx
+git commit -m "calls: render voicemail + transfer events on timeline"
+```
+
+---
+
+### Task 11: Voicemail badge on `/calls` list
+
+**Files:**
+- Modify: `dashboard/lib/schemas/call.ts` — add `voicemail_left: bool` to call summary schema
+- Modify: `dashboard/components/calls/calls-table.tsx` — render the badge
+- Modify: `app/main.py` — surface `voicemail_left` on `/calls` API response
+- Test: `dashboard/tests/calls-table.test.tsx` (NEW or extend)
+
+- [ ] **Step 1: Surface the flag on the backend**
+
+Open `app/main.py`. Find the `/calls` list endpoint. When projecting the call session into the response, include `voicemail_left: bool(session.get("voicemail_recording_url"))` and `transfer_attempted: bool(session.get("transfer_attempted"))`.
+
+(If there isn't yet a `/calls` list endpoint and the list is fed from Firestore directly via `onSnapshot`, then the flags read straight off the call session doc — no backend change needed. Verify by reading `dashboard/lib/api/calls.ts`.)
+
+- [ ] **Step 2: Update the dashboard call summary schema**
+
+Open `dashboard/lib/schemas/call.ts`. Add to the call summary schema:
+
+```typescript
+voicemail_left: z.boolean().default(false),
+transfer_attempted: z.boolean().default(false),
+```
+
+- [ ] **Step 3: Render badges in the table**
+
+Open `dashboard/components/calls/calls-table.tsx`. In the row, after the existing status pill, add:
+
+```tsx
+{call.voicemail_left ? (
+  <span className="rounded-md bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
+    Voicemail
+  </span>
+) : null}
+{call.transfer_attempted ? (
+  <span className="rounded-md bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-sky-900 dark:bg-sky-900/30 dark:text-sky-200">
+    Transferred
+  </span>
+) : null}
+```
+
+(For a polished version, extract these into the existing `status-styles` helper — out of scope for this task; placeholder colors above are fine for first pass.)
+
+- [ ] **Step 4: Vitest**
+
+Append to `dashboard/tests/calls-table.test.tsx` (or create if missing):
+
+```tsx
+it('renders a Voicemail badge on rows with voicemail_left', () => {
+  const row = {
+    call_sid: 'CAtest',
+    started_at: new Date(),
+    ended_at: new Date(),
+    status: 'ended',
+    transcript_count: 0,
+    has_error: false,
+    voicemail_left: true,
+    transfer_attempted: false,
+  };
+  render(<CallsTable calls={[row]} />);
+  expect(screen.getByText('Voicemail')).toBeInTheDocument();
+});
+
+it('renders a Transferred badge when transfer_attempted is true', () => {
+  const row = {
+    call_sid: 'CAtest',
+    started_at: new Date(),
+    ended_at: new Date(),
+    status: 'ended',
+    transcript_count: 0,
+    has_error: false,
+    voicemail_left: false,
+    transfer_attempted: true,
+  };
+  render(<CallsTable calls={[row]} />);
+  expect(screen.getByText('Transferred')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 5: Run + smoke**
+
+Run: `cd dashboard && pnpm vitest run tests/calls-table.test.tsx && pnpm typecheck`
+Expected: green.
+
+Manual: leave a voicemail via test number, refresh `/calls`, see the row with both Voicemail badge and audio + transcript on the detail page.
+
+- [ ] **Step 6: Commit + push + open Phase E PR**
+
+```bash
+git add dashboard/lib/schemas/call.ts dashboard/components/calls/calls-table.tsx dashboard/tests/calls-table.test.tsx app/main.py
+git commit -m "calls: voicemail + transferred badges on calls list"
+git push origin <branch>
+gh pr create --title "Sprint 2.4 — voicemail surface on /calls (#7)" --body "$(cat <<'EOF'
+## Summary
+
+- Voicemail badge on `/calls` rows; click into a call → audio player + transcript inline on the timeline (or "Transcript pending…" while Twilio's transcription job runs).
+- Transferred badge for calls that hit the fallback dial.
+- New event-kind handling in `lib/formatters/call-timeline.ts`.
+
+## Test plan
+
+- [ ] `cd dashboard && pnpm vitest run tests/call-timeline.test.tsx tests/calls-table.test.tsx`
+- [ ] Manual: leave a voicemail; row shows the badge; detail page shows audio + transcript.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- 2a Call transfer — Phases A + B + C (Tasks 1–6). ✓
+- 2b Voicemail with transcription — Phase D (Tasks 7–9). ✓
+- `/calls` voicemail surface — Phase E (Tasks 10–11). ✓
+
+**Cross-track inputs consumed:**
+- `restaurants/{rid}.fallback_phone` — Task 5 reads this. Track 1 ships day 2; Task 5 schedules day 3 (week 1 close).
+- `restaurants/{rid}.hours_structured` — Task 9 reads this via `is_open_now`. Track 1 ships hours editor day 2–3; Task 9 schedules day 7 (week 2 open).
+- Both fields default safely (None → no transfer attempt / always-open) so Track 2 builds in parallel without blocking on Track 1.
+
+**Spec deviations recorded:**
+- Human-intent detection uses regex, not LLM classification. Tunable post-pilot.
+
+**Open follow-ups (do NOT do in this plan):**
+- Twilio signature verification on the new webhooks. Existing `/voice` already verifies; the new endpoints should match. Add as a pre-merge polish task on Phase D's PR if needed.
+- Voicemail email notification to the owner. Out of 2.4 scope; revisit when pilot owners ask.
+- Configurable transcription provider (Deepgram instead of Twilio's transcription) if quality is poor. Re-evaluate after first 20 voicemails per Risk #2 in the spec.
+- Per-restaurant transfer routing (intent → number, escalation chains). Phase 3+ per spec.
+- Twilio webhook signature verification on the four new endpoints (`/voice/stream-ended`, `/voice/transfer-result`, `/voice/voicemail-recorded`, `/voice/voicemail-transcription`). Match the existing `/voice` handler's pattern.

--- a/docs/superpowers/specs/2026-05-01-sprint-2.4-design.md
+++ b/docs/superpowers/specs/2026-05-01-sprint-2.4-design.md
@@ -1,0 +1,316 @@
+# Sprint 2.4 design — Dashboard & Polish
+
+**Date:** 2026-05-01
+**Issue:** #7 (Sprint 2.4 — Dashboard & Polish)
+**Related:** #6 (Sprint 2.3 rescope — pins the `app/sms/` contract this spec consumes)
+**Status:** Spec — approved, ready for implementation plan
+
+---
+
+## Context
+
+Sprint 2.4 is the dashboard + polish surface that lets a real restaurant owner self-manage niko. The roadmap (`docs/02-product-roadmap.md`) lists nine deliverables. After the recent ship-out and the Sprint 2.3 rescope, the picture has changed:
+
+- Sprint 2.2 + the polish bundle (PR #126) shipped most of the orders-side dashboard.
+- PR #134 shipped a read-only menu view; the editor side is missing.
+- PRs #127 + #136–144 shipped call recording + audio player; transcript-display polish remains.
+- The Sprint 2.3 rescope introduced an `app/sms/` module that 2.4's outbound SMS work will share.
+
+This spec audits what's shipped, defines pilot-blocker scope, sequences the build across three parallel agent tracks, and pins the `app/sms/` contract that 2.3 will consume unchanged.
+
+---
+
+## Audit — what's already shipped vs the nine #7 deliverables
+
+| # | Deliverable | Status | Evidence |
+|---|---|---|---|
+| 1 | Call history with transcripts | Substantially done | `/calls` page, `call-timeline.tsx` (live + historical), `timeline-export.tsx`, audio recording + player (PRs #127, #136–144). Transcript display polish remains. |
+| 2 | Order history + status | Done | Orders feed, detail page, lifecycle statuses (#108), tablet alert (#110), kitchen workflow UI (#112), polish bundle (#126). |
+| 3 | Menu editor (CRUD) | Read-only only | `/menu` renders categories/items via `MenuView` (#134). Editor not built. |
+| 4 | Business hours + info editor | Not started | `/settings` is `ComingSoon` stub. |
+| 5 | Basic analytics | Not started | No `/analytics` route. |
+| 6 | Call transfer to live staff | Not started | No transfer logic in `app/telephony/`. |
+| 7 | Voicemail with transcription | Not started | No voicemail flow in TwiML. |
+| 8 | Outbound SMS for order confirmations | Not started | `app/sms/` module to be built shared with 2.3. |
+| 9 | Landing page / marketing site | Not started | Out of this sprint's build scope (see below). |
+
+---
+
+## Scope decision — pilot-blocker definition
+
+This sprint optimizes for **credible self-serve pilot readiness**: a pickup-only pilot the owner can run themselves for 2+ weeks without ops holding their hand.
+
+The ruthless minimum (menu + hours + transfer + voicemail) is too thin — no SMS confirmation feels broken to callers in 2026, and no analytics means owners can't tell if it's working. Full-spec including landing page is not gating; landing page is a parallel marketing track that doesn't block onboarding pilot 1.
+
+### In scope (8 deliverables)
+
+| ID | Deliverable | Roadmap mapping |
+|---|---|---|
+| 1a | Settings page + restaurant info + hours editor + `fallback_phone` field | #7 deliverable 4 |
+| 1b | Menu editor — items + prices + availability | #7 deliverable 3 |
+| 1c | Basic analytics (calls, orders, AOV, completion rate) | #7 deliverable 5 |
+| 1d | Transcript display polish on `/calls/[call_sid]` | #7 deliverable 1 (close-out) |
+| 2a | Call transfer — single fallback per restaurant | #7 deliverable 6 |
+| 2b | Voicemail with transcription + `/calls` surface | #7 deliverable 7 |
+| 3a | `app/sms/` module — shared with Sprint 2.3 | #7 deliverable 8 (infra) |
+| 3b | Order confirmation SMS wired to lifecycle | #7 deliverable 8 (wiring) |
+
+### Out of scope
+
+- **Landing page / marketing site** (#7 deliverable 9) → separate marketing track, runs in parallel but does not gate pilot kickoff.
+- **Reservations** → stays in Sprint 3.1 per the 2.3 rescope.
+- **Intent-aware routing, manager-vs-staff numbers, escalation chains** → Phase 3+ once pilot data tells us the segment needs it. Pilot 1 target (small independents) typically has one staff phone.
+- **Structured menu modifiers** → Phase 2+ per `dashboard/CLAUDE.md`.
+- **Stripe Connect onboarding section in settings** → Sprint 2.3 — only an empty placeholder card lands in 2.4.
+- **Per-tenant 10DLC brand registration** → defer until pilot ramp; ship on a shared Messaging Service pool.
+- **SMS templates beyond `order_confirmation`** (`payment_link`, `payment_expired`, `voicemail_left`) → Sprint 2.3 / later.
+
+---
+
+## Architectural sketch
+
+Three parallel agent tracks. Each touches a distinct part of the codebase; coordination surface is small (three pinned contracts, see Cross-track dependencies).
+
+### Track 1 — Dashboard
+
+**1a. Settings page** (`dashboard/app/(dashboard)/settings/page.tsx`)
+
+Replaces the `ComingSoon` stub. Three sections:
+- **Restaurant info form** — `name`, `address`, `twilio_phone` (read-only), `fallback_phone` (new, used by Track 2).
+- **Hours editor** — Mon–Sun open/close ranges with per-day `closed: bool`.
+- **Future placeholders** — empty cards for Stripe Connect (Sprint 2.3) and SMS toggles.
+
+Backend additions:
+- `restaurants/{rid}` schema gains `hours: {[day]: {open: "HH:MM", close: "HH:MM", closed: bool}}` and `fallback_phone: string | null`.
+- New endpoint `PATCH /restaurants/me` behind owner role for owner-driven edits.
+
+**1b. Menu editor** (`dashboard/app/(dashboard)/menu/page.tsx`)
+
+Replaces the read-only `MenuView`:
+- Add / edit / delete items with `name`, `price`, `available: bool`, `category`.
+- Add new categories (no reorder, no rename).
+- Free-text modifiers preserved as-is — no structured-modifier work.
+
+Backend: granular endpoints for clearer audit log:
+- `POST /restaurants/me/menu/items`
+- `PATCH /restaurants/me/menu/items/{item_id}`
+- `DELETE /restaurants/me/menu/items/{item_id}`
+- `POST /restaurants/me/menu/categories`
+
+**1c. Analytics** (`dashboard/app/(dashboard)/analytics/page.tsx`)
+
+New page, linked from sidebar. Four tile metrics:
+- Calls today + 7-day rolling
+- Orders today + 7-day rolling
+- Average order value (7-day)
+- Completion rate (orders `confirmed` → `completed`, 7-day)
+
+Pulls from existing `orders` and `call_sessions` collections. No new backend writes; a small `app/storage/analytics.py` aggregation helper is acceptable.
+
+Empty state: when collections are sparse (pre-pilot), show "Make a test call to see numbers here" rather than `0 / 0 / 0` tiles.
+
+**1d. Transcript display polish** on `/calls/[call_sid]`
+
+Audit + fix pass on the existing call timeline:
+- Transcript turns copyable.
+- Time-aligned with the audio player (click a turn → audio seeks to that timestamp).
+- Export already exists (`timeline-export.tsx`); confirm it captures the polished output.
+
+Pure frontend. No backend changes.
+
+### Track 2 — Telephony
+
+**2a. Call transfer** (`app/telephony/transfer.py`)
+
+Trigger conditions (any one):
+- Three consecutive misheard turns (heuristic — `low_confidence_turn_count >= 3` on the call session).
+- LLM error (any unrecoverable Anthropic exception).
+- LLM-classified "I want a human" intent — reuses the existing intent classification path.
+
+TwiML behavior:
+- `<Dial action="/voice/transfer-result">` to `restaurants/{rid}.fallback_phone`.
+- `action` callback handles `no-answer | busy | failed` → cascades into voicemail flow (2b).
+
+Call session writes:
+- `transfer_attempted: bool`
+- `transfer_status: "answered" | "no_answer" | "busy" | "failed"`
+- `transfer_initiated_at: timestamp`
+
+**2b. Voicemail** (`app/telephony/voicemail.py`)
+
+TwiML `<Record maxLength="90" transcribeCallback="/voice/voicemail-recorded">`.
+
+Triggers:
+- After-hours (uses hours from 1a — if all-closed, skip transfer attempt and go directly to voicemail).
+- Transfer no-answer / busy / failed (cascades from 2a).
+
+Storage:
+- Recording lands in GCS via the existing recording flow (PRs #136–144).
+- Transcript via Twilio's transcription, stored on the call session.
+
+Call session writes:
+- `voicemail_recording_url: string`
+- `voicemail_transcript: string | null`
+- `voicemail_recorded_at: timestamp`
+
+`/calls` surface:
+- New event-type badge ("Voicemail") on the calls table.
+- On the detail page, voicemail shows audio player + inline transcript (same components as the call recording).
+
+### Track 3 — SMS infra
+
+**3a. `app/sms/` module** — shared with Sprint 2.3
+
+```
+app/sms/
+  __init__.py
+  client.py     # Twilio SMS wrapper, idempotency-keyed
+  templates.py  # order_confirmation (2.4); payment_link, payment_expired, voicemail_left (later)
+```
+
+Twilio Messaging Service with shared 10DLC pool. Per-tenant brand registration deferred to pilot ramp.
+
+Idempotency at our layer (not Twilio's): `orders/{oid}.sms_sent: {[template_name]: {sid, sent_at}}` written before send, confirmed after. Re-sends short-circuit if a record exists for that key.
+
+**3b. Order confirmation SMS**
+
+Hook into `app/orders/lifecycle.py`. When a transition writes `status = "confirmed"`, fire `order_confirmation` template against the order's `caller_phone`.
+
+Template body (initial draft, owner-tunable later): short order summary + total + ETA window.
+
+---
+
+## Build sequence
+
+### Week 1 (sprint days 1–5)
+
+```
+Track 1 Dashboard ──► [1a Settings page + fallback_phone field] ──► [1b Menu editor (start)]
+Track 2 Telephony ──► [2a Call transfer (TwiML + fallback flow)]
+Track 3 SMS infra ──► [3a app/sms/ module + templates scaffold]
+```
+
+Settings page ships `fallback_phone` first so Track 2 isn't blocked. Track 2 stubs a hardcoded fallback during day 1–2 and swaps to the real Firestore field on day 3.
+
+### Week 2 (sprint days 6–10)
+
+```
+Track 1 Dashboard ──► [1b Menu editor (finish)] ──► [1c Analytics] ──► [1d Transcript polish]
+Track 2 Telephony ──► [2b Voicemail flow + /calls surface]
+Track 3 SMS infra ──► [3b Wire order_confirmation to lifecycle]
+```
+
+---
+
+## Cross-track dependencies
+
+| # | Producer → Consumer | Surface | Mitigation |
+|---|---|---|---|
+| 1 | Track 1 (1a) → Track 2 (2a) | `restaurants/{rid}.fallback_phone` field | Track 1 ships day 2; Track 2 reads from day 3. Stubbed before that. |
+| 2 | Track 1 (1a) → Track 2 (2b) | `restaurants/{rid}.hours` field — voicemail uses it for the after-hours trigger | Same shipping window as #1. Track 2 stubs "always-open" until the field lands. |
+| 3 | Track 3 (3a) → Track 3 (3b) | `app/sms/templates.py` `order_confirmation` body | Same agent — no coordination. |
+| 4 | Track 2 (2b) → Track 1 (1d) | `call_sessions.{voicemail_recording_url, voicemail_transcript}` field | Track 1's transcript polish is the last dashboard item; Track 2 ships voicemail data ~day 7, Track 1 surfaces it day 9–10. |
+
+---
+
+## `app/sms/` contract — pinned for Sprint 2.3 to consume unchanged
+
+```python
+# app/sms/client.py
+async def send_sms(
+    to: str,                    # E.164
+    body: str,
+    *,
+    idempotency_key: str,       # e.g. f"{order_id}:order_confirmation"
+    tenant_id: str,             # for logging + future per-tenant Messaging Service
+) -> SmsResult:                 # {sid, status, sent_at} or raises SmsError
+    ...
+```
+
+```python
+# app/sms/templates.py
+def order_confirmation(order: Order) -> str: ...
+# Added later by Sprint 2.3:
+def payment_link(order: Order, checkout_url: str) -> str: ...
+def payment_expired(order: Order) -> str: ...
+```
+
+**Locked decisions for 2.3 to inherit:**
+- Twilio Messaging Service (shared 10DLC pool) — set in `app/config.py`.
+- Idempotency at our layer: `orders/{oid}.sms_sent` dedup record written before send.
+- Single `send_sms` entry point, no per-template helpers — 2.3's payment templates plug in without touching the client.
+
+---
+
+## Sprint 2.4 deliverables — rewritten checklist for issue #7
+
+- [ ] **1a.** Settings page replaces `ComingSoon` stub: restaurant info form, hours editor, `fallback_phone` field. `restaurants/{rid}` schema migration. `PATCH /restaurants/me` endpoint behind owner role.
+- [ ] **1b.** Menu editor replaces read-only `MenuView`: items add/edit/delete, price + availability, category add. Granular `POST/PATCH/DELETE /restaurants/me/menu/items/{id}` endpoints + `POST /restaurants/me/menu/categories`.
+- [ ] **1c.** Analytics page with calls / orders / AOV / completion-rate tiles + sparse-data empty state.
+- [ ] **1d.** Transcript display polish on `/calls/[call_sid]`: copyable turns, audio-seek on click.
+- [ ] **2a.** Call transfer: `<Dial>` to `fallback_phone` on AI failure / "human" intent / 3 misheard turns. Transfer status fields on call session.
+- [ ] **2b.** Voicemail flow: `<Record>` + Twilio transcription, after-hours and transfer-no-answer triggers, `/calls` surface (badge + audio + transcript).
+- [ ] **3a.** `app/sms/` module: `send_sms` client, `order_confirmation` template, idempotency-keyed via `orders/{oid}.sms_sent`.
+- [ ] **3b.** Wire `order_confirmation` to `app/orders/lifecycle.py` on `confirmed` transition.
+
+---
+
+## Done criteria + pilot-readiness gate
+
+### Sprint 2.4 done
+
+- All eight deliverables merged to master with niko-reviewer sign-off.
+- End-to-end manual smoke: test call → AI takes order → SMS confirmation lands on a real phone → owner edits menu/hours from the dashboard.
+- Transfer + voicemail manually verified via test-mode call.
+
+### Pilot-ready (one external dep)
+
+Sprint 2.4 done + Sprint 2.1 cleanup (#82, #83, #115–122, #146 — call quality, latency, error recovery) lands. Sprint 2.1 cleanup is the fourth-track work; not part of 2.4 build but the gate to onboarding pilot 1.
+
+---
+
+## Risks and open questions
+
+| # | Risk / Question | Mitigation / Where decided |
+|---|---|---|
+| 1 | Granular menu endpoints add backend surface area vs full-doc PATCH | Granular chosen for clearer audit log; menu still reads as a single doc client-side from `restaurants/{rid}.menu`. |
+| 2 | Voicemail Twilio transcription quality may be poor — caller leaves message, transcript is gibberish | Recording is always stored; transcript is best-effort. Re-evaluate after first 20 voicemails; consider Deepgram post-processing if Twilio output is unusable. |
+| 3 | "3 misheard turns" trigger may false-positive on noisy calls | Tunable threshold via config; instrument false-positive rate during pilot smoke tests. |
+| 4 | Analytics page may show garbage when collections are sparse pre-pilot | Empty state with "make a test call" copy when 7-day window has zero data. |
+| 5 | Order confirmation SMS may double-send on retry | Idempotency at our layer: `orders/{oid}.sms_sent` dedup before each send. |
+| 6 | Sprint 2.1 cleanup is not in 2.4 but blocks pilot kickoff | Documented as fourth track running after 2.4 build; brainstorm at sprint-end to triage which 2.1 issues are pilot-blockers vs polish. |
+| 7 | Twilio Messaging Service shared 10DLC pool may rate-limit or be flagged before per-tenant brand registration | Acceptable for pilot volume; track delivery failures, escalate to per-tenant brand if a pilot is impacted. |
+| 8 | Hours editor timezone — restaurant local vs UTC storage | Store as `America/Toronto` (matches dashboard `<LocalTime />` convention); UTC conversion is a deferred problem when multi-tz pilots arrive. |
+
+---
+
+## Action items
+
+### Now (this spec PR)
+
+- [x] Write spec.
+- [ ] Land this spec on master via PR.
+
+### When sprint starts
+
+- [ ] Update issue #7 body with the rewritten deliverable checklist above + link to this spec.
+- [ ] Create the implementation plan via the `superpowers:writing-plans` skill.
+- [ ] Flip issue #7 status to **In progress** on the project board.
+
+### Deferred — at sprint end
+
+- [ ] Brainstorm Sprint 2.1 cleanup track (the 11 open issues — triage pilot-blockers vs polish).
+- [ ] Update `docs/02-product-roadmap.md` Sprint 2.4 section to reflect the rewritten deliverables (currently lists nine; rewritten lists eight + a parallel landing-page track).
+
+---
+
+## References
+
+- Issue #7 — Sprint 2.4 — Dashboard & Polish
+- Issue #6 — Sprint 2.3 (rescoped to payment vendor)
+- `docs/superpowers/specs/2026-05-01-sprint-2.3-payments-rescope-design.md` — Sprint 2.3 rescope; source of the `app/sms/` contract pinned in this spec
+- `docs/02-product-roadmap.md` — original nine deliverables for Sprint 2.4
+- `dashboard/CLAUDE.md` — dashboard conventions (server-first, Zod-via-converter, OKLCH tokens, deferred-modifier note)
+- PR #126 — polish bundle (optimistic UI + prep timer + flash token)
+- PR #134 — read-only menu view
+- PRs #127, #136–144 — call recording + audio player infrastructure


### PR DESCRIPTION
## Summary

- **Spec** at \`docs/superpowers/specs/2026-05-01-sprint-2.4-design.md\` — audits shipped work, picks credible self-serve pilot readiness as the scope frame, sequences the build across three parallel agent tracks, pins the \`app/sms/\` contract that Sprint 2.3 will consume.
- **Plan: Track 3 — SMS infra** at \`docs/superpowers/plans/2026-05-01-sprint-2.4-sms-infra.md\` (8 tasks). Adds \`app/sms/\` module + \`order_confirmation\` SMS wired to \`lifecycle.persist_on_confirm\`. Smallest track, no cross-track inputs, unblocks 2.3.
- **Plan: Track 1 — Dashboard** at \`docs/superpowers/plans/2026-05-01-sprint-2.4-dashboard.md\` (21 tasks across 6 phases, each its own PR). Settings page + hours editor + \`fallback_phone\`, menu CRUD editor, analytics tiles, transcript polish. Biggest track.
- **Plan: Track 2 — Telephony** at \`docs/superpowers/plans/2026-05-01-sprint-2.4-telephony.md\` (11 tasks across 5 phases). Call transfer to fallback + voicemail with Twilio transcription + dashboard surface on \`/calls\`.

## Key decisions

- **Out of 2.4:** landing page (parallel marketing track), reservations (3.1), intent-aware call routing (Phase 3+), structured menu modifiers (Phase 2+), Stripe Connect onboarding (2.3 owns), per-tenant 10DLC registration.
- **Menu editor depth:** items + prices + availability only; categories addable but not reorderable. Free-text modifiers preserved.
- **Call transfer:** single \`fallback_phone\` per restaurant. Triggers on 3 misheard turns, LLM error, or "I want a human" regex match.
- **Pilot-readiness gate:** Sprint 2.4 done + Sprint 2.1 cleanup (#82, #83, #115–122, #146) — the latter runs as a fourth track after 2.4 build.

## Spec deviations recorded in plans

- \`send_sms\` async → sync (Twilio SDK is sync; matches existing storage layer).
- Menu item URL: \`/menu/items/{item_id}\` → \`/menu/items/{category}/{name}\` composite key (no stable IDs migration needed).
- Hours field: kept additively — \`hours: str\` preserved for the LLM prompt builder; \`hours_structured\` added separately for the editor.
- Human-intent detection: regex match instead of LLM classification (deterministic, fast; LLM upgrade is a Phase 3 follow-up).

## Test plan

- [ ] Spec reads coherently end-to-end — audit, scope, three tracks, build sequence, contracts, deliverables checklist, done criteria.
- [ ] Cross-track dependencies in the spec match the build sequences in the three plans (every dep has a producer earlier than its consumer).
- [ ] \`app/sms/\` contract in the spec matches the \`send_sms\` signature in Track 3 plan Task 5 (which Sprint 2.3 will consume).
- [ ] Each plan's tasks have concrete file paths, complete code, exact pytest/vitest commands, no placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)