### PR TITLE
Sprint 2.4 Track 3 — app/sms/ module + order confirmation SMS (#7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ PUBLIC_BASE_URL=
 # Square — POS sandbox (Phase 2.3)
 SQUARE_ACCESS_TOKEN=
 SQUARE_APPLICATION_ID=
+
+# Twilio Messaging Service SID — used by app/sms/ for outbound SMS.
+# Get from https://console.twilio.com → Messaging → Services → your service.
+TWILIO_MESSAGING_SERVICE_SID=

--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,13 @@ class Settings(BaseSettings):
     twilio_auth_token: Optional[str] = None
     twilio_phone_number: Optional[str] = None
 
+    # Twilio Messaging Service SID for outbound SMS. Shared 10DLC pool
+    # for pilot; per-tenant brand registration deferred until pilot ramp.
+    # Required when wiring outbound SMS in Sprint 2.4 (#7) — None elsewhere
+    # so importing this module doesn't crash environments that don't
+    # send SMS yet.
+    twilio_messaging_service_sid: Optional[str] = None
+
     # Public HTTPS base URL of this service (e.g. "https://niko-xyz.run.app"
     # or an ngrok URL locally). Required for Twilio recording callbacks:
     # the URL we hand Twilio when starting a recording must equal the URL

--- a/app/orders/lifecycle.py
+++ b/app/orders/lifecycle.py
@@ -15,10 +15,15 @@ the Phase 1 demo.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
 from app.orders.models import Order, OrderStatus
+from app.sms import SmsError, send_sms
+from app.sms.templates import order_confirmation as render_order_confirmation
 from app.storage import firestore as order_storage
+
+_log = logging.getLogger(__name__)
 
 
 class OrderNotReadyError(ValueError):
@@ -63,6 +68,25 @@ def persist_on_confirm(order: Order) -> Order:
     )
 
     order_storage.save_order(confirmed_order)
+
+    if confirmed_order.caller_phone:
+        try:
+            send_sms(
+                to=confirmed_order.caller_phone,
+                body=render_order_confirmation(confirmed_order),
+                idempotency_key=f"{confirmed_order.call_sid}:order_confirmation",
+                tenant_id=confirmed_order.restaurant_id,
+            )
+        except SmsError as exc:
+            # Best-effort: SMS failure must not roll back the order.
+            # Tablet UX still shows the order; owner can resend manually
+            # post-pilot if it matters.
+            _log.warning(
+                "order_confirmation SMS failed for %s: %s",
+                confirmed_order.call_sid,
+                exc,
+            )
+
     return confirmed_order
 
 

--- a/app/orders/lifecycle.py
+++ b/app/orders/lifecycle.py
@@ -19,7 +19,7 @@ import logging
 from datetime import datetime, timezone
 
 from app.orders.models import Order, OrderStatus
-from app.sms import SmsError, send_sms
+from app.sms import send_sms
 from app.sms.templates import order_confirmation as render_order_confirmation
 from app.storage import firestore as order_storage
 
@@ -77,10 +77,11 @@ def persist_on_confirm(order: Order) -> Order:
                 idempotency_key=f"{confirmed_order.call_sid}:order_confirmation",
                 tenant_id=confirmed_order.restaurant_id,
             )
-        except SmsError as exc:
-            # Best-effort: SMS failure must not roll back the order.
-            # Tablet UX still shows the order; owner can resend manually
-            # post-pilot if it matters.
+        except Exception as exc:
+            # Best-effort: any failure rendering or sending the
+            # confirmation SMS must not roll back the order. The
+            # tablet UX still shows the order; owner can resend
+            # manually post-pilot if it matters.
             _log.warning(
                 "order_confirmation SMS failed for %s: %s",
                 confirmed_order.call_sid,

--- a/app/orders/models.py
+++ b/app/orders/models.py
@@ -79,6 +79,16 @@ class LineItem(BaseModel):
         return round(self.unit_price * self.quantity, 2)
 
 
+class SmsSentRecord(BaseModel):
+    """Idempotency record for an outbound SMS — written to
+    ``orders/{call_sid}.sms_sent[template_name]`` after a successful
+    Twilio send. Presence of a record short-circuits future sends with
+    the same key (e.g. on persist_on_confirm retry)."""
+
+    sid: str  # Twilio Message SID, e.g. "SM..."
+    sent_at: datetime
+
+
 class Order(BaseModel):
     call_sid: str
     caller_phone: Optional[str] = None
@@ -98,6 +108,11 @@ class Order(BaseModel):
     ready_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     cancelled_at: Optional[datetime] = None
+    # Idempotency record map for outbound SMS. Keys are template names
+    # (e.g. "order_confirmation"); values are SmsSentRecord. Populated
+    # by app.sms.send_sms after each successful Twilio send. Default
+    # empty so legacy docs (pre-#7) and partially-built orders parse.
+    sms_sent: dict[str, SmsSentRecord] = Field(default_factory=dict)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/app/sms/__init__.py
+++ b/app/sms/__init__.py
@@ -1,0 +1,9 @@
+"""Outbound SMS — Twilio Messaging Service wrapper, idempotency-keyed.
+
+Shared with Sprint 2.3 payments work (which adds payment_link and
+payment_expired templates without touching the client).
+"""
+
+from app.sms.exceptions import SmsError
+
+__all__ = ["SmsError"]

--- a/app/sms/__init__.py
+++ b/app/sms/__init__.py
@@ -4,6 +4,7 @@ Shared with Sprint 2.3 payments work (which adds payment_link and
 payment_expired templates without touching the client).
 """
 
+from app.sms.client import SmsResult, send_sms
 from app.sms.exceptions import SmsError
 
-__all__ = ["SmsError"]
+__all__ = ["SmsError", "SmsResult", "send_sms"]

--- a/app/sms/client.py
+++ b/app/sms/client.py
@@ -1,0 +1,93 @@
+"""Outbound SMS client — Twilio REST wrapper with idempotency.
+
+The function flow:
+
+1. Parse the idempotency key into (call_sid, template_name).
+2. Read the order doc from Firestore.
+3. If sms_sent[template_name] already exists, short-circuit — the
+   original record is the source of truth.
+4. Otherwise, send via Twilio's Messaging Service.
+5. Write sms_sent[template_name] back to the order doc.
+
+Sync — Twilio's SDK is sync, the storage layer is sync, async callers
+wrap with asyncio.to_thread.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel
+from twilio.rest import Client as TwilioClient
+
+from app.config import settings
+from app.orders.models import SmsSentRecord
+from app.sms.exceptions import SmsError
+from app.storage import firestore as order_storage
+
+
+class SmsResult(BaseModel):
+    sid: str
+    sent_at: datetime
+
+
+def _twilio_client() -> TwilioClient:
+    """Construct a Twilio client at call time so tests can patch this."""
+    if not settings.twilio_account_sid or not settings.twilio_auth_token:
+        raise SmsError(
+            "Twilio credentials missing — set TWILIO_ACCOUNT_SID and "
+            "TWILIO_AUTH_TOKEN."
+        )
+    return TwilioClient(settings.twilio_account_sid, settings.twilio_auth_token)
+
+
+def send_sms(
+    to: str,
+    body: str,
+    *,
+    idempotency_key: str,
+    tenant_id: str,
+) -> SmsResult:
+    """Send a single SMS, idempotent on (call_sid, template_name).
+
+    ``idempotency_key`` is ``f"{call_sid}:{template_name}"``. The split
+    is the contract — callers form keys this way and ``send_sms`` parses
+    back. Returns the existing record if one is already present for the
+    key. Raises ``SmsError`` on Twilio failure or missing order.
+    """
+    if ":" not in idempotency_key:
+        raise SmsError(
+            f"idempotency_key must be 'call_sid:template_name', "
+            f"got {idempotency_key!r}"
+        )
+    call_sid, template_name = idempotency_key.split(":", 1)
+
+    order = order_storage.get_order(call_sid, tenant_id)
+    if order is None:
+        raise SmsError(
+            f"order {call_sid!r} not found under tenant {tenant_id!r} — "
+            "cannot record SMS idempotency without the order doc"
+        )
+
+    existing = order.sms_sent.get(template_name)
+    if existing is not None:
+        return SmsResult(sid=existing.sid, sent_at=existing.sent_at)
+
+    try:
+        message = _twilio_client().messages.create(
+            to=to,
+            body=body,
+            messaging_service_sid=settings.twilio_messaging_service_sid,
+        )
+    except SmsError:
+        raise
+    except Exception as exc:  # twilio raises various subclasses
+        raise SmsError(f"Twilio send failed: {exc}") from exc
+
+    sent_at = datetime.now(timezone.utc)
+    record = SmsSentRecord(sid=message.sid, sent_at=sent_at)
+    updated = order.model_copy(
+        update={"sms_sent": {**order.sms_sent, template_name: record}},
+    )
+    order_storage.save_order(updated)
+    return SmsResult(sid=message.sid, sent_at=sent_at)

--- a/app/sms/client.py
+++ b/app/sms/client.py
@@ -73,6 +73,12 @@ def send_sms(
     if existing is not None:
         return SmsResult(sid=existing.sid, sent_at=existing.sent_at)
 
+    if not settings.twilio_messaging_service_sid:
+        raise SmsError(
+            "TWILIO_MESSAGING_SERVICE_SID not configured — outbound SMS "
+            "requires a Messaging Service for 10DLC compliance."
+        )
+
     try:
         message = _twilio_client().messages.create(
             to=to,

--- a/app/sms/client.py
+++ b/app/sms/client.py
@@ -28,6 +28,7 @@ from app.storage import firestore as order_storage
 
 class SmsResult(BaseModel):
     sid: str
+    status: str  # Twilio message status (queued | sending | sent | delivered | failed)
     sent_at: datetime
 
 
@@ -71,7 +72,11 @@ def send_sms(
 
     existing = order.sms_sent.get(template_name)
     if existing is not None:
-        return SmsResult(sid=existing.sid, sent_at=existing.sent_at)
+        return SmsResult(
+            sid=existing.sid,
+            status="sent",  # Re-sends would have updated the record; presence implies a successful prior dispatch
+            sent_at=existing.sent_at,
+        )
 
     if not settings.twilio_messaging_service_sid:
         raise SmsError(
@@ -96,4 +101,8 @@ def send_sms(
         update={"sms_sent": {**order.sms_sent, template_name: record}},
     )
     order_storage.save_order(updated)
-    return SmsResult(sid=message.sid, sent_at=sent_at)
+    return SmsResult(
+        sid=message.sid,
+        status=message.status,
+        sent_at=sent_at,
+    )

--- a/app/sms/exceptions.py
+++ b/app/sms/exceptions.py
@@ -1,0 +1,9 @@
+"""Exception types raised by app.sms."""
+
+from __future__ import annotations
+
+
+class SmsError(Exception):
+    """Outbound SMS failed. Caller decides whether to retry or surface
+    the failure. The lifecycle hook treats this as best-effort and
+    does not roll back the order on failure."""

--- a/app/sms/templates.py
+++ b/app/sms/templates.py
@@ -1,0 +1,37 @@
+"""SMS body templates rendered from order data.
+
+Each function takes the data it needs and returns a plain string — no
+Twilio dependency, no I/O. Templates are intentionally short to fit a
+single 160-char SMS segment for typical orders; multi-item delivery
+orders may spill into a second segment, accepted.
+"""
+
+from __future__ import annotations
+
+from app.orders.models import Order, OrderType
+
+
+def order_confirmation(order: Order) -> str:
+    """Body for the post-confirmation SMS. Format:
+
+        Niko: order confirmed.
+        1x Pepperoni (large)
+        Total: $18.99
+        Pickup at the restaurant.
+
+    For delivery orders, the last line carries the delivery address.
+    """
+    lines = ["Niko: order confirmed."]
+
+    for item in order.items:
+        size_part = f" ({item.size})" if item.size else ""
+        lines.append(f"{item.quantity}x {item.name}{size_part}")
+
+    lines.append(f"Total: ${order.subtotal:.2f}")
+
+    if order.order_type is OrderType.DELIVERY:
+        lines.append(f"Delivery to {order.delivery_address}.")
+    else:
+        lines.append("Pickup at the restaurant.")
+
+    return "\n".join(lines)

--- a/app/sms/templates.py
+++ b/app/sms/templates.py
@@ -30,7 +30,13 @@ def order_confirmation(order: Order) -> str:
     lines.append(f"Total: ${order.subtotal:.2f}")
 
     if order.order_type is OrderType.DELIVERY:
-        lines.append(f"Delivery to {order.delivery_address}.")
+        if order.delivery_address:
+            lines.append(f"Delivery to {order.delivery_address}.")
+        else:
+            # Defensive: ``Order.is_ready_to_confirm`` already requires
+            # delivery_address for delivery orders. This guards against
+            # future caller paths that skip that gate.
+            lines.append("Delivery — address on file.")
     else:
         lines.append("Pickup at the restaurant.")
 

--- a/tests/test_order_models.py
+++ b/tests/test_order_models.py
@@ -119,3 +119,43 @@ def test_order_json_roundtrip_includes_computed_fields():
     assert dumped["items"][0]["line_total"] == 35.98
     assert dumped["order_type"] == "pickup"
     assert dumped["status"] == "in_progress"
+
+
+def test_order_has_sms_sent_field_defaulting_to_empty_dict():
+    """Order model carries an sms_sent record map, default empty.
+
+    Used by app.sms for idempotency: keys are template names
+    (e.g. "order_confirmation"), values record {sid, sent_at}.
+    """
+    from app.orders.models import Order, SmsSentRecord
+
+    order = Order(call_sid="CAtest")
+    assert order.sms_sent == {}
+
+
+def test_order_sms_sent_record_round_trips():
+    from datetime import datetime, timezone
+    from app.orders.models import Order, SmsSentRecord
+
+    sent_at = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+    record = SmsSentRecord(sid="SMabc123", sent_at=sent_at)
+    order = Order(call_sid="CAtest", sms_sent={"order_confirmation": record})
+
+    dumped = order.model_dump(mode="python")
+    restored = Order.model_validate(dumped)
+    assert restored.sms_sent["order_confirmation"].sid == "SMabc123"
+    assert restored.sms_sent["order_confirmation"].sent_at == sent_at
+
+
+def test_order_sms_sent_back_compat_for_docs_without_field():
+    """Existing Firestore docs predate sms_sent — model_validate must
+    not blow up when the field is absent."""
+    from app.orders.models import Order
+
+    legacy_doc = {
+        "call_sid": "CAlegacy",
+        "items": [],
+        "status": "in_progress",
+    }
+    order = Order.model_validate(legacy_doc)
+    assert order.sms_sent == {}

--- a/tests/test_orders_lifecycle.py
+++ b/tests/test_orders_lifecycle.py
@@ -468,3 +468,19 @@ def test_persist_on_confirm_swallows_sms_errors():
         confirmed = persist_on_confirm(order)
 
     assert confirmed.status is OrderStatus.CONFIRMED
+
+
+def test_persist_on_confirm_swallows_non_sms_errors_too():
+    """Defensive: even non-SmsError raised by send_sms (or by the
+    template renderer) must not roll back the order."""
+    from unittest.mock import patch
+    _fake_client()
+    order = _ready_pickup_order(caller_phone="+15551234567")
+
+    with patch(
+        "app.orders.lifecycle.send_sms",
+        side_effect=ValueError("unexpected"),
+    ):
+        confirmed = persist_on_confirm(order)
+
+    assert confirmed.status is OrderStatus.CONFIRMED

--- a/tests/test_orders_lifecycle.py
+++ b/tests/test_orders_lifecycle.py
@@ -419,3 +419,52 @@ def test_cancel_order_is_idempotent():
 
     assert updated.cancelled_at == original_ts
     _order_doc(client).set.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# SMS hook tests (Sprint 2.4 Task 6)
+# ---------------------------------------------------------------------------
+
+
+def test_persist_on_confirm_sends_order_confirmation_sms():
+    """After Firestore write, persist_on_confirm fires the SMS."""
+    from unittest.mock import patch
+    _fake_client()
+    order = _ready_pickup_order(caller_phone="+15551234567")
+
+    with patch("app.orders.lifecycle.send_sms") as fake_send:
+        persist_on_confirm(order)
+
+    fake_send.assert_called_once()
+    kwargs = fake_send.call_args.kwargs
+    assert kwargs["to"] == "+15551234567"
+    assert kwargs["idempotency_key"] == f"{order.call_sid}:order_confirmation"
+    assert kwargs["tenant_id"] == order.restaurant_id
+    assert "Pepperoni" in kwargs["body"]
+
+
+def test_persist_on_confirm_skips_sms_when_no_caller_phone():
+    """An order without caller_phone (rare — the call had bad caller ID)
+    is still confirmable; we just don't send a confirmation SMS."""
+    from unittest.mock import patch
+    _fake_client()
+    order = _ready_pickup_order(caller_phone=None)
+
+    with patch("app.orders.lifecycle.send_sms") as fake_send:
+        persist_on_confirm(order)
+
+    fake_send.assert_not_called()
+
+
+def test_persist_on_confirm_swallows_sms_errors():
+    """SMS is best-effort: a Twilio failure must not block the order
+    from persisting as confirmed."""
+    from unittest.mock import patch
+    from app.sms.exceptions import SmsError
+    _fake_client()
+    order = _ready_pickup_order(caller_phone="+15551234567")
+
+    with patch("app.orders.lifecycle.send_sms", side_effect=SmsError("boom")):
+        confirmed = persist_on_confirm(order)
+
+    assert confirmed.status is OrderStatus.CONFIRMED

--- a/tests/test_sms_client.py
+++ b/tests/test_sms_client.py
@@ -70,7 +70,7 @@ def _ready_order() -> Order:
 def test_send_sms_calls_twilio_with_messaging_service():
     order = _ready_order()
     _fake_storage(order)
-    fake_message = MagicMock(sid="SM123")
+    fake_message = MagicMock(sid="SM123", status="queued")
 
     with (
         patch("app.sms.client._twilio_client") as twilio_factory,
@@ -91,6 +91,7 @@ def test_send_sms_calls_twilio_with_messaging_service():
     assert "messaging_service_sid" in kwargs
     assert isinstance(result, SmsResult)
     assert result.sid == "SM123"
+    assert result.status == "queued"
 
 
 def test_send_sms_short_circuits_when_record_already_exists():
@@ -114,6 +115,7 @@ def test_send_sms_short_circuits_when_record_already_exists():
 
     twilio_factory.return_value.messages.create.assert_not_called()
     assert result.sid == "SMexisting"
+    assert result.status == "sent"  # short-circuit returns "sent" since record's presence implies success
 
 
 def test_send_sms_writes_record_back_to_firestore_on_success():
@@ -126,6 +128,7 @@ def test_send_sms_writes_record_back_to_firestore_on_success():
     ):
         twilio_factory.return_value.messages.create.return_value = MagicMock(
             sid="SMnew",
+            status="queued",
         )
         send_sms(
             to="+15551234567",

--- a/tests/test_sms_client.py
+++ b/tests/test_sms_client.py
@@ -1,0 +1,183 @@
+"""Unit tests for app.sms.client.send_sms.
+
+Mocks Twilio's REST client and Firestore, mirroring
+test_orders_lifecycle.py's MagicMock pattern.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderType,
+    SmsSentRecord,
+)
+from app.sms.client import SmsResult, send_sms
+from app.sms.exceptions import SmsError
+from app.storage import firestore as storage
+
+
+@pytest.fixture(autouse=True)
+def reset_storage_client():
+    yield
+    storage.set_client(None)
+
+
+def _fake_storage(order: Order | None) -> MagicMock:
+    """Wire the firestore module to return ``order`` for the
+    restaurants/{rid}/orders/{call_sid} read."""
+    client = MagicMock()
+    storage.set_client(client)
+    snapshot = MagicMock()
+    if order is None:
+        snapshot.exists = False
+    else:
+        snapshot.exists = True
+        snapshot.to_dict.return_value = order.model_dump(mode="python")
+    (
+        client.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .get
+        .return_value
+    ) = snapshot
+    return client
+
+
+def _ready_order() -> Order:
+    return Order(
+        call_sid="CAabc",
+        caller_phone="+15551234567",
+        restaurant_id="niko-pizza-kitchen",
+        items=[
+            LineItem(
+                name="Pepperoni",
+                category=ItemCategory.PIZZA,
+                size="large",
+                quantity=1,
+                unit_price=18.99,
+            ),
+        ],
+        order_type=OrderType.PICKUP,
+    )
+
+
+def test_send_sms_calls_twilio_with_messaging_service():
+    order = _ready_order()
+    _fake_storage(order)
+    fake_message = MagicMock(sid="SM123")
+
+    with patch("app.sms.client._twilio_client") as twilio_factory:
+        twilio_factory.return_value.messages.create.return_value = fake_message
+        result = send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="CAabc:order_confirmation",
+            tenant_id="niko-pizza-kitchen",
+        )
+
+    twilio_factory.return_value.messages.create.assert_called_once()
+    kwargs = twilio_factory.return_value.messages.create.call_args.kwargs
+    assert kwargs["to"] == "+15551234567"
+    assert kwargs["body"] == "hello"
+    assert "messaging_service_sid" in kwargs
+    assert isinstance(result, SmsResult)
+    assert result.sid == "SM123"
+
+
+def test_send_sms_short_circuits_when_record_already_exists():
+    """If sms_sent[template] already has a record, return it without
+    calling Twilio."""
+    existing = SmsSentRecord(
+        sid="SMexisting",
+        sent_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    order = _ready_order()
+    order.sms_sent["order_confirmation"] = existing
+    _fake_storage(order)
+
+    with patch("app.sms.client._twilio_client") as twilio_factory:
+        result = send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="CAabc:order_confirmation",
+            tenant_id="niko-pizza-kitchen",
+        )
+
+    twilio_factory.return_value.messages.create.assert_not_called()
+    assert result.sid == "SMexisting"
+
+
+def test_send_sms_writes_record_back_to_firestore_on_success():
+    order = _ready_order()
+    client = _fake_storage(order)
+
+    with patch("app.sms.client._twilio_client") as twilio_factory:
+        twilio_factory.return_value.messages.create.return_value = MagicMock(
+            sid="SMnew",
+        )
+        send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="CAabc:order_confirmation",
+            tenant_id="niko-pizza-kitchen",
+        )
+
+    # Confirm the doc was set with the new record under sms_sent
+    set_call = (
+        client.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .set
+    )
+    set_call.assert_called_once()
+    payload = set_call.call_args.args[0]
+    assert "order_confirmation" in payload["sms_sent"]
+    assert payload["sms_sent"]["order_confirmation"]["sid"] == "SMnew"
+
+
+def test_send_sms_raises_sms_error_when_twilio_fails():
+    order = _ready_order()
+    _fake_storage(order)
+
+    with patch("app.sms.client._twilio_client") as twilio_factory:
+        twilio_factory.return_value.messages.create.side_effect = Exception(
+            "twilio is sad",
+        )
+        with pytest.raises(SmsError) as exc:
+            send_sms(
+                to="+15551234567",
+                body="hello",
+                idempotency_key="CAabc:order_confirmation",
+                tenant_id="niko-pizza-kitchen",
+            )
+        assert "twilio is sad" in str(exc.value)
+
+
+def test_send_sms_raises_sms_error_when_order_not_found():
+    _fake_storage(None)
+
+    with pytest.raises(SmsError) as exc:
+        send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="CAmissing:order_confirmation",
+            tenant_id="niko-pizza-kitchen",
+        )
+    assert "not found" in str(exc.value).lower()
+
+
+def test_send_sms_rejects_malformed_idempotency_key():
+    with pytest.raises(SmsError):
+        send_sms(
+            to="+15551234567",
+            body="hello",
+            idempotency_key="no-colon-here",
+            tenant_id="niko-pizza-kitchen",
+        )

--- a/tests/test_sms_client.py
+++ b/tests/test_sms_client.py
@@ -72,7 +72,10 @@ def test_send_sms_calls_twilio_with_messaging_service():
     _fake_storage(order)
     fake_message = MagicMock(sid="SM123")
 
-    with patch("app.sms.client._twilio_client") as twilio_factory:
+    with (
+        patch("app.sms.client._twilio_client") as twilio_factory,
+        patch("app.config.settings.twilio_messaging_service_sid", "MGfake"),
+    ):
         twilio_factory.return_value.messages.create.return_value = fake_message
         result = send_sms(
             to="+15551234567",
@@ -117,7 +120,10 @@ def test_send_sms_writes_record_back_to_firestore_on_success():
     order = _ready_order()
     client = _fake_storage(order)
 
-    with patch("app.sms.client._twilio_client") as twilio_factory:
+    with (
+        patch("app.sms.client._twilio_client") as twilio_factory,
+        patch("app.config.settings.twilio_messaging_service_sid", "MGfake"),
+    ):
         twilio_factory.return_value.messages.create.return_value = MagicMock(
             sid="SMnew",
         )
@@ -146,7 +152,10 @@ def test_send_sms_raises_sms_error_when_twilio_fails():
     order = _ready_order()
     _fake_storage(order)
 
-    with patch("app.sms.client._twilio_client") as twilio_factory:
+    with (
+        patch("app.sms.client._twilio_client") as twilio_factory,
+        patch("app.config.settings.twilio_messaging_service_sid", "MGfake"),
+    ):
         twilio_factory.return_value.messages.create.side_effect = Exception(
             "twilio is sad",
         )
@@ -181,3 +190,24 @@ def test_send_sms_rejects_malformed_idempotency_key():
             idempotency_key="no-colon-here",
             tenant_id="niko-pizza-kitchen",
         )
+
+
+def test_send_sms_raises_when_messaging_service_sid_missing():
+    """Production safeguard: env var unset → fail fast with a clear
+    error rather than letting Twilio reject opaquely."""
+    order = _ready_order()
+    _fake_storage(order)
+
+    with (
+        patch("app.sms.client._twilio_client") as twilio_factory,
+        patch("app.config.settings.twilio_messaging_service_sid", None),
+    ):
+        with pytest.raises(SmsError) as exc:
+            send_sms(
+                to="+15551234567",
+                body="hello",
+                idempotency_key="CAabc:order_confirmation",
+                tenant_id="niko-pizza-kitchen",
+            )
+        assert "MESSAGING_SERVICE_SID" in str(exc.value)
+        twilio_factory.return_value.messages.create.assert_not_called()

--- a/tests/test_sms_e2e.py
+++ b/tests/test_sms_e2e.py
@@ -71,6 +71,7 @@ def test_confirm_to_sms_full_path():
     ):
         twilio_factory.return_value.messages.create.return_value = MagicMock(
             sid="SMend2end",
+            status="queued",
         )
         confirmed = persist_on_confirm(order)
 

--- a/tests/test_sms_e2e.py
+++ b/tests/test_sms_e2e.py
@@ -1,0 +1,81 @@
+"""End-to-end test: Order confirmation triggers SMS through the full
+lifecycle path with only Twilio mocked at the boundary."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.orders.lifecycle import persist_on_confirm
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderType,
+)
+from app.storage import firestore as storage
+
+
+@pytest.fixture(autouse=True)
+def reset_storage_client():
+    yield
+    storage.set_client(None)
+
+
+def test_confirm_to_sms_full_path():
+    fs_client = MagicMock()
+    storage.set_client(fs_client)
+
+    # Wire get_order to return an order without sms_sent populated, so
+    # the idempotency check passes through to Twilio.
+    order = Order(
+        call_sid="CAfull",
+        caller_phone="+15551234567",
+        restaurant_id="niko-pizza-kitchen",
+        items=[
+            LineItem(
+                name="Pepperoni",
+                category=ItemCategory.PIZZA,
+                size="medium",
+                quantity=1,
+                unit_price=17.99,
+            ),
+        ],
+        order_type=OrderType.PICKUP,
+    )
+
+    snapshot = MagicMock()
+    snapshot.exists = True
+    # First save_order writes the confirmed order; later get_order reads
+    # it back. Stub get to return the confirmed order.
+    confirmed_dump = order.model_copy(
+        update={"status": "confirmed"},
+    ).model_dump(mode="python")
+    snapshot.to_dict.return_value = confirmed_dump
+    (
+        fs_client.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .get
+        .return_value
+    ) = snapshot
+
+    with (
+        patch("app.sms.client._twilio_client") as twilio_factory,
+        patch(
+            "app.config.settings.twilio_messaging_service_sid",
+            "MGfake",
+        ),
+        patch("app.config.settings.twilio_account_sid", "ACfake"),
+        patch("app.config.settings.twilio_auth_token", "tokenfake"),
+    ):
+        twilio_factory.return_value.messages.create.return_value = MagicMock(
+            sid="SMend2end",
+        )
+        confirmed = persist_on_confirm(order)
+
+    twilio_factory.return_value.messages.create.assert_called_once()
+    body = twilio_factory.return_value.messages.create.call_args.kwargs["body"]
+    assert "Pepperoni" in body
+    assert "$17.99" in body
+    assert confirmed.status.value == "confirmed"

--- a/tests/test_sms_templates.py
+++ b/tests/test_sms_templates.py
@@ -1,0 +1,82 @@
+"""Unit tests for app.sms.templates."""
+
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderType,
+)
+from app.sms.templates import order_confirmation
+
+
+def _sample_pickup_order() -> Order:
+    return Order(
+        call_sid="CAabc",
+        caller_phone="+15551234567",
+        items=[
+            LineItem(
+                name="Pepperoni",
+                category=ItemCategory.PIZZA,
+                size="large",
+                quantity=1,
+                unit_price=18.99,
+            ),
+        ],
+        order_type=OrderType.PICKUP,
+    )
+
+
+def _sample_delivery_order() -> Order:
+    return Order(
+        call_sid="CAdef",
+        caller_phone="+15551234567",
+        items=[
+            LineItem(
+                name="Margherita",
+                category=ItemCategory.PIZZA,
+                quantity=2,
+                unit_price=15.00,
+            ),
+        ],
+        order_type=OrderType.DELIVERY,
+        delivery_address="123 Main Street",
+    )
+
+
+def test_order_confirmation_includes_total_and_summary_for_pickup():
+    body = order_confirmation(_sample_pickup_order())
+    assert "$18.99" in body
+    assert "Pepperoni" in body
+    assert "pickup" in body.lower()
+
+
+def test_order_confirmation_includes_delivery_address_for_delivery():
+    body = order_confirmation(_sample_delivery_order())
+    assert "$30.00" in body
+    assert "Margherita" in body
+    assert "123 Main Street" in body
+
+
+def test_order_confirmation_handles_multi_item_orders():
+    order = _sample_pickup_order()
+    order.items.append(
+        LineItem(
+            name="Garlic Knots",
+            category=ItemCategory.SIDE,
+            quantity=1,
+            unit_price=5.00,
+        ),
+    )
+    body = order_confirmation(order)
+    assert "Pepperoni" in body
+    assert "Garlic Knots" in body
+    assert "$23.99" in body  # 18.99 + 5.00
+
+
+def test_order_confirmation_under_sms_segment_limit():
+    """Single-segment SMS is 160 GSM-7 chars. Two-segment is 306. We aim
+    for one segment for typical orders so the per-pilot SMS cost stays
+    predictable. Tolerance: 320 chars accommodates edge cases without
+    blowing past two segments."""
+    body = order_confirmation(_sample_pickup_order())
+    assert len(body) <= 320

--- a/tests/test_sms_templates.py
+++ b/tests/test_sms_templates.py
@@ -80,3 +80,14 @@ def test_order_confirmation_under_sms_segment_limit():
     blowing past two segments."""
     body = order_confirmation(_sample_pickup_order())
     assert len(body) <= 320
+
+
+def test_order_confirmation_delivery_without_address_uses_safe_fallback():
+    """Defensive branch — if delivery_address is None (shouldn't happen
+    in practice given is_ready_to_confirm gate), render a safe fallback
+    rather than 'Delivery to None.'"""
+    order = _sample_delivery_order()
+    order.delivery_address = None
+    body = order_confirmation(order)
+    assert "None" not in body
+    assert "address on file" in body.lower()


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 3 (Issue #7, deliverables 3a + 3b). Adds the \`app/sms/\` outbound SMS module shared with the queued Sprint 2.3 work, plus an \`order_confirmation\` SMS that fires when an order transitions to \`confirmed\` via \`lifecycle.persist_on_confirm\`. Best-effort: SMS or template-render failure does not roll back the order.

## What landed

- **\`app/sms/\` module** (4 files): \`__init__.py\` (exports \`SmsError\`, \`SmsResult\`, \`send_sms\`), \`client.py\` (Twilio Messaging Service wrapper, Firestore-backed idempotency on \`(call_sid, template_name)\`), \`exceptions.py\` (\`SmsError\`), \`templates.py\` (\`order_confirmation\` template, defensive against missing \`delivery_address\`).
- **\`Order.sms_sent\`** — new \`dict[str, SmsSentRecord]\` field on the Pydantic model + Firestore doc shape, default empty (back-compat with legacy docs that predate the field).
- **\`SmsSentRecord\`** — Pydantic model carrying \`sid\` + \`sent_at\`. Persisted on the order doc to dedupe re-sends.
- **\`SmsResult\`** — return type from \`send_sms\` carrying \`sid\`, \`status\`, \`sent_at\` (matches spec contract that Sprint 2.3 will consume unchanged).
- **\`lifecycle.persist_on_confirm\` hook** — fires \`order_confirmation\` after the Firestore write; broad \`except Exception\` to honor the best-effort contract; \`caller_phone is None\` short-circuits silently.
- **\`TWILIO_MESSAGING_SERVICE_SID\` config** + \`.env.example\` entry.

Spec deviations vs. \`docs/superpowers/specs/2026-05-01-sprint-2.4-design.md\` documented in the plan: \`send_sms\` is sync (Twilio SDK is sync, matches existing storage layer); async callers wrap with \`asyncio.to_thread\`.

## Pin for Sprint 2.3

The \`send_sms\` signature is the contract Sprint 2.3 inherits. \`payment_link\` and \`payment_expired\` templates plug into \`app/sms/templates.py\` without touching the client. Idempotency lives in \`send_sms\` itself; lifecycle callers don't dedupe.

## Test plan

- [x] \`pytest tests/test_sms_templates.py -v\` — 5 passes (4 + 1 defensive)
- [x] \`pytest tests/test_sms_client.py -v\` — 7 passes (covers happy path, idempotency short-circuit, Firestore write-back, Twilio fail, missing order, malformed key, missing config)
- [x] \`pytest tests/test_orders_lifecycle.py -v\` — 14 passes (existing + 4 new SMS hook tests)
- [x] \`pytest tests/test_order_models.py -v\` — 14 passes (existing + 3 new \`sms_sent\` tests)
- [x] \`pytest tests/test_sms_e2e.py -v\` — 1 pass (full path with mocked Twilio + Firestore)
- [x] \`pytest tests/ -x\` — 269 passed / 1 skipped / 0 failures (modulo pre-existing \`pickup_only_soft_pivot\` LLM-flake unrelated to this change)
- [ ] **Manual smoke (gating, owner does this):** Set \`TWILIO_MESSAGING_SERVICE_SID\` to a real test Messaging Service, place a confirmed order via test number, verify SMS lands on a real phone with the correct order summary.

## Follow-ups deliberately deferred

Flagged in the final niko-reviewer pass; non-blocking for pilot:

- **Read-modify-write race in \`send_sms\` save path.** \`order.model_copy(update=...)\` then \`save_order(updated)\` overwrites the full Order doc; a concurrent kitchen-side update during the brief \`persist_on_confirm\` → \`send_sms\` window could clobber. Practical risk ~zero (kitchen needs to see the order in the dashboard before tapping a transition button), but worth a Firestore field-level update (\`document.update({"sms_sent.foo": ...})\`) when we add automatic transitions.
- **Idempotency-key parsing is permissive.** \`split(":", 1)\` accepts empty halves. Twilio call SIDs are well-formed in practice. Tighten with a non-empty guard or call-SID regex when convenient.
- **\`except SmsError: raise\` in \`send_sms\` looks dead at first glance** but is load-bearing (\`_twilio_client()\` raises \`SmsError\` from inside the try). Cleaner: hoist \`client = _twilio_client()\` outside the try.
- **E2E test only verifies the first send, not the second-send short-circuit.** Adding a second \`persist_on_confirm\` call (with stub returning the doc with \`sms_sent\` populated) closes the loop. Already covered at the unit layer in \`test_sms_client.py\`.

## Issue checklist

Updates issue #7 deliverables 3a + 3b. Track 1 (Dashboard) and Track 2 (Telephony) plans are already on master from PR #148; they ship via separate branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)