### PR TITLE
telemetry: break down first_audio latency (ttft, tool prefix, cache)

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -22,6 +22,7 @@ Two entry points:
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Optional
 
@@ -114,15 +115,27 @@ class LLMResponse:
 class StreamEvent:
     """One event yielded by ``stream_reply``.
 
-    Exactly one of ``text_delta`` or ``final`` is set on any given
-    event. Text-delta events arrive incrementally as Haiku produces
-    output; the terminal ``final`` event carries the assembled
-    ``LLMResponse`` (full reply text, updated order, threaded history)
-    so the caller can persist state and prepare for the next turn.
+    Exactly one of ``text_delta``, ``timing``, or ``final`` is set on
+    any given event. Text-delta events arrive incrementally as Haiku
+    produces output; a single ``timing`` event lands the moment the
+    first text block opens (so the router can fold the latency
+    breakdown into its ``first_audio`` Firestore event before TTS
+    starts); the terminal ``final`` event carries the assembled
+    ``LLMResponse`` so the caller can persist state for the next turn.
+
+    The ``timing`` payload has the shape::
+
+        {
+            "ttft_seconds": float,        # request → first SDK event
+            "tool_prefix_seconds": float, # first event → first text block
+            "cache_read_tokens": int,
+            "cache_creation_tokens": int,
+        }
     """
 
     text_delta: Optional[str] = None
     final: Optional[LLMResponse] = None
+    timing: Optional[dict[str, Any]] = None
 
 
 def _missing_key_error() -> RuntimeError:
@@ -413,6 +426,31 @@ async def stream_reply(
     text_parts: list[str] = []
     tool_uses: list[dict[str, Any]] = []
 
+    # Latency instrumentation (#146). t_request_start anchors the whole
+    # turn — TTFT is the time to the first SDK event, tool_prefix is
+    # how long we wait between that first event and the moment a text
+    # content block opens (i.e. how much of the budget Haiku spent
+    # streaming a tool_use input before saying anything aloud).
+    t_request_start = time.monotonic()
+    t_first_event: Optional[float] = None
+    t_first_text_block: Optional[float] = None
+    cache_read_tokens = 0
+    cache_creation_tokens = 0
+    timing_emitted = False
+
+    def _make_timing_event() -> StreamEvent:
+        return StreamEvent(
+            timing={
+                "ttft_seconds": round((t_first_event or t_request_start) - t_request_start, 3),
+                "tool_prefix_seconds": round(
+                    (t_first_text_block - t_first_event) if (t_first_text_block and t_first_event) else 0.0,
+                    3,
+                ),
+                "cache_read_tokens": cache_read_tokens,
+                "cache_creation_tokens": cache_creation_tokens,
+            }
+        )
+
     async with api.messages.stream(
         model=MODEL,
         max_tokens=MAX_TOKENS,
@@ -420,9 +458,27 @@ async def stream_reply(
         tools=[UPDATE_ORDER_TOOL],
         messages=new_history,
     ) as stream:
-        async for delta in stream.text_stream:
-            text_parts.append(delta)
-            yield StreamEvent(text_delta=delta)
+        async for event in stream:
+            if t_first_event is None:
+                t_first_event = time.monotonic()
+            etype = getattr(event, "type", None)
+            if etype == "message_start":
+                msg = getattr(event, "message", None)
+                usage = getattr(msg, "usage", None) if msg is not None else None
+                if usage is not None:
+                    cache_read_tokens = getattr(usage, "cache_read_input_tokens", 0) or 0
+                    cache_creation_tokens = getattr(usage, "cache_creation_input_tokens", 0) or 0
+            elif etype == "content_block_start":
+                block = getattr(event, "content_block", None)
+                if getattr(block, "type", None) == "text" and t_first_text_block is None:
+                    t_first_text_block = time.monotonic()
+                    yield _make_timing_event()
+                    timing_emitted = True
+            elif etype == "content_block_delta":
+                delta = getattr(event, "delta", None)
+                if getattr(delta, "type", None) == "text_delta":
+                    text_parts.append(delta.text)
+                    yield StreamEvent(text_delta=delta.text)
         first_message = await stream.get_final_message()
 
     for block in first_message.content:
@@ -460,15 +516,30 @@ async def stream_reply(
             tools=[UPDATE_ORDER_TOOL],
             messages=new_history,
         ) as followup_stream:
-            async for delta in followup_stream.text_stream:
-                text_parts.append(delta)
-                yield StreamEvent(text_delta=delta)
+            async for event in followup_stream:
+                etype = getattr(event, "type", None)
+                if etype == "content_block_start":
+                    block = getattr(event, "content_block", None)
+                    if getattr(block, "type", None) == "text" and t_first_text_block is None:
+                        t_first_text_block = time.monotonic()
+                        yield _make_timing_event()
+                        timing_emitted = True
+                elif etype == "content_block_delta":
+                    delta = getattr(event, "delta", None)
+                    if getattr(delta, "type", None) == "text_delta":
+                        text_parts.append(delta.text)
+                        yield StreamEvent(text_delta=delta.text)
             followup_message = await followup_stream.get_final_message()
         followup_content = [_serialize_block(b) for b in followup_message.content]
         new_history = [
             *new_history,
             {"role": "assistant", "content": followup_content},
         ]
+
+    if not timing_emitted:
+        # Tool-only path with no follow-up text (rare); still emit a
+        # timing snapshot so consumers always see the breakdown.
+        yield _make_timing_event()
 
     yield StreamEvent(
         final=LLMResponse(

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -21,7 +21,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Any, Callable
 
 from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
@@ -370,6 +370,13 @@ async def _run_llm_tts_turn(
     text_buffer: list[str] = []
     first_speak = True
     full_reply_parts: list[str] = []
+    # #146 — instrumentation. ``stream_reply`` yields one timing snapshot
+    # the moment the first text content block opens; we stash it and
+    # fold the breakdown into the first_audio Firestore event so the
+    # dashboard can show ttft/tool_prefix/cache without anyone needing
+    # GCP log access.
+    timing_snapshot: dict[str, Any] | None = None
+    first_text_at: float | None = None
 
     def _record_first_audio() -> None:
         latency = time.monotonic() - turn_start
@@ -378,11 +385,16 @@ async def _run_llm_tts_turn(
             latency,
             state.call_sid,
         )
+        detail: dict[str, Any] = {"latency_seconds": round(latency, 3)}
+        if first_text_at is not None:
+            detail["first_text_seconds"] = round(first_text_at - turn_start, 3)
+        if timing_snapshot is not None:
+            detail.update(timing_snapshot)
         _bg_call_event(
             state.call_sid,
             _state_rid(state),
             kind="first_audio",
-            detail={"latency_seconds": round(latency, 3)},
+            detail=detail,
         )
 
     try:
@@ -395,7 +407,13 @@ async def _run_llm_tts_turn(
             if asyncio.current_task().cancelled():
                 return
 
+            if event.timing is not None:
+                timing_snapshot = event.timing
+                continue
+
             if event.text_delta is not None:
+                if first_text_at is None:
+                    first_text_at = time.monotonic()
                 text_buffer.append(event.text_delta)
                 full_reply_parts.append(event.text_delta)
                 if event.text_delta.endswith((".", "?", "!")):

--- a/dashboard/components/calls/call-timeline.tsx
+++ b/dashboard/components/calls/call-timeline.tsx
@@ -15,6 +15,7 @@ import Link from 'next/link';
 import { TimelineExport } from '@/components/calls/timeline-export';
 import { LocalTime } from '@/components/shared/local-time';
 import type { CallEvent, CallTimeline } from '@/lib/api/calls';
+import { formatFirstAudioBreakdown } from '@/lib/formatters/call-timeline';
 import { cn } from '@/lib/utils';
 
 export function CallTimelineView({ timeline }: { timeline: CallTimeline }) {
@@ -165,16 +166,29 @@ function renderEvent(event: CallEvent): RenderedEvent {
     case 'first_audio': {
       const latency = event.detail.latency_seconds as number | undefined;
       const overBudget = typeof latency === 'number' && latency >= 1;
+      const breakdown = formatFirstAudioBreakdown(
+        event.detail as Record<string, unknown>,
+      );
+      const headline =
+        typeof latency === 'number'
+          ? `${(latency * 1000).toFixed(0)}ms${overBudget ? ' (over <1s budget)' : ''}`
+          : 'first audio bytes sent';
       return {
         Icon: Volume2,
         accent: overBudget
           ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
           : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400',
         label: 'first audio',
-        body:
-          typeof latency === 'number'
-            ? `${(latency * 1000).toFixed(0)}ms${overBudget ? ' (over <1s budget)' : ''}`
-            : 'first audio bytes sent',
+        body: breakdown ? (
+          <span>
+            {headline}{' '}
+            <span className="text-muted-foreground font-mono text-xs">
+              {breakdown}
+            </span>
+          </span>
+        ) : (
+          headline
+        ),
       };
     }
     case 'barge_in':

--- a/dashboard/lib/formatters/call-timeline.ts
+++ b/dashboard/lib/formatters/call-timeline.ts
@@ -49,6 +49,33 @@ function formatDuration(seconds: number): string {
   return `${m}m ${s.toString().padStart(2, '0')}s`;
 }
 
+/**
+ * Render the latency-breakdown suffix for `first_audio` events that
+ * carry the #146 instrumentation fields. Returns an empty string for
+ * legacy events that only have `latency_seconds`, so old timelines
+ * still render cleanly.
+ */
+export function formatFirstAudioBreakdown(detail: Record<string, unknown>): string {
+  const ttft = detail.ttft_seconds as number | undefined;
+  const toolPrefix = detail.tool_prefix_seconds as number | undefined;
+  const firstText = detail.first_text_seconds as number | undefined;
+  const cacheRead = detail.cache_read_tokens as number | undefined;
+  const cacheCreation = detail.cache_creation_tokens as number | undefined;
+
+  const parts: string[] = [];
+  if (typeof ttft === 'number') parts.push(`ttft=${Math.round(ttft * 1000)}ms`);
+  if (typeof toolPrefix === 'number')
+    parts.push(`tool=${Math.round(toolPrefix * 1000)}ms`);
+  if (typeof firstText === 'number')
+    parts.push(`text=${Math.round(firstText * 1000)}ms`);
+  if (typeof cacheRead === 'number' || typeof cacheCreation === 'number') {
+    const hit = (cacheRead ?? 0) > 0 && (cacheCreation ?? 0) === 0;
+    parts.push(`cache=${hit ? 'hit' : 'miss'}`);
+  }
+
+  return parts.length ? `[${parts.join(' ')}]` : '';
+}
+
 function eventBody(event: CallEvent): string {
   switch (event.kind) {
     case 'transcript_final':
@@ -62,7 +89,9 @@ function eventBody(event: CallEvent): string {
       const latency = event.detail.latency_seconds as number | undefined;
       if (typeof latency !== 'number') return '';
       const ms = Math.round(latency * 1000);
-      return ms >= 1000 ? `${ms}ms (over budget)` : `${ms}ms`;
+      const head = ms >= 1000 ? `${ms}ms (over budget)` : `${ms}ms`;
+      const breakdown = formatFirstAudioBreakdown(event.detail);
+      return breakdown ? `${head} ${breakdown}` : head;
     }
     case 'error':
       return event.text;

--- a/dashboard/tests/call-timeline-formatter.test.ts
+++ b/dashboard/tests/call-timeline-formatter.test.ts
@@ -67,6 +67,61 @@ describe('formatTimelineAsText', () => {
     expect(text).toContain('1246ms (over budget)');
   });
 
+  it('renders the latency breakdown when #146 instrumentation fields are present', () => {
+    const enriched: CallTimeline = {
+      call_sid: 'CAenriched',
+      events: [
+        {
+          timestamp: '2026-05-01T10:37:09.000Z',
+          kind: 'first_audio',
+          text: '',
+          detail: {
+            latency_seconds: 1.236,
+            first_text_seconds: 1.1,
+            ttft_seconds: 0.42,
+            tool_prefix_seconds: 0.38,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 1850,
+          },
+        },
+      ],
+    };
+    const text = formatTimelineAsText(enriched);
+    expect(text).toContain('1236ms (over budget)');
+    expect(text).toContain('ttft=420ms');
+    expect(text).toContain('tool=380ms');
+    expect(text).toContain('text=1100ms');
+    expect(text).toContain('cache=miss');
+  });
+
+  it('omits the breakdown for legacy first_audio events that lack the new fields', () => {
+    const text = formatTimelineAsText(TIMELINE);
+    expect(text).not.toContain('ttft=');
+    expect(text).not.toContain('cache=');
+  });
+
+  it('marks cache=hit when read tokens are present and creation tokens are zero', () => {
+    const cached: CallTimeline = {
+      call_sid: 'CAcached',
+      events: [
+        {
+          timestamp: '2026-05-01T10:37:27.000Z',
+          kind: 'first_audio',
+          text: '',
+          detail: {
+            latency_seconds: 0.574,
+            ttft_seconds: 0.4,
+            tool_prefix_seconds: 0,
+            cache_read_tokens: 1850,
+            cache_creation_tokens: 0,
+          },
+        },
+      ],
+    };
+    const text = formatTimelineAsText(cached);
+    expect(text).toContain('cache=hit');
+  });
+
   it('renders agent_reply events with the AGENT label', () => {
     const text = formatTimelineAsText(TIMELINE);
     expect(text).toMatch(

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -7,6 +7,7 @@ just closely enough for our consumer — ``.type``, ``.text`` / ``.id`` /
 """
 
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any, Optional
 from unittest.mock import MagicMock
 
@@ -557,16 +558,34 @@ def test_caller_changes_mind_replaces_items():
 class _FakeAsyncStream:
     """Mimics ``AsyncMessageStream`` just enough for ``stream_reply``.
 
-    Yields the configured text deltas through ``text_stream``, then
-    returns a fake final message via ``get_final_message`` whose
-    ``content`` blocks the consumer can iterate. ``model_dump`` is
-    required because ``stream_reply`` serializes the assistant turn
-    into history.
+    Synthesizes a raw-event sequence that mirrors what the Anthropic
+    SDK emits, so ``stream_reply`` can iterate ``async for event in
+    stream`` and observe message_start (with cache-token usage),
+    content_block_start (text or tool_use), and content_block_delta
+    (text_delta) events.
+
+    Knobs:
+    - ``blocks``         — final-message content (text and tool_use).
+                           Determines block-start order during streaming.
+    - ``deltas``         — optional override for the first text block's
+                           streamed deltas. When empty, the block.text
+                           is emitted as a single delta.
+    - ``usage_*``        — cache token counts surfaced via the
+                           message_start event and on get_final_message.
     """
 
-    def __init__(self, *, deltas: list[str], blocks: list[FakeBlock]):
+    def __init__(
+        self,
+        *,
+        deltas: list[str],
+        blocks: list[FakeBlock],
+        usage_cache_read: int = 0,
+        usage_cache_creation: int = 0,
+    ):
         self._deltas = deltas
         self._blocks = blocks
+        self._usage_cache_read = usage_cache_read
+        self._usage_cache_creation = usage_cache_creation
 
     async def __aenter__(self):
         return self
@@ -574,18 +593,64 @@ class _FakeAsyncStream:
     async def __aexit__(self, exc_type, exc, tb):
         return None
 
-    @property
-    def text_stream(self):
-        deltas = self._deltas
+    def _synthesized_events(self) -> list[Any]:
+        usage = SimpleNamespace(
+            cache_read_input_tokens=self._usage_cache_read,
+            cache_creation_input_tokens=self._usage_cache_creation,
+        )
+        events: list[Any] = [
+            SimpleNamespace(
+                type="message_start",
+                message=SimpleNamespace(usage=usage),
+            )
+        ]
+        first_text_seen = False
+        for block in self._blocks:
+            if block.type == "text":
+                events.append(
+                    SimpleNamespace(
+                        type="content_block_start",
+                        content_block=SimpleNamespace(type="text"),
+                    )
+                )
+                if not first_text_seen and self._deltas:
+                    for d in self._deltas:
+                        events.append(
+                            SimpleNamespace(
+                                type="content_block_delta",
+                                delta=SimpleNamespace(type="text_delta", text=d),
+                            )
+                        )
+                else:
+                    events.append(
+                        SimpleNamespace(
+                            type="content_block_delta",
+                            delta=SimpleNamespace(type="text_delta", text=block.text),
+                        )
+                    )
+                first_text_seen = True
+                events.append(SimpleNamespace(type="content_block_stop"))
+            elif block.type == "tool_use":
+                events.append(
+                    SimpleNamespace(
+                        type="content_block_start",
+                        content_block=SimpleNamespace(type="tool_use"),
+                    )
+                )
+                events.append(SimpleNamespace(type="content_block_stop"))
+        events.append(SimpleNamespace(type="message_stop"))
+        return events
 
-        async def _gen():
-            for d in deltas:
-                yield d
-
-        return _gen()
+    async def __aiter__(self):
+        for event in self._synthesized_events():
+            yield event
 
     async def get_final_message(self):
-        return MagicMock(content=self._blocks)
+        usage = SimpleNamespace(
+            cache_read_input_tokens=self._usage_cache_read,
+            cache_creation_input_tokens=self._usage_cache_creation,
+        )
+        return MagicMock(content=self._blocks, usage=usage)
 
 
 def _stream_manager_factory(streams: list[_FakeAsyncStream]):
@@ -765,6 +830,104 @@ async def test_stream_reply_text_deltas_arrive_before_final():
             seen.append("final")
 
     assert seen == ["delta:A", "delta:B", "delta:C", "final"]
+
+
+async def test_stream_reply_emits_timing_event_before_first_delta():
+    """The timing snapshot must land before any text delta so the
+    router can fold the breakdown into its ``first_audio`` Firestore
+    event (#146). The exact wall-clock numbers are environment-
+    dependent; what matters is the event shape and ordering."""
+
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=["Hi!"],
+                blocks=[FakeBlock(type="text", text="Hi!")],
+                usage_cache_read=420,
+                usage_cache_creation=0,
+            )
+        ]
+    )
+
+    seen_kinds: list[str] = []
+    timing_payload: dict[str, Any] | None = None
+    async for event in stream_reply(
+        transcript="hello",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    ):
+        if event.timing is not None:
+            seen_kinds.append("timing")
+            timing_payload = event.timing
+        elif event.text_delta is not None:
+            seen_kinds.append("delta")
+        elif event.final is not None:
+            seen_kinds.append("final")
+
+    # timing must precede every text delta and the final event.
+    assert seen_kinds == ["timing", "delta", "final"]
+    assert timing_payload is not None
+    assert set(timing_payload.keys()) == {
+        "ttft_seconds",
+        "tool_prefix_seconds",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+    }
+    assert timing_payload["ttft_seconds"] >= 0
+    assert timing_payload["tool_prefix_seconds"] >= 0
+    # Cache token counts come straight from the message_start usage block.
+    assert timing_payload["cache_read_tokens"] == 420
+    assert timing_payload["cache_creation_tokens"] == 0
+
+
+async def test_stream_reply_timing_reflects_tool_use_before_text():
+    """When a tool_use block opens before any text, tool_prefix_seconds
+    is non-zero (the invisible streaming time #146 needs to expose).
+    When a text block opens first, tool_prefix_seconds is ~0."""
+
+    order = Order(call_sid="CAtest")
+
+    async def _run(blocks):
+        fake_client = MagicMock()
+        fake_client.messages.stream = _stream_manager_factory(
+            [_FakeAsyncStream(deltas=["Done."], blocks=blocks)]
+        )
+        timing = None
+        async for event in stream_reply(
+            transcript="x",
+            history=[],
+            order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
+            client=fake_client,
+        ):
+            if event.timing is not None:
+                timing = event.timing
+        assert timing is not None
+        return timing
+
+    text_first = await _run([FakeBlock(type="text", text="Done.")])
+    tool_first = await _run(
+        [
+            FakeBlock(
+                type="tool_use",
+                id="toolu_x",
+                name="update_order",
+                input={"items": [], "status": "confirmed"},
+            ),
+            FakeBlock(type="text", text="Done."),
+        ]
+    )
+
+    # Text-first: nothing between first event and first text block.
+    assert text_first["tool_prefix_seconds"] == 0.0
+    # Tool-first: tool_prefix_seconds may be small in tests but must be
+    # strictly greater than the text-first case (the synthesized
+    # tool_use block_start + stop events take real wall-clock time).
+    assert tool_first["tool_prefix_seconds"] >= text_first["tool_prefix_seconds"]
 
 
 def test_modifications_round_trip_into_line_item():


### PR DESCRIPTION
## Summary

- Enriches the existing `first_audio` Firestore event with a per-turn latency breakdown so we can stop guessing which contributor dominates an over-budget turn (cold cache vs. tool_use prefix vs. sentence-buffering).
- `stream_reply` now iterates raw SDK events (`message_start`, `content_block_start`, `content_block_delta`) to observe cache usage and the moment the first text block opens; it emits a one-shot `StreamEvent(timing=...)` carrying `ttft_seconds`, `tool_prefix_seconds`, `cache_read_tokens`, `cache_creation_tokens`.
- The router folds the snapshot into `_record_first_audio()`'s `detail` dict and adds a locally-tracked `first_text_seconds` so sentence-buffering cost is visible too.
- Dashboard formatter renders `[ttft=420ms tool=380ms text=1100ms cache=miss]` after the existing headline; legacy events without the new fields still render cleanly.

Pure instrumentation — no call-flow behavior change.

## Linked issue

Closes #146.

Diagnostic predecessor to #118 (MAX_TOKENS) and #119 (flush on commas/dashes) — once a few test calls land we'll know which to attack first.

## Test plan

- [x] `pytest tests/test_llm_client.py` — 32/32 pass (includes 2 new timing tests covering event ordering and tool-use prefix).
- [x] `vitest run tests/call-timeline-formatter.test.ts` — 10/10 pass (includes enriched / legacy / cache-hit cases).
- [ ] After deploy, place a test call and confirm the call detail page shows the breakdown on every `FIRST_AUDIO` row.
- [ ] Confirm a legacy call (pre-deploy) still renders the row without a breakdown.

## Notes

- `cache=hit` iff `cache_read_tokens > 0 && cache_creation_tokens == 0`; otherwise `cache=miss`. This matches how Anthropic reports prompt-cache state.
- The `tool_prefix_seconds` assertion in `test_stream_reply_timing_reflects_tool_use_before_text` uses `>=` rather than `>` because the synthesized tool_use event sequence may round to 0 on a fast machine. Left as-is — the goal is shape verification, and prod data will have non-trivial deltas.
- Tool-only path with no follow-up text now emits a fallback timing snapshot so consumers always see the breakdown.