### PR TITLE
Sprint 2.4 Track 1 Phase A+B — settings page + hours editor (#7)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-import re as _re
+import re
 import time
 
 from fastapi import Depends, FastAPI, HTTPException, Response
@@ -17,7 +17,6 @@ from app.auth import Tenant, current_tenant
 from app.restaurants.hours import render_hours_text
 from app.restaurants.models import HoursStructured
 
-_E164 = _re.compile(r"^\+\d{8,15}$")
 from app.config import settings
 from app.orders.lifecycle import (
     OrderTransitionError,
@@ -35,6 +34,8 @@ from app.storage import (
 )
 from app.storage.restaurants import DEMO_RID
 from app.telephony.router import router as telephony_router
+
+_E164 = re.compile(r"^\+\d{8,15}$")
 
 app = FastAPI(title="niko")
 app.include_router(telephony_router)
@@ -125,22 +126,12 @@ def patch_restaurant(
     if restaurant is None:
         raise HTTPException(status_code=404, detail="restaurant not found")
 
-    # Build a typed patch dict so nested models stay as Pydantic objects
-    # (avoids a Pydantic serializer warning when hours_structured is a
-    # plain dict inside model_copy).
-    patch: dict = {}
-    if "name" in update.model_fields_set:
-        patch["name"] = update.name
-    if "display_phone" in update.model_fields_set:
-        patch["display_phone"] = update.display_phone
-    if "address" in update.model_fields_set:
-        patch["address"] = update.address
+    # Dump scalar fields via model_dump; assign hours_structured manually
+    # so it stays a Pydantic object inside model_copy (avoids a
+    # serializer warning when nested models pass through as raw dicts).
+    patch = update.model_dump(exclude_unset=True, exclude={"hours_structured"})
     if "hours_structured" in update.model_fields_set:
         patch["hours_structured"] = update.hours_structured
-    if "fallback_phone" in update.model_fields_set:
-        patch["fallback_phone"] = update.fallback_phone
-    if "offers_delivery" in update.model_fields_set:
-        patch["offers_delivery"] = update.offers_delivery
 
     updated = restaurant.model_copy(update=patch)
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO)
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from app.auth import Tenant, current_tenant
 from app.restaurants.hours import render_hours_text
@@ -95,9 +95,9 @@ class RestaurantUpdate(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    name: Optional[str] = None
-    display_phone: Optional[str] = None
-    address: Optional[str] = None
+    name: Optional[str] = Field(default=None, min_length=1)
+    display_phone: Optional[str] = Field(default=None, min_length=1)
+    address: Optional[str] = Field(default=None, min_length=1)
     hours_structured: Optional[HoursStructured] = None
     fallback_phone: Optional[str] = None
     offers_delivery: Optional[bool] = None
@@ -122,6 +122,11 @@ def patch_restaurant(
     """Apply an owner-driven update to the calling tenant's Restaurant
     doc. Owner-editable fields only — id and twilio_phone are not
     patchable here (provisioning concerns)."""
+    if tenant.role != "owner":
+        raise HTTPException(
+            status_code=403,
+            detail="owner role required to edit restaurant settings",
+        )
     restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
     if restaurant is None:
         raise HTTPException(status_code=404, detail="restaurant not found")
@@ -137,13 +142,17 @@ def patch_restaurant(
 
     # If hours_structured was set, regenerate hours text so the prompt
     # builder reflects the new schedule on the next call.
-    if update.hours_structured is not None:
-        updated = updated.model_copy(
-            update={"hours": render_hours_text(update.hours_structured)},
-        )
+    if "hours_structured" in update.model_fields_set:
+        if update.hours_structured is not None:
+            updated = updated.model_copy(
+                update={"hours": render_hours_text(update.hours_structured)},
+            )
+        # else: hours_structured was explicitly cleared. Leave hours: str
+        # alone for now — clearing structured hours doesn't necessarily
+        # mean the prompt-builder string should change. Revisit if a
+        # "clear hours" UX surfaces.
 
-    restaurants_storage.save_restaurant(updated)
-    restaurants_storage.clear_cache()
+    restaurants_storage.save_restaurant(updated)  # also refreshes the in-process cache for this rid
     return updated.model_dump(mode="json")
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re as _re
 import time
 
 from fastapi import Depends, FastAPI, HTTPException, Response
@@ -8,9 +9,15 @@ from fastapi.responses import RedirectResponse
 logging.basicConfig(level=logging.INFO)
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
+
+from pydantic import BaseModel, field_validator
 
 from app.auth import Tenant, current_tenant
+from app.restaurants.hours import render_hours_text
+from app.restaurants.models import HoursStructured
+
+_E164 = _re.compile(r"^\+\d{8,15}$")
 from app.config import settings
 from app.orders.lifecycle import (
     OrderTransitionError,
@@ -78,6 +85,75 @@ def restaurants_me(tenant: Tenant = Depends(current_tenant)):
     if restaurant is None:
         raise HTTPException(status_code=404, detail="restaurant not found")
     return restaurant.model_dump(mode="json")
+
+
+class RestaurantUpdate(BaseModel):
+    """Owner-editable fields for PATCH /restaurants/me. Strict-extra so
+    typos and security-sensitive fields (id, twilio_phone) are rejected
+    rather than silently dropped."""
+
+    model_config = {"extra": "forbid"}
+
+    name: Optional[str] = None
+    display_phone: Optional[str] = None
+    address: Optional[str] = None
+    hours_structured: Optional[HoursStructured] = None
+    fallback_phone: Optional[str] = None
+    offers_delivery: Optional[bool] = None
+
+    @field_validator("fallback_phone")
+    @classmethod
+    def _check_e164(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or v == "":
+            return v
+        if not _E164.match(v):
+            raise ValueError(
+                f"fallback_phone must be E.164 (+1...), got {v!r}"
+            )
+        return v
+
+
+@app.patch("/restaurants/me")
+def patch_restaurant(
+    update: RestaurantUpdate,
+    tenant: Tenant = Depends(current_tenant),
+):
+    """Apply an owner-driven update to the calling tenant's Restaurant
+    doc. Owner-editable fields only — id and twilio_phone are not
+    patchable here (provisioning concerns)."""
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+
+    # Build a typed patch dict so nested models stay as Pydantic objects
+    # (avoids a Pydantic serializer warning when hours_structured is a
+    # plain dict inside model_copy).
+    patch: dict = {}
+    if "name" in update.model_fields_set:
+        patch["name"] = update.name
+    if "display_phone" in update.model_fields_set:
+        patch["display_phone"] = update.display_phone
+    if "address" in update.model_fields_set:
+        patch["address"] = update.address
+    if "hours_structured" in update.model_fields_set:
+        patch["hours_structured"] = update.hours_structured
+    if "fallback_phone" in update.model_fields_set:
+        patch["fallback_phone"] = update.fallback_phone
+    if "offers_delivery" in update.model_fields_set:
+        patch["offers_delivery"] = update.offers_delivery
+
+    updated = restaurant.model_copy(update=patch)
+
+    # If hours_structured was set, regenerate hours text so the prompt
+    # builder reflects the new schedule on the next call.
+    if update.hours_structured is not None:
+        updated = updated.model_copy(
+            update={"hours": render_hours_text(update.hours_structured)},
+        )
+
+    restaurants_storage.save_restaurant(updated)
+    restaurants_storage.clear_cache()
+    return updated.model_dump(mode="json")
 
 
 @app.get("/orders")

--- a/app/restaurants/hours.py
+++ b/app/restaurants/hours.py
@@ -1,0 +1,52 @@
+"""Render an ``HoursStructured`` value to the LLM-readable ``hours: str``
+the prompt builder consumes. The renderer collapses contiguous runs of
+identical days (Mon-Wed 11:00-22:00) and inlines closed-day notes
+(Sun: closed) so the rendered text stays compact."""
+
+from __future__ import annotations
+
+from app.restaurants.models import DayHours, HoursStructured
+
+_DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+_LABELS = {
+    "mon": "Mon",
+    "tue": "Tue",
+    "wed": "Wed",
+    "thu": "Thu",
+    "fri": "Fri",
+    "sat": "Sat",
+    "sun": "Sun",
+}
+
+
+def _key(d: DayHours) -> tuple[bool, str, str]:
+    return (d.closed, d.open, d.close)
+
+
+def render_hours_text(hours: HoursStructured) -> str:
+    """Collapse contiguous runs of identical days into ranges; mark
+    closed days inline. Returns a compact one-line description suitable
+    for the system prompt."""
+    days = [(d, getattr(hours, d)) for d in _DAYS]
+
+    parts: list[str] = []
+    i = 0
+    while i < len(days):
+        start_key = _key(days[i][1])
+        j = i
+        while j + 1 < len(days) and _key(days[j + 1][1]) == start_key:
+            j += 1
+
+        first_label = _LABELS[days[i][0]]
+        last_label = _LABELS[days[j][0]]
+        span = first_label if i == j else f"{first_label}-{last_label}"
+
+        spec = days[i][1]
+        if spec.closed:
+            parts.append(f"{span}: closed")
+        else:
+            parts.append(f"{span} {spec.open}-{spec.close}")
+
+        i = j + 1
+
+    return ", ".join(parts)

--- a/app/restaurants/models.py
+++ b/app/restaurants/models.py
@@ -51,14 +51,55 @@ owns the menu CRUD UI and is the right time to tighten validation.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
+
+
+_HHMM = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+def _validate_hhmm(value: str) -> str:
+    if not _HHMM.match(value):
+        raise ValueError(f"time must be HH:MM (24-hour), got {value!r}")
+    return value
+
+
+class DayHours(BaseModel):
+    """Open/close pair for a single day. Times are local to the
+    restaurant's timezone (Phase 1: America/Toronto for everyone;
+    multi-tz arrives with multi-location, deferred per
+    dashboard/CLAUDE.md)."""
+
+    open: str = Field(description="Local opening time, HH:MM 24-hour")
+    close: str = Field(description="Local closing time, HH:MM 24-hour")
+    closed: bool = False
+
+    @field_validator("open", "close")
+    @classmethod
+    def _check_format(cls, v: str) -> str:
+        return _validate_hhmm(v)
+
+
+class HoursStructured(BaseModel):
+    """Per-day open/close ranges. The dashboard's hours editor writes
+    this; the prompt builder reads ``Restaurant.hours`` (the str
+    rendering) so changing this without regenerating ``hours`` would
+    drift the LLM. ``RestaurantUpdate`` regenerates ``hours`` on save."""
+
+    mon: DayHours
+    tue: DayHours
+    wed: DayHours
+    thu: DayHours
+    fri: DayHours
+    sat: DayHours
+    sun: DayHours
 
 
 class Restaurant(BaseModel):
@@ -82,5 +123,9 @@ class Restaurant(BaseModel):
     # pickup-only restaurants — the system prompt branches accordingly.
     offers_delivery: bool = True
     recording_retention_days: int = Field(default=90, ge=1, le=3650)
+    hours_structured: Optional[HoursStructured] = None
+    # Used by Sprint 2.4 Track 2 (call transfer). E.164. None means
+    # the call falls through to voicemail without an attempted dial.
+    fallback_phone: Optional[str] = None
     created_at: datetime = Field(default_factory=_now_utc)
     updated_at: datetime = Field(default_factory=_now_utc)

--- a/dashboard/app/(dashboard)/settings/page.tsx
+++ b/dashboard/app/(dashboard)/settings/page.tsx
@@ -1,10 +1,29 @@
-import { ComingSoon } from '@/components/shared/coming-soon';
+import { redirect } from 'next/navigation';
 
-export default function SettingsPage() {
-  return (
-    <ComingSoon
-      title="Settings"
-      description="Restaurant profile, hours, and integrations (Square, etc.) will live here in Phase 2."
-    />
-  );
+import { SettingsShell } from '@/components/settings/settings-shell';
+import { getMyRestaurant } from '@/lib/api/restaurant';
+import { getServerSession } from '@/lib/auth/session';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SettingsPage() {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
+  let restaurant;
+  try {
+    restaurant = await getMyRestaurant();
+  } catch (err) {
+    console.error('[settings page] /restaurants/me fetch failed', err);
+    return (
+      <section className="flex flex-1 flex-col gap-3 p-6 lg:p-10">
+        <h2 className="text-3xl font-medium tracking-tight">Settings</h2>
+        <p className="text-sm text-muted-foreground">
+          Could not reach the backend to load your restaurant configuration.
+        </p>
+      </section>
+    );
+  }
+
+  return <SettingsShell restaurant={restaurant} />;
 }

--- a/dashboard/app/actions/update-restaurant.ts
+++ b/dashboard/app/actions/update-restaurant.ts
@@ -1,0 +1,27 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import {
+  updateRestaurant,
+  type RestaurantUpdate,
+} from '@/lib/api/restaurant';
+
+export type UpdateRestaurantResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export async function updateRestaurantAction(
+  patch: RestaurantUpdate,
+): Promise<UpdateRestaurantResult> {
+  try {
+    await updateRestaurant(patch);
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    };
+  }
+  revalidatePath('/settings');
+  return { success: true };
+}

--- a/dashboard/components/settings/hours-editor.tsx
+++ b/dashboard/components/settings/hours-editor.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { updateRestaurantAction } from '@/app/actions/update-restaurant';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { DayHours, HoursStructured, Restaurant } from '@/lib/schemas/restaurant';
+
+const DAYS: { key: keyof HoursStructured; label: string }[] = [
+  { key: 'mon', label: 'Monday' },
+  { key: 'tue', label: 'Tuesday' },
+  { key: 'wed', label: 'Wednesday' },
+  { key: 'thu', label: 'Thursday' },
+  { key: 'fri', label: 'Friday' },
+  { key: 'sat', label: 'Saturday' },
+  { key: 'sun', label: 'Sunday' },
+];
+
+const DEFAULT_DAY: DayHours = { open: '11:00', close: '22:00', closed: false };
+
+function seedHours(r: Restaurant): HoursStructured {
+  if (r.hours_structured) return r.hours_structured;
+  return {
+    mon: { ...DEFAULT_DAY },
+    tue: { ...DEFAULT_DAY },
+    wed: { ...DEFAULT_DAY },
+    thu: { ...DEFAULT_DAY },
+    fri: { ...DEFAULT_DAY },
+    sat: { ...DEFAULT_DAY },
+    sun: { ...DEFAULT_DAY },
+  };
+}
+
+export function HoursEditor({ restaurant }: { restaurant: Restaurant }) {
+  const [hours, setHours] = useState<HoursStructured>(seedHours(restaurant));
+  const [pending, startTransition] = useTransition();
+
+  function update(day: keyof HoursStructured, patch: Partial<DayHours>) {
+    setHours((prev) => ({
+      ...prev,
+      [day]: { ...prev[day], ...patch },
+    }));
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await updateRestaurantAction({ hours_structured: hours });
+      if (!result.success) {
+        toast.error(`Save failed: ${result.error}`);
+        return;
+      }
+      toast.success('Hours saved.');
+    });
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h3 className="text-base font-medium">Hours</h3>
+      <p className="text-xs text-muted-foreground">
+        Times are local to the restaurant. Use 24-hour format. Niko reads
+        these to callers and routes after-hours calls to voicemail.
+      </p>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Day</TableHead>
+            <TableHead>Open</TableHead>
+            <TableHead>Close</TableHead>
+            <TableHead>Closed</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {DAYS.map(({ key, label }) => {
+            const day = hours[key];
+            return (
+              <TableRow key={key}>
+                <TableCell className="font-medium">{label}</TableCell>
+                <TableCell>
+                  <Label htmlFor={`open-${key}`} className="sr-only">
+                    {label} open time
+                  </Label>
+                  <Input
+                    id={`open-${key}`}
+                    type="time"
+                    value={day.open}
+                    disabled={day.closed}
+                    onChange={(e) => update(key, { open: e.target.value })}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Label htmlFor={`close-${key}`} className="sr-only">
+                    {label} close time
+                  </Label>
+                  <Input
+                    id={`close-${key}`}
+                    type="time"
+                    value={day.close}
+                    disabled={day.closed}
+                    onChange={(e) => update(key, { close: e.target.value })}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Label htmlFor={`closed-${key}`} className="sr-only">
+                    {label} closed
+                  </Label>
+                  <input
+                    id={`closed-${key}`}
+                    type="checkbox"
+                    checked={day.closed}
+                    onChange={(e) => update(key, { closed: e.target.checked })}
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      <div className="flex justify-end">
+        <Button type="button" onClick={handleSave} disabled={pending}>
+          {pending ? 'Saving…' : 'Save hours'}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/components/settings/restaurant-info-form.tsx
+++ b/dashboard/components/settings/restaurant-info-form.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { updateRestaurantAction } from '@/app/actions/update-restaurant';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { Restaurant } from '@/lib/schemas/restaurant';
+
+const E164 = /^\+\d{8,15}$/;
+
+export function RestaurantInfoForm({ restaurant }: { restaurant: Restaurant }) {
+  const [name, setName] = useState(restaurant.name);
+  const [address, setAddress] = useState(restaurant.address);
+  const [displayPhone, setDisplayPhone] = useState(restaurant.display_phone);
+  const [fallbackPhone, setFallbackPhone] = useState(
+    restaurant.fallback_phone ?? '',
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function buildPatch() {
+    const patch: Record<string, unknown> = {};
+    if (name !== restaurant.name) patch.name = name;
+    if (address !== restaurant.address) patch.address = address;
+    if (displayPhone !== restaurant.display_phone)
+      patch.display_phone = displayPhone;
+    const trimmedFallback = fallbackPhone.trim();
+    const restaurantFallback = restaurant.fallback_phone ?? '';
+    if (trimmedFallback !== restaurantFallback) {
+      patch.fallback_phone = trimmedFallback === '' ? null : trimmedFallback;
+    }
+    return patch;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedFallback = fallbackPhone.trim();
+    if (trimmedFallback !== '' && !E164.test(trimmedFallback)) {
+      setError('Fallback number must be in E.164 format (e.g. +15551234567).');
+      return;
+    }
+
+    const patch = buildPatch();
+    if (Object.keys(patch).length === 0) {
+      toast.info('Nothing to save.');
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await updateRestaurantAction(patch);
+      if (!result.success) {
+        setError(result.error);
+        toast.error('Save failed.');
+        return;
+      }
+      toast.success('Saved.');
+    });
+  }
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h3 className="text-base font-medium">Restaurant info</h3>
+      <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="restaurant-name">Restaurant name</Label>
+          <Input
+            id="restaurant-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="address">Address</Label>
+          <Input
+            id="address"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="display-phone">Display number</Label>
+          <Input
+            id="display-phone"
+            value={displayPhone}
+            onChange={(e) => setDisplayPhone(e.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            What customers dial. Forwards into Niko via your carrier.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="twilio-phone">Twilio number</Label>
+          <Input
+            id="twilio-phone"
+            value={restaurant.twilio_phone || '(awaiting)'}
+            readOnly
+            className="bg-muted"
+          />
+          <p className="text-xs text-muted-foreground">
+            Provisioned by Niko — not editable from here.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="fallback-phone">Fallback number</Label>
+          <Input
+            id="fallback-phone"
+            value={fallbackPhone}
+            placeholder="+15551234567"
+            onChange={(e) => setFallbackPhone(e.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            Niko transfers callers here when the AI hits a snag or the caller
+            asks for a human. Leave blank to skip the transfer attempt and go
+            straight to voicemail.
+          </p>
+        </div>
+
+        {error ? (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={pending}>
+            {pending ? 'Saving…' : 'Save info'}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/dashboard/components/settings/settings-shell.tsx
+++ b/dashboard/components/settings/settings-shell.tsx
@@ -1,0 +1,42 @@
+import type { Restaurant } from '@/lib/schemas/restaurant';
+
+import { HoursEditor } from '@/components/settings/hours-editor';
+import { RestaurantInfoForm } from '@/components/settings/restaurant-info-form';
+
+export function SettingsShell({ restaurant }: { restaurant: Restaurant }) {
+  return (
+    <section className="flex flex-1 flex-col gap-10 p-6 lg:p-10">
+      <header className="flex max-w-3xl flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-3xl font-medium tracking-tight">Settings</h2>
+          <span aria-hidden className="h-px flex-1 translate-y-[-0.5rem] bg-border" />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Restaurant info, hours, and call-handling fallbacks. Changes take
+          effect on the next call.
+        </p>
+      </header>
+
+      <div className="flex max-w-3xl flex-col gap-12">
+        <RestaurantInfoForm restaurant={restaurant} />
+        <HoursEditor restaurant={restaurant} />
+
+        <section className="flex flex-col gap-2 rounded-lg border border-dashed border-border p-6">
+          <h3 className="text-base font-medium">Stripe Connect</h3>
+          <p className="text-xs text-muted-foreground">
+            Configured during onboarding when delivery or prepay-for-pickup is
+            enabled. Lands in Sprint 2.3.
+          </p>
+        </section>
+
+        <section className="flex flex-col gap-2 rounded-lg border border-dashed border-border p-6">
+          <h3 className="text-base font-medium">SMS preferences</h3>
+          <p className="text-xs text-muted-foreground">
+            Order confirmations send by default. Opt-out toggles arrive
+            post-pilot.
+          </p>
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/lib/api/restaurant.ts
+++ b/dashboard/lib/api/restaurant.ts
@@ -7,13 +7,18 @@
  * updates to restaurant config aren't a Phase 2 concern (changes are
  * rare and mostly admin-driven), so no `onSnapshot` here.
  *
- * Endpoint:
- *   GET /restaurants/me   ← LIVE (app/main.py)
+ * Endpoints:
+ *   GET   /restaurants/me   ← LIVE (app/main.py)
+ *   PATCH /restaurants/me   ← LIVE (app/main.py)
  */
 import 'server-only';
 
 import { apiFetch } from '@/lib/api/http';
-import { RestaurantSchema, type Restaurant } from '@/lib/schemas/restaurant';
+import {
+  RestaurantSchema,
+  type HoursStructured,
+  type Restaurant,
+} from '@/lib/schemas/restaurant';
 
 export async function getMyRestaurant(): Promise<Restaurant> {
   const res = await apiFetch('/restaurants/me');
@@ -30,6 +35,40 @@ export async function getMyRestaurant(): Promise<Restaurant> {
       parsed.error.flatten(),
     );
     throw new Error('restaurant payload failed schema validation');
+  }
+  return parsed.data;
+}
+
+export type RestaurantUpdate = Partial<{
+  name: string;
+  display_phone: string;
+  address: string;
+  hours_structured: HoursStructured;
+  fallback_phone: string | null;
+  offers_delivery: boolean;
+}>;
+
+export async function updateRestaurant(
+  update: RestaurantUpdate,
+): Promise<Restaurant> {
+  const res = await apiFetch('/restaurants/me', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(update),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `PATCH /restaurants/me failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  const body = (await res.json()) as unknown;
+  const parsed = RestaurantSchema.safeParse(body);
+  if (!parsed.success) {
+    console.error(
+      '[lib/api/restaurant] PATCH response failed validation',
+      parsed.error.flatten(),
+    );
+    throw new Error('updated restaurant payload failed schema validation');
   }
   return parsed.data;
 }

--- a/dashboard/lib/schemas/restaurant.ts
+++ b/dashboard/lib/schemas/restaurant.ts
@@ -14,6 +14,26 @@
  */
 import { z } from 'zod';
 
+const HHMM = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export const DayHoursSchema = z.object({
+  open: z.string().regex(HHMM, 'must be HH:MM (24-hour)'),
+  close: z.string().regex(HHMM, 'must be HH:MM (24-hour)'),
+  closed: z.boolean(),
+});
+export type DayHours = z.infer<typeof DayHoursSchema>;
+
+export const HoursStructuredSchema = z.object({
+  mon: DayHoursSchema,
+  tue: DayHoursSchema,
+  wed: DayHoursSchema,
+  thu: DayHoursSchema,
+  fri: DayHoursSchema,
+  sat: DayHoursSchema,
+  sun: DayHoursSchema,
+});
+export type HoursStructured = z.infer<typeof HoursStructuredSchema>;
+
 export const RestaurantSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -21,6 +41,13 @@ export const RestaurantSchema = z.object({
   twilio_phone: z.string(),
   address: z.string(),
   hours: z.string(),
+  hours_structured: HoursStructuredSchema.nullable().default(null),
+  fallback_phone: z
+    .string()
+    .regex(/^\+\d{8,15}$/, 'must be E.164')
+    .nullable()
+    .default(null),
+  offers_delivery: z.boolean().default(true),
   menu: z.record(z.string(), z.unknown()).default({}),
   prompt_overrides: z.record(z.string(), z.string()).default({}),
   forwarding_mode: z.enum(['always', 'busy', 'noanswer']).default('always'),

--- a/dashboard/tests/__mocks__/server-only.ts
+++ b/dashboard/tests/__mocks__/server-only.ts
@@ -1,0 +1,4 @@
+// Stub for 'server-only'. The real package throws at import time when
+// bundled outside an RSC context. We swap it for this no-op in vitest
+// via the resolve.alias in vitest.config.mts.
+export {};

--- a/dashboard/tests/hours-editor.test.tsx
+++ b/dashboard/tests/hours-editor.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HoursEditor } from '@/components/settings/hours-editor';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/app/actions/update-restaurant', () => ({
+  updateRestaurantAction: vi.fn().mockResolvedValue({ success: true }),
+}));
+import { updateRestaurantAction } from '@/app/actions/update-restaurant';
+
+const day = { open: '11:00', close: '22:00', closed: false };
+const BASE = {
+  id: 'r1',
+  name: 'R',
+  display_phone: '+15551234567',
+  twilio_phone: '+15551234567',
+  address: '1 Main',
+  hours: 'Mon-Sun 11-22',
+  hours_structured: {
+    mon: day,
+    tue: day,
+    wed: day,
+    thu: day,
+    fri: day,
+    sat: day,
+    sun: day,
+  },
+  fallback_phone: null,
+  offers_delivery: true,
+  menu: {},
+  prompt_overrides: {},
+  forwarding_mode: 'always' as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('HoursEditor', () => {
+  it('renders seven day rows', () => {
+    render(<HoursEditor restaurant={BASE} />);
+    expect(screen.getAllByRole('row')).toHaveLength(7 + 1); // 7 days + header
+  });
+
+  it('seeds from hours_structured when present', () => {
+    render(<HoursEditor restaurant={BASE} />);
+    const opens = screen.getAllByLabelText(/open time/i);
+    expect(opens[0]).toHaveValue('11:00');
+  });
+
+  it('seeds with default 11:00-22:00 when hours_structured is null', () => {
+    render(<HoursEditor restaurant={{ ...BASE, hours_structured: null }} />);
+    const opens = screen.getAllByLabelText(/open time/i);
+    expect(opens[0]).toHaveValue('11:00');
+  });
+
+  it('disables open/close inputs when the day is marked closed', () => {
+    render(<HoursEditor restaurant={BASE} />);
+    const monClosed = screen.getByLabelText(/monday closed/i);
+    fireEvent.click(monClosed);
+    const opens = screen.getAllByLabelText(/open time/i);
+    expect(opens[0]).toBeDisabled();
+  });
+
+  it('submits hours_structured when saved', async () => {
+    render(<HoursEditor restaurant={BASE} />);
+    const monClosed = screen.getByLabelText(/monday closed/i);
+    fireEvent.click(monClosed);
+    fireEvent.click(screen.getByRole('button', { name: /save hours/i }));
+
+    await waitFor(() => {
+      expect(updateRestaurantAction).toHaveBeenCalled();
+      const call = (updateRestaurantAction as ReturnType<typeof vi.fn>).mock
+        .calls[0][0];
+      expect(call.hours_structured.mon.closed).toBe(true);
+    });
+  });
+});

--- a/dashboard/tests/restaurant-api.test.ts
+++ b/dashboard/tests/restaurant-api.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { updateRestaurant } from '@/lib/api/restaurant';
+
+vi.mock('@/lib/api/http', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/lib/api/http';
+
+describe('updateRestaurant', () => {
+  it('PATCHes /restaurants/me with the patch body and parses the response', async () => {
+    const updated = {
+      id: 'r1',
+      name: 'New Name',
+      display_phone: '+15551234567',
+      twilio_phone: '+15551234567',
+      address: '1 Main',
+      hours: 'Mon-Sun 11-22',
+      hours_structured: null,
+      fallback_phone: null,
+      offers_delivery: true,
+      menu: {},
+      prompt_overrides: {},
+      forwarding_mode: 'always',
+    };
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => updated,
+    });
+
+    const result = await updateRestaurant({ name: 'New Name' });
+
+    expect(apiFetch).toHaveBeenCalledWith('/restaurants/me', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'New Name' }),
+    });
+    expect(result.name).toBe('New Name');
+  });
+
+  it('throws when the response is not ok', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable',
+    });
+    await expect(updateRestaurant({ name: 'X' })).rejects.toThrow();
+  });
+});

--- a/dashboard/tests/restaurant-info-form.test.tsx
+++ b/dashboard/tests/restaurant-info-form.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RestaurantInfoForm } from '@/components/settings/restaurant-info-form';
+
+vi.mock('@/app/actions/update-restaurant', () => ({
+  updateRestaurantAction: vi.fn().mockResolvedValue({ success: true }),
+}));
+import { updateRestaurantAction } from '@/app/actions/update-restaurant';
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const BASE = {
+  id: 'r1',
+  name: 'Niko Pizza Kitchen',
+  display_phone: '+15551234567',
+  twilio_phone: '+16479058093',
+  address: '123 Main',
+  hours: 'Mon-Sun 11-22',
+  hours_structured: null,
+  fallback_phone: null,
+  offers_delivery: true,
+  menu: {},
+  prompt_overrides: {},
+  forwarding_mode: 'always' as const,
+};
+
+describe('RestaurantInfoForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits a patch with edited fields only', async () => {
+    render(<RestaurantInfoForm restaurant={BASE} />);
+
+    const nameInput = screen.getByLabelText(/restaurant name/i);
+    fireEvent.change(nameInput, { target: { value: 'New Name' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(updateRestaurantAction).toHaveBeenCalledWith({
+        name: 'New Name',
+      }),
+    );
+  });
+
+  it('shows the twilio_phone read-only', () => {
+    render(<RestaurantInfoForm restaurant={BASE} />);
+    const twilio = screen.getByLabelText(/twilio number/i);
+    expect(twilio).toHaveAttribute('readOnly');
+    expect(twilio).toHaveValue('+16479058093');
+  });
+
+  it('validates fallback_phone format on submit', async () => {
+    render(<RestaurantInfoForm restaurant={BASE} />);
+    const fallback = screen.getByLabelText(/fallback number/i);
+    fireEvent.change(fallback, { target: { value: 'abc' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await screen.findByText(/E\.164/i);
+    expect(updateRestaurantAction).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/tests/restaurant-schema.test.ts
+++ b/dashboard/tests/restaurant-schema.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { RestaurantSchema } from '@/lib/schemas/restaurant';
+
+const BASE = {
+  id: 'r1',
+  name: 'R',
+  display_phone: '+15551234567',
+  twilio_phone: '+15551234567',
+  address: '1 Main',
+  hours: 'Mon-Sun 11-22',
+};
+
+describe('RestaurantSchema', () => {
+  it('accepts a doc without hours_structured or fallback_phone', () => {
+    const parsed = RestaurantSchema.safeParse(BASE);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.hours_structured).toBeNull();
+      expect(parsed.data.fallback_phone).toBeNull();
+    }
+  });
+
+  it('accepts hours_structured with all seven days', () => {
+    const day = { open: '11:00', close: '22:00', closed: false };
+    const parsed = RestaurantSchema.safeParse({
+      ...BASE,
+      hours_structured: {
+        mon: day,
+        tue: day,
+        wed: day,
+        thu: day,
+        fri: day,
+        sat: day,
+        sun: { open: '00:00', close: '00:00', closed: true },
+      },
+      fallback_phone: '+15559999999',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects malformed hour times', () => {
+    const parsed = RestaurantSchema.safeParse({
+      ...BASE,
+      hours_structured: {
+        mon: { open: '99', close: '22:00', closed: false },
+        tue: { open: '11:00', close: '22:00', closed: false },
+        wed: { open: '11:00', close: '22:00', closed: false },
+        thu: { open: '11:00', close: '22:00', closed: false },
+        fri: { open: '11:00', close: '22:00', closed: false },
+        sat: { open: '11:00', close: '22:00', closed: false },
+        sun: { open: '11:00', close: '22:00', closed: false },
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/dashboard/vitest.config.mts
+++ b/dashboard/vitest.config.mts
@@ -6,6 +6,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '.'),
+      // 'server-only' is a Next.js guard that throws in non-RSC contexts.
+      // Stub it out for vitest so server-side modules can be unit-tested.
+      'server-only': path.resolve(__dirname, 'tests/__mocks__/server-only.ts'),
     },
   },
   test: {

--- a/tests/test_restaurants_api.py
+++ b/tests/test_restaurants_api.py
@@ -130,3 +130,27 @@ def test_patch_restaurant_validates_fallback_phone_format(client: TestClient):
     # rejected.
     resp = client.patch("/restaurants/me", json={"fallback_phone": "abc"})
     assert resp.status_code == 422
+
+
+def test_patch_restaurant_403_for_non_owner(client: TestClient, fake_tenant: Tenant):
+    """Staff and other non-owner roles cannot edit settings."""
+    import dataclasses
+
+    from app.auth.dependency import current_tenant
+
+    staff = dataclasses.replace(fake_tenant, role="staff")
+    app.dependency_overrides[current_tenant] = lambda: staff
+
+    _wire_storage(_existing_doc())
+    resp = client.patch("/restaurants/me", json={"name": "X"})
+    assert resp.status_code == 403
+
+
+def test_patch_restaurant_rejects_empty_strings(client: TestClient):
+    """Setting name/address/display_phone to empty string via PATCH must
+    fail validation rather than break the LLM prompt."""
+    _wire_storage(_existing_doc())
+
+    for field in ("name", "address", "display_phone"):
+        resp = client.patch("/restaurants/me", json={field: ""})
+        assert resp.status_code == 422, f"{field} empty should 422"

--- a/tests/test_restaurants_api.py
+++ b/tests/test_restaurants_api.py
@@ -1,0 +1,132 @@
+"""Integration tests for the dashboard-facing restaurants endpoints
+(``GET /restaurants/me`` already exists; this file covers the new
+``PATCH /restaurants/me``)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependency import Tenant, current_tenant
+from app.main import app
+from app.storage import restaurants as r_storage
+
+
+@pytest.fixture
+def fake_tenant():
+    return Tenant(
+        uid="user-1",
+        email="owner@niko.test",
+        restaurant_id="niko-pizza-kitchen",
+        role="owner",
+    )
+
+
+@pytest.fixture
+def client(fake_tenant: Tenant):
+    app.dependency_overrides[current_tenant] = lambda: fake_tenant
+    yield TestClient(app)
+    app.dependency_overrides.pop(current_tenant, None)
+
+
+@pytest.fixture(autouse=True)
+def reset_storage():
+    yield
+    r_storage.set_client(None)
+    r_storage.clear_cache()
+
+
+def _existing_doc() -> dict:
+    return {
+        "id": "niko-pizza-kitchen",
+        "name": "Niko Pizza Kitchen",
+        "display_phone": "+15551234567",
+        "twilio_phone": "+16479058093",
+        "address": "123 Main",
+        "hours": "Mon-Sun 11-22",
+        "menu": {},
+    }
+
+
+def _wire_storage(existing: dict) -> MagicMock:
+    fs = MagicMock()
+    r_storage.set_client(fs)
+    snap = MagicMock()
+    snap.exists = True
+    snap.to_dict.return_value = existing
+    fs.collection.return_value.document.return_value.get.return_value = snap
+    return fs
+
+
+def test_patch_restaurant_updates_name_and_address(client: TestClient):
+    fs = _wire_storage(_existing_doc())
+
+    resp = client.patch(
+        "/restaurants/me",
+        json={"name": "Niko Pizza Kitchen 2.0", "address": "456 New Street"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Niko Pizza Kitchen 2.0"
+    assert body["address"] == "456 New Street"
+    fs.collection.return_value.document.return_value.set.assert_called_once()
+
+
+def test_patch_restaurant_regenerates_hours_text_when_structured_changes(
+    client: TestClient,
+):
+    _wire_storage(_existing_doc())
+
+    structured = {
+        "mon": {"open": "11:00", "close": "22:00", "closed": False},
+        "tue": {"open": "11:00", "close": "22:00", "closed": False},
+        "wed": {"open": "11:00", "close": "22:00", "closed": False},
+        "thu": {"open": "11:00", "close": "22:00", "closed": False},
+        "fri": {"open": "11:00", "close": "23:00", "closed": False},
+        "sat": {"open": "11:00", "close": "23:00", "closed": False},
+        "sun": {"open": "00:00", "close": "00:00", "closed": True},
+    }
+    resp = client.patch(
+        "/restaurants/me",
+        json={"hours_structured": structured},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["hours_structured"] == structured
+    # Regenerated ``hours`` text should reflect the structured input
+    assert "Mon-Thu 11:00-22:00" in body["hours"]
+    assert "Sun: closed" in body["hours"]
+
+
+def test_patch_restaurant_rejects_unknown_fields(client: TestClient):
+    _wire_storage(_existing_doc())
+
+    resp = client.patch(
+        "/restaurants/me",
+        json={"id": "different-id", "twilio_phone": "+15550000000"},
+    )
+
+    # Pydantic strict-extra → 422
+    assert resp.status_code == 422
+
+
+def test_patch_restaurant_404_when_doc_missing(client: TestClient):
+    fs = MagicMock()
+    r_storage.set_client(fs)
+    snap = MagicMock()
+    snap.exists = False
+    fs.collection.return_value.document.return_value.get.return_value = snap
+
+    resp = client.patch("/restaurants/me", json={"name": "X"})
+    assert resp.status_code == 404
+
+
+def test_patch_restaurant_validates_fallback_phone_format(client: TestClient):
+    _wire_storage(_existing_doc())
+
+    # Loose validation: any non-empty E.164-like string is fine; "abc"
+    # rejected.
+    resp = client.patch("/restaurants/me", json={"fallback_phone": "abc"})
+    assert resp.status_code == 422

--- a/tests/test_restaurants_hours.py
+++ b/tests/test_restaurants_hours.py
@@ -1,0 +1,54 @@
+"""Unit tests for app.restaurants.hours.render_hours_text."""
+
+from app.restaurants.hours import render_hours_text
+from app.restaurants.models import DayHours, HoursStructured
+
+
+def _all_days(open_t: str, close_t: str, closed: bool = False) -> HoursStructured:
+    payload = DayHours(open=open_t, close=close_t, closed=closed)
+    return HoursStructured(
+        mon=payload,
+        tue=payload,
+        wed=payload,
+        thu=payload,
+        fri=payload,
+        sat=payload,
+        sun=payload,
+    )
+
+
+def test_render_hours_text_collapses_uniform_week():
+    """All seven days identical → "Mon-Sun 11:00-22:00"."""
+    text = render_hours_text(_all_days("11:00", "22:00"))
+    assert text == "Mon-Sun 11:00-22:00"
+
+
+def test_render_hours_text_handles_per_day_when_mixed():
+    h = HoursStructured(
+        mon=DayHours(open="11:00", close="22:00", closed=False),
+        tue=DayHours(open="11:00", close="22:00", closed=False),
+        wed=DayHours(open="11:00", close="22:00", closed=False),
+        thu=DayHours(open="11:00", close="22:00", closed=False),
+        fri=DayHours(open="11:00", close="23:00", closed=False),
+        sat=DayHours(open="11:00", close="23:00", closed=False),
+        sun=DayHours(open="00:00", close="00:00", closed=True),
+    )
+    text = render_hours_text(h)
+    assert "Mon" in text and "11:00-22:00" in text
+    assert "Fri" in text and "11:00-23:00" in text
+    assert "Sun: closed" in text
+
+
+def test_render_hours_text_marks_all_closed_day_as_closed():
+    h = HoursStructured(
+        mon=DayHours(open="00:00", close="00:00", closed=True),
+        tue=DayHours(open="11:00", close="22:00", closed=False),
+        wed=DayHours(open="11:00", close="22:00", closed=False),
+        thu=DayHours(open="11:00", close="22:00", closed=False),
+        fri=DayHours(open="11:00", close="22:00", closed=False),
+        sat=DayHours(open="11:00", close="22:00", closed=False),
+        sun=DayHours(open="11:00", close="22:00", closed=False),
+    )
+    text = render_hours_text(h)
+    assert "Mon: closed" in text
+    assert "Tue-Sun 11:00-22:00" in text

--- a/tests/test_restaurants_storage.py
+++ b/tests/test_restaurants_storage.py
@@ -246,3 +246,52 @@ def test_restaurant_recording_retention_rejects_zero_or_negative():
             menu={"pizzas": [], "sides": [], "drinks": []},
             recording_retention_days=0,
         )
+
+
+def test_restaurant_has_optional_hours_structured_and_fallback_phone():
+    """New optional fields land additively — old Firestore docs without
+    them must still validate."""
+    from app.restaurants.models import (
+        DayHours,
+        HoursStructured,
+        Restaurant,
+    )
+
+    legacy_doc = {
+        "id": "demo",
+        "name": "Demo",
+        "display_phone": "+15551234567",
+        "twilio_phone": "+15551234567",
+        "address": "123 Main",
+        "hours": "Mon-Sun 11-22",
+    }
+    legacy = Restaurant.model_validate(legacy_doc)
+    assert legacy.hours_structured is None
+    assert legacy.fallback_phone is None
+
+    structured = HoursStructured(
+        mon=DayHours(open="11:00", close="22:00", closed=False),
+        tue=DayHours(open="11:00", close="22:00", closed=False),
+        wed=DayHours(open="11:00", close="22:00", closed=False),
+        thu=DayHours(open="11:00", close="22:00", closed=False),
+        fri=DayHours(open="11:00", close="23:00", closed=False),
+        sat=DayHours(open="11:00", close="23:00", closed=False),
+        sun=DayHours(open="11:00", close="22:00", closed=True),
+    )
+    full = Restaurant.model_validate(
+        {**legacy_doc, "hours_structured": structured.model_dump(), "fallback_phone": "+15559999999"},
+    )
+    assert full.hours_structured is not None
+    assert full.hours_structured.sun.closed is True
+    assert full.fallback_phone == "+15559999999"
+
+
+def test_day_hours_rejects_invalid_time_format():
+    from app.restaurants.models import DayHours
+
+    import pytest
+
+    with pytest.raises(Exception):
+        DayHours(open="11", close="22:00", closed=False)
+    with pytest.raises(Exception):
+        DayHours(open="25:00", close="22:00", closed=False)


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 1 Phase A + B (Issue #7 deliverable 4 — \"Business hours and info editor\"). Replaces the dashboard's \`ComingSoon\` settings stub with a working settings page: restaurant info form (name, address, display number, fallback number) and a per-day hours editor. Also lands the cross-track \`fallback_phone\` and \`hours_structured\` fields that Track 2 (telephony) will consume.

## What landed

**Backend (Phase A):**
- \`Restaurant\` model gains optional \`hours_structured: HoursStructured\` (per-day open/close + closed bool) and \`fallback_phone: str\`. Backwards-compat with legacy docs (no migration).
- \`app/restaurants/hours.py\` — pure helper \`render_hours_text\` collapses HoursStructured into the LLM-readable \`hours: str\`.
- \`PATCH /restaurants/me\` endpoint with strict-extra \`RestaurantUpdate\` body. Owner-editable fields only (id + twilio_phone explicitly NOT patchable). When \`hours_structured\` is patched, regenerates \`hours: str\` so the prompt builder stays aligned. **Owner-role gate** (403 for staff/etc.). \`min_length=1\` on name/address/display_phone.

**Dashboard (Phase B):**
- \`RestaurantSchema\` extended with the new fields + Zod validators (HHMM regex, E.164, sensible defaults).
- \`updateRestaurant\` API helper (PATCH wrapper, Zod-validated response).
- Settings page replaces the \`ComingSoon\` stub. Server Component fetches the restaurant doc, renders \`SettingsShell\` with \`RestaurantInfoForm\` + \`HoursEditor\` + 2 placeholder cards (Stripe Connect for Sprint 2.3, SMS prefs for post-pilot).
- \`RestaurantInfoForm\` — diff-only patch, E.164 validation client-side, twilio_phone shown read-only.
- \`HoursEditor\` — 7-row table, per-day open/close + closed checkbox, disabled inputs when closed.
- Server Action \`updateRestaurantAction\` wraps the API call with revalidatePath + discriminated-union result.
- Vitest infra: \`server-only\` mock + alias so server-side helpers can be unit-tested.

## Cross-track contract pin

Track 2 (telephony — call transfer + voicemail) reads:
- \`Restaurant.fallback_phone\` — Track 2 \`<Dial>\`s here when AI fails / caller asks for human. Empty/null = skip transfer attempt.
- \`Restaurant.hours_structured\` — Track 2's \`is_open_now\` helper uses this for after-hours voicemail routing.

Both default safely (None → no transfer, None → assume open) so Track 2 can build in parallel without blocking on owners configuring values.

## Test plan

- [x] \`pytest tests/test_restaurants_storage.py tests/test_restaurants_hours.py tests/test_restaurants_api.py -v\` — 13 backend tests pass
- [x] \`cd dashboard && pnpm vitest run\` — 85/85 green across 12 files
- [x] \`cd dashboard && pnpm typecheck\` — clean
- [x] \`pytest tests/ -x\` — 272 passed / 1 skipped (Track 3 SMS suite preserved, no regressions)
- [ ] **Manual smoke (gating, owner does this):** Open \`/settings\`, edit name + fallback_phone + Sunday hours (mark closed), save, reload, verify persistence. Confirm staff role gets 403 from PATCH (use a non-owner test account).

## Follow-ups deliberately deferred

Flagged in the final niko-reviewer pass; non-blocking for pilot:

- **\`offers_delivery\` toggle in the form.** \`RestaurantUpdate\` type allows it but no UI control exists. Wire when needed; currently configured at provisioning time.
- **\`HoursEditor\` always sends full \`hours_structured\`** (no diff). Harmless (idempotent backend) but produces a \"saved\" toast on no-op clicks. Cosmetic.
- **Bare \`<input type=\"checkbox\">\`** in HoursEditor instead of ShadCN \`<Checkbox>\`. Minor convention drift; works fine; swap to Radix when convenient.
- **No cross-tenant scoping test.** Current dependency-override pattern doesn't exercise \`tenant.restaurant_id\` flowing into \`get_restaurant\`. Worth adding before Phase 2/3 to lock the invariant.
- **Verify LLM prompt parses the new \`render_hours_text\` output.** Output format is more precise (\`Mon-Sun 11:00-22:00\` vs prior \`11am-10pm\`); should still parse cleanly but worth a sanity check during the manual smoke.
- **Inline E.164 feedback while typing** (currently only on submit). UX polish.
- **Misleading comment in \`tests/test_restaurants_api.py:131\`** says \"Loose validation\" but the test asserts strict 422.

## Tasks → PR

| Plan task | Commit |
|---|---|
| T1.A.1 Restaurant schema | \`37b38a3\` |
| T1.A.2 PATCH endpoint | \`a30c3ac\` + \`cab304d\` (cleanup) |
| T1.B.3 Dashboard schema | \`1c2f1ff\` |
| T1.B.4 updateRestaurant helper | \`712b21e\` |
| T1.B.5 Settings page scaffold | \`6844d0d\` |
| T1.B.6 Info form | \`c94079f\` |
| T1.B.7 Hours editor | \`b2f2fa9\` |
| Final review fixes | \`d5cd91c\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)