### PR TITLE
Sprint 2.4 Track 1 Phase C+D — menu editor (#7)

### DIFF
--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -219,8 +219,14 @@ def _format_menu(restaurant: Restaurant) -> str:
         items = menu.get(category)
         if not isinstance(items, list) or not items:
             continue
+        available_items = [
+            i for i in items
+            if not (isinstance(i, dict) and i.get("available", True) is False)
+        ]
+        if not available_items:
+            continue
         lines.append(f"{_humanize_category(category)}:")
-        for item in items:
+        for item in available_items:
             name = item.get("name", "")
             if not name:
                 continue

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 import time
+from urllib.parse import unquote
 
 from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi.responses import RedirectResponse
@@ -15,7 +16,20 @@ from pydantic import BaseModel, Field, field_validator
 
 from app.auth import Tenant, current_tenant
 from app.restaurants.hours import render_hours_text
-from app.restaurants.models import HoursStructured
+from app.restaurants.menu_writes import (
+    DuplicateMenuItem,
+    MenuItemNotFound,
+    add_category,
+    add_menu_item,
+    delete_menu_item,
+    update_menu_item,
+)
+from app.restaurants.models import (
+    CategoryCreate,
+    HoursStructured,
+    MenuItemCreate,
+    MenuItemUpdate,
+)
 
 from app.config import settings
 from app.orders.lifecycle import (
@@ -153,6 +167,98 @@ def patch_restaurant(
         # "clear hours" UX surfaces.
 
     restaurants_storage.save_restaurant(updated)  # also refreshes the in-process cache for this rid
+    return updated.model_dump(mode="json")
+
+
+def _require_owner(tenant: Tenant) -> None:
+    """Owner role check — settings + menu CRUD are owner-scope.
+    Mirrors the gate in patch_restaurant."""
+    if tenant.role != "owner":
+        raise HTTPException(
+            status_code=403,
+            detail="owner role required",
+        )
+
+
+@app.post("/restaurants/me/menu/items", status_code=201)
+def post_menu_item(
+    item: MenuItemCreate,
+    tenant: Tenant = Depends(current_tenant),
+):
+    _require_owner(tenant)
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+    try:
+        updated = add_menu_item(restaurant, item)
+    except DuplicateMenuItem as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    restaurants_storage.save_restaurant(updated)
+    return updated.model_dump(mode="json")
+
+
+@app.patch("/restaurants/me/menu/items/{category}/{name}")
+def patch_menu_item(
+    category: str,
+    name: str,
+    update: MenuItemUpdate,
+    tenant: Tenant = Depends(current_tenant),
+):
+    _require_owner(tenant)
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+    try:
+        updated = update_menu_item(
+            restaurant,
+            category=unquote(category),
+            name=unquote(name),
+            update=update,
+        )
+    except MenuItemNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except DuplicateMenuItem as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    restaurants_storage.save_restaurant(updated)
+    return updated.model_dump(mode="json")
+
+
+@app.delete("/restaurants/me/menu/items/{category}/{name}")
+def delete_menu_item_endpoint(
+    category: str,
+    name: str,
+    tenant: Tenant = Depends(current_tenant),
+):
+    _require_owner(tenant)
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+    try:
+        updated = delete_menu_item(
+            restaurant,
+            category=unquote(category),
+            name=unquote(name),
+        )
+    except MenuItemNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    restaurants_storage.save_restaurant(updated)
+    return updated.model_dump(mode="json")
+
+
+@app.post("/restaurants/me/menu/categories", status_code=201)
+def post_menu_category(
+    category: CategoryCreate,
+    tenant: Tenant = Depends(current_tenant),
+):
+    _require_owner(tenant)
+    restaurant = restaurants_storage.get_restaurant(tenant.restaurant_id)
+    if restaurant is None:
+        raise HTTPException(status_code=404, detail="restaurant not found")
+    try:
+        updated = add_category(restaurant, category)
+    except DuplicateMenuItem as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    restaurants_storage.save_restaurant(updated)
     return updated.model_dump(mode="json")
 
 

--- a/app/restaurants/menu_writes.py
+++ b/app/restaurants/menu_writes.py
@@ -81,25 +81,27 @@ def update_menu_item(
     idx = _find_item(menu, category, name)
     item = dict(menu[category][idx])
 
-    if update.new_name is not None:
-        target_cat = update.new_category or category
+    effective_name = update.new_name if update.new_name is not None else name
+    target_cat = update.new_category if update.new_category is not None else category
+    if update.new_name is not None or (update.new_category is not None and update.new_category != category):
         target_items = (
             menu.get(target_cat, [])
             if target_cat != category
             else menu[category]
         )
-        # Reject rename collision — but allow renaming to same value
-        # (no-op) by skipping the index of the item being modified.
+        # Reject collision in target — but allow same-name same-category
+        # no-op by skipping the index of the item being modified.
         for i_idx, i in enumerate(target_items):
             if not isinstance(i, dict):
                 continue
-            if i.get("name") != update.new_name:
+            if i.get("name") != effective_name:
                 continue
             if target_cat == category and i_idx == idx:
                 continue
             raise DuplicateMenuItem(
-                f"item {update.new_name!r} already exists in {target_cat!r}"
+                f"item {effective_name!r} already exists in {target_cat!r}"
             )
+    if update.new_name is not None:
         item["name"] = update.new_name
     if update.description is not None:
         item["description"] = update.description

--- a/app/restaurants/menu_writes.py
+++ b/app/restaurants/menu_writes.py
@@ -1,0 +1,140 @@
+"""Pure-function menu mutations on a Restaurant.menu dict.
+
+The dashboard's editor sends granular create/update/delete operations
+against this module's functions; the FastAPI handler reads the
+restaurant doc, calls the helper, writes the new doc back. Keeping the
+logic free of Firestore I/O lets us unit-test mutations without mocks.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from app.restaurants.models import (
+    CategoryCreate,
+    MenuItemCreate,
+    MenuItemUpdate,
+    Restaurant,
+)
+
+
+class MenuItemNotFound(KeyError):
+    """The (category, name) pair didn't match any item."""
+
+
+class DuplicateMenuItem(ValueError):
+    """An item with this name already exists in the target category,
+    or the target category already exists."""
+
+
+_RESERVED_KEYS = {"_category_order"}
+
+
+def _menu_copy(r: Restaurant) -> dict[str, Any]:
+    return deepcopy(r.menu)
+
+
+def add_menu_item(r: Restaurant, item: MenuItemCreate) -> Restaurant:
+    menu = _menu_copy(r)
+    cat = menu.setdefault(item.category, [])
+    if any(existing.get("name") == item.name for existing in cat):
+        raise DuplicateMenuItem(
+            f"item {item.name!r} already exists in category {item.category!r}"
+        )
+
+    payload: dict[str, Any] = {
+        "name": item.name,
+        "available": item.available,
+    }
+    if item.description:
+        payload["description"] = item.description
+    if item.price is not None:
+        payload["price"] = item.price
+    if item.sizes is not None:
+        payload["sizes"] = dict(item.sizes)
+
+    cat.append(payload)
+    return r.model_copy(update={"menu": menu})
+
+
+def _find_item(menu: dict[str, Any], category: str, name: str) -> int:
+    items = menu.get(category)
+    if not isinstance(items, list):
+        raise MenuItemNotFound(f"category {category!r} not found")
+    for idx, item in enumerate(items):
+        if isinstance(item, dict) and item.get("name") == name:
+            return idx
+    raise MenuItemNotFound(
+        f"item {name!r} not found in category {category!r}"
+    )
+
+
+def update_menu_item(
+    r: Restaurant,
+    *,
+    category: str,
+    name: str,
+    update: MenuItemUpdate,
+) -> Restaurant:
+    menu = _menu_copy(r)
+    idx = _find_item(menu, category, name)
+    item = dict(menu[category][idx])
+
+    if update.new_name is not None:
+        target_cat = update.new_category or category
+        target_items = (
+            menu.get(target_cat, [])
+            if target_cat != category
+            else menu[category]
+        )
+        # Reject rename collision — but allow renaming to same value
+        # (no-op) by skipping the index of the item being modified.
+        for i_idx, i in enumerate(target_items):
+            if not isinstance(i, dict):
+                continue
+            if i.get("name") != update.new_name:
+                continue
+            if target_cat == category and i_idx == idx:
+                continue
+            raise DuplicateMenuItem(
+                f"item {update.new_name!r} already exists in {target_cat!r}"
+            )
+        item["name"] = update.new_name
+    if update.description is not None:
+        item["description"] = update.description
+    if update.available is not None:
+        item["available"] = update.available
+    if update.price is not None:
+        item["price"] = update.price
+        item.pop("sizes", None)
+    if update.sizes is not None:
+        item["sizes"] = dict(update.sizes)
+        item.pop("price", None)
+
+    if update.new_category is not None and update.new_category != category:
+        menu[category].pop(idx)
+        menu.setdefault(update.new_category, []).append(item)
+    else:
+        menu[category][idx] = item
+
+    return r.model_copy(update={"menu": menu})
+
+
+def delete_menu_item(
+    r: Restaurant, *, category: str, name: str
+) -> Restaurant:
+    menu = _menu_copy(r)
+    idx = _find_item(menu, category, name)
+    menu[category].pop(idx)
+    return r.model_copy(update={"menu": menu})
+
+
+def add_category(r: Restaurant, category: CategoryCreate) -> Restaurant:
+    menu = _menu_copy(r)
+    if category.key in _RESERVED_KEYS or category.key in menu:
+        raise DuplicateMenuItem(
+            f"category {category.key!r} already exists"
+        )
+    menu[category.key] = []
+    return r.model_copy(update={"menu": menu})

--- a/app/restaurants/models.py
+++ b/app/restaurants/models.py
@@ -137,7 +137,7 @@ class MenuItemCreate(BaseModel):
 
     model_config = {"extra": "forbid"}
 
-    category: str = Field(min_length=1)
+    category: str = Field(min_length=1, pattern=r"^[a-z0-9][a-z0-9_]*$")
     name: str = Field(min_length=1)
     description: Optional[str] = None
     price: Optional[float] = Field(default=None, ge=0)
@@ -169,7 +169,7 @@ class MenuItemUpdate(BaseModel):
     model_config = {"extra": "forbid"}
 
     new_name: Optional[str] = Field(default=None, min_length=1)
-    new_category: Optional[str] = Field(default=None, min_length=1)
+    new_category: Optional[str] = Field(default=None, min_length=1, pattern=r"^[a-z0-9][a-z0-9_]*$")
     description: Optional[str] = None
     price: Optional[float] = Field(default=None, ge=0)
     sizes: Optional[dict[str, float]] = Field(default=None, min_length=1)

--- a/app/restaurants/models.py
+++ b/app/restaurants/models.py
@@ -55,7 +55,7 @@ import re
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 def _now_utc() -> datetime:
@@ -129,3 +129,59 @@ class Restaurant(BaseModel):
     fallback_phone: Optional[str] = None
     created_at: datetime = Field(default_factory=_now_utc)
     updated_at: datetime = Field(default_factory=_now_utc)
+
+
+class MenuItemCreate(BaseModel):
+    """Body for POST /restaurants/me/menu/items. Exactly one of
+    ``price`` or ``sizes`` is required."""
+
+    model_config = {"extra": "forbid"}
+
+    category: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    description: Optional[str] = None
+    price: Optional[float] = Field(default=None, ge=0)
+    sizes: Optional[dict[str, float]] = None
+    available: bool = True
+
+    @model_validator(mode="after")
+    def _exactly_one_price(self):
+        has_price = self.price is not None
+        has_sizes = self.sizes is not None and len(self.sizes) > 0
+        if has_price and has_sizes:
+            raise ValueError("specify exactly one of price or sizes, not both")
+        if not has_price and not has_sizes:
+            raise ValueError("specify either price or sizes")
+        if has_sizes:
+            for size_name, price in (self.sizes or {}).items():
+                if price < 0:
+                    raise ValueError(
+                        f"size {size_name!r} price must be non-negative"
+                    )
+        return self
+
+
+class MenuItemUpdate(BaseModel):
+    """Body for PATCH /restaurants/me/menu/items/{category}/{name}.
+    All fields optional. Specifying both ``price`` and ``sizes``
+    together is an error; specifying one clears the other on save."""
+
+    model_config = {"extra": "forbid"}
+
+    new_name: Optional[str] = Field(default=None, min_length=1)
+    new_category: Optional[str] = Field(default=None, min_length=1)
+    description: Optional[str] = None
+    price: Optional[float] = Field(default=None, ge=0)
+    sizes: Optional[dict[str, float]] = None
+    available: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def _not_both_price_and_sizes(self):
+        if self.price is not None and self.sizes is not None:
+            raise ValueError("specify at most one of price or sizes")
+        return self
+
+
+class CategoryCreate(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(min_length=1, pattern=r"^[a-z0-9_]+$")

--- a/app/restaurants/models.py
+++ b/app/restaurants/models.py
@@ -141,13 +141,13 @@ class MenuItemCreate(BaseModel):
     name: str = Field(min_length=1)
     description: Optional[str] = None
     price: Optional[float] = Field(default=None, ge=0)
-    sizes: Optional[dict[str, float]] = None
+    sizes: Optional[dict[str, float]] = Field(default=None, min_length=1)
     available: bool = True
 
     @model_validator(mode="after")
     def _exactly_one_price(self):
         has_price = self.price is not None
-        has_sizes = self.sizes is not None and len(self.sizes) > 0
+        has_sizes = self.sizes is not None
         if has_price and has_sizes:
             raise ValueError("specify exactly one of price or sizes, not both")
         if not has_price and not has_sizes:
@@ -172,16 +172,22 @@ class MenuItemUpdate(BaseModel):
     new_category: Optional[str] = Field(default=None, min_length=1)
     description: Optional[str] = None
     price: Optional[float] = Field(default=None, ge=0)
-    sizes: Optional[dict[str, float]] = None
+    sizes: Optional[dict[str, float]] = Field(default=None, min_length=1)
     available: Optional[bool] = None
 
     @model_validator(mode="after")
-    def _not_both_price_and_sizes(self):
+    def _validate_sizes(self):
         if self.price is not None and self.sizes is not None:
             raise ValueError("specify at most one of price or sizes")
+        if self.sizes is not None:
+            for size_name, price in self.sizes.items():
+                if price < 0:
+                    raise ValueError(
+                        f"size {size_name!r} price must be non-negative"
+                    )
         return self
 
 
 class CategoryCreate(BaseModel):
     model_config = {"extra": "forbid"}
-    key: str = Field(min_length=1, pattern=r"^[a-z0-9_]+$")
+    key: str = Field(min_length=1, pattern=r"^[a-z0-9][a-z0-9_]*$")

--- a/dashboard/app/(dashboard)/menu/page.tsx
+++ b/dashboard/app/(dashboard)/menu/page.tsx
@@ -1,15 +1,13 @@
 import { redirect } from 'next/navigation';
 
+import { MenuEditor } from '@/components/menu/menu-editor';
 import { MenuEmptyState } from '@/components/menu/menu-empty-state';
 import { MenuParseError } from '@/components/menu/menu-parse-error';
-import { MenuView } from '@/components/menu/menu-view';
 import { getMyRestaurant } from '@/lib/api/restaurant';
 import { getServerSession } from '@/lib/auth/session';
 import { humanizeRestaurantId } from '@/lib/formatters/restaurant';
 import { parseMenu } from '@/lib/schemas/menu';
 
-// Menu config is admin-driven — Firestore writes are rare and we want the
-// page to always reflect the latest doc, not a cached render.
 export const dynamic = 'force-dynamic';
 
 export default async function MenuPage() {
@@ -41,7 +39,7 @@ export default async function MenuPage() {
   }
 
   return (
-    <MenuView
+    <MenuEditor
       categories={result.categories}
       itemCount={result.itemCount}
       restaurantName={restaurantName}

--- a/dashboard/app/actions/edit-menu.ts
+++ b/dashboard/app/actions/edit-menu.ts
@@ -1,0 +1,60 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import {
+  createMenuCategory,
+  createMenuItem,
+  deleteMenuItem,
+  updateMenuItem,
+  type CreateMenuItem,
+  type UpdateMenuItem,
+} from '@/lib/api/menu';
+
+export type ActionResult =
+  | { success: true }
+  | { success: false; error: string };
+
+function wrap<T>(work: () => Promise<T>): Promise<ActionResult> {
+  return work()
+    .then(() => ({ success: true as const }))
+    .catch((err) => ({
+      success: false as const,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    }));
+}
+
+export async function createMenuItemAction(
+  payload: CreateMenuItem,
+): Promise<ActionResult> {
+  const result = await wrap(() => createMenuItem(payload));
+  revalidatePath('/menu');
+  return result;
+}
+
+export async function updateMenuItemAction(args: {
+  category: string;
+  name: string;
+  patch: UpdateMenuItem;
+}): Promise<ActionResult> {
+  const result = await wrap(() => updateMenuItem(args));
+  revalidatePath('/menu');
+  return result;
+}
+
+export async function deleteMenuItemAction(args: {
+  category: string;
+  name: string;
+}): Promise<ActionResult> {
+  const result = await wrap(() => deleteMenuItem(args));
+  revalidatePath('/menu');
+  return result;
+}
+
+export async function createCategoryAction(payload: {
+  key: string;
+}): Promise<ActionResult> {
+  const result = await wrap(() => createMenuCategory(payload));
+  revalidatePath('/menu');
+  return result;
+}

--- a/dashboard/components/menu/add-category-dialog.tsx
+++ b/dashboard/components/menu/add-category-dialog.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { createCategoryAction } from '@/app/actions/edit-menu';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export function AddCategoryDialog({ onClose }: { onClose: () => void }) {
+  const [key, setKey] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function submit() {
+    setError(null);
+    const cleaned = key.trim().toLowerCase().replace(/\s+/g, '_');
+    if (!/^[a-z0-9][a-z0-9_]*$/.test(cleaned)) {
+      setError('Use letters, numbers, and underscores only. Must not start with an underscore.');
+      return;
+    }
+    startTransition(async () => {
+      const result = await createCategoryAction({ key: cleaned });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      toast.success(`Category ${cleaned} added.`);
+      onClose();
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (!open ? onClose() : null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add category</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="cat-key">Key</Label>
+          <Input
+            id="cat-key"
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            placeholder="e.g. drinks or caribbean_appetizers"
+            autoFocus
+          />
+          <p className="text-xs text-muted-foreground">
+            Lowercase, underscores instead of spaces. Display name is
+            generated automatically.
+          </p>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={pending} type="button">
+            {pending ? 'Adding…' : 'Add category'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/components/menu/add-item-dialog.tsx
+++ b/dashboard/components/menu/add-item-dialog.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { createMenuItemAction } from '@/app/actions/edit-menu';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export function AddItemDialog({
+  category,
+  onClose,
+}: {
+  category: string;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [price, setPrice] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function submit() {
+    setError(null);
+    if (!name.trim()) {
+      setError('Name is required.');
+      return;
+    }
+    const priceNum = Number(price);
+    if (!Number.isFinite(priceNum) || priceNum < 0) {
+      setError('Price must be a non-negative number.');
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await createMenuItemAction({
+        category,
+        name: name.trim(),
+        price: priceNum,
+        description: description.trim() || undefined,
+      });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      toast.success(`${name} added.`);
+      onClose();
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (!open ? onClose() : null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add item to {category}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="item-name">Name</Label>
+            <Input
+              id="item-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              autoFocus
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="item-price">Price (CAD)</Label>
+            <Input
+              id="item-price"
+              type="number"
+              min="0"
+              step="0.01"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="item-desc">Description (optional)</Label>
+            <Input
+              id="item-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={pending} type="button">
+            {pending ? 'Adding…' : 'Add item'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/components/menu/item-edit-dialog.tsx
+++ b/dashboard/components/menu/item-edit-dialog.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { updateMenuItemAction } from '@/app/actions/edit-menu';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { type MenuItem, isSizedItem } from '@/lib/schemas/menu';
+
+export function ItemEditDialog({
+  category,
+  item,
+  onClose,
+}: {
+  category: string;
+  item: MenuItem;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState(item.name);
+  const [price, setPrice] = useState(
+    isSizedItem(item) ? '' : String(item.price),
+  );
+  const [description, setDescription] = useState(item.description ?? '');
+  const [available, setAvailable] = useState(item.available !== false);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function submit() {
+    setError(null);
+    const patch: Record<string, unknown> = {};
+    if (name.trim() !== item.name) patch.new_name = name.trim();
+    if (description.trim() !== (item.description ?? '')) {
+      patch.description = description.trim();
+    }
+    if (available !== (item.available !== false)) {
+      patch.available = available;
+    }
+    if (!isSizedItem(item)) {
+      const priceNum = Number(price);
+      if (!Number.isFinite(priceNum) || priceNum < 0) {
+        setError('Price must be a non-negative number.');
+        return;
+      }
+      if (priceNum !== item.price) patch.price = priceNum;
+    }
+
+    if (Object.keys(patch).length === 0) {
+      onClose();
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await updateMenuItemAction({
+        category,
+        name: item.name,
+        patch,
+      });
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+      toast.success(`${item.name} updated.`);
+      onClose();
+    });
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => (!open ? onClose() : null)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit {item.name}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-name">Name</Label>
+            <Input
+              id="edit-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          {isSizedItem(item) ? (
+            <p className="text-xs text-muted-foreground">
+              This item has size variants. Editing size prices isn&apos;t yet
+              supported in the dashboard — contact support to update.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-price">Price (CAD)</Label>
+              <Input
+                id="edit-price"
+                type="number"
+                min="0"
+                step="0.01"
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+              />
+            </div>
+          )}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edit-desc">Description</Label>
+            <Input
+              id="edit-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              id="edit-available"
+              type="checkbox"
+              checked={available}
+              onChange={(e) => setAvailable(e.target.checked)}
+            />
+            <Label htmlFor="edit-available">Available right now</Label>
+          </div>
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={pending} type="button">
+            {pending ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/components/menu/menu-editor.tsx
+++ b/dashboard/components/menu/menu-editor.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState } from 'react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { AddCategoryDialog } from '@/components/menu/add-category-dialog';
+import { AddItemDialog } from '@/components/menu/add-item-dialog';
+import { ItemEditDialog } from '@/components/menu/item-edit-dialog';
+import { Button } from '@/components/ui/button';
+import { deleteMenuItemAction } from '@/app/actions/edit-menu';
+import { formatCAD } from '@/lib/formatters/money';
+import {
+  type Category,
+  type MenuItem,
+  humanizeCategoryKey,
+  isSizedItem,
+} from '@/lib/schemas/menu';
+
+type Props = {
+  categories: Category[];
+  itemCount: number;
+  restaurantName: string;
+};
+
+export function MenuEditor({
+  categories,
+  itemCount,
+  restaurantName,
+}: Props) {
+  const [editing, setEditing] = useState<{
+    category: string;
+    item: MenuItem;
+  } | null>(null);
+  const [addingTo, setAddingTo] = useState<string | null>(null);
+  const [addingCategory, setAddingCategory] = useState(false);
+
+  async function handleDelete(category: string, name: string) {
+    if (!confirm(`Delete "${name}" from ${humanizeCategoryKey(category)}?`)) {
+      return;
+    }
+    const result = await deleteMenuItemAction({ category, name });
+    if (!result.success) {
+      toast.error(`Delete failed: ${result.error}`);
+      return;
+    }
+    toast.success('Item deleted.');
+  }
+
+  return (
+    <section className="flex flex-1 flex-col gap-10 p-6 lg:p-10">
+      <header className="flex max-w-3xl flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-3xl font-medium tracking-tight">Menu</h2>
+          <span aria-hidden className="h-px flex-1 translate-y-[-0.5rem] bg-border" />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => setAddingCategory(true)}
+          >
+            <Plus className="h-4 w-4" /> Add category
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {restaurantName}
+          <span className="mx-2 text-muted-foreground/40">·</span>
+          <span className="tabular-nums">{categories.length}</span>{' '}
+          {categories.length === 1 ? 'category' : 'categories'}
+          <span className="mx-2 text-muted-foreground/40">·</span>
+          <span className="tabular-nums">{itemCount}</span>{' '}
+          {itemCount === 1 ? 'item' : 'items'}
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-14">
+        {categories.map((c) => (
+          <section
+            key={c.key}
+            id={`category-${c.key}`}
+            className="scroll-mt-8"
+          >
+            <header className="mb-6 flex items-baseline gap-4 border-b border-border pb-3">
+              <h3 className="text-xl font-medium tracking-tight">
+                {humanizeCategoryKey(c.key)}
+              </h3>
+              <span aria-hidden className="h-px flex-1 bg-border/60" />
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setAddingTo(c.key)}
+              >
+                <Plus className="h-4 w-4" /> Add item
+              </Button>
+            </header>
+
+            <ul className="grid gap-x-12 gap-y-6 sm:grid-cols-2">
+              {c.items.map((item, idx) => (
+                <li key={`${c.key}-${idx}-${item.name}`}>
+                  <article className="flex flex-col gap-1.5">
+                    <div className="flex items-baseline gap-3">
+                      <h4
+                        className={`font-medium leading-snug ${
+                          item.available === false
+                            ? 'text-muted-foreground line-through'
+                            : 'text-foreground'
+                        }`}
+                      >
+                        {item.name}
+                        {item.available === false ? (
+                          <span className="ml-2 rounded-md bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                            unavailable
+                          </span>
+                        ) : null}
+                      </h4>
+                      <span
+                        aria-hidden
+                        className="min-w-4 flex-1 translate-y-[-0.25rem] border-b border-dotted border-border"
+                      />
+                      <span className="font-mono text-sm tabular-nums text-foreground">
+                        {isSizedItem(item)
+                          ? Object.entries(item.sizes)
+                              .map(
+                                ([size, price]) =>
+                                  `${size} ${formatCAD(price)}`,
+                              )
+                              .join(' · ')
+                          : formatCAD(item.price)}
+                      </span>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        aria-label={`Edit ${item.name}`}
+                        onClick={() =>
+                          setEditing({ category: c.key, item })
+                        }
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        aria-label={`Delete ${item.name}`}
+                        onClick={() => handleDelete(c.key, item.name)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    {item.description ? (
+                      <p className="text-xs leading-relaxed text-muted-foreground">
+                        {item.description}
+                      </p>
+                    ) : null}
+                  </article>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+
+      {editing ? (
+        <ItemEditDialog
+          category={editing.category}
+          item={editing.item}
+          onClose={() => setEditing(null)}
+        />
+      ) : null}
+      {addingTo ? (
+        <AddItemDialog
+          category={addingTo}
+          onClose={() => setAddingTo(null)}
+        />
+      ) : null}
+      {addingCategory ? (
+        <AddCategoryDialog onClose={() => setAddingCategory(false)} />
+      ) : null}
+    </section>
+  );
+}

--- a/dashboard/lib/api/menu.ts
+++ b/dashboard/lib/api/menu.ts
@@ -1,0 +1,92 @@
+/**
+ * HTTP client for the FastAPI menu CRUD endpoints.
+ *
+ * Server-only. All four mutations return the full updated Restaurant doc
+ * so callers can revalidate their local state without an extra GET.
+ *
+ * Endpoints (Sprint 2.4 backend, commit 5b6ab8e):
+ *   POST   /restaurants/me/menu/items
+ *   PATCH  /restaurants/me/menu/items/:category/:name
+ *   DELETE /restaurants/me/menu/items/:category/:name
+ *   POST   /restaurants/me/menu/categories
+ */
+import 'server-only';
+
+import { apiFetch } from '@/lib/api/http';
+import { RestaurantSchema, type Restaurant } from '@/lib/schemas/restaurant';
+
+export type CreateMenuItem = {
+  category: string;
+  name: string;
+  description?: string;
+  available?: boolean;
+  price?: number;
+  sizes?: Record<string, number>;
+};
+
+export type UpdateMenuItem = {
+  new_name?: string;
+  new_category?: string;
+  description?: string;
+  price?: number;
+  sizes?: Record<string, number>;
+  available?: boolean;
+};
+
+async function parseRestaurant(res: Response, what: string): Promise<Restaurant> {
+  if (!res.ok) {
+    throw new Error(`${what} failed: ${res.status} ${res.statusText}`);
+  }
+  const body = (await res.json()) as unknown;
+  const parsed = RestaurantSchema.safeParse(body);
+  if (!parsed.success) {
+    console.error(`[lib/api/menu] ${what} response failed validation`);
+    throw new Error(`${what} response failed schema validation`);
+  }
+  return parsed.data;
+}
+
+export async function createMenuItem(
+  payload: CreateMenuItem,
+): Promise<Restaurant> {
+  const res = await apiFetch('/restaurants/me/menu/items', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return parseRestaurant(res, 'POST /menu/items');
+}
+
+export async function updateMenuItem(args: {
+  category: string;
+  name: string;
+  patch: UpdateMenuItem;
+}): Promise<Restaurant> {
+  const url = `/restaurants/me/menu/items/${encodeURIComponent(args.category)}/${encodeURIComponent(args.name)}`;
+  const res = await apiFetch(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(args.patch),
+  });
+  return parseRestaurant(res, 'PATCH /menu/items');
+}
+
+export async function deleteMenuItem(args: {
+  category: string;
+  name: string;
+}): Promise<Restaurant> {
+  const url = `/restaurants/me/menu/items/${encodeURIComponent(args.category)}/${encodeURIComponent(args.name)}`;
+  const res = await apiFetch(url, { method: 'DELETE' });
+  return parseRestaurant(res, 'DELETE /menu/items');
+}
+
+export async function createMenuCategory(payload: {
+  key: string;
+}): Promise<Restaurant> {
+  const res = await apiFetch('/restaurants/me/menu/categories', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return parseRestaurant(res, 'POST /menu/categories');
+}

--- a/dashboard/lib/schemas/menu.ts
+++ b/dashboard/lib/schemas/menu.ts
@@ -33,6 +33,7 @@ const CATEGORY_ORDER_KEY = '_category_order';
 export const SizedItemSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
+  available: z.boolean().default(true),
   sizes: z
     .record(z.string().min(1), z.number().nonnegative())
     .refine((s) => Object.keys(s).length > 0, {
@@ -44,6 +45,7 @@ export type SizedItem = z.infer<typeof SizedItemSchema>;
 export const SinglePriceItemSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
+  available: z.boolean().default(true),
   price: z.number().nonnegative(),
 });
 export type SinglePriceItem = z.infer<typeof SinglePriceItemSchema>;

--- a/dashboard/tests/menu-api.test.ts
+++ b/dashboard/tests/menu-api.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createMenuItem,
+  createMenuCategory,
+  deleteMenuItem,
+  updateMenuItem,
+} from '@/lib/api/menu';
+
+vi.mock('@/lib/api/http', () => ({
+  apiFetch: vi.fn(),
+}));
+import { apiFetch } from '@/lib/api/http';
+
+const okJson = (body: unknown) =>
+  ({ ok: true, json: async () => body }) as Response;
+
+const FAKE_RESTAURANT = {
+  id: 'r1',
+  name: 'R',
+  display_phone: '+15551234567',
+  twilio_phone: '+15551234567',
+  address: '1 Main',
+  hours: '11-22',
+  hours_structured: null,
+  fallback_phone: null,
+  offers_delivery: true,
+  menu: {
+    pizzas: [{ name: 'Margherita', price: 12.99, available: true }],
+  },
+  prompt_overrides: {},
+  forwarding_mode: 'always',
+};
+
+describe('menu api helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('createMenuItem POSTs and returns parsed restaurant', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      okJson(FAKE_RESTAURANT),
+    );
+    const r = await createMenuItem({
+      category: 'pizzas',
+      name: 'Pepperoni',
+      price: 15.99,
+    });
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/restaurants/me/menu/items',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(r.id).toBe('r1');
+  });
+
+  it('updateMenuItem PATCHes with URL-encoded names', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      okJson(FAKE_RESTAURANT),
+    );
+    await updateMenuItem({
+      category: 'pizzas',
+      name: 'Marg & Cheese',
+      patch: { price: 14.99 },
+    });
+    const url = (apiFetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(url).toBe('/restaurants/me/menu/items/pizzas/Marg%20%26%20Cheese');
+  });
+
+  it('deleteMenuItem DELETEs', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      okJson(FAKE_RESTAURANT),
+    );
+    await deleteMenuItem({ category: 'pizzas', name: 'Margherita' });
+    const init = (apiFetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('createMenuCategory POSTs the key', async () => {
+    (apiFetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      okJson(FAKE_RESTAURANT),
+    );
+    await createMenuCategory({ key: 'drinks' });
+    const init = (apiFetch as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(init.body).toBe(JSON.stringify({ key: 'drinks' }));
+  });
+});

--- a/dashboard/tests/menu-editor.test.tsx
+++ b/dashboard/tests/menu-editor.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+window.confirm = vi.fn(() => true);
+
+vi.mock('@/app/actions/edit-menu', () => ({
+  deleteMenuItemAction: vi.fn().mockResolvedValue({ success: true }),
+  createMenuItemAction: vi.fn().mockResolvedValue({ success: true }),
+  updateMenuItemAction: vi.fn().mockResolvedValue({ success: true }),
+  createCategoryAction: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { MenuEditor } from '@/components/menu/menu-editor';
+
+describe('MenuEditor', () => {
+  it('renders edit/delete affordances on each item row', () => {
+    render(
+      <MenuEditor
+        restaurantName="Niko"
+        itemCount={1}
+        categories={[
+          {
+            key: 'pizzas',
+            items: [
+              { name: 'Margherita', price: 12.99, available: true },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByLabelText(/edit margherita/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/delete margherita/i)).toBeInTheDocument();
+  });
+
+  it('shows "unavailable" badge on items where available is false', () => {
+    render(
+      <MenuEditor
+        restaurantName="Niko"
+        itemCount={1}
+        categories={[
+          {
+            key: 'pizzas',
+            items: [
+              { name: 'Margherita', price: 12.99, available: false },
+            ],
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/unavailable/i)).toBeInTheDocument();
+  });
+
+  it('shows "Add item" buttons per category and a global "Add category"', () => {
+    render(
+      <MenuEditor
+        restaurantName="Niko"
+        itemCount={0}
+        categories={[
+          { key: 'pizzas', items: [] },
+          { key: 'drinks', items: [] },
+        ]}
+      />,
+    );
+    expect(screen.getAllByRole('button', { name: /add item/i })).toHaveLength(2);
+    expect(screen.getByRole('button', { name: /add category/i })).toBeInTheDocument();
+  });
+});

--- a/dashboard/tests/menu-schema.test.ts
+++ b/dashboard/tests/menu-schema.test.ts
@@ -19,7 +19,7 @@ describe('MenuItemSchema', () => {
       name: 'French Fries',
       price: 7.25,
     });
-    expect(parsed).toEqual({ name: 'French Fries', price: 7.25 });
+    expect(parsed).toEqual({ name: 'French Fries', available: true, price: 7.25 });
     expect(isSizedItem(parsed)).toBe(false);
   });
 
@@ -171,7 +171,7 @@ describe('humanizeCategoryKey', () => {
 
 describe('itemPriceRange', () => {
   it('returns the same min/max for a single-priced item', () => {
-    expect(itemPriceRange({ name: 'X', price: 9.5 })).toEqual({
+    expect(itemPriceRange({ name: 'X', available: true, price: 9.5 })).toEqual({
       min: 9.5,
       max: 9.5,
     });
@@ -179,7 +179,7 @@ describe('itemPriceRange', () => {
 
   it('returns min and max across sizes', () => {
     expect(
-      itemPriceRange({ name: 'X', sizes: { small: 10, medium: 14, large: 18 } }),
+      itemPriceRange({ name: 'X', available: true, sizes: { small: 10, medium: 14, large: 18 } }),
     ).toEqual({ min: 10, max: 18 });
   });
 });

--- a/tests/test_menu_api.py
+++ b/tests/test_menu_api.py
@@ -134,6 +134,22 @@ def test_post_category_rejects_underscore_prefix(client: TestClient):
     assert resp.status_code == 422
 
 
+def test_patch_menu_item_409_on_rename_collision(client: TestClient):
+    """PATCH that renames to an existing item's name in the same
+    category must return 409."""
+    _wire({
+        "pizzas": [
+            {"name": "Margherita", "price": 12.99, "available": True},
+            {"name": "Pepperoni", "price": 15.99, "available": True},
+        ],
+    })
+    resp = client.patch(
+        "/restaurants/me/menu/items/pizzas/Margherita",
+        json={"new_name": "Pepperoni"},
+    )
+    assert resp.status_code == 409
+
+
 def test_post_menu_item_403_for_non_owner(client: TestClient, fake_tenant: Tenant):
     """Staff cannot add menu items — owner-only."""
     import dataclasses

--- a/tests/test_menu_api.py
+++ b/tests/test_menu_api.py
@@ -1,0 +1,149 @@
+"""Integration tests for the granular menu endpoints."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependency import Tenant, current_tenant
+from app.main import app
+from app.storage import restaurants as r_storage
+
+
+@pytest.fixture
+def fake_tenant():
+    return Tenant(
+        uid="user-1",
+        email="owner@niko.test",
+        restaurant_id="r1",
+        role="owner",
+    )
+
+
+@pytest.fixture
+def client(fake_tenant: Tenant):
+    app.dependency_overrides[current_tenant] = lambda: fake_tenant
+    yield TestClient(app)
+    app.dependency_overrides.pop(current_tenant, None)
+
+
+@pytest.fixture(autouse=True)
+def reset_storage():
+    yield
+    r_storage.set_client(None)
+    r_storage.clear_cache()
+
+
+def _wire(menu: dict) -> MagicMock:
+    fs = MagicMock()
+    r_storage.set_client(fs)
+    snap = MagicMock()
+    snap.exists = True
+    snap.to_dict.return_value = {
+        "id": "r1",
+        "name": "R",
+        "display_phone": "+15551234567",
+        "twilio_phone": "+15551234567",
+        "address": "1 Main",
+        "hours": "11-22",
+        "menu": menu,
+    }
+    fs.collection.return_value.document.return_value.get.return_value = snap
+    return fs
+
+
+def test_post_menu_item_appends(client: TestClient):
+    fs = _wire({"pizzas": [{"name": "Margherita", "price": 12.99, "available": True}]})
+    resp = client.post(
+        "/restaurants/me/menu/items",
+        json={"category": "pizzas", "name": "Pepperoni", "price": 15.99},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert any(i["name"] == "Pepperoni" for i in body["menu"]["pizzas"])
+    fs.collection.return_value.document.return_value.set.assert_called_once()
+
+
+def test_post_menu_item_409_on_duplicate(client: TestClient):
+    _wire({"pizzas": [{"name": "Margherita", "price": 12.99, "available": True}]})
+    resp = client.post(
+        "/restaurants/me/menu/items",
+        json={"category": "pizzas", "name": "Margherita", "price": 99.00},
+    )
+    assert resp.status_code == 409
+
+
+def test_patch_menu_item_updates_price(client: TestClient):
+    _wire({"pizzas": [{"name": "Margherita", "price": 12.99, "available": True}]})
+    resp = client.patch(
+        "/restaurants/me/menu/items/pizzas/Margherita",
+        json={"price": 14.99},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    item = body["menu"]["pizzas"][0]
+    assert item["price"] == 14.99
+
+
+def test_patch_menu_item_404_when_not_found(client: TestClient):
+    _wire({"pizzas": []})
+    resp = client.patch(
+        "/restaurants/me/menu/items/pizzas/NotThere",
+        json={"price": 10.00},
+    )
+    assert resp.status_code == 404
+
+
+def test_delete_menu_item_removes(client: TestClient):
+    _wire({"pizzas": [{"name": "Margherita", "price": 12.99}]})
+    resp = client.delete(
+        "/restaurants/me/menu/items/pizzas/Margherita",
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["menu"]["pizzas"] == []
+
+
+def test_post_category_creates_empty(client: TestClient):
+    _wire({"pizzas": []})
+    resp = client.post(
+        "/restaurants/me/menu/categories",
+        json={"key": "drinks"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["menu"]["drinks"] == []
+
+
+def test_post_category_409_on_duplicate(client: TestClient):
+    _wire({"pizzas": []})
+    resp = client.post(
+        "/restaurants/me/menu/categories",
+        json={"key": "pizzas"},
+    )
+    assert resp.status_code == 409
+
+
+def test_post_category_rejects_underscore_prefix(client: TestClient):
+    _wire({"pizzas": []})
+    resp = client.post(
+        "/restaurants/me/menu/categories",
+        json={"key": "_secret"},
+    )
+    # Underscore prefix violates the regex pattern
+    assert resp.status_code == 422
+
+
+def test_post_menu_item_403_for_non_owner(client: TestClient, fake_tenant: Tenant):
+    """Staff cannot add menu items — owner-only."""
+    import dataclasses
+    from app.auth.dependency import current_tenant
+    staff = dataclasses.replace(fake_tenant, role="staff")
+    app.dependency_overrides[current_tenant] = lambda: staff
+
+    _wire({"pizzas": []})
+    resp = client.post(
+        "/restaurants/me/menu/items",
+        json={"category": "pizzas", "name": "X", "price": 10.00},
+    )
+    assert resp.status_code == 403

--- a/tests/test_menu_models.py
+++ b/tests/test_menu_models.py
@@ -50,3 +50,43 @@ def test_menu_item_update_allows_partial_fields():
 def test_menu_item_update_rejects_both_price_and_sizes_together():
     with pytest.raises(ValueError):
         MenuItemUpdate(price=10.00, sizes={"small": 8.00})
+
+
+def test_category_create_accepts_snake_case_keys():
+    from app.restaurants.models import CategoryCreate
+
+    CategoryCreate(key="pizzas")
+    CategoryCreate(key="fried_rice")
+    CategoryCreate(key="caribbean_appetizers")
+    CategoryCreate(key="x")  # single char OK
+    CategoryCreate(key="abc123_xyz")
+
+
+def test_category_create_rejects_invalid_keys():
+    from app.restaurants.models import CategoryCreate
+
+    invalid = [
+        "Pizzas",          # uppercase
+        "fried rice",      # space
+        "fried-rice",      # hyphen
+        "_underscore",     # underscore prefix reserved for internal keys
+        "",                # empty
+    ]
+    for key in invalid:
+        with pytest.raises(Exception):
+            CategoryCreate(key=key)
+
+
+def test_menu_item_update_rejects_negative_size_price():
+    from app.restaurants.models import MenuItemUpdate
+
+    with pytest.raises(Exception):
+        MenuItemUpdate(sizes={"small": -1.00, "large": 18.00})
+
+
+def test_menu_item_update_rejects_empty_sizes_dict():
+    """Empty sizes dict is not the same as "not provided"; reject explicitly."""
+    from app.restaurants.models import MenuItemUpdate
+
+    with pytest.raises(Exception):
+        MenuItemUpdate(sizes={})

--- a/tests/test_menu_models.py
+++ b/tests/test_menu_models.py
@@ -1,0 +1,52 @@
+"""Unit tests for the granular-menu request bodies."""
+
+import pytest
+
+from app.restaurants.models import MenuItemCreate, MenuItemUpdate
+
+
+def test_menu_item_create_accepts_single_price():
+    item = MenuItemCreate(category="pizzas", name="Margherita", price=12.99)
+    assert item.available is True
+    assert item.sizes is None
+    assert item.price == 12.99
+
+
+def test_menu_item_create_accepts_sizes():
+    item = MenuItemCreate(
+        category="pizzas",
+        name="Pepperoni",
+        sizes={"small": 12.99, "large": 18.99},
+    )
+    assert item.price is None
+    assert item.sizes == {"small": 12.99, "large": 18.99}
+
+
+def test_menu_item_create_rejects_both_price_and_sizes():
+    with pytest.raises(ValueError):
+        MenuItemCreate(
+            category="pizzas",
+            name="X",
+            price=10.00,
+            sizes={"small": 8.00},
+        )
+
+
+def test_menu_item_create_rejects_neither_price_nor_sizes():
+    with pytest.raises(ValueError):
+        MenuItemCreate(category="pizzas", name="X")
+
+
+def test_menu_item_create_rejects_negative_price():
+    with pytest.raises(ValueError):
+        MenuItemCreate(category="pizzas", name="X", price=-1.00)
+
+
+def test_menu_item_update_allows_partial_fields():
+    upd = MenuItemUpdate(price=14.99)
+    assert upd.model_dump(exclude_unset=True) == {"price": 14.99}
+
+
+def test_menu_item_update_rejects_both_price_and_sizes_together():
+    with pytest.raises(ValueError):
+        MenuItemUpdate(price=10.00, sizes={"small": 8.00})

--- a/tests/test_menu_writes.py
+++ b/tests/test_menu_writes.py
@@ -146,3 +146,50 @@ def test_add_category_rejects_duplicate():
     r = _r()
     with pytest.raises(DuplicateMenuItem):
         add_category(r, CategoryCreate(key="pizzas"))
+
+
+def test_update_menu_item_rename_to_same_name_is_noop():
+    """Renaming Margherita → Margherita should NOT raise — the skip-self
+    check in update_menu_item must allow the no-op."""
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(new_name="Margherita"),
+    )
+    assert out.menu["pizzas"][0]["name"] == "Margherita"
+
+
+def test_update_menu_item_rename_within_category_409_on_collision():
+    """Renaming Margherita → Pepperoni when both exist in pizzas should
+    raise DuplicateMenuItem."""
+    r = _r()
+    r = add_menu_item(
+        r,
+        MenuItemCreate(category="pizzas", name="Pepperoni", price=15.99),
+    )
+    with pytest.raises(DuplicateMenuItem):
+        update_menu_item(
+            r,
+            category="pizzas",
+            name="Margherita",
+            update=MenuItemUpdate(new_name="Pepperoni"),
+        )
+
+
+def test_update_menu_item_move_to_category_with_existing_name_409():
+    """Moving Margherita to sides where a 'Margherita' already exists
+    should raise DuplicateMenuItem."""
+    r = _r()
+    r = add_menu_item(
+        r,
+        MenuItemCreate(category="sides", name="Margherita", price=5.00),
+    )
+    with pytest.raises(DuplicateMenuItem):
+        update_menu_item(
+            r,
+            category="pizzas",
+            name="Margherita",
+            update=MenuItemUpdate(new_category="sides"),
+        )

--- a/tests/test_menu_writes.py
+++ b/tests/test_menu_writes.py
@@ -1,0 +1,148 @@
+"""Unit tests for app.restaurants.menu_writes — pure-function menu
+mutations on a Restaurant.menu dict."""
+
+import pytest
+
+from app.restaurants.menu_writes import (
+    DuplicateMenuItem,
+    MenuItemNotFound,
+    add_category,
+    add_menu_item,
+    delete_menu_item,
+    update_menu_item,
+)
+from app.restaurants.models import (
+    CategoryCreate,
+    MenuItemCreate,
+    MenuItemUpdate,
+    Restaurant,
+)
+
+
+def _r() -> Restaurant:
+    return Restaurant(
+        id="r1",
+        name="R",
+        display_phone="+15551234567",
+        twilio_phone="+15551234567",
+        address="1 Main",
+        hours="11-22",
+        menu={
+            "pizzas": [
+                {"name": "Margherita", "price": 12.99, "available": True},
+            ],
+            "sides": [],
+        },
+    )
+
+
+def test_add_menu_item_appends_to_existing_category():
+    r = _r()
+    out = add_menu_item(
+        r,
+        MenuItemCreate(category="pizzas", name="Pepperoni", price=15.99),
+    )
+    items = out.menu["pizzas"]
+    assert len(items) == 2
+    assert items[1]["name"] == "Pepperoni"
+    assert items[1]["available"] is True
+
+
+def test_add_menu_item_creates_category_if_missing():
+    r = _r()
+    out = add_menu_item(
+        r,
+        MenuItemCreate(category="drinks", name="Coke", price=2.50),
+    )
+    assert out.menu["drinks"][0]["name"] == "Coke"
+
+
+def test_add_menu_item_rejects_duplicate_name_in_category():
+    r = _r()
+    with pytest.raises(DuplicateMenuItem):
+        add_menu_item(
+            r,
+            MenuItemCreate(category="pizzas", name="Margherita", price=10.00),
+        )
+
+
+def test_update_menu_item_modifies_price_in_place():
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(price=14.99),
+    )
+    assert out.menu["pizzas"][0]["price"] == 14.99
+
+
+def test_update_menu_item_renames_when_new_name_set():
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(new_name="Margherita DOP"),
+    )
+    assert out.menu["pizzas"][0]["name"] == "Margherita DOP"
+
+
+def test_update_menu_item_moves_category_when_new_category_set():
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(new_category="sides"),
+    )
+    assert out.menu["pizzas"] == []
+    assert any(i["name"] == "Margherita" for i in out.menu["sides"])
+
+
+def test_update_menu_item_swaps_price_for_sizes():
+    r = _r()
+    out = update_menu_item(
+        r,
+        category="pizzas",
+        name="Margherita",
+        update=MenuItemUpdate(sizes={"small": 10.00, "large": 16.00}),
+    )
+    item = out.menu["pizzas"][0]
+    assert "price" not in item
+    assert item["sizes"] == {"small": 10.00, "large": 16.00}
+
+
+def test_update_menu_item_404_when_not_found():
+    r = _r()
+    with pytest.raises(MenuItemNotFound):
+        update_menu_item(
+            r,
+            category="pizzas",
+            name="NonExistent",
+            update=MenuItemUpdate(price=10.00),
+        )
+
+
+def test_delete_menu_item_removes_from_category():
+    r = _r()
+    out = delete_menu_item(r, category="pizzas", name="Margherita")
+    assert out.menu["pizzas"] == []
+
+
+def test_delete_menu_item_404_when_not_found():
+    r = _r()
+    with pytest.raises(MenuItemNotFound):
+        delete_menu_item(r, category="pizzas", name="NonExistent")
+
+
+def test_add_category_creates_empty_array():
+    r = _r()
+    out = add_category(r, CategoryCreate(key="drinks"))
+    assert out.menu["drinks"] == []
+
+
+def test_add_category_rejects_duplicate():
+    r = _r()
+    with pytest.raises(DuplicateMenuItem):
+        add_category(r, CategoryCreate(key="pizzas"))

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -294,6 +294,76 @@ def test_prompt_renders_delivery_offered_branch():
     assert "pickup-only" not in lower
 
 
+def test_format_menu_skips_unavailable_items():
+    """Items with available=False must not appear in the LLM-readable
+    menu — the dashboard's 'out of stock' toggle is the load-bearing
+    feature that lets owners hide items from callers."""
+    from app.llm.prompts import _format_menu
+
+    restaurant = Restaurant(
+        id="t",
+        name="T",
+        display_phone="+10000000000",
+        twilio_phone="+10000000001",
+        address="-",
+        hours="-",
+        menu={
+            "pizzas": [
+                {"name": "Margherita", "price": 12.99, "available": True},
+                {"name": "Pepperoni", "price": 15.99, "available": False},
+            ],
+        },
+    )
+    rendered = _format_menu(restaurant)
+    assert "Margherita" in rendered
+    assert "Pepperoni" not in rendered
+
+
+def test_format_menu_treats_missing_available_as_true():
+    """Legacy items without an `available` field default to available
+    (back-compat with pre-Sprint-2.4 menu docs)."""
+    from app.llm.prompts import _format_menu
+
+    restaurant = Restaurant(
+        id="t",
+        name="T",
+        display_phone="+10000000000",
+        twilio_phone="+10000000001",
+        address="-",
+        hours="-",
+        menu={
+            "pizzas": [
+                {"name": "Margherita", "price": 12.99},  # no available field
+            ],
+        },
+    )
+    rendered = _format_menu(restaurant)
+    assert "Margherita" in rendered
+
+
+def test_format_menu_skips_category_when_all_items_unavailable():
+    """A category whose every item is unavailable should not appear as
+    a naked header in the prompt."""
+    from app.llm.prompts import _format_menu
+
+    restaurant = Restaurant(
+        id="t",
+        name="T",
+        display_phone="+10000000000",
+        twilio_phone="+10000000001",
+        address="-",
+        hours="-",
+        menu={
+            "pizzas": [
+                {"name": "Pepperoni", "price": 15.99, "available": False},
+            ],
+        },
+    )
+    rendered = _format_menu(restaurant)
+    assert "Pizzas:" not in rendered
+    assert "Pepperoni" not in rendered
+
+
 def test_prompt_renders_pickup_only_branch():
     """Sprint 2.2 #105 — when offers_delivery=False, the prompt frames
     the restaurant as pickup-only and tells Haiku to soft-pivot when


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 1 Phase C + D (Issue #7 deliverable 3 — \"Menu editor (CRUD)\"). Replaces the read-only menu page with a full CRUD editor: add/edit/delete items, toggle availability, add categories. The \`available: false\` toggle is wired through to the LLM prompt builder so unavailable items disappear from what the agent offers callers.

## What landed

**Backend (Phase C):**
- 3 Pydantic v2 validation models in \`app/restaurants/models.py\`: \`MenuItemCreate\`, \`MenuItemUpdate\`, \`CategoryCreate\`. Strict-extra. \`category\` + \`new_category\` enforce \`^[a-z0-9][a-z0-9_]*$\` (no leading underscore — protects \`_category_order\`). Exactly-one-of price/sizes invariant on Create. Per-size non-negative on both.
- Pure-function mutations in \`app/restaurants/menu_writes.py\`: \`add_menu_item\`, \`update_menu_item\` (rename + move + price/sizes swap, collision-checked across both axes), \`delete_menu_item\`, \`add_category\`. No Firestore I/O.
- 4 new endpoints in \`app/main.py\`: \`POST/PATCH/DELETE /restaurants/me/menu/items/{category}/{name}\` + \`POST /restaurants/me/menu/categories\`. All owner-gated via \`_require_owner\`. 409 on dupe, 404 on missing, 422 on invalid body, 403 for non-owner. URL-encoded path params.
- **Prompt builder now filters \`available: false\` items** — \`app/llm/prompts.py::_format_menu\`. Legacy items without the field default to available (back-compat). Categories with no available items are suppressed entirely.

**Dashboard (Phase D):**
- \`available: boolean\` added to both menu item Zod schemas (defaults true, back-compat).
- \`dashboard/lib/api/menu.ts\` — server-only API helpers with URL encoding.
- \`dashboard/app/actions/edit-menu.ts\` — 4 Server Actions wrapping the helpers with \`revalidatePath('/menu')\`.
- \`MenuEditor\` replaces \`MenuView\`. Per-item edit/delete buttons, per-category \"Add item\", global \"Add category\". Strikethrough + \"unavailable\" badge for items with \`available: false\`.
- 3 ShadCN Dialogs: \`AddItemDialog\`, \`ItemEditDialog\`, \`AddCategoryDialog\`. Sized items show a partial-edit hint (name/description/availability editable; size prices are a deferred follow-up).

## Cross-system contract

The unavailable toggle is the marquee feature. Owner toggles → dashboard PATCH → \`Restaurant.menu[category][i].available = false\` → next call's prompt build → LLM doesn't offer the item.

## Spec deviations

Same as the plan called out: menu items use \`{category}/{name}\` composite-key URLs instead of stable IDs. Item-ID restructure stays in the deferred list (\`dashboard/CLAUDE.md\` Phase 2+).

## Test plan

- [x] \`pytest tests/test_menu_models.py tests/test_menu_writes.py tests/test_menu_api.py tests/test_prompts.py -v\` — 55 passes
- [x] \`cd dashboard && pnpm vitest run\` — 95/95 across 14 files
- [x] \`cd dashboard && pnpm typecheck\` — clean
- [x] \`pytest tests/ -x\` — 322 passed / 1 skipped / 0 failures
- [ ] **Manual smoke (gating, owner does this):** Open \`/menu\`, add a category, add an item, edit its price, toggle unavailable, delete it. Reload — persists. Place a test call and verify the unavailable item is NOT offered by the agent.

## Follow-ups deliberately deferred

Flagged in the final niko-reviewer pass; non-blocking for pilot. Track 1 Phase A+B's scheduled follow-up (PR will fire 2026-05-15) covers a different list — the items below are this phase's:

- **Swap \`window.confirm\` for ShadCN \`AlertDialog\`** in \`MenuEditor.handleDelete\`. Theming + accessibility consistency. Tests already mock \`window.confirm\`.
- **Sized-item edit UI.** Currently sized items are read-only for prices; only name/description/availability editable. Add a sub-dialog for editing/adding size variants.
- **Sized-item creation in \`AddItemDialog\`.** Same gap on the create path.
- **Category delete + rename.** No backend endpoint or UI. An owner stuck with a typo'd category has no recovery path.
- **Rewording sized-item edit copy.** Currently says \"contact support\"; should explicitly say what IS editable.

## Tasks → commits

| Task | Commit |
|---|---|
| C.9 Pydantic models | \`c8ec85c\` + \`1e86468\` (parity fix) |
| C.10 Pure-function mutations | \`d1f7e03\` |
| C.11 Endpoints | \`5b6ab8e\` |
| D.12 Dashboard schema + API | \`ca220c4\` |
| D.13 Server Actions | \`9844e8f\` |
| D.14 MenuEditor + dialogs | \`7e414b2\` |
| Final review fixes | \`125c7b3\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)