### PR TITLE
prompts: strengthen speak-first rule + cap modification ack length

### DIFF
--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -38,7 +38,9 @@ _PREAMBLE = dedent("""\
 
     Item customizations:
     - After the caller picks an item and size, ask once whether they have
-      any customizations ("Any modifications — extra cheese, no onions?").
+      any customizations. Keep this question to ONE short sentence. Do not expand the example list beyond two items.
+      Good: "Any modifications — extra cheese, no onions?"
+      Too long: "Any modifications on the pizza — like extra cheese, no onions, mushrooms, anything else like that?"
     - If they say no or give nothing, move on — do not ask again.
     - Accept any free-text customization; capture it exactly as stated.
       Do not validate against a fixed list and do not invent customizations
@@ -108,11 +110,17 @@ _PREAMBLE = dedent("""\
       which restaurant they called. End pickup confirmations with something
       generic like "we'll have it ready for you soon" instead.
 
-    When you call the update_order tool:
-    - Say a brief acknowledgement to the caller in plain text FIRST, then
-      call the tool. For example: "One large Margherita coming up." then
-      update_order(...). Never emit update_order before any spoken words —
-      it delays audio and the caller thinks you stopped listening.
+    When you call the update_order tool — ORDERING IS CRITICAL:
+    1. ALWAYS speak a short acknowledgement first, THEN call update_order.
+       This is non-negotiable: the caller hears nothing while you stream
+       the tool's JSON, so a tool-first turn produces 1-2 seconds of dead
+       air that callers experience as "the bot froze".
+    2. Correct: "One large Margherita coming up." → update_order(...)
+    3. Correct: "Got it, two now." → update_order(...)
+    4. Wrong (DO NOT DO THIS): update_order(...) → "One large Margherita
+       coming up." — the spoken words must come first in your output.
+    5. Even a 4-word acknowledgement ("Got it, one moment.") is enough.
+       Brevity is fine; silence is not.
 
     If a caller asks for something off-menu, politely say you don't offer it and
     suggest a close alternative. If you're unsure what they said, ask them to

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -38,13 +38,46 @@ def test_prompt_warns_against_reciting_address_on_pickup_wrapup():
 
 
 def test_prompt_requires_text_before_tool_use():
-    """Regression for #76 — Haiku must speak first then call update_order,
-    so audio starts streaming within the <1s budget on commit turns."""
+    """Regression for #76 and #155 — Haiku must speak first then call update_order,
+    so audio starts streaming within the <1s budget on commit turns. In #155 the
+    rule was strengthened from a soft bullet to a numbered CRITICAL block after
+    Haiku was observed ignoring the soft form (1192ms tool_prefix on 18:33 call)."""
     prompt = build_system_prompt(_demo())
     lower = prompt.lower()
     assert "when you call the update_order tool" in lower
     assert "first" in lower
-    assert "never emit update_order before any spoken words" in lower
+    # Updated for #155 — the rule was strengthened to a numbered CRITICAL block.
+    # The "do not do this" string is the new equivalent assertion that the
+    # rule still forbids tool-first turns.
+    assert "do not do this" in lower
+
+
+def test_prompt_speak_first_rule_is_critical_and_numbered():
+    """Regression for #155 — the speak-first rule was strengthened
+    from a soft bullet to a numbered CRITICAL section after Haiku
+    was observed ignoring the soft form (1192ms tool_prefix on the
+    18:33 test call). Don't soften this back without filing a fresh
+    observability run that proves Haiku now obeys the soft form."""
+    prompt = build_system_prompt(_demo())
+    lower = prompt.lower()
+    # The block must read as a non-negotiable directive, not a hint.
+    assert "ordering is critical" in lower
+    assert "non-negotiable" in lower
+    # Concrete WRONG example so the model has something to pattern-match against.
+    assert "do not do this" in lower
+    # Existing requirements still hold (regression for #76).
+    assert "always speak a short acknowledgement first" in lower
+
+
+def test_prompt_caps_modification_question_length():
+    """Regression for #155 — the modification ack was too long on the
+    18:43 test call (~6s spoken, induced barge-in). Prompt now caps
+    the question to one sentence and forbids expanding the example
+    list beyond two items."""
+    prompt = build_system_prompt(_demo())
+    lower = prompt.lower()
+    assert "keep this question to one short sentence" in lower
+    assert "do not expand the example list beyond two items" in lower
 
 
 def test_prompt_makes_confirmation_goodbyes_terminal():


### PR DESCRIPTION
## Summary
Two prompt-only tuning changes from observations on the 18:33 and 18:43 test calls:

- **Speak-first rule strengthened.** Haiku was ignoring the soft bullet from #76 — \`tool_prefix=1192ms\` on the 18:33 confirmation turn. Replaced with a numbered CRITICAL block plus a \"do not do this\" wrong example.
- **Modification ack capped.** The question was ~6s spoken on 18:43, inducing barge-in. Now: one sentence, two example items max.

Pure prompt change. No code-path changes.

## Linked issue
Closes #155

## Test plan
- [x] \`pytest tests/\` green (18/18 prompt tests pass; the 20 pre-existing \`lameenc\` failures are unrelated to this PR).
- [x] 2 new tests in \`tests/test_prompts.py\` guard the new directives.
- [x] Existing #76 regression test updated for the new wording.
- [ ] Live test call (Sandeep) — target: \`tool_prefix < 100ms\` on cache=hit confirmation turns; modification ack ≤ 4s spoken. If 3 calls don't show improvement, file the heavier server-side follow-up.