### PR TITLE
instrument: first_tts_byte event for actual TTS arrival

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -422,6 +422,23 @@ async def _run_llm_tts_turn(
             detail=detail,
         )
 
+    def _record_first_tts_byte() -> None:
+        # #152 — captures the actual moment the first audio byte arrives
+        # from Deepgram Aura, closing the gap that first_audio misses
+        # (first_audio fires before await speak(), hiding TTS network time).
+        latency = time.monotonic() - turn_start
+        logger.info(
+            "llm_turn first_tts_byte latency=%.3fs call_sid=%s",
+            latency,
+            state.call_sid,
+        )
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="first_tts_byte",
+            detail={"latency_seconds": round(latency, 3)},
+        )
+
     try:
         async for event in stream_reply(
             transcript=transcript,
@@ -449,11 +466,15 @@ async def _run_llm_tts_turn(
                         if first_speak:
                             _record_first_audio()
                             first_speak = False
+                            on_first_byte = _record_first_tts_byte
+                        else:
+                            on_first_byte = None
                         await speak(
                             chunk,
                             websocket,
                             state.stream_sid,
                             recording_session=state.recording_session,
+                            on_first_byte=on_first_byte,
                         )
 
             elif event.final is not None:
@@ -462,11 +483,16 @@ async def _run_llm_tts_turn(
                 if remainder and state.stream_sid:
                     if first_speak:
                         _record_first_audio()
+                        first_speak = False
+                        on_first_byte = _record_first_tts_byte
+                    else:
+                        on_first_byte = None
                     await speak(
                         remainder,
                         websocket,
                         state.stream_sid,
                         recording_session=state.recording_session,
+                        on_first_byte=on_first_byte,
                     )
                 state.history = event.final.history
                 state.order = event.final.order

--- a/app/tts/client.py
+++ b/app/tts/client.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import base64
 import logging
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import httpx
 from fastapi import WebSocket
@@ -60,6 +60,7 @@ async def speak(
     *,
     client: Optional[httpx.AsyncClient] = None,
     recording_session: Optional[Any] = None,
+    on_first_byte: Optional[Callable[[], None]] = None,
 ) -> None:
     """Stream Deepgram Aura TTS audio back into the Twilio call.
 
@@ -81,6 +82,11 @@ async def speak(
                            inbound audio from Twilio, so the only way
                            to get the agent's voice into the recording is
                            to capture the bytes we generate ourselves.
+        on_first_byte:     Optional zero-arg sync callable fired exactly once
+                           when the first non-empty chunk arrives from
+                           Deepgram. Used by the router to measure actual
+                           TTS network latency (#152). Exceptions are
+                           swallowed so a buggy callback never breaks a call.
     """
     if not text.strip():
         return
@@ -102,6 +108,7 @@ async def speak(
     body = {"text": text}
 
     _client = client if client is not None else _get_client()
+    first_byte_fired = False
 
     async with _client.stream(
         "POST", url, headers=headers, params=params, json=body
@@ -122,6 +129,14 @@ async def speak(
         async for chunk in response.aiter_bytes():
             if not chunk:
                 continue
+            if not first_byte_fired and on_first_byte is not None:
+                first_byte_fired = True
+                try:
+                    on_first_byte()
+                except Exception:
+                    logger.exception(
+                        "tts: on_first_byte callback raised stream_sid=%s", stream_sid
+                    )
             payload = base64.b64encode(chunk).decode()
             try:
                 await websocket.send_json(

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -893,3 +893,63 @@ def test_run_llm_tts_turn_does_not_flush_at_short_comma(monkeypatch, mock_pipeli
     # No chunk should be just "Got it,"
     assert "Got it," not in chunks_spoken
 
+
+# ---------------------------------------------------------------------------
+# first_tts_byte event (#152)
+# ---------------------------------------------------------------------------
+
+
+def test_first_tts_byte_event_emitted_on_turn(monkeypatch):
+    """A first_tts_byte Firestore event with a latency_seconds field is
+    emitted on the first speak() call of a turn. The existing first_audio
+    event must still be present — we ADD, not replace."""
+    from app.storage import call_sessions
+
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, restaurant_id, on_final):
+        return fake_dg
+
+    # A speak() stub that invokes on_first_byte so the callback fires
+    # as it would with a real TTS stream delivering its first chunk.
+    async def speak_with_callback(text, websocket, stream_sid, **kw):
+        cb = kw.get("on_first_byte")
+        if cb is not None:
+            cb()
+
+    recorded_events: list[dict] = []
+
+    def capture_bg_event(call_sid, restaurant_id, **kwargs):
+        recorded_events.append({"call_sid": call_sid, "rid": restaurant_id, **kwargs})
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", speak_with_callback)
+    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
+    monkeypatch.setattr("app.telephony.router._bg_call_event", capture_bg_event)
+    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    first_tts_events = [e for e in recorded_events if e.get("kind") == "first_tts_byte"]
+    assert len(first_tts_events) >= 1, (
+        f"expected at least one first_tts_byte event; got events: "
+        f"{[e.get('kind') for e in recorded_events]}"
+    )
+    evt = first_tts_events[0]
+    assert "detail" in evt
+    assert "latency_seconds" in evt["detail"], (
+        f"first_tts_byte event missing latency_seconds: {evt}"
+    )
+    assert isinstance(evt["detail"]["latency_seconds"], float)
+
+    # first_audio must still be emitted — backwards compatibility
+    first_audio_events = [e for e in recorded_events if e.get("kind") == "first_audio"]
+    assert len(first_audio_events) >= 1, "first_audio event must not be removed"
+

--- a/tests/test_tts_client.py
+++ b/tests/test_tts_client.py
@@ -283,3 +283,73 @@ async def test_speak_does_not_close_default_client(monkeypatch):
     await speak("Hello", ws, stream_sid="MZ123")
 
     fake_default.aclose.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# on_first_byte callback (#152)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_speak_invokes_on_first_byte_once(monkeypatch):
+    """on_first_byte fires exactly once when the first non-empty chunk
+    arrives, regardless of how many chunks follow."""
+    chunks = [b"\xab\xcd", b"\xef\x01", b"\x02"]
+    mock_client = make_mock_client(chunks)
+    ws = make_mock_websocket()
+
+    calls: list[float] = []
+
+    def cb():
+        calls.append(1.0)
+
+    await speak("Hello", ws, stream_sid="MZ123", client=mock_client, on_first_byte=cb)
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_speak_skips_on_first_byte_for_empty_chunks():
+    """Empty chunks must not trigger the callback — first non-empty
+    chunk wins. The existing aiter_bytes loop already skips empty
+    chunks before sending; verify the callback respects the same gate."""
+    chunks = [b"", b"", b"\xab", b"\xcd"]
+    mock_client = make_mock_client(chunks)
+    ws = make_mock_websocket()
+
+    calls: list[int] = []
+    await speak(
+        "Hello", ws, stream_sid="MZ123", client=mock_client,
+        on_first_byte=lambda: calls.append(1),
+    )
+    assert calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_speak_swallows_on_first_byte_exception():
+    """A buggy callback must not break the call. The chunk send still
+    happens; the exception is logged and discarded."""
+    chunks = [b"\xab"]
+    mock_client = make_mock_client(chunks)
+    ws = make_mock_websocket()
+
+    def bad_cb():
+        raise RuntimeError("boom")
+
+    # Should not raise
+    await speak(
+        "Hello", ws, stream_sid="MZ123", client=mock_client,
+        on_first_byte=bad_cb,
+    )
+    ws.send_json.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_speak_without_on_first_byte_works(monkeypatch):
+    """Callback is optional — omitting it is the existing behaviour."""
+    chunks = [b"\xab"]
+    mock_client = make_mock_client(chunks)
+    ws = make_mock_websocket()
+    # No on_first_byte kwarg
+    await speak("Hello", ws, stream_sid="MZ123", client=mock_client)
+    ws.send_json.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds a new `first_tts_byte` Firestore call event measured at the moment the first audio chunk arrives from Deepgram Aura.
- The existing `first_audio` event is unchanged — it still records when the first sentence is handed to `speak()` (the LLM-side latency budget). The new event captures TTS network + synthesis time.
- Without this, `speak()` improvements (e.g., the persistent httpx client from #154) are invisible in our metrics — `first_audio` fires before `await speak()`.

## Linked issue
Closes #152

## Test plan
- [x] `pytest tests/` green — 286 passed, 15 skipped (API-key-gated integration tests, pre-existing).
- [x] 4 new unit tests in `tests/test_tts_client.py` covering: callback fires once / skips empty chunks / swallows exceptions / optional kwarg.
- [x] 1 integration test in `tests/test_telephony.py` (`test_first_tts_byte_event_emitted_on_turn`) confirms the event lands with a `latency_seconds` field and that `first_audio` is still emitted.
- [ ] Live test call (Sandeep) showing the new event in the dashboard call timeline.