### PR TITLE
Sprint 2.4 Track 1 Phase E — analytics page (#7)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ from app.orders.lifecycle import (
 )
 from app.orders.models import ItemCategory, LineItem, Order, OrderType
 from app.storage import (
+    analytics,
     call_sessions,
     firestore as order_storage,
     recordings,
@@ -260,6 +261,14 @@ def post_menu_category(
         raise HTTPException(status_code=409, detail=str(exc))
     restaurants_storage.save_restaurant(updated)
     return updated.model_dump(mode="json")
+
+
+@app.get("/analytics/summary")
+def get_analytics_summary(tenant: Tenant = Depends(current_tenant)):
+    """Tile metrics for the dashboard's /analytics page. Tenant-scoped."""
+    return analytics.summarize_orders(
+        restaurant_id=tenant.restaurant_id,
+    ).model_dump()
 
 
 @app.get("/orders")

--- a/app/storage/analytics.py
+++ b/app/storage/analytics.py
@@ -1,0 +1,102 @@
+"""Analytics aggregations on Firestore order data.
+
+Computes the four tile metrics (today_count, seven_day_count,
+average_order_value_7d, completion_rate_7d) the dashboard's analytics
+page renders. No new collections — reads from
+``restaurants/{rid}/orders``.
+
+Streams the past 7 days into memory; for pilot scale this is fine
+(<200 orders/day per restaurant). When restaurants get to 1k orders/
+day we'll move to scheduled aggregations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from pydantic import BaseModel
+
+from app.orders.models import Order, OrderStatus
+from app.storage import firestore as order_storage
+
+
+@dataclass(frozen=True)
+class _Window:
+    today_start: datetime
+    seven_days_ago: datetime
+
+
+def _window(now: datetime | None = None) -> _Window:
+    now = now or datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    return _Window(
+        today_start=today_start,
+        seven_days_ago=now - timedelta(days=7),
+    )
+
+
+class OrderSummary(BaseModel):
+    today_count: int
+    seven_day_count: int
+    average_order_value_7d: float
+    completion_rate_7d: float
+
+
+def _stream_recent_orders(restaurant_id: str, since: datetime) -> list[Order]:
+    """Read orders newer than ``since`` for one tenant. Uses the
+    restaurants/{rid}/orders subcollection that
+    ``app.storage.firestore`` writes to."""
+    client = order_storage._get_client()
+    coll = (
+        client.collection("restaurants")
+        .document(restaurant_id)
+        .collection("orders")
+        .where("created_at", ">=", since)
+    )
+    return [Order.model_validate(snap.to_dict()) for snap in coll.stream()]
+
+
+def summarize_orders(*, restaurant_id: str) -> OrderSummary:
+    win = _window()
+    orders = _stream_recent_orders(restaurant_id, win.seven_days_ago)
+
+    today: list[Order] = []
+    seven_day: list[Order] = []
+    for o in orders:
+        if o.created_at >= win.today_start:
+            today.append(o)
+        if o.created_at >= win.seven_days_ago:
+            seven_day.append(o)
+
+    if seven_day:
+        aov = round(sum(o.subtotal for o in seven_day) / len(seven_day), 2)
+        completed = sum(
+            1 for o in seven_day if o.status is OrderStatus.COMPLETED
+        )
+        # Denominator: orders that reached confirmed (or beyond) — i.e.
+        # excluding still-in-progress and cancelled-before-confirm.
+        confirmed_or_later = sum(
+            1
+            for o in seven_day
+            if o.status
+            in {
+                OrderStatus.CONFIRMED,
+                OrderStatus.PREPARING,
+                OrderStatus.READY,
+                OrderStatus.COMPLETED,
+            }
+        )
+        completion_rate = (
+            completed / confirmed_or_later if confirmed_or_later else 0.0
+        )
+    else:
+        aov = 0.0
+        completion_rate = 0.0
+
+    return OrderSummary(
+        today_count=len(today),
+        seven_day_count=len(seven_day),
+        average_order_value_7d=aov,
+        completion_rate_7d=completion_rate,
+    )

--- a/app/storage/analytics.py
+++ b/app/storage/analytics.py
@@ -14,11 +14,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel
 
 from app.orders.models import Order, OrderStatus
 from app.storage import firestore as order_storage
+
+# Phase 1: hardcoded restaurant timezone, matching dashboard <LocalTime />
+# default. When multi-location lands, read from restaurants/{rid}.timezone.
+_LOCAL_TZ = ZoneInfo("America/Toronto")
 
 
 @dataclass(frozen=True)
@@ -29,9 +34,15 @@ class _Window:
 
 def _window(now: datetime | None = None) -> _Window:
     now = now or datetime.now(timezone.utc)
-    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    # Compute "today" boundary in the restaurant's local timezone, then
+    # convert back to UTC for the Firestore query.
+    local_now = now.astimezone(_LOCAL_TZ)
+    local_today_start = local_now.replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    today_start_utc = local_today_start.astimezone(timezone.utc)
     return _Window(
-        today_start=today_start,
+        today_start=today_start_utc,
         seven_days_ago=now - timedelta(days=7),
     )
 
@@ -70,13 +81,31 @@ def summarize_orders(*, restaurant_id: str) -> OrderSummary:
             seven_day.append(o)
 
     if seven_day:
-        aov = round(sum(o.subtotal for o in seven_day) / len(seven_day), 2)
+        # AOV: average over orders that actually became real revenue
+        # opportunities — confirmed, preparing, ready, completed.
+        # Excludes IN_PROGRESS (call live) and CANCELLED (no revenue).
+        aov_orders = [
+            o for o in seven_day
+            if o.status in {
+                OrderStatus.CONFIRMED,
+                OrderStatus.PREPARING,
+                OrderStatus.READY,
+                OrderStatus.COMPLETED,
+            }
+        ]
+        if aov_orders:
+            aov = round(
+                sum(o.subtotal for o in aov_orders) / len(aov_orders), 2
+            )
+        else:
+            aov = 0.0
         completed = sum(
             1 for o in seven_day if o.status is OrderStatus.COMPLETED
         )
-        # Denominator: orders that reached confirmed (or beyond) — i.e.
-        # excluding still-in-progress and cancelled-before-confirm.
-        confirmed_or_later = sum(
+        # Denominator: orders that had a chance to complete — i.e. anything
+        # past the in-progress (call-live) state. Cancelled orders count
+        # against the rate.
+        had_chance_to_complete = sum(
             1
             for o in seven_day
             if o.status
@@ -85,10 +114,11 @@ def summarize_orders(*, restaurant_id: str) -> OrderSummary:
                 OrderStatus.PREPARING,
                 OrderStatus.READY,
                 OrderStatus.COMPLETED,
+                OrderStatus.CANCELLED,
             }
         )
         completion_rate = (
-            completed / confirmed_or_later if confirmed_or_later else 0.0
+            completed / had_chance_to_complete if had_chance_to_complete else 0.0
         )
     else:
         aov = 0.0

--- a/dashboard/app/(dashboard)/analytics/page.tsx
+++ b/dashboard/app/(dashboard)/analytics/page.tsx
@@ -1,0 +1,75 @@
+import { redirect } from 'next/navigation';
+
+import { Tile } from '@/components/analytics/tile';
+import { getOrderSummary } from '@/lib/api/analytics';
+import { getServerSession } from '@/lib/auth/session';
+import { formatCAD } from '@/lib/formatters/money';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AnalyticsPage() {
+  const session = await getServerSession();
+  if (!session) redirect('/login');
+
+  let summary;
+  try {
+    summary = await getOrderSummary();
+  } catch (err) {
+    console.error('[analytics page] /analytics/summary fetch failed', err);
+    return (
+      <section className="flex flex-1 flex-col gap-3 p-6 lg:p-10">
+        <h2 className="text-3xl font-medium tracking-tight">Analytics</h2>
+        <p className="text-sm text-muted-foreground">
+          Could not load metrics. Try again in a moment.
+        </p>
+      </section>
+    );
+  }
+
+  const empty = summary.seven_day_count === 0;
+
+  return (
+    <section className="flex flex-1 flex-col gap-10 p-6 lg:p-10">
+      <header className="flex max-w-3xl flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-3xl font-medium tracking-tight">Analytics</h2>
+          <span aria-hidden className="h-px flex-1 translate-y-[-0.5rem] bg-border" />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          Today and the past seven days.
+        </p>
+      </header>
+
+      {empty ? (
+        <p className="rounded-lg border border-dashed border-border p-6 text-sm text-muted-foreground">
+          No orders in the last seven days yet. Make a test call to your
+          Niko number — the metrics will populate automatically.
+        </p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <Tile
+            label="Orders today"
+            value={String(summary.today_count)}
+            unit={summary.today_count === 1 ? 'order' : 'orders'}
+          />
+          <Tile
+            label="Orders this week"
+            value={String(summary.seven_day_count)}
+            unit={summary.seven_day_count === 1 ? 'order' : 'orders'}
+            hint="rolling 7 days"
+          />
+          <Tile
+            label="Avg order value"
+            value={formatCAD(summary.average_order_value_7d)}
+            hint="rolling 7 days"
+          />
+          <Tile
+            label="Completion rate"
+            value={`${Math.round(summary.completion_rate_7d * 100)}%`}
+            hint="of orders confirmed → completed"
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/dashboard/components/analytics/tile.tsx
+++ b/dashboard/components/analytics/tile.tsx
@@ -1,0 +1,30 @@
+export function Tile({
+  label,
+  value,
+  unit,
+  hint,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+  hint?: string;
+}) {
+  return (
+    <article className="flex flex-col gap-2 rounded-lg border border-border p-6">
+      <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex items-baseline gap-2">
+        <span className="text-3xl font-medium tabular-nums tracking-tight">
+          {value}
+        </span>
+        {unit ? (
+          <span className="text-sm text-muted-foreground">{unit}</span>
+        ) : null}
+      </div>
+      {hint ? (
+        <p className="text-xs text-muted-foreground">{hint}</p>
+      ) : null}
+    </article>
+  );
+}

--- a/dashboard/components/app-sidebar.tsx
+++ b/dashboard/components/app-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ListOrdered, Menu, Phone, Settings } from 'lucide-react';
+import { BarChart3, ListOrdered, Menu, Phone, Settings } from 'lucide-react';
 
 import { NikoMark } from '@/components/shared/niko-mark';
 import {
@@ -34,6 +34,7 @@ const NAV: NavItem[] = [
   },
   { label: 'Calls', href: '/calls', icon: Phone },
   { label: 'Menu', href: '/menu', icon: Menu },
+  { label: 'Analytics', href: '/analytics', icon: BarChart3 },
   { label: 'Settings', href: '/settings', icon: Settings },
 ];
 

--- a/dashboard/lib/api/analytics.ts
+++ b/dashboard/lib/api/analytics.ts
@@ -1,0 +1,26 @@
+import 'server-only';
+
+import { apiFetch } from '@/lib/api/http';
+import {
+  OrderSummarySchema,
+  type OrderSummary,
+} from '@/lib/schemas/analytics';
+
+export async function getOrderSummary(): Promise<OrderSummary> {
+  const res = await apiFetch('/analytics/summary');
+  if (!res.ok) {
+    throw new Error(
+      `GET /analytics/summary failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  const body = (await res.json()) as unknown;
+  const parsed = OrderSummarySchema.safeParse(body);
+  if (!parsed.success) {
+    console.error(
+      '[lib/api/analytics] /analytics/summary failed validation',
+      parsed.error.flatten(),
+    );
+    throw new Error('analytics summary failed schema validation');
+  }
+  return parsed.data;
+}

--- a/dashboard/lib/schemas/analytics.ts
+++ b/dashboard/lib/schemas/analytics.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const OrderSummarySchema = z.object({
+  today_count: z.number().int().nonnegative(),
+  seven_day_count: z.number().int().nonnegative(),
+  average_order_value_7d: z.number().nonnegative(),
+  completion_rate_7d: z.number().min(0).max(1),
+});
+
+export type OrderSummary = z.infer<typeof OrderSummarySchema>;

--- a/dashboard/tests/analytics-tile.test.tsx
+++ b/dashboard/tests/analytics-tile.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Tile } from '@/components/analytics/tile';
+
+describe('analytics Tile', () => {
+  it('renders label, value, and unit', () => {
+    render(<Tile label="Calls today" value="3" unit="calls" />);
+    expect(screen.getByText('Calls today')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('calls')).toBeInTheDocument();
+  });
+
+  it('omits unit when not provided', () => {
+    render(<Tile label="x" value="5" />);
+    expect(screen.queryByText(/calls/)).not.toBeInTheDocument();
+  });
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ google-cloud-logging>=3.0,<4.0
 firebase-admin>=6.0,<7.0
 deepgram-sdk>=3.0,<4.0
 httpx>=0.27,<1.0
+tzdata>=2024.1

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -1,0 +1,64 @@
+"""Integration test for GET /analytics/summary."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependency import current_tenant, Tenant
+from app.main import app
+from app.storage import analytics, firestore as order_storage
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[current_tenant] = lambda: Tenant(
+        uid="u1",
+        email="o@niko.test",
+        restaurant_id="r1",
+        role="owner",
+    )
+    yield TestClient(app)
+    app.dependency_overrides.pop(current_tenant, None)
+
+
+@pytest.fixture(autouse=True)
+def reset_storage():
+    yield
+    order_storage.set_client(None)
+
+
+def test_get_analytics_summary_returns_metrics(client: TestClient):
+    fake = analytics.OrderSummary(
+        today_count=3,
+        seven_day_count=21,
+        average_order_value_7d=24.50,
+        completion_rate_7d=0.92,
+    )
+    with patch(
+        "app.main.analytics.summarize_orders",
+        return_value=fake,
+    ):
+        resp = client.get("/analytics/summary")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["today_count"] == 3
+    assert body["seven_day_count"] == 21
+    assert body["average_order_value_7d"] == 24.50
+    assert body["completion_rate_7d"] == 0.92
+
+
+def test_get_analytics_summary_passes_tenant_id(client: TestClient):
+    """Verify the handler scopes the aggregation to the calling tenant."""
+    fake = analytics.OrderSummary(
+        today_count=0,
+        seven_day_count=0,
+        average_order_value_7d=0.0,
+        completion_rate_7d=0.0,
+    )
+    with patch(
+        "app.main.analytics.summarize_orders",
+        return_value=fake,
+    ) as mock_fn:
+        client.get("/analytics/summary")
+    mock_fn.assert_called_once_with(restaurant_id="r1")

--- a/tests/test_storage_analytics.py
+++ b/tests/test_storage_analytics.py
@@ -1,0 +1,111 @@
+"""Unit tests for app.storage.analytics aggregations."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.orders.models import (
+    ItemCategory,
+    LineItem,
+    Order,
+    OrderStatus,
+    OrderType,
+)
+from app.storage import analytics, firestore as order_storage
+
+
+@pytest.fixture(autouse=True)
+def reset_storage():
+    yield
+    order_storage.set_client(None)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _wire_orders(orders: list[Order]) -> None:
+    fs = MagicMock()
+    order_storage.set_client(fs)
+    snapshots = []
+    for o in orders:
+        snap = MagicMock()
+        snap.to_dict.return_value = o.model_dump(mode="python")
+        snapshots.append(snap)
+    (
+        fs.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .where.return_value
+        .stream
+    ).return_value = iter(snapshots)
+
+
+def _confirmed(call_sid: str, total: float, age_days: float = 0) -> Order:
+    return Order(
+        call_sid=call_sid,
+        items=[
+            LineItem(
+                name="P",
+                category=ItemCategory.PIZZA,
+                quantity=1,
+                unit_price=total,
+            ),
+        ],
+        order_type=OrderType.PICKUP,
+        status=OrderStatus.CONFIRMED,
+        created_at=_now() - timedelta(days=age_days),
+        confirmed_at=_now() - timedelta(days=age_days),
+    )
+
+
+def _completed(call_sid: str, total: float, age_days: float = 0) -> Order:
+    base = _confirmed(call_sid, total, age_days=age_days)
+    return base.model_copy(update={"status": OrderStatus.COMPLETED})
+
+
+def test_summarize_orders_counts_today_and_seven_day_window():
+    _wire_orders(
+        [
+            _confirmed("CA1", 20.00, age_days=0),
+            _confirmed("CA2", 30.00, age_days=2),
+            _confirmed("CA3", 50.00, age_days=8),  # outside 7d window
+        ],
+    )
+    s = analytics.summarize_orders(restaurant_id="r1")
+    assert s.today_count == 1
+    assert s.seven_day_count == 2  # CA1 + CA2; CA3 too old
+
+
+def test_summarize_orders_average_order_value_uses_seven_day_window():
+    _wire_orders(
+        [
+            _confirmed("CA1", 20.00, age_days=0),
+            _confirmed("CA2", 30.00, age_days=2),
+        ],
+    )
+    s = analytics.summarize_orders(restaurant_id="r1")
+    assert s.average_order_value_7d == 25.00
+
+
+def test_summarize_orders_completion_rate_seven_day():
+    _wire_orders(
+        [
+            _completed("CA1", 20.00, age_days=0),
+            _completed("CA2", 30.00, age_days=2),
+            _confirmed("CA3", 40.00, age_days=3),  # not yet completed
+        ],
+    )
+    s = analytics.summarize_orders(restaurant_id="r1")
+    # 2 completed of 3 confirmed-or-later in window
+    assert s.completion_rate_7d == pytest.approx(2 / 3, rel=1e-3)
+
+
+def test_summarize_orders_handles_empty():
+    _wire_orders([])
+    s = analytics.summarize_orders(restaurant_id="r1")
+    assert s.today_count == 0
+    assert s.seven_day_count == 0
+    assert s.average_order_value_7d == 0.0
+    assert s.completion_rate_7d == 0.0

--- a/tests/test_storage_analytics.py
+++ b/tests/test_storage_analytics.py
@@ -109,3 +109,62 @@ def test_summarize_orders_handles_empty():
     assert s.seven_day_count == 0
     assert s.average_order_value_7d == 0.0
     assert s.completion_rate_7d == 0.0
+
+
+def test_summarize_orders_completion_rate_counts_cancelled_against():
+    """Cancelled orders count against the completion rate. They had a
+    chance to complete and didn't — that's exactly what the rate
+    measures."""
+    _wire_orders(
+        [
+            _completed("CA1", 20.00, age_days=0),
+            _completed("CA2", 30.00, age_days=2),
+            _confirmed("CA3", 40.00, age_days=3).model_copy(
+                update={"status": OrderStatus.CANCELLED},
+            ),
+        ],
+    )
+    s = analytics.summarize_orders(restaurant_id="r1")
+    # 2 completed of 3 had-chance-to-complete (denominator now includes cancelled)
+    assert s.completion_rate_7d == pytest.approx(2 / 3, rel=1e-3)
+
+
+def test_summarize_orders_aov_excludes_cancelled_and_in_progress():
+    """AOV averages over orders that became real revenue
+    opportunities."""
+    _wire_orders(
+        [
+            _confirmed("CA1", 20.00, age_days=0),
+            _confirmed("CA2", 30.00, age_days=2),
+            _confirmed("CA3", 999.00, age_days=3).model_copy(
+                update={"status": OrderStatus.CANCELLED},
+            ),
+            _confirmed("CA4", 999.00, age_days=4).model_copy(
+                update={"status": OrderStatus.IN_PROGRESS},
+            ),
+        ],
+    )
+    s = analytics.summarize_orders(restaurant_id="r1")
+    # AOV averages CA1 + CA2 only (the two CONFIRMED). CA3/CA4 excluded.
+    assert s.average_order_value_7d == 25.00
+
+
+def test_summarize_orders_today_start_uses_local_timezone():
+    """An order placed at 22:00 Toronto local on 2026-05-01 (= 02:00 UTC
+    on 2026-05-02) should count as TODAY when checked at 23:00 Toronto
+    local on 2026-05-01 (= 03:00 UTC on 2026-05-02), not yesterday."""
+    from datetime import datetime, timezone, timedelta
+
+    _wire_orders([])
+    # Use the public window helper directly to assert the boundary
+    # without time-traveling the test clock.
+    win = analytics._window()
+    # today_start should be in UTC but match local-midnight Toronto.
+    # Toronto is UTC-4 (EDT in May), so local midnight = 04:00 UTC.
+    # The test asserts the boundary is at 04:00 or 05:00 UTC, never
+    # 00:00 UTC — that's the bug we're fixing.
+    assert win.today_start.tzinfo == timezone.utc
+    assert win.today_start.hour in (4, 5), (
+        f"Expected today_start at 04:00 or 05:00 UTC (Toronto local "
+        f"midnight EDT/EST), got {win.today_start.isoformat()}"
+    )


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 1 Phase E (Issue #7 deliverable 5 — \"Basic analytics\"). New \`/analytics\` page in the dashboard with 4 tile metrics (today / 7-day rolling / AOV / completion rate) and a sparse-data empty state.

## What landed

**Backend:**
- \`app/storage/analytics.py\` — \`summarize_orders\` aggregation reading from existing \`restaurants/{rid}/orders\` subcollection. No new collections.
- \`GET /analytics/summary\` endpoint in \`app/main.py\` — tenant-scoped via \`current_tenant\`. Not owner-gated (deliberate: staff role can see metrics).
- Timezone-correct: \`today_start\` is computed in \`America/Toronto\` local time and converted to UTC for the Firestore query. \`tzdata\` added to \`requirements.txt\` for Windows + Alpine Docker support.
- AOV restricted to \`{CONFIRMED, PREPARING, READY, COMPLETED}\` — excludes IN_PROGRESS and CANCELLED.
- Completion rate denominator includes CANCELLED — orders that had a chance to complete and didn't count against the rate.

**Dashboard:**
- \`OrderSummarySchema\` Zod, \`getOrderSummary\` server-only API helper.
- \`/analytics\` page (Server Component) with 4-tile grid OR empty-state copy when 7-day count is zero.
- \`Tile\` component (label + value + optional unit + optional hint).
- Sidebar gains \"Analytics\" entry with \`BarChart3\` icon between Menu and Settings.

## Test plan

- [x] \`pytest tests/test_storage_analytics.py tests/test_analytics_api.py -v\` — 9 passes (7 aggregation + 2 endpoint)
- [x] \`pytest tests/ -x\` — 343 passed / 1 skipped / 0 failures
- [x] \`cd dashboard && pnpm vitest run\` — 97/97 across 15 files
- [x] \`cd dashboard && pnpm typecheck\` — clean
- [ ] **Manual smoke (gating, owner does this):** Open \`/analytics\` with no recent orders → empty state shows. Make a few test calls → tiles populate with correct counts/AOV/completion-rate after refresh.

## Follow-ups deliberately deferred

Flagged in the final niko-reviewer pass; non-blocking for pilot:

- **Owner-gate the endpoint** — currently any authenticated tenant can read tile metrics. Inconsistent with \`patch_restaurant\` and the menu endpoints. Either gate it with \`_require_owner\` or document the deliberate exception inline.
- **Negative-auth test on \`/analytics/summary\`** — every other endpoint has 401/403 path coverage; analytics doesn't.
- **Page-level integration test** — current dashboard tests cover the \`Tile\` component in isolation but not the page-with-real-data-mocked case (4 tiles + empty state + error state).
- **Multi-tenant timezone** — Phase 1 hardcodes \`America/Toronto\`. When multi-location lands, read tz from \`restaurants/{rid}.timezone\`.
- **Performance at scale** — \`_stream_recent_orders\` materializes 7 days of orders into memory. Pilot scale (<200 orders/day) is fine; switch to scheduled aggregations when >1k orders/day.

## Tasks → commits

| Task | Commit |
|---|---|
| E.16 Backend aggregation | \`2efc648\` |
| E.17 Endpoint | \`e25bf84\` |
| E.18 Dashboard page + sidebar | \`454a2b3\` |
| Final review fixes | \`7fce2c4\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)