### PR TITLE
Sprint 2.4 Track 1 Phase F — transcript polish on /calls (#7)

### DIFF
--- a/dashboard/components/calls/call-timeline.tsx
+++ b/dashboard/components/calls/call-timeline.tsx
@@ -1,7 +1,11 @@
+'use client';
+
+import { useRef } from 'react';
 import {
   AlertTriangle,
   ArrowLeft,
   CheckCircle2,
+  Copy,
   Mic,
   PhoneCall,
   PhoneOff,
@@ -11,17 +15,39 @@ import {
   Zap,
 } from 'lucide-react';
 import Link from 'next/link';
+import { toast } from 'sonner';
 
 import { TimelineExport } from '@/components/calls/timeline-export';
+import { Button } from '@/components/ui/button';
 import { LocalTime } from '@/components/shared/local-time';
 import type { CallEvent, CallTimeline } from '@/lib/api/calls';
 import { formatFirstAudioBreakdown } from '@/lib/formatters/call-timeline';
 import { cn } from '@/lib/utils';
 
+const TRANSCRIPT_KINDS = new Set(['transcript_final', 'agent_reply']);
+
 export function CallTimelineView({ timeline }: { timeline: CallTimeline }) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
   const recordingUrl = timeline.recording_available
     ? `/api/calls/${timeline.call_sid}/recording`
     : null;
+
+  // Use the FIRST event's timestamp as the call-start anchor for
+  // computing per-turn offsets into the recording. Fallback to the
+  // earliest event if the explicit `start` event is missing.
+  const callStartMs = (() => {
+    const firstEvent = timeline.events[0];
+    return firstEvent ? new Date(firstEvent.timestamp).getTime() : 0;
+  })();
+
+  function seekTo(seconds: number) {
+    if (!audioRef.current) return;
+    audioRef.current.currentTime = Math.max(0, seconds);
+    void audioRef.current.play().catch(() => {
+      // play() can fail in browsers that require a user gesture per
+      // load — the seek still succeeded, the user can press play.
+    });
+  }
 
   return (
     <section className="flex flex-1 flex-col gap-4 p-6">
@@ -53,6 +79,7 @@ export function CallTimelineView({ timeline }: { timeline: CallTimeline }) {
           </p>
           {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
           <audio
+            ref={audioRef}
             controls
             src={recordingUrl}
             className="w-full"
@@ -63,38 +90,100 @@ export function CallTimelineView({ timeline }: { timeline: CallTimeline }) {
 
       <ol className="flex flex-col gap-2 rounded-xl border bg-card p-4">
         {timeline.events.map((event, i) => (
-          <TimelineRow key={i} event={event} />
+          <TimelineRow
+            key={i}
+            event={event}
+            onSeek={recordingUrl ? seekTo : undefined}
+            callStartMs={callStartMs}
+          />
         ))}
       </ol>
     </section>
   );
 }
 
-function TimelineRow({ event }: { event: CallEvent }) {
+function TimelineRow({
+  event,
+  onSeek,
+  callStartMs,
+}: {
+  event: CallEvent;
+  onSeek?: (seconds: number) => void;
+  callStartMs: number;
+}) {
   const ts = new Date(event.timestamp);
-  const { Icon, accent, label, body } = renderEvent(event);
+  const { Icon, accent, label, body, copyText } = renderEvent(event);
+
+  const isTranscript = TRANSCRIPT_KINDS.has(event.kind);
+  const offsetSec = Math.max(0, (ts.getTime() - callStartMs) / 1000);
+  const canSeek = isTranscript && onSeek !== undefined;
+
+  function handleSeek() {
+    if (canSeek) onSeek!(offsetSec);
+  }
+
+  function handleCopy() {
+    if (!copyText) return;
+    void navigator.clipboard.writeText(copyText).then(
+      () => toast.success('Turn copied'),
+      () => toast.error('Copy failed'),
+    );
+  }
+
+  const RowTag = canSeek ? 'button' : 'div';
 
   return (
-    <li className="flex items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-muted/40">
-      <div
+    <li className={cn(
+      'flex items-start gap-3 rounded-lg px-2 py-1.5 hover:bg-muted/40',
+      canSeek && 'cursor-pointer',
+    )}>
+      <RowTag
+        type={canSeek ? 'button' : undefined}
+        onClick={canSeek ? handleSeek : undefined}
         className={cn(
-          'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full',
-          accent,
+          'flex flex-1 items-start gap-3 text-left bg-transparent p-0',
+          canSeek && 'cursor-pointer focus-visible:outline-2 focus-visible:outline-primary',
         )}
+        aria-label={canSeek ? `Seek to ${label} at ${formatOffset(offsetSec)}` : undefined}
       >
-        <Icon className="h-3.5 w-3.5" aria-hidden />
-      </div>
-      <div className="flex min-w-[5rem] shrink-0 flex-col text-xs text-muted-foreground tabular-nums">
-        <LocalTime date={ts} mode="absolute" />
-      </div>
-      <div className="flex flex-1 flex-col gap-0.5">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          {label}
-        </p>
-        <p className="text-sm">{body}</p>
-      </div>
+        <div
+          className={cn(
+            'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full',
+            accent,
+          )}
+        >
+          <Icon className="h-3.5 w-3.5" aria-hidden />
+        </div>
+        <div className="flex min-w-[5rem] shrink-0 flex-col text-xs text-muted-foreground tabular-nums">
+          <LocalTime date={ts} mode="absolute" />
+        </div>
+        <div className="flex flex-1 flex-col gap-0.5">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {label}
+          </p>
+          <p className="text-sm">{body}</p>
+        </div>
+      </RowTag>
+      {copyText ? (
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="h-7 w-7 shrink-0"
+          aria-label={`Copy ${label} text`}
+          onClick={handleCopy}
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </Button>
+      ) : null}
     </li>
   );
+}
+
+function formatOffset(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
 }
 
 type RenderedEvent = {
@@ -102,6 +191,8 @@ type RenderedEvent = {
   accent: string;
   label: string;
   body: React.ReactNode;
+  // Plain-text version for clipboard. Only set on transcript-style events.
+  copyText?: string;
 };
 
 function renderEvent(event: CallEvent): RenderedEvent {
@@ -133,7 +224,8 @@ function renderEvent(event: CallEvent): RenderedEvent {
         Icon: Mic,
         accent: 'bg-foreground/10 text-foreground',
         label: 'caller',
-        body: <span className="italic">“{text}”</span>,
+        body: <span className="italic">"{text}"</span>,
+        copyText: text,
       };
     }
     case 'transcript_interim': {
@@ -142,7 +234,7 @@ function renderEvent(event: CallEvent): RenderedEvent {
         Icon: Mic,
         accent: 'bg-muted text-muted-foreground',
         label: 'interim transcript',
-        body: <span className="text-muted-foreground italic">“{text}”</span>,
+        body: <span className="text-muted-foreground italic">"{text}"</span>,
       };
     }
     case 'llm_turn_start': {
@@ -160,7 +252,8 @@ function renderEvent(event: CallEvent): RenderedEvent {
         Icon: Sparkles,
         accent: 'bg-violet-500/15 text-violet-600 dark:text-violet-400',
         label: 'agent',
-        body: <span className="italic">“{reply}”</span>,
+        body: <span className="italic">"{reply}"</span>,
+        copyText: reply,
       };
     }
     case 'first_audio': {

--- a/dashboard/components/calls/call-timeline.tsx
+++ b/dashboard/components/calls/call-timeline.tsx
@@ -224,7 +224,7 @@ function renderEvent(event: CallEvent): RenderedEvent {
         Icon: Mic,
         accent: 'bg-foreground/10 text-foreground',
         label: 'caller',
-        body: <span className="italic">"{text}"</span>,
+        body: <span className="italic">“{text}”</span>,
         copyText: text,
       };
     }
@@ -234,7 +234,7 @@ function renderEvent(event: CallEvent): RenderedEvent {
         Icon: Mic,
         accent: 'bg-muted text-muted-foreground',
         label: 'interim transcript',
-        body: <span className="text-muted-foreground italic">"{text}"</span>,
+        body: <span className="text-muted-foreground italic">“{text}”</span>,
       };
     }
     case 'llm_turn_start': {
@@ -252,7 +252,7 @@ function renderEvent(event: CallEvent): RenderedEvent {
         Icon: Sparkles,
         accent: 'bg-violet-500/15 text-violet-600 dark:text-violet-400',
         label: 'agent',
-        body: <span className="italic">"{reply}"</span>,
+        body: <span className="italic">“{reply}”</span>,
         copyText: reply,
       };
     }

--- a/dashboard/tests/call-timeline.test.tsx
+++ b/dashboard/tests/call-timeline.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CallTimelineView } from '@/components/calls/call-timeline';
+import type { CallTimeline } from '@/lib/api/calls';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const TIMELINE_BASE: CallTimeline = {
+  call_sid: 'CAtest',
+  recording_available: true,
+  events: [
+    {
+      timestamp: '2026-05-01T18:00:00Z',
+      kind: 'start',
+      text: '',
+      detail: {},
+    },
+    {
+      timestamp: '2026-05-01T18:00:05Z',
+      kind: 'transcript_final',
+      text: '',
+      detail: { text: 'Hi I want a pizza' },
+    },
+    {
+      timestamp: '2026-05-01T18:00:08Z',
+      kind: 'agent_reply',
+      text: '',
+      detail: { text: 'Sure, what kind?' },
+    },
+  ],
+};
+
+describe('CallTimelineView', () => {
+  it('renders a copy button on transcript_final and agent_reply rows', () => {
+    render(<CallTimelineView timeline={TIMELINE_BASE} />);
+    expect(screen.getByRole('button', { name: /Copy caller text/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copy agent text/i })).toBeInTheDocument();
+  });
+
+  it('does not render a copy button on non-transcript rows', () => {
+    render(<CallTimelineView timeline={TIMELINE_BASE} />);
+    expect(screen.queryByRole('button', { name: /Copy call started/i })).not.toBeInTheDocument();
+  });
+
+  it('copies turn text to the clipboard when the copy button is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<CallTimelineView timeline={TIMELINE_BASE} />);
+    fireEvent.click(screen.getByRole('button', { name: /Copy caller text/i }));
+    expect(writeText).toHaveBeenCalledWith('Hi I want a pizza');
+  });
+
+  it('makes transcript rows seekable buttons and non-transcript rows plain divs', () => {
+    render(<CallTimelineView timeline={TIMELINE_BASE} />);
+    // Transcript rows render as <button> with seek aria-label
+    expect(screen.getByRole('button', { name: /Seek to caller/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Seek to agent/i })).toBeInTheDocument();
+  });
+
+  it('seeks the audio when a transcript row is clicked', () => {
+    render(<CallTimelineView timeline={TIMELINE_BASE} />);
+    const audio = screen.getByLabelText('Call recording audio player') as HTMLAudioElement;
+    // jsdom doesn't implement HTMLMediaElement.play by default — stub it
+    audio.play = vi.fn().mockResolvedValue(undefined);
+
+    fireEvent.click(screen.getByRole('button', { name: /Seek to caller/i }));
+    // First event is at 18:00:00, transcript_final is at 18:00:05 → 5s offset
+    expect(audio.currentTime).toBe(5);
+  });
+
+  it('does not render seek affordance when no recording is available', () => {
+    const noRecording = { ...TIMELINE_BASE, recording_available: false };
+    render(<CallTimelineView timeline={noRecording} />);
+    // Without a recording, the rows should not be buttons.
+    expect(screen.queryByRole('button', { name: /Seek to caller/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 1 Phase F (Issue #7 deliverable 1, close-out — \"Call history with transcripts\" polish). Adds two affordances to the existing call-detail timeline that the audit identified as gaps.

## What landed

- **Per-turn copy button** on \`transcript_final\` (caller) and \`agent_reply\` (agent) rows. Uses \`navigator.clipboard.writeText\` + sonner toast on success/failure. Copy text is the raw transcript without surrounding curly quotes, so the clipboard stays clean.
- **Click-to-seek** on transcript rows. Clicking a turn jumps the audio player to that turn's offset (computed from the call's first event timestamp). The audio element gets a \`useRef\`; \`seekTo(seconds)\` sets \`audio.currentTime\` and calls \`play()\` (with a soft-fail catch for browsers that require a user-gesture-per-load).
- Transcript rows render as \`<button>\` with \`aria-label=\"Seek to {role} at M:SS\"\`, focus-visible outline, and pointer cursor. Non-transcript rows stay plain \`<div>\` (no false interactivity).
- Curly quotes (\"...\") preserved on transcript-row body rendering — fixed an editor-induced regression in commit \`41d8c71\`.

## Test plan

- [x] \`cd dashboard && pnpm vitest run tests/call-timeline.test.tsx\` — 6 passes (copy button presence, non-transcript exclusion, clipboard write, seek button presence, currentTime mutation, no-recording guard)
- [x] \`cd dashboard && pnpm vitest run\` — 103/103 across 16 files
- [x] \`cd dashboard && pnpm typecheck\` — clean
- [ ] **Manual smoke (gating, owner does this):** Open a call with a recording, click an early transcript row → audio jumps + plays from there. Click the copy button on a turn → clipboard contains the raw text.

## Follow-ups deliberately deferred

Flagged in the final niko-reviewer pass (none blocking pilot):

- **Snapshot tests for unchanged render paths** (icons, accents, formatting on non-transcript rows). The 6 new tests cover the new affordances meaningfully but don't re-assert structural coverage of \`renderEvent\`'s 13 branches. Worth a defense-in-depth follow-up.
- **Clipboard fallback for non-secure contexts.** \`navigator.clipboard.writeText\` requires HTTPS (or localhost). Acceptable for Cloud Run (HTTPS) and \`pnpm dev\` (localhost); no fallback for someone running over plain HTTP.

## Tasks → commits

| Task | Commit |
|---|---|
| F.20+21 Copy + click-to-seek | \`ec69be9\` |
| Curly-quote restore | \`41d8c71\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)