### PR TITLE
Sprint 2.4 Track 2 Phase A — call_session schema + is_open_now helper (#7)

### DIFF
--- a/app/restaurants/open_check.py
+++ b/app/restaurants/open_check.py
@@ -1,0 +1,53 @@
+"""Is-the-restaurant-open-right-now check.
+
+Phase 1 hardcodes the timezone to America/Toronto (matches the
+dashboard's <LocalTime /> default and ``app.storage.analytics``).
+Multi-tz support arrives with multi-location, deferred per
+``dashboard/CLAUDE.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from app.restaurants.models import DayHours, HoursStructured, Restaurant
+
+_TZ = ZoneInfo("America/Toronto")
+_DAY_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+
+
+def _parse_hhmm(value: str) -> time:
+    hour, minute = value.split(":")
+    return time(int(hour), int(minute))
+
+
+def _day_for(dt_local: datetime) -> str:
+    # Python: Monday == 0, Sunday == 6. Map to our day keys.
+    return _DAY_KEYS[dt_local.weekday()]
+
+
+def is_open_now(
+    restaurant: Restaurant,
+    now_utc: Optional[datetime] = None,
+) -> bool:
+    """Return True if the restaurant is currently open in its local
+    timezone. Falls back to True when ``hours_structured`` is None —
+    don't silently route callers to voicemail just because hours
+    haven't been configured yet."""
+    if restaurant.hours_structured is None:
+        return True
+
+    now = now_utc or datetime.now(_TZ)
+    local = now.astimezone(_TZ)
+    day_key = _day_for(local)
+    day: DayHours = getattr(restaurant.hours_structured, day_key)
+
+    if day.closed:
+        return False
+
+    open_t = _parse_hhmm(day.open)
+    close_t = _parse_hhmm(day.close)
+    current = local.time()
+    return open_t <= current < close_t

--- a/app/storage/call_sessions.py
+++ b/app/storage/call_sessions.py
@@ -292,6 +292,114 @@ def mark_recording_deleted(call_sid: str, restaurant_id: str) -> None:
         )
 
 
+def mark_transfer_attempted(
+    call_sid: str,
+    restaurant_id: str,
+    *,
+    status: str,  # "answered" | "no_answer" | "busy" | "failed" | "skipped"
+    fallback_phone: Optional[str] = None,
+) -> None:
+    """Stamp the call session with transfer outcome + emit a
+    ``transfer_attempted`` event. Mirrors ``mark_recording_ready``'s
+    dual-write shape."""
+    ts = _now()
+    patch = {
+        "transfer_attempted": True,
+        "transfer_status": status,
+        "transfer_initiated_at": ts,
+        "last_event_at": ts,
+    }
+    event = {
+        "timestamp": ts,
+        "kind": "transfer_attempted",
+        "text": "",
+        "detail": {"status": status, "fallback_phone": fallback_phone},
+    }
+    try:
+        client = _get_client()
+        legacy = _legacy_parent(client, call_sid)
+        legacy.update(patch)
+        legacy.collection(_EVENTS_SUBCOLLECTION).add(event)
+
+        nested = _nested_parent(client, restaurant_id, call_sid)
+        nested.update(patch)
+        nested.collection(_EVENTS_SUBCOLLECTION).add(event)
+    except Exception:
+        logger.exception(
+            "call_sessions: mark_transfer_attempted failed call_sid=%s",
+            call_sid,
+        )
+
+
+def mark_voicemail_left(
+    call_sid: str,
+    restaurant_id: str,
+    *,
+    recording_url: str,
+    recording_sid: str,
+    duration_seconds: int,
+    transcript: Optional[str],
+) -> None:
+    """Stamp the call session with voicemail recording metadata + emit
+    a ``voicemail_left`` event."""
+    ts = _now()
+    patch = {
+        "voicemail_recording_url": recording_url,
+        "voicemail_recording_sid": recording_sid,
+        "voicemail_duration_seconds": duration_seconds,
+        "voicemail_transcript": transcript,
+        "voicemail_recorded_at": ts,
+        "last_event_at": ts,
+    }
+    event = {
+        "timestamp": ts,
+        "kind": "voicemail_left",
+        "text": transcript or "",
+        "detail": {
+            "recording_sid": recording_sid,
+            "duration_seconds": duration_seconds,
+        },
+    }
+    try:
+        client = _get_client()
+        legacy = _legacy_parent(client, call_sid)
+        legacy.update(patch)
+        legacy.collection(_EVENTS_SUBCOLLECTION).add(event)
+
+        nested = _nested_parent(client, restaurant_id, call_sid)
+        nested.update(patch)
+        nested.collection(_EVENTS_SUBCOLLECTION).add(event)
+    except Exception:
+        logger.exception(
+            "call_sessions: mark_voicemail_left failed call_sid=%s",
+            call_sid,
+        )
+
+
+def update_voicemail_transcript(
+    call_sid: str,
+    restaurant_id: str,
+    *,
+    transcript: str,
+) -> None:
+    """Patch the voicemail transcript after Twilio's transcribeCallback
+    fires (out-of-band from the recording-ready callback)."""
+    ts = _now()
+    patch = {
+        "voicemail_transcript": transcript,
+        "last_event_at": ts,
+    }
+    try:
+        client = _get_client()
+        _legacy_parent(client, call_sid).update(patch)
+        _nested_parent(client, restaurant_id, call_sid).update(patch)
+    except Exception:
+        logger.exception(
+            "call_sessions: update_voicemail_transcript failed call_sid=%s",
+            call_sid,
+        )
+
+
 def get_session(
     call_sid: str, restaurant_id: str
 ) -> Optional[dict[str, Any]]:

--- a/tests/test_call_sessions_storage.py
+++ b/tests/test_call_sessions_storage.py
@@ -11,6 +11,7 @@ arbitrary path segments so tests can assert both writes landed.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -369,3 +370,80 @@ def test_mark_recording_deleted_clears_url_and_emits_event(monkeypatch):
     assert len(events) == 2
     for ev in events:
         assert ev["kind"] == "recording_deleted"
+
+
+def test_mark_transfer_attempted_writes_status_to_both_paths():
+    """Transfer status patches the call session and emits an event."""
+    fs = MagicMock()
+    call_sessions.set_client(fs)
+
+    call_sessions.mark_transfer_attempted(
+        "CAxfer",
+        "r1",
+        status="answered",
+        fallback_phone="+15551234567",
+    )
+
+    legacy_update = fs.collection.return_value.document.return_value.update
+    nested_update = (
+        fs.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .update
+    )
+    assert legacy_update.called
+    assert nested_update.called
+    payload = legacy_update.call_args.args[0]
+    assert payload["transfer_attempted"] is True
+    assert payload["transfer_status"] == "answered"
+
+
+def test_mark_voicemail_left_sets_recording_url_and_transcript():
+    fs = MagicMock()
+    call_sessions.set_client(fs)
+
+    call_sessions.mark_voicemail_left(
+        "CAvm",
+        "r1",
+        recording_url="gs://bucket/path.mp3",
+        recording_sid="REabc",
+        duration_seconds=42,
+        transcript=None,
+    )
+
+    nested_update = (
+        fs.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .update
+    )
+    payload = nested_update.call_args.args[0]
+    assert payload["voicemail_recording_url"] == "gs://bucket/path.mp3"
+    assert payload["voicemail_recording_sid"] == "REabc"
+    assert payload["voicemail_duration_seconds"] == 42
+
+
+def test_update_voicemail_transcript_patches_transcript():
+    fs = MagicMock()
+    call_sessions.set_client(fs)
+
+    call_sessions.update_voicemail_transcript(
+        "CAvm",
+        "r1",
+        transcript="Hi please call me back",
+    )
+
+    legacy_update = fs.collection.return_value.document.return_value.update
+    nested_update = (
+        fs.collection.return_value
+        .document.return_value
+        .collection.return_value
+        .document.return_value
+        .update
+    )
+    assert legacy_update.called
+    assert nested_update.called
+    legacy_payload = legacy_update.call_args.args[0]
+    assert legacy_payload["voicemail_transcript"] == "Hi please call me back"

--- a/tests/test_open_check.py
+++ b/tests/test_open_check.py
@@ -1,0 +1,74 @@
+"""Unit tests for app.restaurants.open_check.is_open_now."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.restaurants.models import DayHours, HoursStructured, Restaurant
+from app.restaurants.open_check import is_open_now
+
+
+def _r(hours: HoursStructured | None) -> Restaurant:
+    return Restaurant(
+        id="r1",
+        name="R",
+        display_phone="+15551234567",
+        twilio_phone="+15551234567",
+        address="1 Main",
+        hours="11-22",
+        hours_structured=hours,
+    )
+
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    """Build a UTC datetime. Caller accounts for America/Toronto offset.
+    May 2026 is EDT (UTC-4)."""
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def test_is_open_now_returns_true_when_hours_structured_is_none():
+    """No configured hours → assume always open. Conservative default
+    so existing tenants don't suddenly land in voicemail."""
+    assert is_open_now(_r(None), _utc(2026, 5, 1, 18)) is True
+
+
+def test_is_open_now_returns_true_within_open_window():
+    day = DayHours(open="11:00", close="22:00", closed=False)
+    h = HoursStructured(mon=day, tue=day, wed=day, thu=day, fri=day, sat=day, sun=day)
+    # 2026-05-01 is a Friday. EDT = UTC-4.
+    # 18:00 UTC = 14:00 local → within 11-22 window.
+    assert is_open_now(_r(h), _utc(2026, 5, 1, 18)) is True
+
+
+def test_is_open_now_returns_false_outside_open_window():
+    day = DayHours(open="11:00", close="22:00", closed=False)
+    h = HoursStructured(mon=day, tue=day, wed=day, thu=day, fri=day, sat=day, sun=day)
+    # 06:00 UTC = 02:00 local Friday → closed.
+    assert is_open_now(_r(h), _utc(2026, 5, 1, 6)) is False
+
+
+def test_is_open_now_returns_false_on_closed_day():
+    open_day = DayHours(open="11:00", close="22:00", closed=False)
+    closed_day = DayHours(open="00:00", close="00:00", closed=True)
+    h = HoursStructured(
+        mon=open_day,
+        tue=open_day,
+        wed=open_day,
+        thu=open_day,
+        fri=open_day,
+        sat=open_day,
+        sun=closed_day,
+    )
+    # 2026-05-03 is a Sunday. 18:00 UTC = 14:00 local Sunday.
+    assert is_open_now(_r(h), _utc(2026, 5, 3, 18)) is False
+
+
+def test_is_open_now_handles_late_night_close():
+    """A close time of 23:00 includes 22:59 local; excludes 23:01."""
+    day = DayHours(open="11:00", close="23:00", closed=False)
+    h = HoursStructured(mon=day, tue=day, wed=day, thu=day, fri=day, sat=day, sun=day)
+    # 2026-05-02 03:00 UTC = 23:00 local Friday → at the close edge,
+    # treat as closed.
+    assert is_open_now(_r(h), _utc(2026, 5, 2, 3)) is False
+    # 02:59 UTC = 22:59 local Friday → still open.
+    assert is_open_now(_r(h), _utc(2026, 5, 2, 2, 59)) is True


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 2 Phase A — pure additive infrastructure for the upcoming call-transfer + voicemail flows. No existing call paths are modified. Track 2 Phase B (trigger detection in the WebSocket loop) and Phase C+D (TwiML endpoints) consume these helpers.

## What landed

**Backend storage:**
- \`app/storage/call_sessions.py\` — three new helpers, all dual-writing the legacy flat + nested-canonical paths (matches \`mark_recording_ready\`'s pattern):
  - \`mark_transfer_attempted(call_sid, rid, *, status, fallback_phone)\` — patches \`transfer_attempted\`, \`transfer_status\`, \`transfer_initiated_at\` + emits a \`transfer_attempted\` event.
  - \`mark_voicemail_left(call_sid, rid, *, recording_url, recording_sid, duration_seconds, transcript)\` — patches \`voicemail_recording_url\`, etc. + emits a \`voicemail_left\` event.
  - \`update_voicemail_transcript(call_sid, rid, *, transcript)\` — out-of-band patch when Twilio's \`transcribeCallback\` fires after the recording-ready callback.

**Backend helper:**
- \`app/restaurants/open_check.py\` — \`is_open_now(restaurant, now_utc)\` checks the per-day \`hours_structured\` against the restaurant's local timezone (\`America/Toronto\`, matches the analytics + dashboard convention). Returns \`True\` when \`hours_structured\` is \`None\` so unconfigured tenants don't suddenly land in voicemail.

## Test plan

- [x] \`pytest tests/test_call_sessions_storage.py -v\` — 14 passes (11 existing + 3 new)
- [x] \`pytest tests/test_open_check.py -v\` — 5 passes
- [x] \`pytest tests/ -x\` — 349 passed / 1 skipped (modulo a transient \`live_llm\` rate-limit unrelated to this change)
- [ ] **No manual smoke gating this PR** — none of these helpers are wired to a runtime path yet. Phase B will integrate them.

## Cross-track contract

These helpers are the foundation Track 2 phases B–E build on. Track 1's \`fallback_phone\` and \`hours_structured\` fields (already on master) are read by the upcoming WebSocket integration + TwiML endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)