### PR TITLE
prompts: revert Fix 2 from #157 — restore mandatory modification ack

### DIFF
--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -38,9 +38,7 @@ _PREAMBLE = dedent("""\
 
     Item customizations:
     - After the caller picks an item and size, ask once whether they have
-      any customizations. Keep this question to ONE short sentence. Do not expand the example list beyond two items.
-      Good: "Any modifications — extra cheese, no onions?"
-      Too long: "Any modifications on the pizza — like extra cheese, no onions, mushrooms, anything else like that?"
+      any customizations ("Any modifications — extra cheese, no onions?").
     - If they say no or give nothing, move on — do not ask again.
     - Accept any free-text customization; capture it exactly as stated.
       Do not validate against a fixed list and do not invent customizations

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -69,17 +69,6 @@ def test_prompt_speak_first_rule_is_critical_and_numbered():
     assert "always speak a short acknowledgement first" in lower
 
 
-def test_prompt_caps_modification_question_length():
-    """Regression for #155 — the modification ack was too long on the
-    18:43 test call (~6s spoken, induced barge-in). Prompt now caps
-    the question to one sentence and forbids expanding the example
-    list beyond two items."""
-    prompt = build_system_prompt(_demo())
-    lower = prompt.lower()
-    assert "keep this question to one short sentence" in lower
-    assert "do not expand the example list beyond two items" in lower
-
-
 def test_prompt_makes_confirmation_goodbyes_terminal():
     """Regression for #78 — once the caller confirms, the agent should
     say a brief terminal goodbye and NOT ask another question. Otherwise


### PR DESCRIPTION
## Summary

Reverts only the modification-ack-length cap added in PR #157 / issue #155 (Fix 2). Keeps Fix 1 (strengthened speak-first rule) intact.

## Why

Three test calls on 2026-05-01 immediately after #157 deployed:

| Call | Mod specified up-front? | Agent asked? | Outcome |
|---|---|---|---|
| CA2242fff3 (19:14) | no | **no** | SILENCE_TIMEOUT after order; caller said \"yep\" |
| CA7b42e591 (19:16) | no | **no** | SILENCE_TIMEOUT after order; caller said \"yep\" |
| CAc4efb0c6 (19:19) | yes (\"with extra sauce\") | n/a | smooth flow |

The Fix 2 prompt block — *\"Keep this question to ONE short sentence... Too long: '…anything else like that?'\"* — pushed Haiku toward avoidance instead of the intended *\"ask but keep short.\"*

## Why Fix 1 stays

Fix 1 (the speak-first CRITICAL block) is doing exactly what we wanted. \`tool_prefix\` on the three test calls (10 turns total): all zero. Pre-#157 had a 1192ms regression on confirmation turns. That's a clear win we're not giving back.

## Linked issues

Closes #161

## Test plan

- [x] \`pytest tests/\` — 341/341 green.
- [x] \`test_prompt_caps_modification_question_length\` removed (the assertion no longer applies).
- [x] All other test_prompts.py assertions still pass — Fix 1's \`test_prompt_speak_first_rule_is_critical_and_numbered\` and the existing #76 regression both still hold.
- [ ] Live test calls (Sandeep) — confirm the agent asks \"any modifications?\" again on orders without pre-specified mods.

## Out of scope (future)

A cleaner prompt that caps length without inducing skip — possibly via *\"You MUST ask this question — it is a required step\"* before the length constraint, or splitting the negative example into a separate block. Not blocking this revert.