### PR TITLE
Sprint 2.4 Track 2 Phase B — transfer-trigger detection (#7)

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -312,7 +312,10 @@ async def _open_deepgram_connection(
         logger.info("transcript [%s] call_sid=%s text=%r", label, call_sid, text)
         if result.is_final:
             # Track confidence for transfer-trigger detection (#7).
-            confidence = getattr(alt, "confidence", 1.0) or 1.0
+            # Explicit None check — `or 1.0` would replace 0.0 (falsy)
+            # with 1.0, masking a legitimate worst-case misheard signal.
+            raw_confidence = getattr(alt, "confidence", 1.0)
+            confidence = 1.0 if raw_confidence is None else raw_confidence
             if state is not None:
                 state.last_caller_transcript = text
                 if confidence < 0.5:

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -284,10 +284,19 @@ class _CallState:
     # further TwiML the call hangs up. Avoids the Twilio REST
     # Calls.update endpoint which 404s on <Connect>-state calls.
     websocket: "WebSocket | None" = None
+    # Transfer trigger accumulators (#7 Sprint 2.4 Track 2). Set by
+    # transcript / LLM-error handlers; read in the finally block to
+    # decide whether to write a transfer flag to the call session.
+    consecutive_low_confidence_turns: int = 0
+    last_caller_transcript: str = ""
+    llm_error_occurred: bool = False
 
 
 async def _open_deepgram_connection(
-    call_sid: str | None, restaurant_id: str | None, on_final: Callable
+    call_sid: str | None,
+    restaurant_id: str | None,
+    on_final: Callable,
+    state: "_CallState | None" = None,
 ):
     assert settings.deepgram_api_key, "DEEPGRAM_API_KEY is not set"
 
@@ -302,12 +311,20 @@ async def _open_deepgram_connection(
         label = "final" if result.is_final else "interim"
         logger.info("transcript [%s] call_sid=%s text=%r", label, call_sid, text)
         if result.is_final:
+            # Track confidence for transfer-trigger detection (#7).
+            confidence = getattr(alt, "confidence", 1.0) or 1.0
+            if state is not None:
+                state.last_caller_transcript = text
+                if confidence < 0.5:
+                    state.consecutive_low_confidence_turns += 1
+                else:
+                    state.consecutive_low_confidence_turns = 0
             _bg_call_event(
                 call_sid,
                 restaurant_id,
                 kind="transcript_final",
                 text=text,
-                detail={"text": text},
+                detail={"text": text, "confidence": confidence},
             )
             asyncio.get_event_loop().create_task(on_final(text))
 
@@ -551,6 +568,8 @@ async def _run_llm_tts_turn(
         raise
     except Exception as exc:
         logger.exception("llm_turn errored call_sid=%s", state.call_sid)
+        # #7: signal the trigger detector at end-of-stream
+        state.llm_error_occurred = True
         _bg_call_event(
             state.call_sid,
             _state_rid(state),
@@ -648,7 +667,7 @@ async def voice(request: Request) -> Response:
         return Response(content=str(twiml), media_type="application/xml")
 
     host = request.headers.get("host", "localhost:8000")
-    connect = Connect()
+    connect = Connect(action="/voice/stream-ended", method="POST")
     # NOTE: <Connect><Stream> only supports the default ``inbound_track``;
     # passing ``track="both_tracks"`` makes Twilio reject the TwiML and
     # the call drops the moment the caller dismisses the trial-account
@@ -742,7 +761,7 @@ async def media_stream(websocket: WebSocket) -> None:
                         detail={"stream_sid": state.stream_sid or ""},
                     )
                 dg_conn = await _open_deepgram_connection(
-                    state.call_sid, state.restaurant.id, on_final
+                    state.call_sid, state.restaurant.id, on_final, state=state
                 )
                 if settings.testing_mode and settings.commit_sha and state.stream_sid:
                     await speak(
@@ -846,6 +865,35 @@ async def media_stream(websocket: WebSocket) -> None:
                     "call_sessions: mark_call_ended scheduling failed call_sid=%s",
                     state.call_sid,
                 )
+        # Sprint 2.4 Track 2: decide whether to flag this call for
+        # transfer in the /voice/stream-ended callback. Reads accumulated
+        # signals on _CallState; persists the verdict as a call_session
+        # event so the action callback can branch on it.
+        if state.call_sid and rid_for_close:
+            from app.telephony.transfer_triggers import should_trigger_transfer
+            transfer_reason = should_trigger_transfer(
+                consecutive_low_confidence_turns=state.consecutive_low_confidence_turns,
+                last_transcript=state.last_caller_transcript,
+                llm_error_occurred=state.llm_error_occurred,
+            )
+            if transfer_reason is not None:
+                logger.info(
+                    "transfer_requested call_sid=%s reason=%s",
+                    state.call_sid,
+                    transfer_reason.value,
+                )
+                try:
+                    call_sessions.record_event(
+                        state.call_sid,
+                        rid_for_close,
+                        kind="transfer_requested",
+                        text=transfer_reason.value,
+                    )
+                except Exception:
+                    logger.exception(
+                        "call_sessions: transfer_requested write failed call_sid=%s",
+                        state.call_sid,
+                    )
         if state.recording_session is not None and rid_for_close:
             try:
                 gs_url, duration = recordings.finalize_recording(state.recording_session)

--- a/app/telephony/transfer_triggers.py
+++ b/app/telephony/transfer_triggers.py
@@ -1,0 +1,68 @@
+"""Pure-function checks that decide whether the AI loop should transfer
+the caller to a human. Kept free of WebSocket / Twilio dependencies so
+they can be unit-tested independently of the call harness.
+
+Track 2's WebSocket integration in ``app/telephony/router.py`` calls
+``should_trigger_transfer`` at end-of-stream with accumulated state and
+persists the result to the call session. The ``/voice/stream-ended``
+action callback (Phase C) reads it and returns either ``<Dial>`` TwiML
+(transfer) or empty TwiML (normal end) accordingly.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Optional
+
+# Threshold above which we assume the ASR is fundamentally not
+# picking the caller up. Tunable post-pilot.
+MISHEARD_THRESHOLD = 3
+
+_HUMAN_INTENT = re.compile(
+    r"\b("
+    r"(let\s+me|i\s+(want\s+to|need\s+to|wanna))\s+"
+    r"(speak|talk)\s+to\s+(a\s+)?(human|person|someone|real\s+person)"
+    r"|"
+    r"can\s+i\s+(speak|talk)\s+to\s+(a\s+)?(human|person|someone)"
+    r"|"
+    r"give\s+me\s+a\s+(real\s+)?(human|person)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+class TransferReason(str, Enum):
+    MISHEARD_TURNS = "misheard_turns"
+    LLM_ERROR = "llm_error"
+    HUMAN_INTENT = "human_intent"
+
+
+def detect_human_intent_in_text(text: str) -> bool:
+    """True if the caller's transcript reads as a request for a human.
+    Conservative regex; tune at sprint-end if false positives are noisy.
+    Future: replace with LLM-based intent classification."""
+    if not text:
+        return False
+    return _HUMAN_INTENT.search(text) is not None
+
+
+def should_trigger_transfer(
+    *,
+    consecutive_low_confidence_turns: int,
+    last_transcript: str,
+    llm_error_occurred: bool,
+) -> Optional[TransferReason]:
+    """Return the first matching transfer reason, or None.
+
+    The order matters — LLM error and human intent dominate the
+    misheard threshold (a hard error or an explicit ask for a human is
+    more important than a noisy mic count).
+    """
+    if llm_error_occurred:
+        return TransferReason.LLM_ERROR
+    if detect_human_intent_in_text(last_transcript):
+        return TransferReason.HUMAN_INTENT
+    if consecutive_low_confidence_turns >= MISHEARD_THRESHOLD:
+        return TransferReason.MISHEARD_TURNS
+    return None

--- a/dashboard/lib/api/calls.ts
+++ b/dashboard/lib/api/calls.ts
@@ -29,6 +29,7 @@ export type CallEventKind =
   | 'stop'
   | 'order_confirmed'
   | 'recording_ready'
+  | 'transfer_requested'
   | 'error'
   | 'log';
 

--- a/dashboard/lib/schemas/call.ts
+++ b/dashboard/lib/schemas/call.ts
@@ -31,6 +31,7 @@ export const CallEventKindSchema = z.enum([
   'stop',
   'order_confirmed',
   'recording_ready',
+  'transfer_requested',
   'error',
   'log',
 ]);

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -1008,3 +1008,86 @@ def test_voice_twiml_includes_stream_ended_action():
     assert 'action="/voice/stream-ended"' in body
     assert 'method="POST"' in body
 
+
+# ---------------------------------------------------------------------------
+# on_transcript confidence handling (Fix 1 regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_transcript_increments_misheard_counter_on_low_confidence(monkeypatch):
+    """Driving on_transcript with low-confidence finals must increment
+    state.consecutive_low_confidence_turns. Reset on a clear final."""
+    from unittest.mock import MagicMock
+
+    from app.telephony.router import _CallState, _open_deepgram_connection
+    import app.telephony.router as router_mod
+
+    # Satisfy the API-key guard without a real credential.
+    monkeypatch.setattr(router_mod.settings, "deepgram_api_key", "fake-key-for-test")
+    # Prevent _bg_call_event from spawning background threads that attempt
+    # real Firestore writes (no GCP in the test environment).
+    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
+
+    state = _CallState()
+    captured: dict = {}
+
+    class FakeDeepgramConn:
+        def on(self, event_type, handler):
+            captured.setdefault(str(event_type), handler)
+
+        async def start(self, *_, **__):
+            return True
+
+        async def finish(self):
+            pass
+
+        async def send(self, *_):
+            pass
+
+        def keepalive(self):
+            pass
+
+    class FakeDeepgramClient:
+        def __init__(self, *_):
+            self.listen = MagicMock()
+            self.listen.asynclive.v.return_value = FakeDeepgramConn()
+
+    monkeypatch.setattr(router_mod, "DeepgramClient", FakeDeepgramClient)
+
+    async def on_final(text):
+        pass
+
+    await _open_deepgram_connection(
+        "CAtest",
+        "r1",
+        on_final,
+        state=state,
+    )
+
+    # LiveTranscriptionEvents.Transcript stringifies to "Results" (Deepgram SDK).
+    handler = captured["Results"]
+
+    def fake_result(text, confidence, is_final=True):
+        r = MagicMock()
+        alt = MagicMock()
+        alt.transcript = text
+        alt.confidence = confidence
+        r.channel.alternatives = [alt]
+        r.is_final = is_final
+        return r
+
+    # Three consecutive low-confidence finals.
+    await handler(None, fake_result("um", 0.2))
+    await handler(None, fake_result("uhh", 0.1))
+    # confidence=0.0 is the key regression: without Fix 1, `0.0 or 1.0`
+    # yields 1.0 and the counter would not advance on this third call.
+    await handler(None, fake_result("what", 0.0))
+
+    assert state.consecutive_low_confidence_turns == 3
+
+    # A clear final resets the counter.
+    await handler(None, fake_result("a large pepperoni pizza", 0.95))
+    assert state.consecutive_low_confidence_turns == 0
+    assert state.last_caller_transcript == "a large pepperoni pizza"
+

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -82,7 +82,7 @@ def mock_pipeline(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, restaurant_id, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):
@@ -125,7 +125,7 @@ def test_voice_twiml_contains_media_stream_no_say(monkeypatch):
     body = response.text
     assert "<Response>" in body
     assert "<Say" not in body          # greeting is now via ElevenLabs on start event
-    assert "<Connect>" in body
+    assert "<Connect" in body
     assert "<Stream" in body
     # TestClient sets Host: testserver
     assert "wss://testserver/media-stream" in body
@@ -310,7 +310,7 @@ def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, restaurant_id, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):
@@ -368,7 +368,7 @@ def test_media_stream_finalizes_recording_on_stop(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, restaurant_id, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
         return fake_dg
 
     monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
@@ -412,7 +412,7 @@ def test_ai_greeting_spawned_on_start(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, restaurant_id, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):
@@ -452,7 +452,7 @@ def test_stop_event_persists_ready_order(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, restaurant_id, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):
@@ -496,7 +496,7 @@ def test_stop_event_skips_persist_if_order_not_ready(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, restaurant_id, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
         return fake_dg
 
     async def fake_speak(text, websocket, stream_sid, **kw):
@@ -909,7 +909,7 @@ def test_first_tts_byte_event_emitted_on_turn(monkeypatch):
     fake_dg.send = AsyncMock()
     fake_dg.finish = AsyncMock()
 
-    async def fake_open_dg(call_sid, restaurant_id, on_final):
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
         return fake_dg
 
     # A speak() stub that invokes on_first_byte so the callback fires
@@ -952,4 +952,59 @@ def test_first_tts_byte_event_emitted_on_turn(monkeypatch):
     # first_audio must still be emitted — backwards compatibility
     first_audio_events = [e for e in recorded_events if e.get("kind") == "first_audio"]
     assert len(first_audio_events) >= 1, "first_audio event must not be removed"
+
+
+# ---------------------------------------------------------------------------
+# Transfer trigger accumulation (#7 Sprint 2.4 Track 2)
+# ---------------------------------------------------------------------------
+
+
+def test_call_state_has_transfer_trigger_fields():
+    """The new fields on _CallState are needed by the trigger detector."""
+    from app.telephony.router import _CallState
+
+    state = _CallState()
+    assert state.consecutive_low_confidence_turns == 0
+    assert state.last_caller_transcript == ""
+    assert state.llm_error_occurred is False
+
+
+def test_voice_twiml_includes_stream_ended_action():
+    """The <Connect> in /voice TwiML must point its action callback at
+    /voice/stream-ended so Phase C can dispatch transfer or hangup."""
+    from unittest.mock import patch
+
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.restaurants.models import Restaurant
+    from app.storage import restaurants as r_storage
+
+    fake = Restaurant(
+        id="r1",
+        name="R",
+        display_phone="+15551234567",
+        twilio_phone="+16479058093",
+        address="1 Main",
+        hours="Mon-Sun 11-22",
+        menu={},
+    )
+
+    with patch.object(
+        r_storage,
+        "get_restaurant_by_twilio_phone",
+        return_value=fake,
+    ):
+        client = TestClient(app)
+        resp = client.post(
+            "/voice",
+            data={"To": "+16479058093", "CallSid": "CAtest"},
+            headers={"host": "test.example.com"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.text
+    assert '<Connect' in body
+    assert 'action="/voice/stream-ended"' in body
+    assert 'method="POST"' in body
 

--- a/tests/test_transfer_triggers.py
+++ b/tests/test_transfer_triggers.py
@@ -1,0 +1,71 @@
+"""Unit tests for app.telephony.transfer_triggers.
+
+Each function is a pure check that returns True if its trigger condition
+is met for a given snapshot of call state."""
+
+from app.telephony.transfer_triggers import (
+    detect_human_intent_in_text,
+    should_trigger_transfer,
+    TransferReason,
+)
+
+
+def test_detect_human_intent_matches_common_phrases():
+    cases = [
+        "let me talk to a human please",
+        "can I speak to a person",
+        "I want to talk to someone",
+        "give me a real person",
+    ]
+    for text in cases:
+        assert detect_human_intent_in_text(text), text
+
+
+def test_detect_human_intent_does_not_match_unrelated():
+    cases = [
+        "I want a pepperoni pizza",
+        "talk dirty to me",
+        "person of interest is a great show",
+    ]
+    for text in cases:
+        assert not detect_human_intent_in_text(text), text
+
+
+def test_detect_human_intent_handles_punctuation_and_case():
+    assert detect_human_intent_in_text("Let me SPEAK to a Person!")
+
+
+def test_should_trigger_transfer_after_three_misheard_turns():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=3,
+        last_transcript="any",
+        llm_error_occurred=False,
+    )
+    assert reason is TransferReason.MISHEARD_TURNS
+
+
+def test_should_trigger_transfer_on_llm_error():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=0,
+        last_transcript="any",
+        llm_error_occurred=True,
+    )
+    assert reason is TransferReason.LLM_ERROR
+
+
+def test_should_trigger_transfer_on_human_intent():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=0,
+        last_transcript="please let me talk to a human",
+        llm_error_occurred=False,
+    )
+    assert reason is TransferReason.HUMAN_INTENT
+
+
+def test_should_trigger_transfer_returns_none_below_threshold():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=2,
+        last_transcript="my pizza order",
+        llm_error_occurred=False,
+    )
+    assert reason is None


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 2 Phase B — wires transfer-trigger detection into the live WebSocket call loop. Triggers fire on (1) 3 consecutive misheard turns (Deepgram confidence <0.5), (2) any LLM error, or (3) a regex match for \"talk to a human\" intent in caller transcripts. The decision is made at end-of-stream and persisted as a \`transfer_requested\` event on the call session — Phase C's \`/voice/stream-ended\` action callback will read it and dispatch \`<Dial>\` TwiML.

## What landed

**Pure-function detector** (`app/telephony/transfer_triggers.py`):
- \`should_trigger_transfer(*, consecutive_low_confidence_turns, last_transcript, llm_error_occurred) -> Optional[TransferReason]\`
- \`detect_human_intent_in_text(text) -> bool\` — conservative regex (LLM-based intent classification is a Phase 3 follow-up).
- \`MISHEARD_THRESHOLD = 3\`.
- 7 unit tests cover every branch.

**WebSocket loop integration** (`app/telephony/router.py`):
- \`_CallState\` extended with 3 new fields (defaults: \`0\`, \`\"\"\`, \`False\`) — accumulators read at end-of-stream.
- Deepgram \`on_transcript\` reads \`alt.confidence\`, increments/resets the misheard counter, stashes \`last_caller_transcript\`. Defensive against \`None\` confidence (some clients omit the attribute) AND legitimate \`0.0\` confidence (worst-case misheard, must not be coerced to \`1.0\`).
- LLM \`except Exception\` clause sets \`state.llm_error_occurred = True\` BEFORE the existing error-event log + re-raise. \`asyncio.CancelledError\` (barge-in) is handled by the earlier \`except\` clause and does NOT trip the flag.
- \`/voice\` TwiML's \`<Connect>\` now carries \`action=\"/voice/stream-ended\" method=\"POST\"\` so Phase C can dispatch on the action callback.
- \`media_stream\` finally block, after \`mark_call_ended\`, computes \`should_trigger_transfer\` and writes a \`transfer_requested\` event to the call session via \`call_sessions.record_event\`. Wrapped in try/except so a Firestore failure can't break the cleanup chain.

**Dashboard schema** (`dashboard/lib/schemas/call.ts` + `dashboard/lib/api/calls.ts`):
- Added \`'transfer_requested'\` to \`CallEventKindSchema\` z.enum + the parallel \`CallEventKind\` TS union, so the dashboard timeline doesn't silently coerce the new event kind to \`'log'\`. (\`detail\` payload is permissive — only the kind needed to be added.)

## Cross-track contract

The Phase B output (`transfer_requested` event on the call session) is exactly what Phase C's `/voice/stream-ended` action callback will read. Phase D's after-hours voicemail flow uses \`is_open_now\` from Phase A — already on master.

## Test plan

- [x] \`pytest tests/test_transfer_triggers.py -v\` — 7 passes
- [x] \`pytest tests/test_telephony.py -v\` — 43 passes (existing + 3 new for trigger fields, TwiML action attribute, on_transcript misheard-counter exercise covering the \`confidence=0.0\` path)
- [x] \`pytest tests/ -x\` — 354 passed / 1 skipped / no regressions on the live call loop
- [x] \`cd dashboard && pnpm typecheck && pnpm vitest run\` — 103/103 across 16 files, typecheck clean
- [ ] **Manual smoke (gating before Phase C lands):** Place a test call, hit the AI with 3 \"unintelligible\" utterances → call ends → call session has a \`transfer_requested\` event with \`text=\"misheard_turns\"\`. Place another and say \"let me talk to a human\" → call session has \`transfer_requested\` with \`text=\"human_intent\"\`. (Phase C is what surfaces this to a real \`<Dial>\` — for now this PR only writes the signal.)

## Risk note

This PR touches the live WebSocket call loop. The new state mutations are pure attribute writes (no awaits, no locks). The trigger decision runs in the \`finally\` block AFTER \`mark_call_ended\`, so it can't block recording finalization. None of \`speak()\`, the silence watchdog, the auto-hangup mark logic, or the recording session were modified.

## Follow-ups deliberately deferred

- **Schema dual-maintenance** in \`dashboard/lib/api/calls.ts\` vs \`dashboard/lib/schemas/call.ts\` — both have \`CallEventKind\` definitions. Worth deriving the TS type from the Zod schema in a future cleanup.
- **Integration test for finally-block transfer-event write.** Would need a full WebSocket harness; the pure-function detector is unit-tested and the new \`on_transcript\` test covers the live state mutation.

## Tasks → commits

| Task | Commit |
|---|---|
| B.3 Pure-function detector | \`9dd3db5\` |
| B.4 WebSocket loop integration | \`f3014fa\` |
| Final review fixes (confidence=0 + dashboard schema) | \`c7583a5\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)