### PR TITLE
Sprint 2.4 Track 2 Phase C — call transfer to fallback number (#7)

### DIFF
--- a/app/storage/call_sessions.py
+++ b/app/storage/call_sessions.py
@@ -411,6 +411,30 @@ def get_session(
     return snap.to_dict()
 
 
+def get_session_by_call_sid(call_sid: str) -> Optional[dict[str, Any]]:
+    """Resolve a call session using only the call_sid, reading the legacy
+    flat collection. Returns the doc dict (which carries ``restaurant_id``)
+    or None when the session was never initialised.
+
+    Used by /voice/stream-ended — Twilio's action callback only posts
+    CallSid, not rid. The legacy flat doc is the cheapest single-key
+    lookup we have before the nested tenant path is known. Phase D will
+    retire the legacy path; at that point this helper becomes a
+    collectionGroup query.
+    """
+    try:
+        client = _get_client()
+        snap = _legacy_parent(client, call_sid).get()
+        if not snap.exists:
+            return None
+        return snap.to_dict()
+    except Exception:
+        logger.exception(
+            "call_sessions: get_session_by_call_sid failed call_sid=%s", call_sid
+        )
+        return None
+
+
 def mark_call_ended(
     call_sid: str,
     restaurant_id: str,

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -25,7 +25,9 @@ from typing import Any, Callable
 
 from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
-from twilio.twiml.voice_response import Connect, VoiceResponse
+from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
+
+from app.telephony.voicemail_twiml import voicemail_response
 
 from app.config import settings
 from app.llm.client import stream_reply
@@ -681,6 +683,127 @@ async def voice(request: Request) -> Response:
     stream.parameter(name="restaurant_id", value=restaurant.id)
     twiml.append(connect)
     return Response(content=str(twiml), media_type="application/xml")
+
+
+_TRANSFER_STATUS_MAP = {
+    "completed": "answered",
+    "no-answer": "no_answer",
+    "busy": "busy",
+    "failed": "failed",
+    "canceled": "failed",
+}
+
+
+@router.post("/voice/stream-ended")
+async def stream_ended(request: Request) -> Response:
+    """Twilio's <Connect> action callback. Decides what happens after
+    the AI flow ends: empty TwiML (hang up), transfer to fallback, or
+    drop to voicemail directly.
+
+    Reads the latest call_session events to see if a `transfer_requested`
+    was written by the WebSocket finally block (Phase B). If so, looks
+    up the tenant's `fallback_phone` and returns <Dial> TwiML; if no
+    fallback is configured, drops to voicemail with status='skipped'.
+    """
+    form = await request.form()
+    call_sid = form.get("CallSid")
+
+    if not call_sid:
+        # Twilio always sends CallSid; missing → defensive hangup.
+        return Response(content=str(VoiceResponse()), media_type="application/xml")
+
+    # Resolve the tenant by reading the call_session doc. Uses the legacy
+    # flat path because this action callback only receives CallSid — the
+    # rid isn't known until we look it up here.
+    try:
+        session_doc = call_sessions.get_session_by_call_sid(call_sid)
+        rid: str | None = (session_doc or {}).get("restaurant_id")
+    except Exception:
+        logger.exception(
+            "stream_ended: session lookup failed call_sid=%s", call_sid
+        )
+        rid = None
+
+    if rid is None:
+        return Response(
+            content=str(VoiceResponse()),
+            media_type="application/xml",
+        )
+
+    events = call_sessions.get_session_events(call_sid, rid) or []
+    last = events[-1] if events else {}
+    transfer_requested = last.get("kind") == "transfer_requested"
+
+    if not transfer_requested:
+        return Response(
+            content=str(VoiceResponse()),
+            media_type="application/xml",
+        )
+
+    restaurant = restaurants_storage.get_restaurant(rid)
+    if restaurant is None or not restaurant.fallback_phone:
+        # Transfer requested but no number to dial → mark + voicemail.
+        try:
+            call_sessions.mark_transfer_attempted(
+                call_sid, rid, status="skipped", fallback_phone=None,
+            )
+        except Exception:
+            logger.exception(
+                "stream_ended: mark_transfer_attempted skipped call_sid=%s",
+                call_sid,
+            )
+        return Response(
+            content=str(voicemail_response(call_sid, rid)),
+            media_type="application/xml",
+        )
+
+    twiml = VoiceResponse()
+    dial = Dial(
+        action=f"/voice/transfer-result?call_sid={call_sid}&rid={rid}",
+        method="POST",
+        timeout=20,
+    )
+    dial.number(restaurant.fallback_phone)
+    twiml.append(dial)
+    return Response(content=str(twiml), media_type="application/xml")
+
+
+@router.post("/voice/transfer-result")
+async def transfer_result(
+    request: Request,
+    call_sid: str,
+    rid: str,
+) -> Response:
+    """<Dial>'s action callback. Maps Twilio DialCallStatus to internal
+    status, marks the call session, and either returns empty (answered)
+    or cascades to voicemail (no-answer/busy/failed)."""
+    form = await request.form()
+    status = form.get("DialCallStatus", "failed")
+    internal_status = _TRANSFER_STATUS_MAP.get(status, "failed")
+
+    try:
+        call_sessions.mark_transfer_attempted(
+            call_sid,
+            rid,
+            status=internal_status,
+            fallback_phone=None,
+        )
+    except Exception:
+        logger.exception(
+            "transfer_result: mark_transfer_attempted failed call_sid=%s",
+            call_sid,
+        )
+
+    if internal_status == "answered":
+        return Response(
+            content=str(VoiceResponse()),
+            media_type="application/xml",
+        )
+
+    return Response(
+        content=str(voicemail_response(call_sid, rid)),
+        media_type="application/xml",
+    )
 
 
 @router.websocket("/media-stream")

--- a/app/telephony/voicemail_twiml.py
+++ b/app/telephony/voicemail_twiml.py
@@ -1,0 +1,30 @@
+"""Voicemail TwiML rendering. Stub for Phase C; Phase D fills out the
+recording + transcription wiring with real <Record> attributes."""
+
+from __future__ import annotations
+
+from twilio.twiml.voice_response import VoiceResponse
+
+
+def voicemail_response(call_sid: str, restaurant_id: str) -> VoiceResponse:
+    """Return TwiML that plays a brief greeting and records the caller's
+    voicemail. Phase D will wire `transcribe=True`, `transcribeCallback`,
+    and `action` for the recording-ready callback. For Phase C, this
+    stub gives downstream tests a `<Record>` element to assert on."""
+    twiml = VoiceResponse()
+    twiml.say(
+        "We weren't able to take your call. Please leave a message after "
+        "the tone, and we'll get back to you.",
+        voice="alice",
+    )
+    twiml.record(
+        max_length=90,
+        action=f"/voice/voicemail-recorded?call_sid={call_sid}&rid={restaurant_id}",
+        transcribe=True,
+        transcribe_callback=(
+            f"/voice/voicemail-transcription?call_sid={call_sid}&rid={restaurant_id}"
+        ),
+        method="POST",
+    )
+    twiml.hangup()
+    return twiml

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -1091,3 +1091,242 @@ async def test_on_transcript_increments_misheard_counter_on_low_confidence(monke
     assert state.consecutive_low_confidence_turns == 0
     assert state.last_caller_transcript == "a large pepperoni pizza"
 
+
+# ---------------------------------------------------------------------------
+# /voice/stream-ended — Phase C call-transfer dispatch (#7 Sprint 2.4 Track 2)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_ended_returns_empty_twiml_when_no_transfer_requested(monkeypatch):
+    """Normal end of call — no transfer_requested event → empty TwiML.
+    Twilio's default behavior on empty TwiML is to hang up."""
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_by_call_sid",
+        lambda sid: {"restaurant_id": "r1"},
+    )
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_events",
+        lambda sid, rid: [
+            {"kind": "transcript_final", "timestamp": None, "text": "hi"},
+        ],
+    )
+
+    c = TestClient(app)
+    resp = c.post("/voice/stream-ended", data={"CallSid": "CAtest"})
+    assert resp.status_code == 200
+    body = resp.text
+    assert "<Dial" not in body
+    assert "<Record" not in body
+
+
+def test_stream_ended_returns_dial_when_transfer_requested(monkeypatch):
+    """transfer_requested event + fallback_phone set → <Dial> TwiML."""
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.restaurants.models import Restaurant
+    from app.storage import call_sessions, restaurants as r_storage
+
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_by_call_sid",
+        lambda sid: {"restaurant_id": "r1"},
+    )
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_events",
+        lambda sid, rid: [
+            {"kind": "transfer_requested", "timestamp": None, "text": "human_intent"},
+        ],
+    )
+    monkeypatch.setattr(
+        r_storage,
+        "get_restaurant",
+        lambda rid: Restaurant(
+            id="r1",
+            name="R",
+            display_phone="+15551234567",
+            twilio_phone="+16479058093",
+            address="1 Main",
+            hours="11-22",
+            menu={},
+            fallback_phone="+15559999999",
+        ),
+    )
+
+    c = TestClient(app)
+    resp = c.post("/voice/stream-ended", data={"CallSid": "CAtest"})
+    assert resp.status_code == 200
+    body = resp.text
+    assert "<Dial" in body
+    assert "+15559999999" in body
+    assert "/voice/transfer-result" in body
+
+
+def test_stream_ended_skips_to_voicemail_when_no_fallback(monkeypatch):
+    """transfer_requested but no fallback_phone configured → mark
+    transfer as skipped + return voicemail TwiML directly."""
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.restaurants.models import Restaurant
+    from app.storage import call_sessions, restaurants as r_storage
+
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_by_call_sid",
+        lambda sid: {"restaurant_id": "r1"},
+    )
+    monkeypatch.setattr(
+        call_sessions,
+        "get_session_events",
+        lambda sid, rid: [
+            {"kind": "transfer_requested", "timestamp": None, "text": "llm_error"},
+        ],
+    )
+    monkeypatch.setattr(
+        r_storage,
+        "get_restaurant",
+        lambda rid: Restaurant(
+            id="r1",
+            name="R",
+            display_phone="+15551234567",
+            twilio_phone="+16479058093",
+            address="1 Main",
+            hours="11-22",
+            menu={},
+            fallback_phone=None,
+        ),
+    )
+
+    mark_calls = []
+    monkeypatch.setattr(
+        call_sessions,
+        "mark_transfer_attempted",
+        lambda *a, **kw: mark_calls.append(kw),
+    )
+
+    c = TestClient(app)
+    resp = c.post("/voice/stream-ended", data={"CallSid": "CAtest"})
+    assert resp.status_code == 200
+    assert "<Dial" not in resp.text
+    assert "<Record" in resp.text
+    assert mark_calls and mark_calls[0]["status"] == "skipped"
+
+
+def test_stream_ended_handles_missing_call_sid_gracefully(monkeypatch):
+    """Defensive — if Twilio's CallSid form field is missing, return
+    empty TwiML rather than 500."""
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    c = TestClient(app)
+    resp = c.post("/voice/stream-ended", data={})
+    assert resp.status_code == 200
+    assert "<Dial" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# /voice/transfer-result — Phase C cascade on no-answer (#7 Sprint 2.4 Track 2)
+# ---------------------------------------------------------------------------
+
+
+def test_transfer_result_completed_returns_empty(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.storage import call_sessions
+
+    mark_calls = []
+    monkeypatch.setattr(
+        call_sessions,
+        "mark_transfer_attempted",
+        lambda *a, **kw: mark_calls.append(kw),
+    )
+
+    c = TestClient(app)
+    resp = c.post(
+        "/voice/transfer-result",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={"DialCallStatus": "completed"},
+    )
+    assert resp.status_code == 200
+    assert "<Record" not in resp.text
+    assert mark_calls and mark_calls[0]["status"] == "answered"
+
+
+def test_transfer_result_no_answer_drops_to_voicemail(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions,
+        "mark_transfer_attempted",
+        lambda *a, **kw: None,
+    )
+
+    c = TestClient(app)
+    resp = c.post(
+        "/voice/transfer-result",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={"DialCallStatus": "no-answer"},
+    )
+    assert resp.status_code == 200
+    assert "<Record" in resp.text
+
+
+def test_transfer_result_busy_drops_to_voicemail(monkeypatch):
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.storage import call_sessions
+
+    monkeypatch.setattr(
+        call_sessions,
+        "mark_transfer_attempted",
+        lambda *a, **kw: None,
+    )
+
+    c = TestClient(app)
+    resp = c.post(
+        "/voice/transfer-result",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={"DialCallStatus": "busy"},
+    )
+    assert resp.status_code == 200
+    assert "<Record" in resp.text
+
+
+def test_transfer_result_failed_status_marks_internal_failed(monkeypatch):
+    """Verify the Twilio-status → internal-status mapping."""
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+    from app.storage import call_sessions
+
+    mark_calls = []
+    monkeypatch.setattr(
+        call_sessions,
+        "mark_transfer_attempted",
+        lambda *a, **kw: mark_calls.append(kw),
+    )
+
+    c = TestClient(app)
+    resp = c.post(
+        "/voice/transfer-result",
+        params={"call_sid": "CAtest", "rid": "r1"},
+        data={"DialCallStatus": "failed"},
+    )
+    assert resp.status_code == 200
+    assert mark_calls and mark_calls[0]["status"] == "failed"
+


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 2 Phase C — the TwiML callback endpoints that turn Phase B's \`transfer_requested\` signal into an actual \`<Dial>\` to the restaurant's fallback number, with cascade-to-voicemail on no-answer.

## What landed

- **\`POST /voice/stream-ended\`** — \`<Connect>\`'s action callback. Reads the latest call_session events (added \`get_session_by_call_sid\` helper to resolve rid from CallSid alone). Branches:
  - No \`transfer_requested\` event → empty TwiML → Twilio hangs up.
  - \`transfer_requested\` + \`restaurant.fallback_phone\` set → \`<Dial action=\"/voice/transfer-result\" method=\"POST\" timeout=\"20\">\` to the fallback.
  - \`transfer_requested\` + no \`fallback_phone\` → \`mark_transfer_attempted(status=\"skipped\")\` then return voicemail TwiML.
- **\`POST /voice/transfer-result\`** — \`<Dial>\`'s action callback. Maps \`DialCallStatus\` (\`completed\`/\`no-answer\`/\`busy\`/\`failed\`/\`canceled\`) to internal status (\`answered\`/\`no_answer\`/\`busy\`/\`failed\`/\`failed\`). On answered → empty TwiML; on anything else → cascade to voicemail.
- **\`app/telephony/voicemail_twiml.py\`** — minimal \`<Say>\` + \`<Record max_length=90, transcribe, transcribe_callback>\` + \`<Hangup>\` stub. Phase D will tighten the recording + transcription wiring (real callbacks land in D).
- **\`app/storage/call_sessions.py\`** — \`get_session_by_call_sid(call_sid)\` helper that reads the legacy flat path so the action callback can resolve rid from CallSid alone.
- 8 new tests + 1 test from Phase B confirming the action attribute on \`<Connect>\`.

## Test plan

- [x] \`pytest tests/test_telephony.py -v -k \"stream_ended or transfer_result\"\` — 9 passes
- [x] \`pytest tests/ -x\` — 362 passed / 1 skipped / 0 failures (pre-existing live-LLM test unrelated)
- [ ] **Manual smoke (gating before pilot):** Configure a test restaurant with \`fallback_phone\`. Place a call, say \"let me talk to a human\" mid-call. Stream ends → Twilio hits \`/voice/stream-ended\` → \`<Dial>\` returns → Twilio dials the fallback. Don't answer the fallback → Twilio hits \`/voice/transfer-result\` with \`DialCallStatus=no-answer\` → voicemail prompt plays.

## Follow-ups deliberately deferred

- **Twilio signature verification on the new webhooks** — repo-wide pre-existing gap (the existing \`/voice\` doesn't verify either). Recommend a separate hardening PR adding \`twilio.request_validator.RequestValidator\` middleware covering all three endpoints (\`/voice\`, \`/voice/stream-ended\`, \`/voice/transfer-result\`) in one shot.
- **Voicemail \`<Say voice=\"alice\">\` greeting** — currently uses Twilio's stock voice. Phase D will swap to a Deepgram Aura-rendered greeting for brand consistency.
- **Phase D wires the actual recording-ready and transcription webhooks** — the voicemail TwiML's \`action\` and \`transcribe_callback\` URLs point at \`/voice/voicemail-recorded\` and \`/voice/voicemail-transcription\` which don't exist yet. They're stubbed in the TwiML but landing in the next PR.

## Tasks → commits

| Task | Commit |
|---|---|
| C.5 + C.6 endpoints + voicemail stub | \`7811982\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)