### PR TITLE
Sprint 2.4 Track 2 Phase E — voicemail + transfer surface on /calls (#7)

### DIFF
--- a/dashboard/components/calls/call-timeline.tsx
+++ b/dashboard/components/calls/call-timeline.tsx
@@ -8,9 +8,11 @@ import {
   Copy,
   Mic,
   PhoneCall,
+  PhoneForwarded,
   PhoneOff,
   Radio,
   Sparkles,
+  Voicemail,
   Volume2,
   Zap,
 } from 'lucide-react';
@@ -161,7 +163,7 @@ function TimelineRow({
           <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
             {label}
           </p>
-          <p className="text-sm">{body}</p>
+          <div className="text-sm">{body}</div>
         </div>
       </RowTag>
       {copyText ? (
@@ -305,6 +307,54 @@ function renderEvent(event: CallEvent): RenderedEvent {
         accent: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
         label: 'recording ready',
         body: typeof duration === 'number' ? `${duration}s recording available` : 'recording available',
+      };
+    }
+    case 'transfer_attempted': {
+      const status = (event.detail.status as string | undefined) ?? 'attempted';
+      const phone = event.detail.fallback_phone as string | undefined;
+      const labelByStatus: Record<string, string> = {
+        answered: 'Transfer connected',
+        no_answer: 'Transfer — no answer',
+        busy: 'Transfer — busy',
+        failed: 'Transfer — failed',
+        skipped: 'Transfer skipped',
+      };
+      const accentByStatus: Record<string, string> = {
+        answered: 'bg-sky-500/15 text-sky-600 dark:text-sky-400',
+        no_answer: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+        busy: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+        failed: 'bg-destructive/15 text-destructive',
+        skipped: 'bg-muted text-muted-foreground',
+      };
+      return {
+        Icon: PhoneForwarded,
+        accent: accentByStatus[status] ?? 'bg-muted text-muted-foreground',
+        label: labelByStatus[status] ?? 'transfer',
+        body: phone ? <span>to {phone}</span> : <span>{status}</span>,
+      };
+    }
+    case 'voicemail_left': {
+      const transcript = (event.text as string) || '';
+      const duration = event.detail.duration_seconds as number | undefined;
+      return {
+        Icon: Voicemail,
+        accent: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+        label: 'voicemail',
+        body: (
+          <div className="flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground">
+              {typeof duration === 'number' ? `${duration}s` : 'recording available'}
+            </span>
+            {transcript ? (
+              <span className="italic">"{transcript}"</span>
+            ) : (
+              <span className="text-xs italic text-muted-foreground">
+                Transcript pending…
+              </span>
+            )}
+          </div>
+        ),
+        copyText: transcript || undefined,
       };
     }
     case 'error':

--- a/dashboard/components/calls/calls-feed.tsx
+++ b/dashboard/components/calls/calls-feed.tsx
@@ -94,5 +94,8 @@ function toRow(c: CallSession) {
     transcript_count: c.transcript_count,
     has_error: c.has_error,
     status: c.status,
+    voicemail_left: Boolean(c.voicemail_recording_url),
+    transfer_attempted: c.transfer_attempted,
+    transfer_status: c.transfer_status,
   };
 }

--- a/dashboard/components/calls/calls-table.tsx
+++ b/dashboard/components/calls/calls-table.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { AlertTriangle, CheckCircle2, PhoneIncoming, Radio } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, PhoneForwarded, PhoneIncoming, Radio, Voicemail } from 'lucide-react';
 
 import { LocalTime } from '@/components/shared/local-time';
 import type { CallStatus, CallSummary } from '@/lib/api/calls';
@@ -64,7 +64,31 @@ function CallRow({ call }: { call: CallSummary }) {
       <Td className="text-right tabular-nums">{formatDuration(durationSec)}</Td>
       <Td className="text-right tabular-nums">{call.transcript_count}</Td>
       <Td>
-        <CallStatusBadge status={call.status} hasError={call.has_error} />
+        <div className="flex flex-wrap items-center gap-1.5">
+          <CallStatusBadge status={call.status} hasError={call.has_error} />
+          {call.voicemail_left ? (
+            <span
+              className="inline-flex items-center gap-1 rounded-md bg-amber-500/15 px-2 py-1 text-xs font-medium text-amber-700 dark:text-amber-400"
+              aria-label="Voicemail left"
+            >
+              <Voicemail className="h-3 w-3" aria-hidden /> voicemail
+            </span>
+          ) : null}
+          {call.transfer_attempted ? (
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium',
+                call.transfer_status === 'answered'
+                  ? 'bg-sky-500/15 text-sky-700 dark:text-sky-400'
+                  : 'bg-muted text-muted-foreground',
+              )}
+              aria-label={`Transfer ${call.transfer_status ?? 'attempted'}`}
+            >
+              <PhoneForwarded className="h-3 w-3" aria-hidden />{' '}
+              {call.transfer_status === 'answered' ? 'transferred' : 'transfer ' + (call.transfer_status ?? 'attempted')}
+            </span>
+          ) : null}
+        </div>
       </Td>
     </tr>
   );

--- a/dashboard/lib/api/calls.ts
+++ b/dashboard/lib/api/calls.ts
@@ -30,6 +30,8 @@ export type CallEventKind =
   | 'order_confirmed'
   | 'recording_ready'
   | 'transfer_requested'
+  | 'transfer_attempted'
+  | 'voicemail_left'
   | 'error'
   | 'log';
 
@@ -40,6 +42,11 @@ export type CallSummary = {
   transcript_count: number;
   has_error: boolean;
   status: CallStatus;
+  // Sprint 2.4 Track 2 — surfacing voicemail + transfer outcomes on the
+  // calls list (only set on calls that hit those flows).
+  voicemail_left?: boolean;
+  transfer_attempted?: boolean;
+  transfer_status?: 'answered' | 'no_answer' | 'busy' | 'failed' | 'skipped';
 };
 
 export type CallEvent = {

--- a/dashboard/lib/firebase/call-converters.ts
+++ b/dashboard/lib/firebase/call-converters.ts
@@ -55,6 +55,10 @@ function normalizeSession(raw: Record<string, unknown>): Record<string, unknown>
     started_at: unwrapTimestamp(raw.started_at),
     ended_at: unwrapTimestamp(raw.ended_at),
     last_event_at: unwrapTimestamp(raw.last_event_at),
+    // Sprint 2.4 Track 2 — new timestamp fields written by
+    // mark_voicemail_left and mark_transfer_attempted.
+    voicemail_recorded_at: unwrapTimestamp(raw.voicemail_recorded_at),
+    transfer_initiated_at: unwrapTimestamp(raw.transfer_initiated_at),
   };
 }
 

--- a/dashboard/lib/schemas/call.ts
+++ b/dashboard/lib/schemas/call.ts
@@ -32,6 +32,8 @@ export const CallEventKindSchema = z.enum([
   'order_confirmed',
   'recording_ready',
   'transfer_requested',
+  'transfer_attempted',
+  'voicemail_left',
   'error',
   'log',
 ]);
@@ -53,6 +55,19 @@ export const CallSessionSchema = z.object({
   // calls that have no recording yet. Frontend never sees the raw URL —
   // it proxies playback through GET /calls/{call_sid}/recording.
   recording_url: z.string().optional(),
+
+  // Sprint 2.4 Track 2 — voicemail + transfer surface fields written by
+  // app.storage.call_sessions.mark_voicemail_left + mark_transfer_attempted.
+  // All optional / default-false because legacy and pre-2.4 calls
+  // predate them.
+  voicemail_recording_url: z.string().optional(),
+  voicemail_recording_sid: z.string().optional(),
+  voicemail_duration_seconds: z.number().int().nonnegative().optional(),
+  voicemail_transcript: z.string().nullable().optional(),
+  voicemail_recorded_at: z.coerce.date().nullish(),
+  transfer_attempted: z.boolean().default(false),
+  transfer_status: z.enum(['answered', 'no_answer', 'busy', 'failed', 'skipped']).optional(),
+  transfer_initiated_at: z.coerce.date().nullish(),
 });
 export type CallSession = z.infer<typeof CallSessionSchema>;
 

--- a/dashboard/tests/call-timeline.test.tsx
+++ b/dashboard/tests/call-timeline.test.tsx
@@ -80,3 +80,67 @@ describe('CallTimelineView', () => {
     expect(screen.queryByRole('button', { name: /Seek to caller/i })).not.toBeInTheDocument();
   });
 });
+
+describe('CallTimelineView voicemail + transfer events', () => {
+  it('renders a transfer_attempted event with the resolved status', () => {
+    render(
+      <CallTimelineView
+        timeline={{
+          call_sid: 'CAtest',
+          recording_available: false,
+          events: [
+            {
+              timestamp: '2026-05-01T18:00:00Z',
+              kind: 'transfer_attempted',
+              text: '',
+              detail: { status: 'answered', fallback_phone: '+15551234567' },
+            },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText(/Transfer connected/i)).toBeInTheDocument();
+    expect(screen.getByText(/\+15551234567/)).toBeInTheDocument();
+  });
+
+  it('renders a voicemail_left event with duration + transcript', () => {
+    render(
+      <CallTimelineView
+        timeline={{
+          call_sid: 'CAtest',
+          recording_available: false,
+          events: [
+            {
+              timestamp: '2026-05-01T18:00:00Z',
+              kind: 'voicemail_left',
+              text: 'Hi please call me back',
+              detail: { duration_seconds: 18, recording_sid: 'REabc' },
+            },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText(/18s/)).toBeInTheDocument();
+    expect(screen.getByText(/Hi please call me back/)).toBeInTheDocument();
+  });
+
+  it('renders "Transcript pending" when voicemail has no transcript yet', () => {
+    render(
+      <CallTimelineView
+        timeline={{
+          call_sid: 'CAtest',
+          recording_available: false,
+          events: [
+            {
+              timestamp: '2026-05-01T18:00:00Z',
+              kind: 'voicemail_left',
+              text: '',
+              detail: { duration_seconds: 12 },
+            },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText(/Transcript pending/i)).toBeInTheDocument();
+  });
+});

--- a/dashboard/tests/calls-table-badges.test.tsx
+++ b/dashboard/tests/calls-table-badges.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { CallsTable } from '@/components/calls/calls-table';
+
+const BASE_CALL = {
+  call_sid: 'CAtest',
+  started_at: '2026-05-01T18:00:00Z',
+  ended_at: '2026-05-01T18:01:00Z',
+  transcript_count: 4,
+  has_error: false,
+  status: 'ended' as const,
+};
+
+describe('CallsTable voicemail + transfer badges', () => {
+  it('renders a Voicemail badge when voicemail_left is true', () => {
+    render(
+      <CallsTable
+        calls={[{ ...BASE_CALL, voicemail_left: true }]}
+        twilioPhone="+15551234567"
+      />,
+    );
+    expect(screen.getByLabelText(/voicemail left/i)).toBeInTheDocument();
+  });
+
+  it('renders a "transferred" badge for answered transfers', () => {
+    render(
+      <CallsTable
+        calls={[
+          { ...BASE_CALL, transfer_attempted: true, transfer_status: 'answered' },
+        ]}
+        twilioPhone="+15551234567"
+      />,
+    );
+    expect(screen.getByText(/transferred/i)).toBeInTheDocument();
+  });
+
+  it('renders a "no_answer" transfer badge for no-answer transfers', () => {
+    render(
+      <CallsTable
+        calls={[
+          { ...BASE_CALL, transfer_attempted: true, transfer_status: 'no_answer' },
+        ]}
+        twilioPhone="+15551234567"
+      />,
+    );
+    expect(screen.getByText(/no_answer/i)).toBeInTheDocument();
+  });
+
+  it('renders no extra badges on a normal call', () => {
+    render(
+      <CallsTable calls={[BASE_CALL]} twilioPhone="+15551234567" />,
+    );
+    expect(screen.queryByLabelText(/voicemail/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/transfer/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements Sprint 2.4 Track 2 Phase E — surfaces the new voicemail + transfer signals on the dashboard. With this PR, the kitchen team can see at a glance which calls hit voicemail or got transferred, and click through to read the voicemail transcript.

**This is the final Sprint 2.4 PR.** All 9 deliverables in issue #7 are now on master (or scoped out per the design spec).

## What landed

**Schema** (\`dashboard/lib/schemas/call.ts\`, \`dashboard/lib/api/calls.ts\`):
- \`CallEventKindSchema\` gains \`'voicemail_left'\` and \`'transfer_attempted'\`. (\`'transfer_requested'\` was already there from Phase B.)
- \`CallSessionSchema\` gains 8 optional voicemail/transfer fields written by Phase D's \`mark_voicemail_left\` + \`mark_transfer_attempted\`.
- \`CallSummary\` TS type gains \`voicemail_left\`, \`transfer_attempted\`, \`transfer_status\`.
- \`call-converters.ts\` unwraps the two new Firestore Timestamp fields.

**Calls list** (\`dashboard/components/calls/calls-table.tsx\` + \`calls-feed.tsx\`):
- Status cell now renders a Voicemail badge (amber, \`<Voicemail>\` icon) when \`voicemail_left=true\`, and a Transfer badge (sky for \`answered\`, muted for other statuses, \`<PhoneForwarded>\` icon) when \`transfer_attempted=true\`. The badge label reflects the resolved status (e.g. \"transferred\", \"transfer no_answer\", \"transfer skipped\").

**Call timeline** (\`dashboard/components/calls/call-timeline.tsx\`):
- \`renderEvent\` handles the two new kinds with status-coded accents:
  - \`transfer_attempted\`: sky for \`answered\`, amber for \`no_answer\`/\`busy\`, destructive for \`failed\`, muted for \`skipped\`.
  - \`voicemail_left\`: amber accent with duration + transcript inline, or \"Transcript pending…\" placeholder while Twilio's transcription job runs.

**Tests** (7 new):
- \`dashboard/tests/calls-table-badges.test.tsx\` — 4 cases covering voicemail badge presence, answered transfer, no_answer transfer, and the no-badges-on-normal-call regression.
- \`dashboard/tests/call-timeline.test.tsx\` — 3 cases for the new event kinds (transfer with status + phone, voicemail with transcript, voicemail with pending transcript).

## Cross-track contract closed

Sprint 2.4 Track 2 (call transfer + voicemail) is now end-to-end complete:
1. **Phase A** — \`mark_*\` storage helpers, \`is_open_now\` predicate.
2. **Phase B** — trigger detection in the WebSocket loop; \`transfer_requested\` event written at end-of-stream.
3. **Phase C** — \`/voice/stream-ended\` action callback dispatches to \`<Dial>\` or voicemail; \`/voice/transfer-result\` cascades to voicemail on no-answer.
4. **Phase D** — voicemail recording uploaded to GCS, transcription patched on the call session, after-hours calls route directly to voicemail.
5. **Phase E (this PR)** — calls list + timeline render the new signals so the kitchen sees them.

## Test plan

- [x] \`cd dashboard && pnpm vitest run\` — 17 test files, 110 tests, all pass
- [x] \`cd dashboard && pnpm typecheck\` — clean
- [ ] **Manual smoke (gating before pilot):** Configure a test restaurant with \`fallback_phone\` + \`hours_structured\` open. Place a call, say \"talk to a human\" → call ends → calls list shows the new \"transfer ...\" badge with the Twilio dial outcome → click into the call → timeline shows the \`transfer_attempted\` row with the status. Place an after-hours call → calls list shows \"voicemail\" badge → click in → timeline shows \`voicemail_left\` with duration + transcript.

## Follow-ups deliberately deferred (carry over to Phase 3 / pilot ramp)

- **Voicemail audio player.** The voicemail MP3 is in GCS at \`voicemail/{rid}/{call_sid}.mp3\` but the dashboard has no signed-URL endpoint for it yet. Phase 3 work — copy the existing \`/calls/{call_sid}/recording\` proxy pattern.
- **Twilio signature verification on all 5 webhooks** (\`/voice\`, \`/voice/stream-ended\`, \`/voice/transfer-result\`, \`/voice/voicemail-recorded\`, \`/voice/voicemail-transcription\`). Repo-wide pre-existing gap — single hardening PR with \`twilio.request_validator.RequestValidator\` middleware.
- **Aura-rendered voicemail greeting.** Currently uses Twilio's stock \`<Say voice=\"alice\">\`.
- **Per-tenant transfer-rule routing.** Phase 3 — the current single-fallback model fits pilot scope.
- **Transfer-trigger tuning post-pilot.** \`MISHEARD_THRESHOLD = 3\` and the regex matcher are conservative defaults; tune from real call data once we have it.

## Tasks → commits

| Task | Commit |
|---|---|
| E.10 + E.11 voicemail/transfer dashboard surface | \`1c7c137\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)