### PR TITLE
llm: persistent AsyncAnthropic client + finer TTFT instrumentation

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -126,11 +126,16 @@ class StreamEvent:
     The ``timing`` payload has the shape::
 
         {
-            "ttft_seconds": float,        # request → first SDK event
-            "tool_prefix_seconds": float, # first event → first text block
+            "ttft_seconds": float,             # request → first SDK event
+            "tool_prefix_seconds": float,      # first event → first text block
+            "network_prefill_seconds": float,  # request → message_start (#175)
+            "decode_seconds": float,           # message_start → first text block (#175)
             "cache_read_tokens": int,
             "cache_creation_tokens": int,
         }
+
+    On tool-use turns a second timing event is emitted for the follow-up
+    call so each network round-trip is measured independently (#175).
     """
 
     text_delta: Optional[str] = None
@@ -149,14 +154,38 @@ def _client() -> Anthropic:
     key = settings.anthropic_api_key
     if not key:
         raise _missing_key_error()
+    # Sync path is only used by tests; intentionally not a singleton so tests
+    # can patch/inject freely without worrying about module-level state. If this
+    # ever needs to be a singleton too, follow the same lazy pattern as
+    # _get_async_client below — but don't change it speculatively.
     return Anthropic(api_key=key)
 
 
-def _async_client() -> AsyncAnthropic:
-    key = settings.anthropic_api_key
-    if not key:
-        raise _missing_key_error()
-    return AsyncAnthropic(api_key=key)
+# Process-wide reusable AsyncAnthropic instance (#175). Constructing a new
+# AsyncAnthropic() on every stream_reply call creates a fresh httpx.AsyncClient
+# per turn; when the local reference goes out of scope the pool closes and the
+# TLS connection is torn down, costing a full TCP+TLS handshake on the next
+# turn (~100-250ms). Reusing one instance keeps the connection pool warm.
+# Lazy-initialised so importing this module never spins up sockets at startup.
+# Reset to None in tests that need a clean slate (see _reset_async_client).
+_default_async_client: Optional[AsyncAnthropic] = None
+
+
+def _get_async_client() -> AsyncAnthropic:
+    global _default_async_client
+    if _default_async_client is None:
+        key = settings.anthropic_api_key
+        if not key:
+            raise _missing_key_error()
+        _default_async_client = AsyncAnthropic(api_key=key)
+    return _default_async_client
+
+
+def _reset_async_client() -> None:
+    """Reset the module-level singleton. Called by tests that inject their own
+    fake client so they don't accidentally touch the real singleton."""
+    global _default_async_client
+    _default_async_client = None
 
 
 def _serialize_block(block: Any) -> dict[str, Any]:
@@ -420,35 +449,53 @@ async def stream_reply(
     the side effect before talking back.
     """
 
-    api = client or _async_client()
+    api = client or _get_async_client()
 
     new_history = _append_user_transcript(history, transcript)
 
     text_parts: list[str] = []
     tool_uses: list[dict[str, Any]] = []
 
-    # Latency instrumentation (#146). t_request_start anchors the whole
-    # turn — TTFT is the time to the first SDK event, tool_prefix is
-    # how long we wait between that first event and the moment a text
-    # content block opens (i.e. how much of the budget Haiku spent
-    # streaming a tool_use input before saying anything aloud).
+    # Latency instrumentation (#146, extended in #175). t_request_start anchors
+    # the whole turn — TTFT is time to first SDK event; tool_prefix is the gap
+    # between first event and first text block. #175 adds two finer fields:
+    # - network_prefill_seconds: request → message_start (TCP+TLS+queue+prefill)
+    # - decode_seconds: message_start → first text block (token-1 decode)
     t_request_start = time.monotonic()
     t_first_event: Optional[float] = None
+    t_message_start: Optional[float] = None
     t_first_text_block: Optional[float] = None
     cache_read_tokens = 0
     cache_creation_tokens = 0
     timing_emitted = False
 
-    def _make_timing_event() -> StreamEvent:
+    def _make_timing_event(
+        _t_req: float,
+        _t_first_ev: Optional[float],
+        _t_msg_start: Optional[float],
+        _t_first_text: Optional[float],
+        _cache_read: int,
+        _cache_creation: int,
+    ) -> StreamEvent:
         return StreamEvent(
             timing={
-                "ttft_seconds": round((t_first_event or t_request_start) - t_request_start, 3),
+                "ttft_seconds": round((_t_first_ev or _t_req) - _t_req, 3),
                 "tool_prefix_seconds": round(
-                    (t_first_text_block - t_first_event) if (t_first_text_block and t_first_event) else 0.0,
+                    (_t_first_text - _t_first_ev) if (_t_first_text and _t_first_ev) else 0.0,
                     3,
                 ),
-                "cache_read_tokens": cache_read_tokens,
-                "cache_creation_tokens": cache_creation_tokens,
+                "network_prefill_seconds": round(
+                    (_t_msg_start - _t_req) if _t_msg_start is not None else 0.0,
+                    3,
+                ),
+                "decode_seconds": round(
+                    (_t_first_text - _t_msg_start)
+                    if (_t_first_text is not None and _t_msg_start is not None)
+                    else 0.0,
+                    3,
+                ),
+                "cache_read_tokens": _cache_read,
+                "cache_creation_tokens": _cache_creation,
             }
         )
 
@@ -464,6 +511,7 @@ async def stream_reply(
                 t_first_event = time.monotonic()
             etype = getattr(event, "type", None)
             if etype == "message_start":
+                t_message_start = time.monotonic()
                 msg = getattr(event, "message", None)
                 usage = getattr(msg, "usage", None) if msg is not None else None
                 if usage is not None:
@@ -473,7 +521,14 @@ async def stream_reply(
                 block = getattr(event, "content_block", None)
                 if getattr(block, "type", None) == "text" and t_first_text_block is None:
                     t_first_text_block = time.monotonic()
-                    yield _make_timing_event()
+                    yield _make_timing_event(
+                        t_request_start,
+                        t_first_event,
+                        t_message_start,
+                        t_first_text_block,
+                        cache_read_tokens,
+                        cache_creation_tokens,
+                    )
                     timing_emitted = True
             elif etype == "content_block_delta":
                 delta = getattr(event, "delta", None)
@@ -508,8 +563,31 @@ async def stream_reply(
             {"role": "user", "content": tool_results},
         ]
 
+    if tool_uses and not timing_emitted:
+        # First stream produced only tool_use blocks (no text). Emit the
+        # first-call timing snapshot before starting the follow-up so the
+        # router always receives a timing event per network round-trip (#175).
+        yield _make_timing_event(
+            t_request_start,
+            t_first_event,
+            t_message_start,
+            t_first_text_block,
+            cache_read_tokens,
+            cache_creation_tokens,
+        )
+
     if tool_uses:
         # tools=[] is intentional — purely verbal continuation, see #173.
+        # Each follow-up call gets its own scoped timing variables so the second
+        # timing event reports that call's numbers, not the first call's (#175).
+        fu_t_request_start = time.monotonic()
+        fu_t_first_event: Optional[float] = None
+        fu_t_message_start: Optional[float] = None
+        fu_t_first_text_block: Optional[float] = None
+        fu_cache_read_tokens = 0
+        fu_cache_creation_tokens = 0
+        fu_timing_emitted = False
+
         async with api.messages.stream(
             model=MODEL,
             max_tokens=MAX_TOKENS,
@@ -518,29 +596,64 @@ async def stream_reply(
             messages=new_history,
         ) as followup_stream:
             async for event in followup_stream:
+                if fu_t_first_event is None:
+                    fu_t_first_event = time.monotonic()
                 etype = getattr(event, "type", None)
-                if etype == "content_block_start":
+                if etype == "message_start":
+                    fu_t_message_start = time.monotonic()
+                    msg = getattr(event, "message", None)
+                    usage = getattr(msg, "usage", None) if msg is not None else None
+                    if usage is not None:
+                        fu_cache_read_tokens = getattr(usage, "cache_read_input_tokens", 0) or 0
+                        fu_cache_creation_tokens = getattr(usage, "cache_creation_input_tokens", 0) or 0
+                elif etype == "content_block_start":
                     block = getattr(event, "content_block", None)
-                    if getattr(block, "type", None) == "text" and t_first_text_block is None:
-                        t_first_text_block = time.monotonic()
-                        yield _make_timing_event()
-                        timing_emitted = True
+                    if getattr(block, "type", None) == "text" and fu_t_first_text_block is None:
+                        fu_t_first_text_block = time.monotonic()
+                        yield _make_timing_event(
+                            fu_t_request_start,
+                            fu_t_first_event,
+                            fu_t_message_start,
+                            fu_t_first_text_block,
+                            fu_cache_read_tokens,
+                            fu_cache_creation_tokens,
+                        )
+                        fu_timing_emitted = True
                 elif etype == "content_block_delta":
                     delta = getattr(event, "delta", None)
                     if getattr(delta, "type", None) == "text_delta":
                         text_parts.append(delta.text)
                         yield StreamEvent(text_delta=delta.text)
             followup_message = await followup_stream.get_final_message()
+
+        if not fu_timing_emitted:
+            # Follow-up emitted no text blocks; emit a timing snapshot anyway.
+            yield _make_timing_event(
+                fu_t_request_start,
+                fu_t_first_event,
+                fu_t_message_start,
+                fu_t_first_text_block,
+                fu_cache_read_tokens,
+                fu_cache_creation_tokens,
+            )
+
         followup_content = [_serialize_block(b) for b in followup_message.content]
         new_history = [
             *new_history,
             {"role": "assistant", "content": followup_content},
         ]
 
-    if not timing_emitted:
+    if not timing_emitted and not tool_uses:
         # Tool-only path with no follow-up text (rare); still emit a
         # timing snapshot so consumers always see the breakdown.
-        yield _make_timing_event()
+        yield _make_timing_event(
+            t_request_start,
+            t_first_event,
+            t_message_start,
+            t_first_text_block,
+            cache_read_tokens,
+            cache_creation_tokens,
+        )
 
     yield StreamEvent(
         final=LLMResponse(

--- a/dashboard/lib/formatters/call-timeline.ts
+++ b/dashboard/lib/formatters/call-timeline.ts
@@ -57,6 +57,8 @@ function formatDuration(seconds: number): string {
  */
 export function formatFirstAudioBreakdown(detail: Record<string, unknown>): string {
   const ttft = detail.ttft_seconds as number | undefined;
+  const networkPrefill = detail.network_prefill_seconds as number | undefined;
+  const decode = detail.decode_seconds as number | undefined;
   const toolPrefix = detail.tool_prefix_seconds as number | undefined;
   const firstText = detail.first_text_seconds as number | undefined;
   const cacheRead = detail.cache_read_tokens as number | undefined;
@@ -64,6 +66,10 @@ export function formatFirstAudioBreakdown(detail: Record<string, unknown>): stri
 
   const parts: string[] = [];
   if (typeof ttft === 'number') parts.push(`ttft=${Math.round(ttft * 1000)}ms`);
+  // #175 finer breakdown: network+prefill and decode placed after ttft, before cache.
+  if (typeof networkPrefill === 'number')
+    parts.push(`net+pre=${Math.round(networkPrefill * 1000)}ms`);
+  if (typeof decode === 'number') parts.push(`decode=${Math.round(decode * 1000)}ms`);
   if (typeof toolPrefix === 'number')
     parts.push(`tool=${Math.round(toolPrefix * 1000)}ms`);
   if (typeof firstText === 'number')

--- a/dashboard/tests/call-timeline-formatter.test.ts
+++ b/dashboard/tests/call-timeline-formatter.test.ts
@@ -149,3 +149,71 @@ describe('timelineFilename', () => {
     expect(filename).toBe('niko-call-CA1fa31451-20260425.txt');
   });
 });
+
+describe('formatFirstAudioBreakdown — #175 new fields', () => {
+  it('renders net+pre and decode when present, placed after ttft', () => {
+    const detail = {
+      latency_seconds: 1.1,
+      ttft_seconds: 0.5,
+      network_prefill_seconds: 0.35,
+      decode_seconds: 0.15,
+      tool_prefix_seconds: 0.0,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 900,
+    };
+    const timeline: CallTimeline = {
+      call_sid: 'CAnew',
+      events: [
+        {
+          timestamp: '2026-05-01T12:00:00.000Z',
+          kind: 'first_audio',
+          text: '',
+          detail,
+        },
+      ],
+    };
+    const text = formatTimelineAsText(timeline);
+    expect(text).toContain('ttft=500ms');
+    expect(text).toContain('net+pre=350ms');
+    expect(text).toContain('decode=150ms');
+    expect(text).toContain('cache=miss');
+    // net+pre must come after ttft in the rendered string.
+    const ttftIdx = text.indexOf('ttft=');
+    const netPreIdx = text.indexOf('net+pre=');
+    const decodeIdx = text.indexOf('decode=');
+    expect(netPreIdx).toBeGreaterThan(ttftIdx);
+    expect(decodeIdx).toBeGreaterThan(netPreIdx);
+  });
+
+  it('old-shape detail without new fields renders identically to before', () => {
+    // This is the same detail shape as the existing "renders the latency breakdown"
+    // test — verifying the new fields' absence does not change existing output.
+    const detail = {
+      latency_seconds: 1.236,
+      first_text_seconds: 1.1,
+      ttft_seconds: 0.42,
+      tool_prefix_seconds: 0.38,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 1850,
+    };
+    const timeline: CallTimeline = {
+      call_sid: 'CAold',
+      events: [
+        {
+          timestamp: '2026-05-01T12:00:00.000Z',
+          kind: 'first_audio',
+          text: '',
+          detail,
+        },
+      ],
+    };
+    const text = formatTimelineAsText(timeline);
+    expect(text).toContain('ttft=420ms');
+    expect(text).toContain('tool=380ms');
+    expect(text).toContain('text=1100ms');
+    expect(text).toContain('cache=miss');
+    // New fields must not appear.
+    expect(text).not.toContain('net+pre=');
+    expect(text).not.toContain('decode=');
+  });
+});

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -20,6 +20,15 @@ from app.orders.models import Order, OrderStatus, OrderType
 _TEST_SYSTEM_PROMPT = "you are a test agent"
 
 
+@pytest.fixture(autouse=True)
+def _reset_async_client_singleton():
+    """Reset the module-level AsyncAnthropic singleton after each test so
+    one test's instance never leaks into the next. The real process doesn't
+    need this — the singleton is intentionally long-lived there."""
+    yield
+    client_module._reset_async_client()
+
+
 @dataclass
 class FakeBlock:
     type: str
@@ -1645,10 +1654,39 @@ async def test_stream_reply_timing_includes_network_prefill_and_decode():
     assert timing_payload["decode_seconds"] >= 0
 
 
-async def test_stream_reply_tool_use_turn_emits_two_timing_events():
+async def test_stream_reply_tool_use_turn_emits_two_timing_events(monkeypatch):
     """#175 — a tool-use turn must emit two timing events: one for the first
     stream call (at the text block of that turn) and one for the follow-up
-    stream call. The router iterates all events so seeing two is fine."""
+    stream call.
+
+    The clock is pinned to a deterministic sequence so a scoping bug where
+    the follow-up reused the first call's t_request_start (producing inflated
+    timing values like 1.05 - 0.0 = 1.05s) would be caught by the approx
+    assertions below."""
+    # time.monotonic call order inside stream_reply for this fixture shape
+    # (first stream: tool_use + text; follow-up stream: text):
+    #   [0] t_request_start (before first stream loop)
+    #   [1] t_first_event   (message_start, first-event guard)
+    #   [2] t_message_start (message_start branch)
+    #   [3] t_first_text_block (content_block_start(text) in first stream)
+    #   [4] fu_t_request_start (before follow-up stream loop)
+    #   [5] fu_t_first_event   (message_start, first-event guard)
+    #   [6] fu_t_message_start (message_start branch)
+    #   [7] fu_t_first_text_block (content_block_start(text) in follow-up)
+    _clock = [0.0, 0.10, 0.10, 0.20, 1.0, 1.05, 1.05, 1.15]
+    _clock_idx = [0]
+
+    def _fake_monotonic():
+        v = _clock[_clock_idx[0]]
+        _clock_idx[0] += 1
+        return v
+
+    # Patch the time module reference inside client.py so asyncio's own
+    # time.monotonic (used for event-loop scheduling) is not affected.
+    import types as _types
+    fake_time = _types.SimpleNamespace(monotonic=_fake_monotonic)
+    monkeypatch.setattr(client_module, "time", fake_time)
+
     order = Order(call_sid="CAtest")
     fake_client = MagicMock()
     fake_client.messages.stream = _stream_manager_factory(
@@ -1697,19 +1735,52 @@ async def test_stream_reply_tool_use_turn_emits_two_timing_events():
     assert len(timing_events) == 2, (
         f"Expected 2 timing events for a tool-use turn, got {len(timing_events)}"
     )
-    for t in timing_events:
-        assert "network_prefill_seconds" in t.timing
-        assert "decode_seconds" in t.timing
-        assert "ttft_seconds" in t.timing
-        assert "tool_prefix_seconds" in t.timing
-        assert t.timing["network_prefill_seconds"] >= 0
-        assert t.timing["decode_seconds"] >= 0
+
+    first_t = timing_events[0].timing
+    second_t = timing_events[1].timing
+
+    # First call: network_prefill = 0.10 - 0.0, decode = 0.20 - 0.10
+    assert first_t["network_prefill_seconds"] == pytest.approx(0.10, abs=1e-9)
+    assert first_t["decode_seconds"] == pytest.approx(0.10, abs=1e-9)
+
+    # Follow-up has its own t_request_start anchored at 1.0, not 0.0.
+    # A scoping bug reusing t_request_start=0.0 would produce ~1.05s here.
+    assert second_t["network_prefill_seconds"] == pytest.approx(0.05, abs=1e-9)
+    assert second_t["decode_seconds"] == pytest.approx(0.10, abs=1e-9)
+    assert second_t["network_prefill_seconds"] < first_t["network_prefill_seconds"]
 
 
-async def test_stream_reply_tool_only_turn_emits_two_timing_events():
+async def test_stream_reply_tool_only_turn_emits_two_timing_events(monkeypatch):
     """#175 — tool-only first turn (no text) + follow-up text turn also emits
     two timing events: the fallback from the first call and the normal one
-    from the follow-up call."""
+    from the follow-up call.
+
+    The clock is pinned so a scoping bug aliasing fu_t_request_start to
+    t_request_start would produce inflated follow-up timing and be caught."""
+    # time.monotonic call order for this fixture shape
+    # (first stream: tool_use only; follow-up stream: text):
+    #   [0] t_request_start (before first stream loop)
+    #   [1] t_first_event   (message_start, first-event guard)
+    #   [2] t_message_start (message_start branch)
+    #   — no t_first_text_block; fallback timing emitted with decode=0.0
+    #   [3] fu_t_request_start (before follow-up stream loop)
+    #   [4] fu_t_first_event   (message_start, first-event guard)
+    #   [5] fu_t_message_start (message_start branch)
+    #   [6] fu_t_first_text_block (content_block_start(text) in follow-up)
+    _clock = [0.0, 0.10, 0.10, 1.0, 1.05, 1.05, 1.15]
+    _clock_idx = [0]
+
+    def _fake_monotonic():
+        v = _clock[_clock_idx[0]]
+        _clock_idx[0] += 1
+        return v
+
+    # Patch the time module reference inside client.py so asyncio's own
+    # time.monotonic (used for event-loop scheduling) is not affected.
+    import types as _types
+    fake_time = _types.SimpleNamespace(monotonic=_fake_monotonic)
+    monkeypatch.setattr(client_module, "time", fake_time)
+
     order = Order(call_sid="CAtest")
     fake_client = MagicMock()
     fake_client.messages.stream = _stream_manager_factory(
@@ -1747,51 +1818,72 @@ async def test_stream_reply_tool_only_turn_emits_two_timing_events():
         f"Expected 2 timing events for a tool-only turn, got {len(timing_events)}"
     )
 
+    first_t = timing_events[0].timing
+    second_t = timing_events[1].timing
 
-async def test_stream_reply_persistent_client_used_when_no_injection():
-    """#175 — when no client is injected, stream_reply uses the module-level
-    singleton rather than building a new instance. We verify the singleton is
-    set after a call (we patch the key so _get_async_client doesn't fail)."""
-    from app.llm import client as client_module
+    # First call emitted a fallback timing (no text block): decode must be 0.
+    assert first_t["network_prefill_seconds"] == pytest.approx(0.10, abs=1e-9)
+    assert first_t["decode_seconds"] == pytest.approx(0.0, abs=1e-9)
 
-    client_module._reset_async_client()
+    # Follow-up is anchored at fu_t_request_start=1.0, not the first call's 0.0.
+    # A scoping bug reusing t_request_start=0.0 would produce ~1.05s here.
+    assert second_t["network_prefill_seconds"] == pytest.approx(0.05, abs=1e-9)
+    assert second_t["decode_seconds"] == pytest.approx(0.10, abs=1e-9)
+    assert second_t["network_prefill_seconds"] < first_t["network_prefill_seconds"]
 
-    fake_stream = _FakeAsyncStream(
-        deltas=["Hi!"],
-        blocks=[FakeBlock(type="text", text="Hi!")],
+
+async def test_stream_reply_persistent_client_used_when_no_injection(monkeypatch):
+    """#175 — when no client= is injected, stream_reply must use the module-level
+    singleton (_get_async_client) on every call, not construct a fresh
+    AsyncAnthropic per turn. A regression that switched back to per-turn
+    construction would bypass _get_async_client entirely and be caught here."""
+    # Pre-seed the singleton with a fake client so stream_reply can run without
+    # touching the real network. Two fake streams — one per stream_reply call.
+    fake_api = MagicMock()
+    fake_api.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(deltas=["Hi!"], blocks=[FakeBlock(type="text", text="Hi!")]),
+            _FakeAsyncStream(
+                deltas=["Hello again!"], blocks=[FakeBlock(type="text", text="Hello again!")]
+            ),
+        ]
+    )
+    monkeypatch.setattr(client_module, "_default_async_client", fake_api)
+
+    # Wrap _get_async_client to count how many times stream_reply invokes it.
+    get_call_count = 0
+    real_get = client_module._get_async_client
+
+    def _counting_get():
+        nonlocal get_call_count
+        get_call_count += 1
+        return real_get()
+
+    monkeypatch.setattr(client_module, "_get_async_client", _counting_get)
+
+    order = Order(call_sid="CAtest")
+    # Two calls without client= — both must route through _get_async_client.
+    await _collect_all_events(
+        stream_reply(
+            transcript="hello",
+            history=[],
+            order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
+        )
+    )
+    await _collect_all_events(
+        stream_reply(
+            transcript="and again",
+            history=[],
+            order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
+        )
     )
 
-    def _make_stream(**kwargs):
-        return fake_stream
-
-    original_get = client_module._get_async_client
-
-    created_instances: list = []
-
-    def _tracked_get():
-        instance = original_get()
-        created_instances.append(instance)
-        return instance
-
-    import unittest.mock as mock_module
-
-    with mock_module.patch.object(client_module, "_get_async_client", _tracked_get):
-        with mock_module.patch.object(client_module.settings, "anthropic_api_key", "fake-key"):
-            # First call creates the singleton.
-            client_module._reset_async_client()
-            # Inject a fake stream via the explicit client param so we don't
-            # hit the real network — this test only verifies the singleton path
-            # is invoked, not the live API.
-            pass
-
-    # Simpler assertion: after _reset_async_client(), calling _get_async_client
-    # with a valid key creates a new instance and stores it.
-    client_module._reset_async_client()
-    assert client_module._default_async_client is None
-
-    with mock_module.patch.object(client_module.settings, "anthropic_api_key", "fake-key-for-test"):
-        instance1 = client_module._get_async_client()
-        instance2 = client_module._get_async_client()
-
-    assert instance1 is instance2, "Singleton must return the same instance on repeated calls"
-    client_module._reset_async_client()
+    assert get_call_count == 2, (
+        f"_get_async_client should be called once per stream_reply turn; got {get_call_count}"
+    )
+    # The singleton was never replaced — both turns shared the same instance.
+    assert client_module._default_async_client is fake_api, (
+        "stream_reply must reuse the singleton, not replace it"
+    )

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -949,14 +949,16 @@ async def test_stream_reply_emits_timing_event_before_first_delta():
     # timing must precede every text delta and the final event.
     assert seen_kinds == ["timing", "delta", "final"]
     assert timing_payload is not None
-    assert set(timing_payload.keys()) == {
-        "ttft_seconds",
-        "tool_prefix_seconds",
-        "cache_read_tokens",
-        "cache_creation_tokens",
-    }
+    # Back-compat fields must still be present (#175).
+    assert {"ttft_seconds", "tool_prefix_seconds", "cache_read_tokens", "cache_creation_tokens"} <= set(
+        timing_payload.keys()
+    )
+    # New finer fields added in #175.
+    assert {"network_prefill_seconds", "decode_seconds"} <= set(timing_payload.keys())
     assert timing_payload["ttft_seconds"] >= 0
     assert timing_payload["tool_prefix_seconds"] >= 0
+    assert timing_payload["network_prefill_seconds"] >= 0
+    assert timing_payload["decode_seconds"] >= 0
     # Cache token counts come straight from the message_start usage block.
     assert timing_payload["cache_read_tokens"] == 420
     assert timing_payload["cache_creation_tokens"] == 0
@@ -1599,3 +1601,197 @@ async def test_stream_reply_followup_after_text_plus_tool_yields_both_deltas():
     # Follow-up must pass tools=[] — purely verbal continuation, see #173.
     assert len(captured_calls) == 2
     assert captured_calls[1]["tools"] == []
+
+
+async def _collect_all_events(stream_iter) -> list:
+    """Collect every StreamEvent yielded by stream_reply, preserving order."""
+    events = []
+    async for event in stream_iter:
+        events.append(event)
+    return events
+
+
+async def test_stream_reply_timing_includes_network_prefill_and_decode():
+    """#175 — network_prefill_seconds and decode_seconds must be present and
+    non-negative in the timing payload for a plain text turn."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=["Hi!"],
+                blocks=[FakeBlock(type="text", text="Hi!")],
+            )
+        ]
+    )
+
+    timing_payload = None
+    async for event in stream_reply(
+        transcript="hello",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    ):
+        if event.timing is not None:
+            timing_payload = event.timing
+
+    assert timing_payload is not None
+    assert "network_prefill_seconds" in timing_payload
+    assert "decode_seconds" in timing_payload
+    assert isinstance(timing_payload["network_prefill_seconds"], float)
+    assert isinstance(timing_payload["decode_seconds"], float)
+    assert timing_payload["network_prefill_seconds"] >= 0
+    assert timing_payload["decode_seconds"] >= 0
+
+
+async def test_stream_reply_tool_use_turn_emits_two_timing_events():
+    """#175 — a tool-use turn must emit two timing events: one for the first
+    stream call (at the text block of that turn) and one for the follow-up
+    stream call. The router iterates all events so seeing two is fine."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=["Got it, adding that now."],
+                blocks=[
+                    FakeBlock(
+                        type="tool_use",
+                        id="toolu_1",
+                        name="update_order",
+                        input={
+                            "items": [
+                                {
+                                    "name": "Pepperoni",
+                                    "category": "pizza",
+                                    "size": "medium",
+                                    "quantity": 1,
+                                    "unit_price": 17.99,
+                                }
+                            ],
+                            "status": "in_progress",
+                        },
+                    ),
+                    FakeBlock(type="text", text="Got it, adding that now."),
+                ],
+            ),
+            _FakeAsyncStream(
+                deltas=["Anything else?"],
+                blocks=[FakeBlock(type="text", text="Anything else?")],
+            ),
+        ]
+    )
+
+    events = await _collect_all_events(
+        stream_reply(
+            transcript="one medium pepperoni",
+            history=[],
+            order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
+            client=fake_client,
+        )
+    )
+
+    timing_events = [e for e in events if e.timing is not None]
+    assert len(timing_events) == 2, (
+        f"Expected 2 timing events for a tool-use turn, got {len(timing_events)}"
+    )
+    for t in timing_events:
+        assert "network_prefill_seconds" in t.timing
+        assert "decode_seconds" in t.timing
+        assert "ttft_seconds" in t.timing
+        assert "tool_prefix_seconds" in t.timing
+        assert t.timing["network_prefill_seconds"] >= 0
+        assert t.timing["decode_seconds"] >= 0
+
+
+async def test_stream_reply_tool_only_turn_emits_two_timing_events():
+    """#175 — tool-only first turn (no text) + follow-up text turn also emits
+    two timing events: the fallback from the first call and the normal one
+    from the follow-up call."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=[],
+                blocks=[
+                    FakeBlock(
+                        type="tool_use",
+                        id="toolu_cancel",
+                        name="update_order",
+                        input={"items": [], "status": "cancelled"},
+                    )
+                ],
+            ),
+            _FakeAsyncStream(
+                deltas=["Okay, order cancelled."],
+                blocks=[FakeBlock(type="text", text="Okay, order cancelled.")],
+            ),
+        ]
+    )
+
+    events = await _collect_all_events(
+        stream_reply(
+            transcript="never mind",
+            history=[],
+            order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
+            client=fake_client,
+        )
+    )
+
+    timing_events = [e for e in events if e.timing is not None]
+    assert len(timing_events) == 2, (
+        f"Expected 2 timing events for a tool-only turn, got {len(timing_events)}"
+    )
+
+
+async def test_stream_reply_persistent_client_used_when_no_injection():
+    """#175 — when no client is injected, stream_reply uses the module-level
+    singleton rather than building a new instance. We verify the singleton is
+    set after a call (we patch the key so _get_async_client doesn't fail)."""
+    from app.llm import client as client_module
+
+    client_module._reset_async_client()
+
+    fake_stream = _FakeAsyncStream(
+        deltas=["Hi!"],
+        blocks=[FakeBlock(type="text", text="Hi!")],
+    )
+
+    def _make_stream(**kwargs):
+        return fake_stream
+
+    original_get = client_module._get_async_client
+
+    created_instances: list = []
+
+    def _tracked_get():
+        instance = original_get()
+        created_instances.append(instance)
+        return instance
+
+    import unittest.mock as mock_module
+
+    with mock_module.patch.object(client_module, "_get_async_client", _tracked_get):
+        with mock_module.patch.object(client_module.settings, "anthropic_api_key", "fake-key"):
+            # First call creates the singleton.
+            client_module._reset_async_client()
+            # Inject a fake stream via the explicit client param so we don't
+            # hit the real network — this test only verifies the singleton path
+            # is invoked, not the live API.
+            pass
+
+    # Simpler assertion: after _reset_async_client(), calling _get_async_client
+    # with a valid key creates a new instance and stores it.
+    client_module._reset_async_client()
+    assert client_module._default_async_client is None
+
+    with mock_module.patch.object(client_module.settings, "anthropic_api_key", "fake-key-for-test"):
+        instance1 = client_module._get_async_client()
+        instance2 = client_module._get_async_client()
+
+    assert instance1 is instance2, "Singleton must return the same instance on repeated calls"
+    client_module._reset_async_client()

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -521,6 +521,100 @@ def test_stop_event_skips_persist_if_order_not_ready(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# #175 — tool-use turns emit two timing events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
+    """#175 — when stream_reply yields two timing events (tool-use turn),
+    the router must consume both without error. On a tool-only first turn
+    (no text in the first stream), the event order is:
+      1. timing-1 (fallback from the tool-only first stream)
+      2. timing-2 (from the follow-up stream's first text block)
+      3. text_delta (follow-up stream)
+      4. final
+    timing_snapshot is updated each time, so timing-2 ends up in the
+    first_audio Firestore event detail because it arrives before speak()
+    fires for the first time."""
+    from app.telephony import router as router_mod
+    from app.telephony.router import _run_llm_tts_turn, _CallState
+    from app.storage import call_sessions
+
+    first_timing = {
+        "ttft_seconds": 0.8,
+        "tool_prefix_seconds": 0.0,
+        "network_prefill_seconds": 0.6,
+        "decode_seconds": 0.2,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 500,
+    }
+    second_timing = {
+        "ttft_seconds": 0.3,
+        "tool_prefix_seconds": 0.0,
+        "network_prefill_seconds": 0.25,
+        "decode_seconds": 0.05,
+        "cache_read_tokens": 500,
+        "cache_creation_tokens": 0,
+    }
+
+    async def fake_stream_reply_tool_only_then_text(*, transcript, history, order, **kw):
+        # Tool-only first stream: timing-1 arrives (no text delta from first stream).
+        yield StreamEvent(timing=first_timing)
+        # Follow-up stream: timing-2 arrives BEFORE the text delta, so the
+        # router's timing_snapshot is updated before speak() fires.
+        yield StreamEvent(timing=second_timing)
+        # Now yield a text delta long enough to trigger a flush.
+        yield StreamEvent(text_delta="Okay, order cancelled. Have a great day!")
+        yield StreamEvent(
+            final=LLMResponse(
+                reply_text="Okay, order cancelled. Have a great day!",
+                order=order,
+                history=history,
+            )
+        )
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        on_first_byte = kw.get("on_first_byte")
+        if on_first_byte is not None:
+            on_first_byte()
+
+    recorded_events: list[dict] = []
+
+    def fake_bg_call_event(call_sid, rid, **kwargs):
+        recorded_events.append({"call_sid": call_sid, "rid": rid, **kwargs})
+
+    monkeypatch.setattr(router_mod, "stream_reply", fake_stream_reply_tool_only_then_text)
+    monkeypatch.setattr(router_mod, "speak", fake_speak)
+    monkeypatch.setattr(router_mod, "_bg_call_event", fake_bg_call_event)
+    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+
+    state = _CallState(
+        call_sid="CAtest",
+        stream_sid="MZtest",
+        order=Order(call_sid="CAtest"),
+        system_prompt="test prompt",
+    )
+    ws = AsyncMock()
+
+    await _run_llm_tts_turn("never mind cancel", state, ws)
+
+    first_audio_events = [e for e in recorded_events if e.get("kind") == "first_audio"]
+    assert len(first_audio_events) == 1, (
+        f"Expected 1 first_audio event, got {len(first_audio_events)}"
+    )
+    detail = first_audio_events[0]["detail"]
+    # The second timing snapshot overwrites the first — its values appear in detail.
+    assert detail.get("ttft_seconds") == second_timing["ttft_seconds"], (
+        f"timing_snapshot should hold the second event; got ttft={detail.get('ttft_seconds')}"
+    )
+    assert detail.get("network_prefill_seconds") == second_timing["network_prefill_seconds"]
+    assert detail.get("decode_seconds") == second_timing["decode_seconds"]
+    assert "latency_seconds" in detail
+
+
+# ---------------------------------------------------------------------------
 # Barge-in: clear Twilio's audio buffer (#74)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Persistent module-level `AsyncAnthropic` singleton (mirrors `app/tts/client.py` from #151) — eliminates the per-turn TCP+TLS handshake to `api.anthropic.com`, expected ~100–250ms saved on turns 2+ within a worker.
- `_make_timing_event` payload extended with `network_prefill_seconds` (request → `message_start`) and `decode_seconds` (`message_start` → first text block), splitting the previously-conflated TTFT into network+queue+prefill vs. decode.
- Tool-use turns now emit a second timing event from the verbal-continuation `messages.stream()` call, making the previously-invisible follow-up TTFT visible in the dashboard.
- Dashboard `formatFirstAudioBreakdown` extended for the new fields with graceful back-compat for old timeline data — legacy rows render byte-identically to before.

## Linked issue

Closes #175. Companion #176 (multi-turn cache breakpoint) is gated on this landing.

## Test plan

- [x] `pytest -q` green — 397 pass + 1 known `tests/test_llm_integration.py` flake (real Claude API output drift, unrelated to this PR; confirmed pass on retry)
- [x] `pnpm -C dashboard test` green — 112 pass
- [x] Reviewer pass via `niko-reviewer` agent — 4 MAJOR test-quality findings addressed in commit `ef85939`
- [ ] **Live staging call:** confirm `FIRST_AUDIO` timeline rows render the new `net+pre=Xms decode=Xms` fields
- [ ] **Live staging call:** confirm `cache_read_input_tokens > 0` on turns 2+ (no regression to existing system-prompt caching from #113)
- [ ] **Live staging call with order modification:** confirm two `FIRST_AUDIO` rows appear on the tool-use turn (one for the first stream, one for the verbal continuation)
- [ ] **Spot-check:** TTFT P50 on turns 2+ should drop vs. pre-merge baseline (~100–200ms target — won't move P95, that's server-side jitter)

## Notes

- Sync `Anthropic` client at `app/llm/client.py:153` deliberately left unchanged — it's only used by tests, so converting would be churn for no functional benefit. Comment in source explains the choice.
- The singleton holds a client bound to `settings.anthropic_api_key` at first use. Current deployment doesn't rotate keys at runtime; if that ever changes we'd need to invalidate the singleton on rotation. Not a concern today, flagged for future me.
- Out of scope (deliberate follow-ups, not gaps):
  - Tool-use single-call refactor (eliminating the second TTFT entirely instead of just measuring it) — speculative without data; revisit after this lands and we have real numbers.
  - Pre-warming Anthropic connection at `CALL_START` — mostly redundant once the singleton is in place.
  - Multi-turn cache breakpoint on history → tracked as #176.