### PR TITLE
dashboard: surface raw cache_read/cache_creation tokens in FIRST_AUDIO breakdown

### DIFF
--- a/dashboard/lib/formatters/call-timeline.ts
+++ b/dashboard/lib/formatters/call-timeline.ts
@@ -76,7 +76,9 @@ export function formatFirstAudioBreakdown(detail: Record<string, unknown>): stri
     parts.push(`text=${Math.round(firstText * 1000)}ms`);
   if (typeof cacheRead === 'number' || typeof cacheCreation === 'number') {
     const hit = (cacheRead ?? 0) > 0 && (cacheCreation ?? 0) === 0;
-    parts.push(`cache=${hit ? 'hit' : 'miss'}`);
+    const r = cacheRead ?? 0;
+    const w = cacheCreation ?? 0;
+    parts.push(`cache=${hit ? 'hit' : 'miss'} r=${r} w=${w}`);
   }
 
   return parts.length ? `[${parts.join(' ')}]` : '';

--- a/dashboard/tests/call-timeline-formatter.test.ts
+++ b/dashboard/tests/call-timeline-formatter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { CallTimeline } from '@/lib/api/calls';
 import {
+  formatFirstAudioBreakdown,
   formatTimelineAsText,
   timelineFilename,
 } from '@/lib/formatters/call-timeline';
@@ -215,5 +216,47 @@ describe('formatFirstAudioBreakdown — #175 new fields', () => {
     // New fields must not appear.
     expect(text).not.toContain('net+pre=');
     expect(text).not.toContain('decode=');
+  });
+});
+
+describe('formatFirstAudioBreakdown — #183 raw cache token counts', () => {
+  it('renders r=N w=M after cache=hit/miss when both token fields are present', () => {
+    const result = formatFirstAudioBreakdown({
+      ttft_seconds: 0.539,
+      network_prefill_seconds: 0.539,
+      decode_seconds: 0.0,
+      tool_prefix_seconds: 0.0,
+      first_text_seconds: 0.541,
+      cache_read_tokens: 4096,
+      cache_creation_tokens: 0,
+    });
+    expect(result).toContain('cache=hit r=4096 w=0');
+    // Verify the entire bracketed format for the issue's suggested example.
+    expect(result).toBe(
+      '[ttft=539ms net+pre=539ms decode=0ms tool=0ms text=541ms cache=hit r=4096 w=0]',
+    );
+  });
+
+  it('omits r= and w= entirely when both token fields are absent', () => {
+    // Legacy event — only timing fields, no cache token counts.
+    const result = formatFirstAudioBreakdown({
+      ttft_seconds: 0.42,
+      tool_prefix_seconds: 0.38,
+      first_text_seconds: 1.1,
+    });
+    expect(result).not.toContain('r=');
+    expect(result).not.toContain('w=');
+    expect(result).not.toContain('cache=');
+    expect(result).toBe('[ttft=420ms tool=380ms text=1100ms]');
+  });
+
+  it('renders cache=miss r=0 w=4096 for a cold cache write (read=0, creation>0)', () => {
+    // cache_read=0 + cache_creation>0 means a fresh write — no prior cache hit.
+    const result = formatFirstAudioBreakdown({
+      ttft_seconds: 0.6,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 4096,
+    });
+    expect(result).toContain('cache=miss r=0 w=4096');
   });
 });


### PR DESCRIPTION
## Summary

- Renders `r=N w=M` (raw `cache_read_tokens` / `cache_creation_tokens`) alongside the existing `cache=hit|miss` label in the `FIRST_AUDIO` timeline breakdown.
- Data was already being emitted by #175 — this PR just surfaces it.
- Back-compat preserved: legacy timeline data without raw token fields renders byte-identically to before (verified by test).

## Linked issue

Closes #183

## Why

The current `cache=hit|miss` binary collapses three meaningfully different states (mostly cached + tiny growth, mostly cold, full eviction) into one label. Raw token counts let us tell them apart, which unblocks decisions on #176 (multi-turn cache breakpoint) and the follow-up `tools=[]` cache hypothesis raised in #175's post-merge review.

## Example output

Before:
```
[ttft=539ms net+pre=539ms decode=0ms tool=0ms text=541ms cache=hit]
```

After:
```
[ttft=539ms net+pre=539ms decode=0ms tool=0ms text=541ms cache=hit r=4096 w=0]
```

## Test plan

- [x] `vitest run tests/call-timeline-formatter.test.ts` — 15/15 pass (3 new + 12 existing)
- [x] `tsc --noEmit` clean
- [x] niko-reviewer: no findings, approve
- [ ] Live staging call: confirm raw `r=` / `w=` numbers appear and reflect what the agent reports

## Notes

- Diff is 4 source lines + 43 test lines. Two files. Nothing else changed.
- Next decisions this unlocks: verify the follow-up `tools=[]` hypothesis from #175's post-merge review (if `r=0 w=N` on every order-modifying turn, hypothesis confirmed → 1-line fix); evaluate #176's value (if `r=` grows turn-over-turn, multi-turn breakpoint isn't needed; if it stays flat, it is).