### PR TITLE
prompts: period-terminated openers on read-back + closing turns (#186)

### DIFF
--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -72,8 +72,9 @@ _PREAMBLE = dedent("""\
     Order confirmation read-back:
     - Before asking for confirmation, read back every item with its
       quantity, size (if applicable), and any modifications. For example:
-      "So that's one large Margherita with extra cheese and no basil, and
-      one Coke — your total is twenty-one ninety-nine. Does that sound right?"
+      "Perfect. So that's one large Margherita with extra cheese and no
+      basil, and one Coke — your total is twenty-one ninety-nine. Does
+      that sound right?"
     - If order_type is delivery, also read the delivery address back as
       part of the summary. Example: "...for delivery to fourteen Main
       Street — your total is twenty-one ninety-nine. Does that sound right?"
@@ -91,9 +92,14 @@ _PREAMBLE = dedent("""\
     Closing the call:
     - Once the caller has confirmed the summary (e.g. "yes that's right",
       "yep", "no that's it"), set the order's status to "confirmed" via
-      update_order and say a brief, terminal goodbye like "Great, your
-      order is in — see you soon!" or "Perfect, we'll have it ready —
+      update_order and say a brief, terminal goodbye like "Got it. Your
+      order is in — see you soon!" or "Perfect. We'll have it ready —
       thanks for calling!"
+    - Lead the read-back and the final goodbye with a one- or two-word
+      acknowledgement that ends in a period — "Got it.", "Perfect.",
+      "Alright.", "Of course." — then continue the sentence. Vary the
+      choice across turns; do not always pick the same one. Periods let
+      TTS start speaking sooner; commas hold the audio back.
     - CRITICAL: any time you say a wrap-up phrase like "your order is in",
       "we'll have it ready", "see you soon", or "thanks for calling", you
       MUST call update_order in the same turn with status="confirmed".

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -92,6 +92,40 @@ def test_prompt_couples_goodbye_phrases_with_status_flip():
     assert 'status="confirmed"' in lower
 
 
+def test_prompt_closing_uses_period_terminated_openers():
+    """Regression for #186 — closing examples must use period-terminated
+    openers so TTS flushes the opener immediately instead of buffering
+    behind a comma. Also pins the variety rule listing at least three of
+    the four named openers."""
+    prompt = build_system_prompt(_demo())
+    lower = prompt.lower()
+    # Period-terminated openers present in the closing examples.
+    # The text wraps across lines in the dedented block, so we check each
+    # part separately rather than as a single substring.
+    assert "got it." in lower
+    assert "your order is in" in lower
+    assert "perfect." in lower
+    assert "we'll have it ready" in lower
+    # Old comma-led forms must be gone (the #186 fix replaced them)
+    assert "great, your order is in" not in lower
+    assert "perfect, we'll have it ready" not in lower
+    # Variety rule — at least 3 of the 4 named openers must appear quoted
+    variety_openers = ['"got it."', '"perfect."', '"alright."', '"of course."']
+    found = sum(1 for o in variety_openers if o in lower)
+    assert found >= 3, f"Expected >=3 variety openers in prompt, found {found}"
+    # Motivation sentence must be present so the model knows WHY
+    assert "periods let" in lower or "tts start speaking sooner" in lower
+
+
+def test_prompt_readback_example_uses_period_terminated_opener():
+    """Regression for #186 — the order confirmation read-back example
+    must also lead with a period-terminated opener ('Perfect.') so the
+    TTS flushing rule is modelled consistently across all examples."""
+    prompt = build_system_prompt(_demo())
+    lower = prompt.lower()
+    assert "perfect. so that's one large margherita" in lower
+
+
 def test_prompt_renders_per_tenant_name():
     """Multi-tenancy (#79): the same builder run against a different
     Restaurant produces a prompt with that restaurant's name — proves


### PR DESCRIPTION
## Summary

- Changes the example wording in `app/llm/prompts.py` for the read-back (lines 72-89) and closing (lines 91-102) sections from comma-led openers (`"Great, your order is in..."`) to period-terminated ones (`"Got it. Your order is in..."`). Periods have no length minimum in the TTS chunker, so the first audio frame ships ~80-120 ms sooner.
- Adds a short variety rule listing 3-4 sample openers (`"Got it."`, `"Perfect."`, `"Alright."`, `"Of course."`) so the model rotates them and doesn't sound robotic.
- Pins the new behavior in `tests/test_prompts.py` with positive assertions on the new openers + variety rule, and negative assertions ensuring the old comma-led closing examples are gone.

## Linked issue

Closes #186.

## Why this isn't a duplicate of #154

#154 added comma flushing to the TTS chunker with `_MIN_CHUNK_CHARS = 20` — that handled the long-clause case (`"One Chicken Fried Rice coming up,"` = 32 chars, flushes). It does not handle short comma-led openers (`"Perfect,"` = 8 chars, holds buffering until the next hard break). This PR attacks the same gap from the prompt side: a period bypasses the 20-char floor entirely. Complementary, not redundant.

## Test plan

- [x] `pytest tests/test_prompts.py -v` green (new tests visibly running)
- [x] `pytest tests/` green — 400 passed, 0 failures
- [x] In-process niko-reviewer pass: ✅ approved on all 8 checklist items (scope, targeted sections, period-terminated openers, variety rule, no determinism break, tests green, no PR opened, modification acks unchanged)
- [ ] **Staged-call A/B** (gates merge per issue done-when):
  - 3+ calls on `master`, capture `FIRST_AUDIO` rows on read-back + final-confirmation turns; record `latency - text` (TTS gap)
  - 3+ calls on this branch, same metric
  - Treatment arm shrinks ~300 ms vs baseline AND subjective listen confirms no clipped/curt phrasing

## Notes

- Builds on PR #154 (comma flushing) — this PR is the prompt-side complement.
- The follow-up to lower `_MIN_CHUNK_CHARS` from 20 → 10 is tracked separately as #187, gated on this PR's staged-call A/B results. If this PR closes the gap, #187 closes as not-needed.
- The comma-led modification ack at `prompts.py:123` (`"Got it, two now."`) is intentionally unchanged — those turns are masked by playback of the first phrase, so changing them is out of scope.
- No determinism break: variety is communicated via prompt instruction, not runtime randomization. Cache key stays stable per restaurant.