### PR TITLE
ci(jarvis): post bot/ events to #jarvis Discord channel

### DIFF
--- a/.github/workflows/jarvis-discord.yml
+++ b/.github/workflows/jarvis-discord.yml
@@ -1,0 +1,67 @@
+name: Jarvis Discord notifications
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review]
+    paths:
+      - 'bot/**'
+      - '.github/workflows/jarvis-discord.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'bot/**'
+      - '.github/workflows/jarvis-discord.yml'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR opened
+        if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_JARVIS_WEBHOOK }}
+          content: |
+            🟢 **PR #${{ github.event.pull_request.number }} opened** by `${{ github.event.pull_request.user.login }}`
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.html_url }}
+
+      - name: PR ready for review
+        if: github.event_name == 'pull_request' && github.event.action == 'ready_for_review'
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_JARVIS_WEBHOOK }}
+          content: |
+            👀 **PR #${{ github.event.pull_request.number }} ready for review** — `${{ github.event.pull_request.user.login }}`
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.html_url }}
+
+      - name: PR merged
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_JARVIS_WEBHOOK }}
+          content: |
+            ✅ **PR #${{ github.event.pull_request.number }} merged** by `${{ github.event.pull_request.user.login }}`
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.html_url }}
+
+      - name: PR closed without merge
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == false
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_JARVIS_WEBHOOK }}
+          content: |
+            ❌ **PR #${{ github.event.pull_request.number }} closed without merge**
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.html_url }}
+
+      - name: Push to master
+        if: github.event_name == 'push'
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_JARVIS_WEBHOOK }}
+          content: |
+            🚀 **bot/ updated on master** — `${{ github.event.pusher.name }}`
+            ${{ github.event.head_commit.message }}
+            ${{ github.event.head_commit.url }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ venv/
 # Claude Code: per-developer local permissions (team-shared config lives in settings.json)
 .claude/settings.local.json
 **/.claude/settings.local.json
+
+# Claude Code: isolated worktrees created by /superpowers and similar workflows
+.claude/worktrees/
+**/.claude/worktrees/


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/jarvis-discord.yml`, a path-filtered workflow scoped to `bot/**` that posts PR opened / ready-for-review / merged / closed-without-merge events, plus push-to-master events, into the new `#jarvis` Discord channel via the `tsickert/discord-webhook@v6.0.0` action.
- The workflow self-triggers on changes to its own file, so this introducing PR will exercise the path once `DISCORD_JARVIS_WEBHOOK` is configured.
- Gitignores `.claude/worktrees/` — Claude Code creates isolated worktrees there for the superpowers workflow and they should not show up as untracked in the parent tree.

## Setup required before merging

1. Discord → `#jarvis` → Edit Channel → Integrations → Webhooks → New Webhook → copy URL.
2. `gh secret set DISCORD_JARVIS_WEBHOOK --repo tsuki-works/niko` and paste the webhook URL when prompted.

Without the secret, the workflow will run and the `discord-webhook` action will no-op / fail the step, but no other CI is affected.

## Test plan

- [ ] After merge, open a trivial follow-up PR touching `bot/` (e.g. a comment in `bot/jarvis/main.py`) and confirm a 🟢 message lands in `#jarvis`.
- [ ] Mark that PR ready-for-review (if drafted) → confirm 👀 message.
- [ ] Merge it → confirm ✅ message + 🚀 push-to-master message both land.
- [ ] Verify nothing fires for a PR that doesn't touch `bot/` (sanity-check the path filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)