### PR TITLE
Jarvis 2.0 — PR 5: GCE e2-micro deploy + Secret Manager + systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,17 @@ venv/
 # Claude Code: isolated worktrees created by /superpowers and similar workflows
 .claude/worktrees/
 **/.claude/worktrees/
+
+# Terraform — local state, plan files, provider plugins, lockfile-overrides
+# (.terraform.lock.hcl is intentionally NOT ignored — it pins provider versions
+# for reproducibility and should be committed.)
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/jarvis/README.md
+++ b/infra/jarvis/README.md
@@ -1,0 +1,200 @@
+# `infra/jarvis/` — GCE deploy for Jarvis 2.0
+
+Terraform that stands up a single Compute Engine VM (`e2-micro`, free tier,
+`us-west1-a`) running the Jarvis Discord bot under systemd. Secrets live
+in GCP Secret Manager; the VM's startup script fetches them on boot.
+
+This is PR 5 of the six-PR Jarvis 2.0 plan
+(`docs/superpowers/specs/2026-05-01-jarvis-bot-design.md`). Exit criteria:
+**bot survives reboot; uptime check green for 24h.**
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `versions.tf` | Terraform + `google` provider pins |
+| `variables.tf` | `project_id`, `region`, `zone`, `vm_name`, `repo_url`, `branch` |
+| `main.tf` | Required APIs, service account, IAM, firewall (IAP-SSH only), VM |
+| `secrets.tf` | Three Secret Manager slots + `secretAccessor` IAM for the VM SA |
+| `outputs.tf` | VM name/zone/internal IP, SA email, IAP-SSH command |
+| `jarvis.service` | systemd unit (User=jarvis, EnvironmentFile=/etc/jarvis/env) |
+| `startup.sh` | Idempotent VM bootstrap (apt, git clone, venv, secrets, unit) |
+
+## State backend
+
+**Local state for now.** When the team needs concurrent applies (probably
+when a second person needs to operate this), migrate to a GCS bucket:
+
+```hcl
+# Add to versions.tf
+terraform {
+  backend "gcs" {
+    bucket = "niko-tsuki-tf-state"
+    prefix = "jarvis"
+  }
+}
+```
+
+Then `terraform init -migrate-state`. Until then, the local `.tfstate` file
+sits next to these files and **must not be committed** (it contains
+resource IDs and metadata, no secret values).
+
+## One-time bootstrap
+
+Prerequisites:
+- `gcloud` authenticated as a user with project owner/editor on `niko-tsuki`
+- `terraform >= 1.6` installed
+- A Discord bot application created in the Developer Portal, **with the
+  Message Content privileged intent enabled** and the bot already invited
+  to the Tsuki Works guild
+
+### 1. Set the active project + auth
+
+```bash
+gcloud config set project niko-tsuki
+gcloud auth application-default login
+```
+
+### 2. Apply Terraform — creates APIs, secret slots, SA, IAM, VM
+
+```bash
+cd infra/jarvis
+terraform init
+terraform plan
+terraform apply
+```
+
+The first apply takes 3–5 minutes (mostly enabling APIs and provisioning
+the VM). The startup script will fail on first boot because the secret
+slots exist but have no versions yet — that's expected; we add versions
+next, then reboot.
+
+### 3. Add secret values
+
+**Do not paste secrets into shell history or commit messages.** Use the
+GCP Console UI for the cleanest flow:
+
+1. Console → Security → Secret Manager → click `jarvis-discord-token`
+2. **+ NEW VERSION** → paste the bot token from Discord Dev Portal → Add
+3. Repeat for `jarvis-post-secret` (any 32+ character random string;
+   generate with `openssl rand -hex 32` if you don't have one)
+4. Repeat for `anthropic-api-key` (the key from `#shared-creds` in Discord)
+
+Or via CLI, with `--data-file=-` to keep the value off the command line:
+
+```bash
+# Reads from stdin; type or paste, then Ctrl+D (Ctrl+Z on Windows)
+gcloud secrets versions add jarvis-discord-token --data-file=-
+gcloud secrets versions add jarvis-post-secret    --data-file=-
+gcloud secrets versions add anthropic-api-key     --data-file=-
+```
+
+### 4. Reboot the VM so the startup script picks up the new secret versions
+
+```bash
+gcloud compute instances reset jarvis --zone us-west1-a
+```
+
+After ~60s, the bot should appear online in the Tsuki Works Discord.
+
+## Verification
+
+### Bot is online
+
+Look at the Discord member list — the Jarvis bot user should show as
+online (green dot). Sending `@Jarvis ping` in any channel where the bot
+has access should produce a response (PR 2 conversational path).
+
+### Health endpoint
+
+```bash
+gcloud compute ssh jarvis --zone us-west1-a --tunnel-through-iap
+```
+
+On the VM:
+
+```bash
+sudo systemctl status jarvis
+sudo journalctl -u jarvis -n 100 --no-pager
+curl -s http://localhost:8080/healthz | jq
+```
+
+Expected `/healthz`:
+
+```json
+{"status": "ok", "commit_sha": "<sha>", "started_at": "<iso8601>"}
+```
+
+### Survives reboot (spec exit criterion)
+
+```bash
+gcloud compute instances reset jarvis --zone us-west1-a
+```
+
+Wait ~90s, re-check `systemctl status jarvis` → should be `active (running)`.
+The startup script re-runs on every boot and is idempotent, so the bot
+comes back with the latest code on `master`.
+
+## Day-2: deploying a new bot version
+
+The startup script clones from `master` and re-runs on every boot, so
+the simplest deploy is:
+
+```bash
+gcloud compute instances reset jarvis --zone us-west1-a
+```
+
+For a faster path (no full reboot, ~10s):
+
+```bash
+gcloud compute ssh jarvis --zone us-west1-a --tunnel-through-iap -- \
+  "cd /opt/niko && sudo git fetch origin master && sudo git reset --hard origin/master && \
+   sudo /opt/niko/.venv/bin/pip install -q -r /opt/niko/bot/requirements.txt && \
+   sudo systemctl restart jarvis"
+```
+
+A GitHub Actions workflow that does this automatically on push-to-master
+(scoped to `bot/**`) is the obvious follow-up — out of scope for PR 5.
+
+## Rollback
+
+To revert to a previous commit:
+
+```bash
+gcloud compute ssh jarvis --zone us-west1-a --tunnel-through-iap -- \
+  "cd /opt/niko && sudo git reset --hard <commit-sha> && \
+   sudo systemctl restart jarvis"
+```
+
+To rotate the Discord token (if it leaks):
+
+1. Discord Dev Portal → Bot → **Reset Token**
+2. Console → Secret Manager → `jarvis-discord-token` → **+ NEW VERSION**
+3. Reset the VM so startup picks up the new version
+
+## Security notes
+
+- **No public ingress.** Firewall allows only TCP/22 from the GCP IAP
+  range (`35.235.240.0/20`). Discord/Anthropic/Firestore traffic is
+  outbound only via the ephemeral public IP.
+- **Bot doesn't store secrets in the repo.** `/etc/jarvis/env` is
+  written at startup, mode `600`, owned by root.
+- **Service account has minimal scope:** `secretAccessor` on the three
+  secrets, `logWriter`/`metricWriter`/`datastore.user` at project level.
+  No broad project IAM.
+- **OS Login is enabled** so SSH access is gated by GCP IAM, not by
+  static keys on the VM.
+
+## Known limitations / follow-ups
+
+- **No formal Cloud Monitoring uptime check.** Adding one requires
+  either exposing `:8080/healthz` publicly (security cost) or standing
+  up an internal LB (overkill for one VM). Manual `systemctl status` +
+  `journalctl` is sufficient until alerting becomes load-bearing.
+- **No auto-deploy on push to master.** Worth a small follow-up GHA
+  workflow scoped to `bot/**` that does the SSH + git pull + restart.
+- **Local Terraform state.** Migrate to GCS once a second operator
+  needs to run `apply`.
+- **Single zone, no failover.** A zonal outage takes the bot down for
+  the duration of the outage. Acceptable for an internal tool; revisit
+  if the bot becomes load-bearing for customer-facing flows.

--- a/infra/jarvis/jarvis.service
+++ b/infra/jarvis/jarvis.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Jarvis 2.0 — Tsuki Works Discord bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=jarvis
+Group=jarvis
+WorkingDirectory=/opt/niko/bot
+EnvironmentFile=/etc/jarvis/env
+Environment=PYTHONPATH=/opt/niko/bot
+ExecStart=/opt/niko/.venv/bin/python -m jarvis.main
+Restart=always
+RestartSec=10s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=jarvis
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/jarvis/main.tf
+++ b/infra/jarvis/main.tf
@@ -1,0 +1,109 @@
+locals {
+  required_apis = [
+    "compute.googleapis.com",
+    "secretmanager.googleapis.com",
+    "iap.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "required" {
+  for_each = toset(local.required_apis)
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_service_account" "jarvis" {
+  account_id   = "jarvis-vm"
+  display_name = "Jarvis bot VM"
+  description  = "Runtime SA for the Jarvis Discord bot on GCE."
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_project_iam_member" "jarvis_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.jarvis.email}"
+}
+
+resource "google_project_iam_member" "jarvis_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.jarvis.email}"
+}
+
+# Firestore native — used by bot/jarvis/memory.py for thread memory.
+resource "google_project_iam_member" "jarvis_datastore_user" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.jarvis.email}"
+}
+
+# Allow IAP-tunneled SSH only. The VM has no other ingress; the Discord
+# gateway is outbound and uses the VM's ephemeral public IP for egress.
+resource "google_compute_firewall" "jarvis_iap_ssh" {
+  name    = "${var.vm_name}-iap-ssh"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["35.235.240.0/20"] # GCP IAP source range
+  target_tags   = [var.vm_name]
+}
+
+resource "google_compute_instance" "jarvis" {
+  name         = var.vm_name
+  machine_type = var.machine_type
+  zone         = var.zone
+  tags         = [var.vm_name]
+
+  boot_disk {
+    initialize_params {
+      image = var.boot_disk_image
+      size  = var.boot_disk_size_gb
+      type  = "pd-standard"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      # Ephemeral public IP — required for outbound to Discord/Anthropic
+      # without paying for a Cloud NAT. No inbound (IAP-SSH only).
+    }
+  }
+
+  service_account {
+    email  = google_service_account.jarvis.email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata = {
+    enable-oslogin = "TRUE"
+  }
+
+  metadata_startup_script = templatefile("${path.module}/startup.sh", {
+    repo_url         = var.repo_url
+    branch           = var.branch
+    project_id       = var.project_id
+    discord_guild_id = var.discord_guild_id
+  })
+
+  labels = {
+    component = "jarvis"
+    managed   = "terraform"
+  }
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.jarvis_discord_token,
+    google_secret_manager_secret_iam_member.jarvis_post_secret,
+    google_secret_manager_secret_iam_member.anthropic_api_key,
+  ]
+}

--- a/infra/jarvis/outputs.tf
+++ b/infra/jarvis/outputs.tf
@@ -1,0 +1,33 @@
+output "vm_name" {
+  description = "Compute Engine instance name."
+  value       = google_compute_instance.jarvis.name
+}
+
+output "vm_zone" {
+  description = "Compute Engine instance zone."
+  value       = google_compute_instance.jarvis.zone
+}
+
+output "vm_internal_ip" {
+  description = "Internal IP of the Jarvis VM."
+  value       = google_compute_instance.jarvis.network_interface[0].network_ip
+}
+
+output "service_account_email" {
+  description = "Service account the VM runs as."
+  value       = google_service_account.jarvis.email
+}
+
+output "ssh_command" {
+  description = "Convenience IAP-SSH command."
+  value       = "gcloud compute ssh ${google_compute_instance.jarvis.name} --zone ${var.zone} --tunnel-through-iap --project ${var.project_id}"
+}
+
+output "secret_ids" {
+  description = "Secret Manager resource IDs (not values)."
+  value = {
+    discord_token = google_secret_manager_secret.jarvis_discord_token.id
+    post_secret   = google_secret_manager_secret.jarvis_post_secret.id
+    anthropic_key = google_secret_manager_secret.anthropic_api_key.id
+  }
+}

--- a/infra/jarvis/secrets.tf
+++ b/infra/jarvis/secrets.tf
@@ -1,0 +1,51 @@
+# Secret Manager slots. Values are written out-of-band during bootstrap
+# (see infra/jarvis/README.md), not by Terraform — keeps secrets out of
+# state and out of TF logs.
+
+resource "google_secret_manager_secret" "jarvis_discord_token" {
+  secret_id = "jarvis-discord-token"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_secret_manager_secret" "jarvis_post_secret" {
+  secret_id = "jarvis-post-secret"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_secret_manager_secret" "anthropic_api_key" {
+  secret_id = "anthropic-api-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_secret_manager_secret_iam_member" "jarvis_discord_token" {
+  secret_id = google_secret_manager_secret.jarvis_discord_token.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.jarvis.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "jarvis_post_secret" {
+  secret_id = google_secret_manager_secret.jarvis_post_secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.jarvis.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "anthropic_api_key" {
+  secret_id = google_secret_manager_secret.anthropic_api_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.jarvis.email}"
+}

--- a/infra/jarvis/startup.sh
+++ b/infra/jarvis/startup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Jarvis VM startup script.
+#
+# Runs as root via metadata_startup_script on first boot AND on every reboot.
+# Designed to be idempotent: re-running picks up the latest code on $branch
+# and the latest secret versions, then restarts the unit.
+#
+# Templated by Terraform — substituted variables: ${repo_url}, ${branch},
+# ${project_id}, ${discord_guild_id}.
+
+set -euo pipefail
+
+REPO_URL="${repo_url}"
+BRANCH="${branch}"
+PROJECT_ID="${project_id}"
+DISCORD_GUILD_ID="${discord_guild_id}"
+
+APP_DIR=/opt/niko
+VENV="$APP_DIR/.venv"
+ENV_DIR=/etc/jarvis
+ENV_FILE="$ENV_DIR/env"
+UNIT_FILE=/etc/systemd/system/jarvis.service
+
+log() { echo "[startup] $*"; }
+
+# 1. System packages
+log "installing apt dependencies"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+  git python3 python3-venv python3-pip ca-certificates
+
+# 2. Service user — separate from the GCP service account; owns the code dir
+if ! id jarvis >/dev/null 2>&1; then
+  log "creating jarvis system user"
+  useradd --system --no-create-home --shell /usr/sbin/nologin jarvis
+fi
+
+# 3. Code: clone or refresh
+if [ ! -d "$APP_DIR/.git" ]; then
+  log "cloning $REPO_URL ($BRANCH) to $APP_DIR"
+  git clone --branch "$BRANCH" --depth 50 "$REPO_URL" "$APP_DIR"
+else
+  log "refreshing $APP_DIR to origin/$BRANCH"
+  git -C "$APP_DIR" fetch origin "$BRANCH"
+  git -C "$APP_DIR" reset --hard "origin/$BRANCH"
+fi
+chown -R jarvis:jarvis "$APP_DIR"
+
+# 4. Python virtualenv + deps
+if [ ! -d "$VENV" ]; then
+  log "creating venv at $VENV"
+  python3 -m venv "$VENV"
+fi
+log "installing bot/requirements.txt"
+"$VENV/bin/pip" install --quiet --upgrade pip
+"$VENV/bin/pip" install --quiet -r "$APP_DIR/bot/requirements.txt"
+chown -R jarvis:jarvis "$VENV"
+
+# 5. Environment file from Secret Manager
+log "fetching secrets from project $PROJECT_ID"
+mkdir -p "$ENV_DIR"
+
+DISCORD_BOT_TOKEN=$(gcloud secrets versions access latest \
+  --secret=jarvis-discord-token --project="$PROJECT_ID")
+JARVIS_POST_SECRET=$(gcloud secrets versions access latest \
+  --secret=jarvis-post-secret --project="$PROJECT_ID")
+ANTHROPIC_API_KEY=$(gcloud secrets versions access latest \
+  --secret=anthropic-api-key --project="$PROJECT_ID")
+
+umask 077
+cat > "$ENV_FILE" <<EOF
+DISCORD_BOT_TOKEN=$DISCORD_BOT_TOKEN
+DISCORD_GUILD_ID=$DISCORD_GUILD_ID
+JARVIS_POST_SECRET=$JARVIS_POST_SECRET
+ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+JARVIS_HTTP_PORT=8080
+JARVIS_LOG_LEVEL=INFO
+EOF
+chmod 600 "$ENV_FILE"
+chown root:root "$ENV_FILE"
+
+# 6. systemd unit
+log "installing systemd unit"
+install -m 0644 "$APP_DIR/infra/jarvis/jarvis.service" "$UNIT_FILE"
+systemctl daemon-reload
+systemctl enable jarvis.service
+systemctl restart jarvis.service
+
+log "done — bot should come online within ~10 seconds"
+log "verify: systemctl status jarvis  /  journalctl -u jarvis -n 50"
+log "health: curl http://localhost:8080/healthz"

--- a/infra/jarvis/variables.tf
+++ b/infra/jarvis/variables.tf
@@ -1,0 +1,59 @@
+variable "project_id" {
+  description = "GCP project ID hosting the Jarvis bot."
+  type        = string
+  default     = "niko-tsuki"
+}
+
+variable "region" {
+  description = "GCE region."
+  type        = string
+  default     = "us-west1"
+}
+
+variable "zone" {
+  description = "GCE zone for the Jarvis VM. e2-micro free-tier is restricted to us-west1, us-central1, us-east1."
+  type        = string
+  default     = "us-west1-a"
+}
+
+variable "vm_name" {
+  description = "Compute Engine instance name."
+  type        = string
+  default     = "jarvis"
+}
+
+variable "machine_type" {
+  description = "GCE machine type. e2-micro is the always-free tier (1 instance per project per month in eligible regions)."
+  type        = string
+  default     = "e2-micro"
+}
+
+variable "boot_disk_image" {
+  description = "Boot disk image family."
+  type        = string
+  default     = "debian-cloud/debian-12"
+}
+
+variable "boot_disk_size_gb" {
+  description = "Boot disk size in GB. Free tier covers 30 GB pd-standard."
+  type        = number
+  default     = 30
+}
+
+variable "repo_url" {
+  description = "HTTPS URL the VM clones niko from. Public repo, no auth needed."
+  type        = string
+  default     = "https://github.com/tsuki-works/niko.git"
+}
+
+variable "branch" {
+  description = "Git branch the VM checks out and runs."
+  type        = string
+  default     = "master"
+}
+
+variable "discord_guild_id" {
+  description = "Discord guild ID the bot joins. Tsuki Works guild."
+  type        = string
+  default     = "1495086675523797032"
+}

--- a/infra/jarvis/versions.tf
+++ b/infra/jarvis/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}


### PR DESCRIPTION
## Summary

PR 5 of the six-PR Jarvis 2.0 plan ([spec](docs/superpowers/specs/2026-05-01-jarvis-bot-design.md)). Stands up the production runtime for the bot.

- **Compute:** single GCE `e2-micro` VM in `us-west1-a` (free tier), Debian 12, ephemeral public IP for outbound to Discord / Anthropic / Firestore. **No inbound except IAP-tunneled SSH.**
- **Identity:** dedicated `jarvis-vm` service account with minimal scopes — `secretAccessor` on the three secrets, `logWriter` / `metricWriter` / `datastore.user` at project level. No broad project IAM.
- **Secrets:** three Secret Manager slots (`jarvis-discord-token`, `jarvis-post-secret`, `anthropic-api-key`). Values are written out-of-band during bootstrap so they never enter Terraform state or commit logs.
- **Process:** systemd unit running under a non-root `jarvis` user, with `NoNewPrivileges` + `PrivateTmp` + `ProtectHome` + `ProtectSystem=full`.
- **Startup:** idempotent `startup.sh` that clones niko, builds a venv, fetches secrets via `gcloud`, writes `/etc/jarvis/env` (mode 600), and enables+starts the unit. Re-runs on every reboot — that's also the deploy mechanism for v1.

Bootstrap and day-2 ops are in [`infra/jarvis/README.md`](infra/jarvis/README.md).

## What's intentionally deferred

- **Cloud Monitoring uptime check.** Adding one requires either exposing `:8080/healthz` publicly (security cost) or standing up an internal LB (overkill for one VM). Manual `systemctl status` + `journalctl` is fine until alerting becomes load-bearing. Documented in the runbook.
- **Auto-deploy on push to master.** Should be a small follow-up GHA workflow scoped to `bot/**` that does IAP-SSH + git pull + restart. Out of scope here.
- **GCS state backend.** Local state for the first apply; migrate to GCS when a second operator needs `terraform apply`.

## Spec exit criteria

> Bot survives reboot; uptime check green for 24h.

The runbook has step-by-step verification:
1. `terraform apply` succeeds.
2. After secret values are added, `gcloud compute instances reset jarvis` brings the bot online.
3. `systemctl status jarvis` shows `active (running)`; `curl localhost:8080/healthz` returns the health JSON.
4. After a `gcloud compute instances reset`, the bot comes back online with the latest `master`.

## Test plan

- [ ] `terraform init && terraform plan` produces a clean plan (no errors, expected resources).
- [ ] `terraform apply` succeeds — APIs enabled, secret slots created, SA + IAM bound, VM provisioned.
- [ ] Add secret values via Console / `gcloud secrets versions add`.
- [ ] `gcloud compute instances reset jarvis --zone us-west1-a` — bot appears online in Discord member list within ~90s.
- [ ] `gcloud compute ssh jarvis --zone us-west1-a --tunnel-through-iap` → `systemctl status jarvis` is active, `journalctl -u jarvis -n 50` has no errors, `curl http://localhost:8080/healthz` returns `{"status": "ok", ...}`.
- [ ] @-mention the bot in a test channel — bot responds (PR 2 conversational path).
- [ ] Reset the VM a second time, confirm the bot reconnects within 90s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)