### PR TITLE
infra(jarvis): trust /opt/niko in git on the VM (fix dubious-ownership)

### DIFF
--- a/infra/jarvis/startup.sh
+++ b/infra/jarvis/startup.sh
@@ -36,6 +36,12 @@ if ! id jarvis >/dev/null 2>&1; then
   useradd --system --no-create-home --shell /usr/sbin/nologin jarvis
 fi
 
+# 2a. Trust /opt/niko for git ops as root.
+# Without this, second-and-subsequent boots fail with
+# `fatal: detected dubious ownership in repository at '/opt/niko'`
+# because step 3 chowns the tree to `jarvis` but git ops run as root.
+git config --system --add safe.directory "$APP_DIR"
+
 # 3. Code: clone or refresh
 if [ ! -d "$APP_DIR/.git" ]; then
   log "cloning $REPO_URL ($BRANCH) to $APP_DIR"


### PR DESCRIPTION
## Summary

Adds `git config --system --add safe.directory /opt/niko` to `infra/jarvis/startup.sh`, immediately after the `jarvis` user is created and before any git operation.

## Why

Without this, the **second-and-subsequent boots** of the Jarvis VM fail in startup.sh with:

```
fatal: detected dubious ownership in repository at '/opt/niko'
```

Step 3 of the script chowns the cloned tree to the `jarvis` service user, but the git fetch/reset on subsequent boots runs as root. Git's `safe.directory` check refuses to operate on a tree it doesn't own unless explicitly trusted.

This makes the script truly idempotent across reboots and unblocks the spec's exit criterion **"bot survives reboot."** Caught live: PR #194 deployed cleanly on the first boot, the post-secret reset hit this exact error, and recovery required SSHing in to fix it manually.

## Test plan

- [ ] After merge, `gcloud compute instances reset jarvis --zone us-west1-a --project niko-tsuki`.
- [ ] Wait ~3 min for the startup script to complete (it'll re-clone, install deps, write env, install unit, start service).
- [ ] `gcloud compute ssh jarvis --zone us-west1-a --tunnel-through-iap --project niko-tsuki -- "sudo systemctl is-active jarvis"` returns `active`.
- [ ] Bot shows online in Tsuki Works guild member list.
- [ ] `journalctl -u jarvis` has no `dubious ownership` errors.
- [ ] Reset the VM a second time, confirm same result — exit criterion met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)