### PR TITLE
fix(infra): wire GITHUB_TOKEN secret into Jarvis VM env

### DIFF
--- a/infra/jarvis/README.md
+++ b/infra/jarvis/README.md
@@ -15,7 +15,7 @@ This is PR 5 of the six-PR Jarvis 2.0 plan
 | `versions.tf` | Terraform + `google` provider pins |
 | `variables.tf` | `project_id`, `region`, `zone`, `vm_name`, `repo_url`, `branch` |
 | `main.tf` | Required APIs, service account, IAM, firewall (IAP-SSH only), VM |
-| `secrets.tf` | Three Secret Manager slots + `secretAccessor` IAM for the VM SA |
+| `secrets.tf` | Four Secret Manager slots + `secretAccessor` IAM for the VM SA |
 | `outputs.tf` | VM name/zone/internal IP, SA email, IAP-SSH command |
 | `jarvis.service` | systemd unit (User=jarvis, EnvironmentFile=/etc/jarvis/env) |
 | `startup.sh` | Idempotent VM bootstrap (apt, git clone, venv, secrets, unit) |
@@ -79,6 +79,11 @@ GCP Console UI for the cleanest flow:
 3. Repeat for `jarvis-post-secret` (any 32+ character random string;
    generate with `openssl rand -hex 32` if you don't have one)
 4. Repeat for `anthropic-api-key` (the key from `#shared-creds` in Discord)
+5. Repeat for `github-token` — a PAT with `read:org` + `repo` scopes
+   (fine-grained equivalent OK). Without a value here the bot still
+   boots, but only `get_recent_messages` is registered as a tool;
+   `get_current_sprint`, `get_recent_commits`, `search_repo_docs`,
+   `get_pr`, `get_issue`, and `open_issue` are unavailable.
 
 Or via CLI, with `--data-file=-` to keep the value off the command line:
 
@@ -87,6 +92,7 @@ Or via CLI, with `--data-file=-` to keep the value off the command line:
 gcloud secrets versions add jarvis-discord-token --data-file=-
 gcloud secrets versions add jarvis-post-secret    --data-file=-
 gcloud secrets versions add anthropic-api-key     --data-file=-
+gcloud secrets versions add github-token          --data-file=-
 ```
 
 ### 4. Reboot the VM so the startup script picks up the new secret versions

--- a/infra/jarvis/secrets.tf
+++ b/infra/jarvis/secrets.tf
@@ -32,6 +32,19 @@ resource "google_secret_manager_secret" "anthropic_api_key" {
   depends_on = [google_project_service.required]
 }
 
+# GitHub PAT for the agent's tool registry (PR 3a/3b). Without it, the bot
+# falls back to chat-only mode (only get_recent_messages registered);
+# startup.sh tolerates a missing version so the bot still boots.
+resource "google_secret_manager_secret" "github_token" {
+  secret_id = "github-token"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.required]
+}
+
 resource "google_secret_manager_secret_iam_member" "jarvis_discord_token" {
   secret_id = google_secret_manager_secret.jarvis_discord_token.id
   role      = "roles/secretmanager.secretAccessor"
@@ -46,6 +59,12 @@ resource "google_secret_manager_secret_iam_member" "jarvis_post_secret" {
 
 resource "google_secret_manager_secret_iam_member" "anthropic_api_key" {
   secret_id = google_secret_manager_secret.anthropic_api_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.jarvis.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "github_token" {
+  secret_id = google_secret_manager_secret.github_token.id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.jarvis.email}"
 }

--- a/infra/jarvis/startup.sh
+++ b/infra/jarvis/startup.sh
@@ -74,12 +74,21 @@ JARVIS_POST_SECRET=$(gcloud secrets versions access latest \
 ANTHROPIC_API_KEY=$(gcloud secrets versions access latest \
   --secret=anthropic-api-key --project="$PROJECT_ID")
 
+# github-token is fetched tolerantly. If it has no version yet, the bot
+# falls back to chat-only mode (only get_recent_messages registered) and
+# logs the degraded path explicitly instead of crashing the unit. Once a
+# value is populated, a VM reset picks it up and the full 7-tool registry
+# comes online.
+GITHUB_TOKEN=$(gcloud secrets versions access latest \
+  --secret=github-token --project="$PROJECT_ID" 2>/dev/null || echo "")
+
 umask 077
 cat > "$ENV_FILE" <<EOF
 DISCORD_BOT_TOKEN=$DISCORD_BOT_TOKEN
 DISCORD_GUILD_ID=$DISCORD_GUILD_ID
 JARVIS_POST_SECRET=$JARVIS_POST_SECRET
 ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+GITHUB_TOKEN=$GITHUB_TOKEN
 JARVIS_HTTP_PORT=8080
 JARVIS_LOG_LEVEL=INFO
 EOF


### PR DESCRIPTION
## The bug

Meet hit this in production tonight:

> **meet:** @Jarvis 2.0 What are the next big remaining items in the roadmap before viable product for market?
>
> **Jarvis 2.0:** Let me check a few places at once to get a full picture. Good context from chat. Let me also pull the sprint board directly. **I don't have a tool to pull the GitHub Project board directly**, but between the chat history, recent issues, and what the team has been discussing, here's a solid picture of what's left…

The bot read chat (worked), then said it had no tool for the project board (lie — `get_current_sprint` shipped in PR 3a). That's the signature of the **no-`GITHUB_TOKEN` degraded path**.

## Root cause

PR #194 (deploy infra) was authored against the post-PR-2 codebase, before PR 3a introduced the `GITHUB_TOKEN` requirement. The deploy infra never picked it up:

- `secrets.tf` declared three Secret Manager slots: `jarvis-discord-token`, `jarvis-post-secret`, `anthropic-api-key`. **No `github-token`.**
- `startup.sh` fetched those three and wrote them to `/etc/jarvis/env`. **No `GITHUB_TOKEN=` line.**
- `bot/jarvis/config.py:Settings.github_token` → `None` (env var missing).
- `bot/jarvis/main.py:_build_handler` → falls into the `else` branch and registers only `get_recent_messages` (the chat-only fallback added in PR 3b).
- System prompt still claims all 7 tools exist (constant string), so the model promised a sprint lookup it couldn't actually do.

## The fix (this PR)

- **`infra/jarvis/secrets.tf`** — add `github-token` Secret Manager slot + `secretAccessor` IAM binding for the VM service account.
- **`infra/jarvis/startup.sh`** — fetch `github-token` *tolerantly* (`2>/dev/null || echo \"\"`) so a missing version degrades gracefully (chat-only) rather than crashing the systemd unit. Write `GITHUB_TOKEN=...` to `/etc/jarvis/env`.
- **`infra/jarvis/README.md`** — document the new secret in the bootstrap step and what happens when no value is populated.

## Post-merge bootstrap

```bash
cd infra/jarvis
terraform apply                          # creates the new secret slot + IAM
echo -n "<PAT>" | gcloud secrets versions add github-token --data-file=- --project=niko-tsuki
gcloud compute instances reset jarvis --zone us-west1-a
```

PAT scopes: `read:org` + `repo` (or fine-grained equivalent).

## Verification

After the VM reboots, ssh in and check the startup log:

```bash
gcloud compute ssh jarvis --zone us-west1-a --tunnel-through-iap -- \
  'sudo journalctl -u jarvis -n 30 --no-pager | grep -E "(tool registry|GITHUB_TOKEN)"'
```

Expected line flips from:

```
GITHUB_TOKEN not set — running with only chat tools: get_recent_messages
```

to:

```
tool registry: get_current_sprint, get_recent_commits, search_repo_docs, get_pr, get_issue, open_issue, get_recent_messages
```

Then re-run Meet's question and confirm the bot actually queries the project board.

## Out of scope

- The system prompt currently claims all 7 tools exist regardless of which are actually registered. When the bot is in chat-only mode, the model promises tools it can't use. Worth a follow-up to make the prompt dynamic based on `tool_registry.names()`. Not blocking — once `GITHUB_TOKEN` is set, the prompt and registry agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)