### PR TITLE
security: validate Twilio request signatures on all webhook routes

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -24,9 +24,10 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
-from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Request, Response, WebSocket, WebSocketDisconnect
 from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
 
+from app.telephony.signature import require_twilio_signature
 from app.telephony.voicemail_twiml import voicemail_response
 
 from app.config import settings
@@ -662,7 +663,10 @@ def _resolve_restaurant_for_voice(
 
 
 @router.post("/voice")
-async def voice(request: Request) -> Response:
+async def voice(
+    request: Request,
+    _sig: None = Depends(require_twilio_signature),
+) -> Response:
     """Respond to Twilio's inbound call webhook with TwiML.
 
     Looks up the tenant by Twilio's ``To`` field, opens a bidirectional
@@ -740,7 +744,10 @@ _TRANSFER_STATUS_MAP = {
 
 
 @router.post("/voice/stream-ended")
-async def stream_ended(request: Request) -> Response:
+async def stream_ended(
+    request: Request,
+    _sig: None = Depends(require_twilio_signature),
+) -> Response:
     """Twilio's <Connect> action callback. Decides what happens after
     the AI flow ends: empty TwiML (hang up), transfer to fallback, or
     drop to voicemail directly.
@@ -818,6 +825,7 @@ async def transfer_result(
     request: Request,
     call_sid: str,
     rid: str,
+    _sig: None = Depends(require_twilio_signature),
 ) -> Response:
     """<Dial>'s action callback. Maps Twilio DialCallStatus to internal
     status, marks the call session, and either returns empty (answered)
@@ -856,6 +864,7 @@ async def voicemail_recorded(
     request: Request,
     call_sid: str,
     rid: str,
+    _sig: None = Depends(require_twilio_signature),
 ) -> Response:
     """Twilio's <Record> action callback. Downloads the recording from
     Twilio's REST and uploads to GCS, then writes metadata to the call
@@ -944,6 +953,7 @@ async def voicemail_transcription(
     request: Request,
     call_sid: str,
     rid: str,
+    _sig: None = Depends(require_twilio_signature),
 ) -> Response:
     """Twilio's transcribeCallback. Patches the voicemail transcript on
     the call session. Empty transcript (Twilio sometimes posts ""

--- a/app/telephony/signature.py
+++ b/app/telephony/signature.py
@@ -1,0 +1,61 @@
+"""FastAPI dependency for validating Twilio request signatures.
+
+Applies to all POST webhook routes that Twilio calls (see router.py).
+Rejects with 403 on missing or invalid X-Twilio-Signature.
+
+Bypass: when settings.testing_mode is True or TWILIO_AUTH_TOKEN is unset
+(local dev without a real Twilio number), validation is skipped with a
+one-time log warning so tests don't need real signatures.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import Depends, Header, HTTPException, Request
+from twilio.request_validator import RequestValidator
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+_bypass_warned = False
+
+
+async def require_twilio_signature(
+    request: Request,
+    x_twilio_signature: str | None = Header(default=None),
+) -> None:
+    global _bypass_warned
+
+    if settings.testing_mode or not settings.twilio_auth_token:
+        if not _bypass_warned:
+            logger.warning(
+                "Twilio signature validation disabled (testing_mode=%s, "
+                "auth_token_set=%s)",
+                settings.testing_mode,
+                bool(settings.twilio_auth_token),
+            )
+            _bypass_warned = True
+        return
+
+    if not x_twilio_signature:
+        raise HTTPException(status_code=403, detail="Missing X-Twilio-Signature")
+
+    if not settings.public_base_url:
+        raise HTTPException(
+            status_code=500,
+            detail="PUBLIC_BASE_URL not configured — cannot validate Twilio signature",
+        )
+
+    # Reconstruct the canonical URL Twilio signed.
+    path = request.url.path
+    if request.url.query:
+        path = f"{path}?{request.url.query}"
+    url = f"{settings.public_base_url.rstrip('/')}{path}"
+
+    form = await request.form()
+    params = dict(form)
+
+    validator = RequestValidator(settings.twilio_auth_token)
+    if not validator.validate(url, params, x_twilio_signature):
+        raise HTTPException(status_code=403, detail="Invalid Twilio signature")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Global test fixtures for the niko test suite.
+
+Sets testing_mode=True on the shared settings singleton so that
+security dependencies (e.g. Twilio signature validation) bypass
+real-credential checks. Tests that need validation enabled override
+this via their own monkeypatch fixtures.
+"""
+
+import pytest
+from app.config import settings
+
+
+@pytest.fixture(autouse=True)
+def _enable_testing_mode():
+    original = settings.testing_mode
+    settings.testing_mode = True
+    yield
+    settings.testing_mode = original

--- a/tests/test_twilio_signature.py
+++ b/tests/test_twilio_signature.py
@@ -1,0 +1,82 @@
+"""Tests for the Twilio request-signature validation dependency (#179).
+
+All tests run in-process via TestClient. No real Twilio credentials
+required — valid signatures are computed with a test auth token.
+"""
+
+import hashlib
+import hmac
+import base64
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.config import settings
+from app.storage import restaurants as restaurants_storage
+
+client = TestClient(app, raise_server_exceptions=False)
+
+_TEST_TOKEN = "test_auth_token_12345"
+_BASE_URL = "https://niko.example.com"
+_VOICE_URL = f"{_BASE_URL}/voice"
+_FORM = {"CallSid": "CAtest", "From": "+10000000000", "To": "+16479058093"}
+
+
+def _twilio_signature(auth_token: str, url: str, params: dict) -> str:
+    """Compute the expected X-Twilio-Signature for a webhook call."""
+    s = url
+    for key in sorted(params.keys()):
+        s += key + params[key]
+    mac = hmac.new(auth_token.encode("utf-8"), s.encode("utf-8"), hashlib.sha1)
+    return base64.b64encode(mac.digest()).decode("utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _reset_restaurants_cache():
+    yield
+    restaurants_storage.clear_cache()
+
+
+@pytest.fixture(autouse=True)
+def _reset_bypass_warning():
+    import app.telephony.signature as sig_mod
+    sig_mod._bypass_warned = False
+    yield
+    sig_mod._bypass_warned = False
+
+
+@pytest.fixture()
+def validation_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "testing_mode", False)
+    monkeypatch.setattr(settings, "twilio_auth_token", _TEST_TOKEN)
+    monkeypatch.setattr(settings, "public_base_url", _BASE_URL)
+
+
+def test_valid_signature_passes(validation_enabled):
+    sig = _twilio_signature(_TEST_TOKEN, _VOICE_URL, _FORM)
+    resp = client.post("/voice", data=_FORM, headers={"X-Twilio-Signature": sig})
+    assert resp.status_code != 403
+
+
+def test_invalid_signature_returns_403(validation_enabled):
+    resp = client.post(
+        "/voice",
+        data=_FORM,
+        headers={"X-Twilio-Signature": "invalidsignature=="},
+    )
+    assert resp.status_code == 403
+
+
+def test_missing_signature_returns_403(validation_enabled):
+    resp = client.post("/voice", data=_FORM)
+    assert resp.status_code == 403
+
+
+def test_testing_mode_bypasses_validation(monkeypatch):
+    monkeypatch.setattr(settings, "testing_mode", True)
+    monkeypatch.setattr(settings, "twilio_auth_token", _TEST_TOKEN)
+    monkeypatch.setattr(settings, "public_base_url", _BASE_URL)
+    resp = client.post("/voice", data=_FORM)
+    assert resp.status_code != 403


### PR DESCRIPTION
## Summary

Closes #179. Sub-task of #83.

- **`app/telephony/signature.py`** — new `require_twilio_signature` FastAPI dependency using `twilio.RequestValidator`. Reconstructs the canonical URL from `settings.public_base_url` + request path, validates `X-Twilio-Signature`, returns 403 on mismatch or missing header. Bypass path: `testing_mode=True` or `TWILIO_AUTH_TOKEN` unset (local dev / CI) with a one-shot log warning.
- **`app/telephony/router.py`** — `Depends(require_twilio_signature)` added to all five Twilio-bound POST routes: `/voice`, `/voice/stream-ended`, `/voice/transfer-result`, `/voice/voicemail-recorded`, `/voice/voicemail-transcription`.
- **`tests/conftest.py`** — new global autouse fixture sets `testing_mode=True` for the entire test suite, so existing tests aren't broken by the new validation gate.
- **`tests/test_twilio_signature.py`** — 4 test cases: valid HMAC-SHA1 passes, invalid sig → 403, missing header → 403, `testing_mode` bypass works.

## Test plan

- [x] `pytest tests/test_twilio_signature.py` — 4/4 pass
- [x] `pytest tests/test_telephony.py tests/test_voice.py` — 70/70 pass (no regressions)
- [ ] Manual: trigger a real Twilio webhook on staging and confirm it passes with a valid signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)