### PR TITLE
feat(stt): Deepgram Nova-3 + keyterm prompting (keep SDK v3.11)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,8 +29,8 @@ class Settings(BaseSettings):
     # Deepgram STT model for the live transcription pipeline. Nova-3 gives
     # ~18% relative WER reduction over Nova-2 and is required for the
     # `keyterm` parameter that fixes domain-vocabulary misfires (#195).
-    # Override via DEEPGRAM_STT_MODEL once Kailash confirms the best
-    # telephony-optimised Nova-3 variant from the Deepgram dashboard.
+    # Override via DEEPGRAM_STT_MODEL if a telephony-optimised Nova-3 variant
+    # becomes available (verify via the Deepgram dashboard before changing).
     deepgram_stt_model: str = "nova-3-general"
 
     twilio_account_sid: Optional[str] = None

--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,13 @@ class Settings(BaseSettings):
     # override via DEEPGRAM_TTS_MODEL.
     deepgram_tts_model: str = "aura-2-thalia-en"
 
+    # Deepgram STT model for the live transcription pipeline. Nova-3 gives
+    # ~18% relative WER reduction over Nova-2 and is required for the
+    # `keyterm` parameter that fixes domain-vocabulary misfires (#195).
+    # Override via DEEPGRAM_STT_MODEL once Kailash confirms the best
+    # telephony-optimised Nova-3 variant from the Deepgram dashboard.
+    deepgram_stt_model: str = "nova-3-general"
+
     twilio_account_sid: Optional[str] = None
     twilio_auth_token: Optional[str] = None
     twilio_phone_number: Optional[str] = None

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -302,6 +302,41 @@ class _CallState:
     in_flight_transcript: str = ""
 
 
+_KEYTERM_INTENT_VOCAB = [
+    "pickup", "delivery", "large", "small", "medium", "extra",
+    "no", "with", "without", "order", "add",
+]
+
+# Deepgram keyterm budget: 500 tokens per request (roughly 500 words).
+_KEYTERM_MAX = 500
+
+
+def _build_keyterms(restaurant: "Restaurant | None") -> list[str]:
+    """Build a per-restaurant keyterm list for Deepgram Nova-3.
+
+    Combines menu item names with a fixed intent vocabulary so Deepgram
+    biases recognition toward domain-specific words (e.g. "pepper soup"
+    over "pepper shrimp"). Capped at _KEYTERM_MAX entries.
+    """
+    terms: list[str] = []
+    if restaurant is not None:
+        for word in restaurant.name.split():
+            clean = word.strip(".,!?").lower()
+            if clean and clean not in terms:
+                terms.append(clean)
+        for items in restaurant.menu.values():
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                name = item.get("name", "") if isinstance(item, dict) else ""
+                if name and name not in terms:
+                    terms.append(name)
+    for word in _KEYTERM_INTENT_VOCAB:
+        if word not in terms:
+            terms.append(word)
+    return terms[:_KEYTERM_MAX]
+
+
 async def _open_deepgram_connection(
     call_sid: str | None,
     restaurant_id: str | None,
@@ -357,8 +392,9 @@ async def _open_deepgram_connection(
     # utterance_end_ms=1000 layers a prosody-aware end-of-utterance
     # signal on top so we wait for "actually finished" instead of just
     # "stopped making noise".
+    restaurant = state.restaurant if state is not None else None
     options = LiveOptions(
-        model="nova-2",
+        model=settings.deepgram_stt_model,
         encoding="mulaw",
         sample_rate=8000,
         channels=1,
@@ -366,6 +402,10 @@ async def _open_deepgram_connection(
         endpointing=800,
         utterance_end_ms=1000,
         vad_events=True,
+        smart_format=True,
+        language="en-US",
+        numerals=True,
+        keyterm=_build_keyterms(restaurant),
     )
     started = await conn.start(options)
     if not started:

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -307,7 +307,7 @@ _KEYTERM_INTENT_VOCAB = [
     "no", "with", "without", "order", "add",
 ]
 
-# Deepgram keyterm budget: 500 tokens per request (roughly 500 words).
+# Deepgram keyterm limit: 500 entries per request.
 _KEYTERM_MAX = 500
 
 
@@ -319,21 +319,25 @@ def _build_keyterms(restaurant: "Restaurant | None") -> list[str]:
     over "pepper shrimp"). Capped at _KEYTERM_MAX entries.
     """
     terms: list[str] = []
+    seen: set[str] = set()
+
+    def _add(term: str) -> None:
+        key = term.lower()
+        if term and key not in seen:
+            seen.add(key)
+            terms.append(term)
+
     if restaurant is not None:
         for word in restaurant.name.split():
-            clean = word.strip(".,!?").lower()
-            if clean and clean not in terms:
-                terms.append(clean)
+            _add(word.strip(".,!?"))
         for items in restaurant.menu.values():
             if not isinstance(items, list):
                 continue
             for item in items:
                 name = item.get("name", "") if isinstance(item, dict) else ""
-                if name and name not in terms:
-                    terms.append(name)
+                _add(name)
     for word in _KEYTERM_INTENT_VOCAB:
-        if word not in terms:
-            terms.append(word)
+        _add(word)
     return terms[:_KEYTERM_MAX]
 
 
@@ -346,7 +350,7 @@ async def _open_deepgram_connection(
     assert settings.deepgram_api_key, "DEEPGRAM_API_KEY is not set"
 
     dg = DeepgramClient(settings.deepgram_api_key)
-    conn = dg.listen.asynclive.v("1")
+    conn = dg.listen.asyncwebsocket.v("1")
 
     async def on_transcript(self, result, **kwargs):
         alt = result.channel.alternatives[0]

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -327,17 +327,21 @@ def _build_keyterms(restaurant: "Restaurant | None") -> list[str]:
             seen.add(key)
             terms.append(term)
 
+    # Intent vocab goes first so it survives _KEYTERM_MAX truncation on large menus.
+    for word in _KEYTERM_INTENT_VOCAB:
+        _add(word)
     if restaurant is not None:
         for word in restaurant.name.split():
             _add(word.strip(".,!?"))
-        for items in restaurant.menu.values():
+        for k, items in restaurant.menu.items():
+            if k.startswith("_"):
+                # Reserved metadata keys (e.g. _category_order) are not menu items.
+                continue
             if not isinstance(items, list):
                 continue
             for item in items:
                 name = item.get("name", "") if isinstance(item, dict) else ""
                 _add(name)
-    for word in _KEYTERM_INTENT_VOCAB:
-        _add(word)
     return terms[:_KEYTERM_MAX]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ anthropic>=0.40,<1.0
 google-cloud-firestore>=2.0,<3.0
 google-cloud-logging>=3.0,<4.0
 firebase-admin>=6.0,<7.0
-deepgram-sdk>=3.0,<4.0
+deepgram-sdk>=7.0,<8.0
 httpx>=0.27,<1.0
 tzdata>=2024.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ anthropic>=0.40,<1.0
 google-cloud-firestore>=2.0,<3.0
 google-cloud-logging>=3.0,<4.0
 firebase-admin>=6.0,<7.0
-deepgram-sdk>=7.0,<8.0
+deepgram-sdk>=3.11,<4.0
 httpx>=0.27,<1.0
 tzdata>=2024.1

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -1146,7 +1146,7 @@ async def test_on_transcript_increments_misheard_counter_on_low_confidence(monke
     class FakeDeepgramClient:
         def __init__(self, *_):
             self.listen = MagicMock()
-            self.listen.asynclive.v.return_value = FakeDeepgramConn()
+            self.listen.asyncwebsocket.v.return_value = FakeDeepgramConn()
 
     monkeypatch.setattr(router_mod, "DeepgramClient", FakeDeepgramClient)
 
@@ -2075,7 +2075,7 @@ def test_open_deepgram_connection_uses_nova3(monkeypatch):
 
     class FakeDG:
         class listen:
-            class asynclive:
+            class asyncwebsocket:
                 @staticmethod
                 def v(_):
                     return FakeConn()
@@ -2083,9 +2083,7 @@ def test_open_deepgram_connection_uses_nova3(monkeypatch):
     monkeypatch.setattr(router_mod, "DeepgramClient", lambda _key: FakeDG())
 
     import asyncio
-    asyncio.get_event_loop().run_until_complete(
-        _open_deepgram_connection("CAtest", "rid", lambda t: None)
-    )
+    asyncio.run(_open_deepgram_connection("CAtest", "rid", lambda t: None))
 
     assert len(captured_options) == 1
     opts = captured_options[0]

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2063,7 +2063,6 @@ def test_open_deepgram_connection_uses_nova3(monkeypatch):
     """_open_deepgram_connection passes nova-3-general (or configured model)
     to LiveOptions."""
     import app.telephony.router as router_mod
-    from app.telephony.router import _open_deepgram_connection
 
     captured_options: list = []
 
@@ -2082,8 +2081,7 @@ def test_open_deepgram_connection_uses_nova3(monkeypatch):
 
     monkeypatch.setattr(router_mod, "DeepgramClient", lambda _key: FakeDG())
 
-    import asyncio
-    asyncio.run(_open_deepgram_connection("CAtest", "rid", lambda t: None))
+    asyncio.run(router_mod._open_deepgram_connection("CAtest", "rid", lambda t: None))
 
     assert len(captured_options) == 1
     opts = captured_options[0]
@@ -2100,7 +2098,6 @@ async def test_open_deepgram_connection_includes_menu_keyterms(monkeypatch):
     carries a populated Restaurant — exercises the path _build_keyterms takes
     when given a real menu, so a regression that drops menu items would be caught."""
     import app.telephony.router as router_mod
-    from app.telephony.router import _open_deepgram_connection, _CallState
     from app.restaurants.models import Restaurant
 
     captured_options: list = []
@@ -2139,9 +2136,9 @@ async def test_open_deepgram_connection_includes_menu_keyterms(monkeypatch):
             ],
         },
     )
-    state = _CallState(restaurant=restaurant)
+    state = router_mod._CallState(restaurant=restaurant)
 
-    await _open_deepgram_connection("CAtest", "test-r", lambda t: None, state=state)
+    await router_mod._open_deepgram_connection("CAtest", "test-r", lambda t: None, state=state)
 
     assert len(captured_options) == 1
     opts = captured_options[0]

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2020,7 +2020,7 @@ def test_deepgram_stt_model_defaults_to_nova3():
 
 
 def test_build_keyterms_includes_menu_items_and_intent_vocab():
-    from app.telephony.router import _build_keyterms, _KEYTERM_INTENT_VOCAB
+    from app.telephony.router import _build_keyterms
     from app.restaurants.models import Restaurant
 
     restaurant = Restaurant(
@@ -2092,4 +2092,91 @@ def test_open_deepgram_connection_uses_nova3(monkeypatch):
     assert opts.language == "en-US"
     assert opts.numerals is True
     assert isinstance(opts.keyterm, list)
+
+
+@pytest.mark.asyncio
+async def test_open_deepgram_connection_includes_menu_keyterms(monkeypatch):
+    """_open_deepgram_connection must thread menu items into keyterm when state
+    carries a populated Restaurant — exercises the path _build_keyterms takes
+    when given a real menu, so a regression that drops menu items would be caught."""
+    import app.telephony.router as router_mod
+    from app.telephony.router import _open_deepgram_connection, _CallState
+    from app.restaurants.models import Restaurant
+
+    captured_options: list = []
+
+    class FakeConn:
+        def on(self, *a, **kw): pass
+        async def start(self, options):
+            captured_options.append(options)
+            return True
+
+    class FakeDG:
+        class listen:
+            class asyncwebsocket:
+                @staticmethod
+                def v(_):
+                    return FakeConn()
+
+    monkeypatch.setattr(router_mod, "DeepgramClient", lambda _key: FakeDG())
+    monkeypatch.setattr(router_mod.settings, "deepgram_api_key", "fake-key-for-test")
+    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
+
+    restaurant = Restaurant(
+        id="test-r",
+        name="Twilight Grill",
+        display_phone="+14165550001",
+        twilio_phone="+16479058093",
+        address="1 Test St",
+        hours="Mon-Sun 11:00-22:00",
+        menu={
+            "_category_order": ["soups", "mains"],
+            "soups": [
+                {"name": "pepper soup", "price": 8.99},
+            ],
+            "mains": [
+                {"name": "jollof rice", "price": 13.99},
+            ],
+        },
+    )
+    state = _CallState(restaurant=restaurant)
+
+    await _open_deepgram_connection("CAtest", "test-r", lambda t: None, state=state)
+
+    assert len(captured_options) == 1
+    opts = captured_options[0]
+    terms = opts.keyterm
+    assert isinstance(terms, list)
+    assert "pepper soup" in terms
+    assert "jollof rice" in terms
+    # Intent vocab must survive even when menu items are present.
+    assert "pickup" in terms
+    # Reserved metadata key must not leak into keyterms.
+    assert "soups" not in terms
+    assert "mains" not in terms
+
+
+def test_build_keyterms_skips_reserved_category_order_key():
+    """_category_order is a reserved metadata key; its values must not appear
+    in keyterms even though they pass the isinstance(items, list) check."""
+    from app.telephony.router import _build_keyterms
+    from app.restaurants.models import Restaurant
+
+    restaurant = Restaurant(
+        id="test-r",
+        name="Test Place",
+        display_phone="+14165550001",
+        twilio_phone="+16479058093",
+        address="1 Test St",
+        hours="Mon-Sun 11:00-22:00",
+        menu={
+            "_category_order": ["mains", "sides"],
+            "mains": [{"name": "burger", "price": 9.99}],
+        },
+    )
+
+    terms = _build_keyterms(restaurant)
+    assert "mains" not in terms
+    assert "sides" not in terms
+    assert "burger" in terms
 

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2009,3 +2009,89 @@ async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch
 
     assert captured == ["and a coke"]
 
+
+# ---------------------------------------------------------------------------
+# Nova-3 + keyterm tests (#195)
+# ---------------------------------------------------------------------------
+
+def test_deepgram_stt_model_defaults_to_nova3():
+    from app.config import settings as app_settings
+    assert app_settings.deepgram_stt_model == "nova-3-general"
+
+
+def test_build_keyterms_includes_menu_items_and_intent_vocab():
+    from app.telephony.router import _build_keyterms, _KEYTERM_INTENT_VOCAB
+    from app.restaurants.models import Restaurant
+
+    restaurant = Restaurant(
+        id="test-r",
+        name="Niko Pizza Kitchen",
+        display_phone="+14165550001",
+        twilio_phone="+16479058093",
+        address="1 Test St",
+        hours="Mon-Sun 11:00-22:00",
+        menu={
+            "pizzas": [
+                {"name": "Margherita", "price": 14.99},
+                {"name": "Pepper Soup Special", "price": 12.99},
+            ],
+            "drinks": [
+                {"name": "Coke", "price": 2.99},
+            ],
+        },
+    )
+
+    terms = _build_keyterms(restaurant)
+
+    assert "Margherita" in terms
+    assert "Pepper Soup Special" in terms
+    assert "Coke" in terms
+    assert "pickup" in terms
+    assert "delivery" in terms
+    assert len(terms) <= 500
+
+
+def test_build_keyterms_handles_none_restaurant():
+    from app.telephony.router import _build_keyterms, _KEYTERM_INTENT_VOCAB
+
+    terms = _build_keyterms(None)
+    assert "pickup" in terms
+    assert len(terms) == len(_KEYTERM_INTENT_VOCAB)
+
+
+def test_open_deepgram_connection_uses_nova3(monkeypatch):
+    """_open_deepgram_connection passes nova-3-general (or configured model)
+    to LiveOptions."""
+    import app.telephony.router as router_mod
+    from app.telephony.router import _open_deepgram_connection
+
+    captured_options: list = []
+
+    class FakeConn:
+        def on(self, *a, **kw): pass
+        async def start(self, options):
+            captured_options.append(options)
+            return True
+
+    class FakeDG:
+        class listen:
+            class asynclive:
+                @staticmethod
+                def v(_):
+                    return FakeConn()
+
+    monkeypatch.setattr(router_mod, "DeepgramClient", lambda _key: FakeDG())
+
+    import asyncio
+    asyncio.get_event_loop().run_until_complete(
+        _open_deepgram_connection("CAtest", "rid", lambda t: None)
+    )
+
+    assert len(captured_options) == 1
+    opts = captured_options[0]
+    assert opts.model == "nova-3-general"
+    assert opts.smart_format is True
+    assert opts.language == "en-US"
+    assert opts.numerals is True
+    assert isinstance(opts.keyterm, list)
+


### PR DESCRIPTION
## Summary

Closes #195.

Fixes three documented STT misfires by upgrading to Nova-3 and adding per-restaurant keyterm biasing:

- **`requirements.txt`** — pin `deepgram-sdk>=3.11,<4.0`. Deliberately stays on v3.x: v7 dropped async support entirely (sync-only SDK), requiring a full threading refactor that is out of scope here. v3.11 is the first v3 release that exposes `keyterm` on `LiveOptions`.
- **`app/config.py`** — add `deepgram_stt_model` setting (default `"nova-3-general"`, overridable via `DEEPGRAM_STT_MODEL`). Kailash to verify if a telephony-tuned Nova-3 variant exists via the Deepgram dashboard before changing.
- **`app/telephony/router.py`**:
  - `dg.listen.asynclive` → `dg.listen.asyncwebsocket` (non-deprecated replacement, identical interface)
  - `model="nova-2"` → `settings.deepgram_stt_model`
  - Add `smart_format=True`, `language="en-US"`, `numerals=True`
  - New `_build_keyterms(restaurant)` helper: extracts menu item names + restaurant name words + fixed intent vocab (`pickup`, `delivery`, sizes, modifiers) into a deduplicated 500-entry list
  - Wire `keyterm=_build_keyterms(state.restaurant)` into `LiveOptions`
- **`tests/test_telephony.py`** — fix `asynclive` → `asyncwebsocket` in mock; replace deprecated `get_event_loop().run_until_complete` with `asyncio.run()`

## Cost impact

~$0.005/call extra at Nova-3 PAYG pricing. Trivial at POC scale.

## Test plan

- [x] `pytest tests/test_telephony.py tests/test_voice.py` — 74/74 pass
- [ ] Manual test call: confirm "pepper soup", "smoke", and "pickup" transcribe correctly with the new model + keyterms
- [ ] Kailash: check Deepgram dashboard for any `nova-3-phonecall` or newer telephony-tuned variant; update `DEEPGRAM_STT_MODEL` in `.env` if found

🤖 Generated with [Claude Code](https://claude.com/claude-code)