### PR TITLE
fix(telephony): silence watchdog — cancel on SpeechStarted + arm on TTS playback end

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -59,6 +59,17 @@ HANGUP_GRACE_SECONDS = 5.0
 # instead of hanging open. Picked > typical mark round-trip (1-3s).
 MARK_ECHO_TIMEOUT_SECONDS = 8.0
 
+# Silence watchdog arms from TTS-playback-end, not byte-send (#178).
+# After the last speak() of each turn we send this named mark; Twilio
+# echoes it back once the buffered audio has actually played out, and
+# only then do we start counting the silence window. A fallback timer
+# arms the watchdog anyway if Twilio never echoes (e.g. WS dropout).
+TTS_TURN_MARK = "tts_turn_end"
+# Max seconds to wait for Twilio to echo TTS_TURN_MARK before falling
+# back to arming the watchdog directly. 15s covers the longest plausible
+# agent TTS reply (~10s audio + 5s buffer); beyond this the mark is lost.
+TTS_MARK_ECHO_TIMEOUT_SECONDS = 15.0
+
 # Chunking thresholds for TTS handoff (#151). Sentence terminators
 # always flush; soft breaks (commas, semicolons, colons, em dashes)
 # only flush once the buffered chunk is ≥ _MIN_CHUNK_CHARS so that
@@ -168,6 +179,33 @@ async def send_end_of_call_mark(
         return False
 
 
+async def send_tts_turn_mark(websocket: WebSocket, stream_sid: str | None) -> bool:
+    """Append TTS_TURN_MARK to the outgoing media stream.
+
+    Twilio echoes it back once all queued TTS audio has played out, which
+    is when the caller can actually start responding (#178). Returns True
+    if the send succeeded.
+    """
+    if not stream_sid:
+        return False
+    try:
+        await websocket.send_json(
+            {
+                "event": "mark",
+                "streamSid": stream_sid,
+                "mark": {"name": TTS_TURN_MARK},
+            }
+        )
+        return True
+    except WebSocketDisconnect:
+        return False
+    except Exception:
+        logger.exception(
+            "mark: failed to send tts_turn_end mark stream_sid=%s", stream_sid
+        )
+        return False
+
+
 async def _hang_up_after_grace(state: _CallState) -> None:
     """Wait HANGUP_GRACE_SECONDS, then close the WebSocket to end the
     call.
@@ -233,6 +271,29 @@ async def _hang_up_after_mark_timeout(state: _CallState) -> None:
     await _hang_up_after_grace(state)
 
 
+async def _arm_silence_after_tts_mark_timeout(
+    state: _CallState, websocket: WebSocket
+) -> None:
+    """Fallback for #178: if Twilio never echoes TTS_TURN_MARK, arm the
+    silence watchdog anyway after ``TTS_MARK_ECHO_TIMEOUT_SECONDS``.
+
+    This prevents the call from hanging in silence forever if the WS
+    mark is dropped. Cancelled by the TTS mark-echo handler when the
+    echo arrives on time.
+    """
+    try:
+        await asyncio.sleep(TTS_MARK_ECHO_TIMEOUT_SECONDS)
+    except asyncio.CancelledError:
+        return
+    logger.warning(
+        "silence watchdog: tts_turn_end mark echo timed out after %.1fs, "
+        "arming watchdog directly call_sid=%s",
+        TTS_MARK_ECHO_TIMEOUT_SECONDS,
+        state.call_sid,
+    )
+    _arm_silence_watchdog(state, websocket)
+
+
 def _abort_pending_hangup(state: _CallState) -> None:
     """Cancel a pending auto-hangup because the caller spoke during
     the grace window. Safe to call when no hangup is pending."""
@@ -275,10 +336,11 @@ class _CallState:
     history:      list[dict]       = field(default_factory=list)
     restaurant:   Restaurant | None = None     # tenant for this call (#79)
     system_prompt: str             = ""        # built from restaurant on start
-    llm_task:          asyncio.Task | None = None   # current LLM→TTS turn
-    silence_task:      asyncio.Task | None = None   # silence watchdog
-    hangup_task:       asyncio.Task | None = None   # pending auto-hangup (#78)
-    mark_timeout_task: asyncio.Task | None = None   # mark-echo fallback (#114)
+    llm_task:              asyncio.Task | None = None   # current LLM→TTS turn
+    silence_task:          asyncio.Task | None = None   # silence watchdog
+    hangup_task:           asyncio.Task | None = None   # pending auto-hangup (#78)
+    mark_timeout_task:     asyncio.Task | None = None   # mark-echo fallback (#114)
+    tts_mark_timeout_task: asyncio.Task | None = None   # fallback if TTS_TURN_MARK never echoes (#178)
     pending_hangup: bool           = False     # set when goodbye mark sent (#78)
     recording_session: "RecordingUploadSession | None" = None
     should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
@@ -320,31 +382,62 @@ async def _open_deepgram_connection(
             return
         label = "final" if result.is_final else "interim"
         logger.info("transcript [%s] call_sid=%s text=%r", label, call_sid, text)
-        if result.is_final:
-            # Track confidence for transfer-trigger detection (#7).
-            # Explicit None check — `or 1.0` would replace 0.0 (falsy)
-            # with 1.0, masking a legitimate worst-case misheard signal.
-            raw_confidence = getattr(alt, "confidence", 1.0)
-            confidence = 1.0 if raw_confidence is None else raw_confidence
+        if not result.is_final:
+            # Caller is actively speaking — cancel both the silence watchdog
+            # and the TTS-mark fallback timer so neither fires while the
+            # caller is mid-sentence (#177).
             if state is not None:
-                state.last_caller_transcript = text
-                if confidence < 0.5:
-                    state.consecutive_low_confidence_turns += 1
-                else:
-                    state.consecutive_low_confidence_turns = 0
-            _bg_call_event(
+                _cancel_silence_task(state)
+                if (
+                    state.tts_mark_timeout_task
+                    and not state.tts_mark_timeout_task.done()
+                ):
+                    state.tts_mark_timeout_task.cancel()
+                    state.tts_mark_timeout_task = None
+            return
+        # Final transcript path.
+        # Track confidence for transfer-trigger detection (#7).
+        # Explicit None check — `or 1.0` would replace 0.0 (falsy)
+        # with 1.0, masking a legitimate worst-case misheard signal.
+        raw_confidence = getattr(alt, "confidence", 1.0)
+        confidence = 1.0 if raw_confidence is None else raw_confidence
+        if state is not None:
+            state.last_caller_transcript = text
+            if confidence < 0.5:
+                state.consecutive_low_confidence_turns += 1
+            else:
+                state.consecutive_low_confidence_turns = 0
+        _bg_call_event(
+            call_sid,
+            restaurant_id,
+            kind="transcript_final",
+            text=text,
+            detail={"text": text, "confidence": confidence},
+        )
+        asyncio.get_event_loop().create_task(on_final(text))
+
+    async def on_speech_started(self, speech_started, **kwargs):
+        # Deepgram fires this the moment VAD detects the caller speaking,
+        # before any transcript is ready. Cancel the silence watchdog
+        # immediately so it doesn't fire while the caller is talking (#177).
+        if state is not None:
+            logger.debug(
+                "speech_started: cancelling silence watchdog call_sid=%s",
                 call_sid,
-                restaurant_id,
-                kind="transcript_final",
-                text=text,
-                detail={"text": text, "confidence": confidence},
             )
-            asyncio.get_event_loop().create_task(on_final(text))
+            _cancel_silence_task(state)
+            if (
+                state.tts_mark_timeout_task
+                and not state.tts_mark_timeout_task.done()
+            ):
+                state.tts_mark_timeout_task.cancel()
+                state.tts_mark_timeout_task = None
 
     async def on_error(self, error, **kwargs):
         logger.error("deepgram error call_sid=%s error=%s", call_sid, error)
 
     conn.on(LiveTranscriptionEvents.Transcript, on_transcript)
+    conn.on(LiveTranscriptionEvents.SpeechStarted, on_speech_started)
     conn.on(LiveTranscriptionEvents.Error, on_error)
 
     # endpointing + utterance_end_ms together control how aggressively
@@ -577,6 +670,23 @@ async def _run_llm_tts_turn(
                             state.mark_timeout_task = asyncio.create_task(
                                 _hang_up_after_mark_timeout(state)
                             )
+                # Send TTS_TURN_MARK so the silence watchdog arms from
+                # audio-playback-end rather than byte-send-end (#178).
+                # On hangup turns the end_of_call mark already owns timing
+                # so we skip to avoid a redundant watchdog arm racing the
+                # grace window.
+                if state.stream_sid and not state.pending_hangup:
+                    tts_sent = await send_tts_turn_mark(websocket, state.stream_sid)
+                    if tts_sent:
+                        if state.tts_mark_timeout_task and not state.tts_mark_timeout_task.done():
+                            state.tts_mark_timeout_task.cancel()
+                        state.tts_mark_timeout_task = asyncio.create_task(
+                            _arm_silence_after_tts_mark_timeout(state, websocket)
+                        )
+                    else:
+                        # Mark send failed (WS disconnected); fall back to
+                        # arming immediately so the watchdog still runs.
+                        _arm_silence_watchdog(state, websocket)
 
     except asyncio.CancelledError:
         logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)
@@ -614,6 +724,11 @@ async def _handle_final_transcript(
         state.silence_task and not state.silence_task.done()
     )
     _cancel_silence_task(state)
+    # Cancel any pending TTS-mark fallback timer — caller is speaking so
+    # we must not arm the silence watchdog behind their back (#177/#178).
+    if state.tts_mark_timeout_task and not state.tts_mark_timeout_task.done():
+        state.tts_mark_timeout_task.cancel()
+    state.tts_mark_timeout_task = None
     # Caller spoke — abort any pending auto-hangup (#78). Even if they
     # spoke during the grace window after a confirmation, we want to
     # keep the call alive and process this transcript.
@@ -626,9 +741,8 @@ async def _handle_final_transcript(
     state.llm_task = asyncio.create_task(
         _run_llm_tts_turn(text, state, websocket)
     )
-    state.llm_task.add_done_callback(
-        lambda _t: _arm_silence_watchdog(state, websocket)
-    )
+    # Silence watchdog is now armed by the TTS_TURN_MARK echo (audio
+    # playback end), not by task completion (byte-send end) — #178.
 
 
 _UNCONFIGURED_TWIML_MESSAGE = (
@@ -1056,9 +1170,8 @@ async def media_stream(websocket: WebSocket) -> None:
                 state.llm_task = asyncio.create_task(
                     _run_llm_tts_turn(GREETING_TRANSCRIPT, state, websocket)
                 )
-                state.llm_task.add_done_callback(
-                    lambda _t: _arm_silence_watchdog(state, websocket)
-                )
+                # Silence watchdog is now armed by the TTS_TURN_MARK echo
+                # (audio playback end), not by task completion — #178.
 
             elif event == "media":
                 payload = base64.b64decode(msg["media"]["payload"])
@@ -1082,7 +1195,8 @@ async def media_stream(websocket: WebSocket) -> None:
             elif event == "mark":
                 # Twilio echoes our outgoing marks once the audio queued
                 # before them has finished playing. We use it to drive
-                # auto-hangup after order confirmation (#78).
+                # auto-hangup after order confirmation (#78) and to arm
+                # the silence watchdog at true audio-end (#178).
                 mark_name = msg.get("mark", {}).get("name")
                 if mark_name == END_OF_CALL_MARK and state.pending_hangup:
                     logger.info(
@@ -1097,6 +1211,18 @@ async def media_stream(websocket: WebSocket) -> None:
                     state.hangup_task = asyncio.create_task(
                         _hang_up_after_grace(state)
                     )
+                elif mark_name == TTS_TURN_MARK:
+                    # Caller has now heard the agent's full reply — start
+                    # the silence countdown from this moment (#178).
+                    logger.debug(
+                        "silence watchdog: tts_turn_end mark received, "
+                        "arming watchdog call_sid=%s",
+                        state.call_sid,
+                    )
+                    if state.tts_mark_timeout_task and not state.tts_mark_timeout_task.done():
+                        state.tts_mark_timeout_task.cancel()
+                    state.tts_mark_timeout_task = None
+                    _arm_silence_watchdog(state, websocket)
 
             elif event == "stop":
                 logger.info("media-stream stop call_sid=%s", state.call_sid)
@@ -1113,6 +1239,9 @@ async def media_stream(websocket: WebSocket) -> None:
         logger.info("media-stream disconnected call_sid=%s", state.call_sid)
     finally:
         _cancel_silence_task(state)
+        if state.tts_mark_timeout_task and not state.tts_mark_timeout_task.done():
+            state.tts_mark_timeout_task.cancel()
+        state.tts_mark_timeout_task = None
         # Auto-hangup: stop any pending grace-window timer; the call is
         # already ending so we don't need to fire the REST close (#78).
         _abort_pending_hangup(state)

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2009,3 +2009,376 @@ async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch
 
     assert captured == ["and a coke"]
 
+
+# ---------------------------------------------------------------------------
+# #177 — silence watchdog cancelled on SpeechStarted / interim transcript
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_cancelled_on_interim_transcript(monkeypatch):
+    """#177 — an interim transcript must cancel the silence watchdog so
+    it doesn't fire while the caller is actively speaking."""
+    from unittest.mock import MagicMock
+
+    import app.telephony.router as router_mod
+    from app.telephony.router import _CallState, _open_deepgram_connection
+
+    monkeypatch.setattr(router_mod.settings, "deepgram_api_key", "fake-key")
+    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    captured: dict = {}
+
+    class FakeConn:
+        def on(self, event_type, handler):
+            captured.setdefault(str(event_type), handler)
+
+        async def start(self, *_, **__):
+            return True
+
+    class FakeDGClient:
+        def __init__(self, *_):
+            self.listen = MagicMock()
+            self.listen.asynclive.v.return_value = FakeConn()
+
+    monkeypatch.setattr(router_mod, "DeepgramClient", FakeDGClient)
+
+    await _open_deepgram_connection("CAtest", "r1", lambda t: None, state=state)
+    handler = captured["Results"]
+
+    def _fake_result(text, is_final):
+        r = MagicMock()
+        alt = MagicMock()
+        alt.transcript = text
+        alt.confidence = 0.9
+        r.channel.alternatives = [alt]
+        r.is_final = is_final
+        return r
+
+    # Plant a live silence task on state.
+    async def _never():
+        await asyncio.sleep(60)
+
+    state.silence_task = asyncio.create_task(_never())
+    assert not state.silence_task.done()
+
+    # Interim transcript arrives — watchdog must be cancelled.
+    await handler(None, _fake_result("i'd like a", is_final=False))
+
+    assert state.silence_task is None, (
+        "silence_task must be cleared on interim transcript"
+    )
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_cancelled_on_speech_started(monkeypatch):
+    """#177 — SpeechStarted event (VAD) must cancel the silence watchdog
+    before any transcript is even produced."""
+    from unittest.mock import MagicMock
+
+    import app.telephony.router as router_mod
+    from app.telephony.router import _CallState, _open_deepgram_connection
+
+    monkeypatch.setattr(router_mod.settings, "deepgram_api_key", "fake-key")
+    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    captured: dict = {}
+
+    class FakeConn:
+        def on(self, event_type, handler):
+            captured.setdefault(str(event_type), handler)
+
+        async def start(self, *_, **__):
+            return True
+
+    class FakeDGClient:
+        def __init__(self, *_):
+            self.listen = MagicMock()
+            self.listen.asynclive.v.return_value = FakeConn()
+
+    monkeypatch.setattr(router_mod, "DeepgramClient", FakeDGClient)
+
+    await _open_deepgram_connection("CAtest", "r1", lambda t: None, state=state)
+
+    speech_started_handler = captured.get("SpeechStarted")
+    assert speech_started_handler is not None, (
+        "SpeechStarted handler must be registered on the Deepgram connection"
+    )
+
+    # Plant a live silence task.
+    async def _never():
+        await asyncio.sleep(60)
+
+    state.silence_task = asyncio.create_task(_never())
+    assert not state.silence_task.done()
+
+    await speech_started_handler(None, MagicMock())
+
+    assert state.silence_task is None, (
+        "silence_task must be cleared on SpeechStarted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_interim_transcript_also_cancels_tts_mark_timeout(monkeypatch):
+    """#177/#178 — an interim transcript must also cancel the TTS mark
+    fallback timer so the watchdog is not re-armed after the caller speaks."""
+    from unittest.mock import MagicMock
+
+    import app.telephony.router as router_mod
+    from app.telephony.router import _CallState, _open_deepgram_connection
+
+    monkeypatch.setattr(router_mod.settings, "deepgram_api_key", "fake-key")
+    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    captured: dict = {}
+
+    class FakeConn:
+        def on(self, event_type, handler):
+            captured.setdefault(str(event_type), handler)
+
+        async def start(self, *_, **__):
+            return True
+
+    class FakeDGClient:
+        def __init__(self, *_):
+            self.listen = MagicMock()
+            self.listen.asynclive.v.return_value = FakeConn()
+
+    monkeypatch.setattr(router_mod, "DeepgramClient", FakeDGClient)
+
+    await _open_deepgram_connection("CAtest", "r1", lambda t: None, state=state)
+    handler = captured["Results"]
+
+    def _fake_result(text, is_final):
+        r = MagicMock()
+        alt = MagicMock()
+        alt.transcript = text
+        alt.confidence = 0.9
+        r.channel.alternatives = [alt]
+        r.is_final = is_final
+        return r
+
+    async def _never():
+        await asyncio.sleep(60)
+
+    state.tts_mark_timeout_task = asyncio.create_task(_never())
+    assert not state.tts_mark_timeout_task.done()
+
+    await handler(None, _fake_result("i'd like a", is_final=False))
+
+    assert state.tts_mark_timeout_task is None, (
+        "tts_mark_timeout_task must be cleared on interim transcript"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #178 — silence watchdog arms on TTS_TURN_MARK echo, not byte-send
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_not_armed_before_tts_mark_echo(monkeypatch):
+    """#178 — the silence watchdog must NOT be armed immediately when the
+    LLM turn task finishes (byte-send); it must wait for the TTS_TURN_MARK
+    echo from Twilio."""
+    import app.telephony.router as router_mod
+    from app.telephony.router import _CallState, _run_llm_tts_turn
+    from app.storage import call_sessions
+
+    arm_calls: list[str] = []
+
+    async def fake_stream_reply(*, transcript, history, order, **kw):
+        yield StreamEvent(text_delta="Sure thing!")
+        yield StreamEvent(
+            final=LLMResponse(reply_text="Sure thing!", order=order, history=history)
+        )
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    monkeypatch.setattr(router_mod, "stream_reply", fake_stream_reply)
+    monkeypatch.setattr(router_mod, "speak", fake_speak)
+    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        router_mod,
+        "_arm_silence_watchdog",
+        lambda state, ws: arm_calls.append("armed"),
+    )
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+
+    state = _CallState(
+        call_sid="CAtest",
+        stream_sid="MZtest",
+        order=Order(call_sid="CAtest"),
+        system_prompt="test",
+    )
+
+    await _run_llm_tts_turn("one pepperoni pizza", state, ws)
+
+    # After the turn completes, the watchdog must NOT have been armed yet.
+    assert arm_calls == [], (
+        "silence watchdog must not be armed at byte-send-end; "
+        "should wait for TTS_TURN_MARK echo"
+    )
+    # But a tts_mark_timeout_task MUST be live (fallback timer).
+    assert state.tts_mark_timeout_task is not None, (
+        "tts_mark_timeout_task must be created so watchdog arms eventually "
+        "even if Twilio never echoes the mark"
+    )
+    # Cleanup
+    if state.tts_mark_timeout_task and not state.tts_mark_timeout_task.done():
+        state.tts_mark_timeout_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_silence_watchdog_armed_on_tts_mark_echo(monkeypatch):
+    """#178 — when the WS handler receives a 'tts_turn_end' mark echo,
+    it must call _arm_silence_watchdog and cancel the fallback timer."""
+    import app.telephony.router as router_mod
+    from app.storage import call_sessions
+
+    arm_calls: list[str] = []
+    monkeypatch.setattr(
+        router_mod,
+        "_arm_silence_watchdog",
+        lambda state, ws: arm_calls.append("armed"),
+    )
+
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
+        return fake_dg
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
+    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
+
+    tts_mark_msg = json.dumps(
+        {"event": "mark", "mark": {"name": "tts_turn_end"}}
+    )
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(
+            json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"})
+        )
+        ws.send_text(json.dumps(_START_MSG))
+        # Echo the TTS mark back as Twilio would after audio finishes.
+        ws.send_text(tts_mark_msg)
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert "armed" in arm_calls, (
+        "silence watchdog must be armed when tts_turn_end mark echo is received"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tts_mark_fallback_arms_watchdog_when_no_echo(monkeypatch):
+    """#178 — if Twilio never echoes TTS_TURN_MARK, the fallback timer
+    must arm the silence watchdog after TTS_MARK_ECHO_TIMEOUT_SECONDS."""
+    import app.telephony.router as router_mod
+    from app.telephony.router import (
+        _CallState,
+        _arm_silence_after_tts_mark_timeout,
+    )
+
+    monkeypatch.setattr(router_mod, "TTS_MARK_ECHO_TIMEOUT_SECONDS", 0.05)
+
+    arm_calls: list[str] = []
+    monkeypatch.setattr(
+        router_mod,
+        "_arm_silence_watchdog",
+        lambda state, ws: arm_calls.append("armed"),
+    )
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    await _arm_silence_after_tts_mark_timeout(state, ws)
+
+    assert "armed" in arm_calls, (
+        "fallback timer must arm the silence watchdog when mark echo never arrives"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tts_mark_fallback_cancelled_by_caller_speech(monkeypatch):
+    """#177/#178 — when _handle_final_transcript runs (caller spoke),
+    it must cancel the TTS mark fallback timer so the watchdog is not
+    re-armed after the caller is already responding."""
+    import app.telephony.router as router_mod
+    from app.telephony.router import _CallState, _handle_final_transcript
+
+    arm_calls: list[str] = []
+    monkeypatch.setattr(
+        router_mod,
+        "_arm_silence_watchdog",
+        lambda state, ws: arm_calls.append("armed"),
+    )
+    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", AsyncMock())
+    monkeypatch.setattr(router_mod, "_abort_pending_hangup", lambda *a: None)
+    monkeypatch.setattr(router_mod, "clear_twilio_audio", AsyncMock())
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    # Plant a live TTS mark fallback timer.
+    async def _never():
+        await asyncio.sleep(60)
+
+    state.tts_mark_timeout_task = asyncio.create_task(_never())
+    assert not state.tts_mark_timeout_task.done()
+
+    await _handle_final_transcript("a large pepperoni", state, ws)
+
+    assert state.tts_mark_timeout_task is None, (
+        "tts_mark_timeout_task must be cancelled when caller speaks"
+    )
+    assert arm_calls == [], (
+        "silence watchdog must not be armed directly on caller speech"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_tts_turn_mark_emits_mark_payload():
+    """send_tts_turn_mark must emit the TTS_TURN_MARK name over the WS."""
+    from app.telephony.router import TTS_TURN_MARK, send_tts_turn_mark
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    sent = await send_tts_turn_mark(ws, "MZtest456")
+
+    assert sent is True
+    ws.send_json.assert_awaited_once_with(
+        {
+            "event": "mark",
+            "streamSid": "MZtest456",
+            "mark": {"name": TTS_TURN_MARK},
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_tts_turn_mark_returns_false_when_stream_sid_missing():
+    from app.telephony.router import send_tts_turn_mark
+
+    ws = AsyncMock()
+    sent = await send_tts_turn_mark(ws, None)
+    assert sent is False
+    ws.send_json.assert_not_called()
+


### PR DESCRIPTION
Fixes #177 and #178. Both issues are in the same subsystem so landing together.

## Root causes

**#177 — watchdog fires mid-speech**
The silence watchdog was only cancelled on a *final* transcript. Deepgram delivers `SpeechStarted` (VAD) and interim transcripts well before a final; the 10-second timer could expire while the caller was still talking.

**#178 — watchdog anchored to byte-send, not playback end**
`_run_llm_tts_turn` armed the watchdog via `add_done_callback`, which fires when the last `speak()` returns — i.e. when the last byte is sent to Twilio's socket. Twilio buffers audio server-side; a 10-second reply takes <1s to send but ~10s to play. The silence timer was counting while the caller was still *hearing* the agent, leaving ~1s to respond before "Are you still there?" played over them. Confirmed by call `CAb1ccc23cf63d2c0c6626150b02a9062b`.

## Changes

### `app/telephony/router.py`
- **New constants**: `TTS_TURN_MARK = "tts_turn_end"`, `TTS_MARK_ECHO_TIMEOUT_SECONDS = 15.0`
- **New helper** `send_tts_turn_mark()`: sends the named mark to Twilio's media stream (mirrors `send_end_of_call_mark`)
- **New coroutine** `_arm_silence_after_tts_mark_timeout()`: fallback timer — if Twilio never echoes `TTS_TURN_MARK`, arm the watchdog directly after 15s
- **New field** `_CallState.tts_mark_timeout_task`: tracks the fallback timer task
- **`_open_deepgram_connection`**: registers `on_speech_started` handler (Deepgram `SpeechStarted` event) that calls `_cancel_silence_task`; updated `on_transcript` to cancel watchdog + `tts_mark_timeout_task` on *interim* results, not just finals
- **`_run_llm_tts_turn`**: after `event.final` speak, sends `TTS_TURN_MARK` and starts fallback timer; removed `add_done_callback` from both call sites (greeting + final transcript handler)
- **WS mark handler**: added `TTS_TURN_MARK` branch — cancels fallback timer and calls `_arm_silence_watchdog`
- **`_handle_final_transcript`**: cancels `tts_mark_timeout_task` when caller speaks (prevents re-arming watchdog after barge-in)
- **`finally` block**: cleans up `tts_mark_timeout_task` on call end

### `tests/test_telephony.py`
9 new unit tests:
- `test_silence_watchdog_cancelled_on_interim_transcript` (#177)
- `test_silence_watchdog_cancelled_on_speech_started` (#177)
- `test_interim_transcript_also_cancels_tts_mark_timeout` (#177/#178)
- `test_silence_watchdog_not_armed_before_tts_mark_echo` (#178)
- `test_silence_watchdog_armed_on_tts_mark_echo` (#178)
- `test_tts_mark_fallback_arms_watchdog_when_no_echo` (#178)
- `test_tts_mark_fallback_cancelled_by_caller_speech` (#177/#178)
- `test_send_tts_turn_mark_emits_mark_payload`
- `test_send_tts_turn_mark_returns_false_when_stream_sid_missing`

## Test plan
- [x] `python -m pytest tests/test_telephony.py tests/test_voice.py -q` — 79 passed, 0 failed
- [ ] Live call: agent gives a long (~8-10 second) reply; caller responds within 2s of audio end; no `silence_timeout` event fires
- [ ] Live call: caller starts speaking mid-agent-reply; no `silence_timeout` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)