### PR TITLE
dashboard(ds): orders feed + order detail (PR 2/4)

### DIFF
--- a/dashboard/app/(dashboard)/orders/[id]/not-found.tsx
+++ b/dashboard/app/(dashboard)/orders/[id]/not-found.tsx
@@ -11,7 +11,7 @@ export default function NotFound() {
           This order may have been deleted, or the link is wrong.
         </p>
         <Button asChild className="mt-4">
-          <Link href="/">Back to orders</Link>
+          <Link href="/orders">Back to orders</Link>
         </Button>
       </div>
     </section>

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -175,6 +175,12 @@
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 
+  /* design-system.md type scale extension. Tailwind v4 ships
+     text-xs/sm/base/lg/xl/2xl by default; --text-md is an addition
+     used for card titles, item names, and empty-state titles. */
+  --text-md: 16px;
+  --text-md--line-height: 22px;
+
   --radius-xs: var(--radius-xs);
   --radius-sm: var(--radius-sm);
   --radius-md: var(--radius-md);

--- a/dashboard/components/orders/cancel-order-button.tsx
+++ b/dashboard/components/orders/cancel-order-button.tsx
@@ -35,7 +35,9 @@ export function CancelOrderButton({ callSid }: { callSid: string }) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline">Cancel order</Button>
+        <Button variant="secondary" size="lg" className="border border-border">
+          Cancel order
+        </Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/dashboard/components/orders/filter-tabs.tsx
+++ b/dashboard/components/orders/filter-tabs.tsx
@@ -12,13 +12,13 @@ type Tab = {
 };
 
 const TABS: Tab[] = [
-  { key: 'all', label: 'All', href: '/' },
-  { key: 'in_progress', label: 'Live', href: '/?status=in_progress' },
-  { key: 'confirmed', label: 'Confirmed', href: '/?status=confirmed' },
-  { key: 'preparing', label: 'Preparing', href: '/?status=preparing' },
-  { key: 'ready', label: 'Ready', href: '/?status=ready' },
-  { key: 'completed', label: 'Completed', href: '/?status=completed' },
-  { key: 'cancelled', label: 'Cancelled', href: '/?status=cancelled' },
+  { key: 'all', label: 'All', href: '/orders' },
+  { key: 'in_progress', label: 'Live', href: '/orders?status=in_progress' },
+  { key: 'confirmed', label: 'Confirmed', href: '/orders?status=confirmed' },
+  { key: 'preparing', label: 'Preparing', href: '/orders?status=preparing' },
+  { key: 'ready', label: 'Ready', href: '/orders?status=ready' },
+  { key: 'completed', label: 'Completed', href: '/orders?status=completed' },
+  { key: 'cancelled', label: 'Cancelled', href: '/orders?status=cancelled' },
 ];
 
 export function FilterTabs({
@@ -29,7 +29,10 @@ export function FilterTabs({
   counts: CountsByStatus;
 }) {
   return (
-    <nav className="flex flex-wrap items-center gap-2">
+    <nav
+      aria-label="Filter orders by status"
+      className="flex flex-wrap items-center gap-1 border-t border-border-subtle pt-3"
+    >
       {TABS.map((tab) => {
         const isActive = tab.key === 'all' ? !active : active === tab.key;
         const count = counts[tab.key] ?? 0;
@@ -37,21 +40,21 @@ export function FilterTabs({
           <Link
             key={tab.key}
             href={tab.href}
-            className={cn(
-              'inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm transition-colors',
-              isActive
-                ? 'border-foreground/20 bg-foreground text-background'
-                : 'border-border bg-background text-foreground hover:bg-muted',
-            )}
             aria-current={isActive ? 'page' : undefined}
+            className={cn(
+              'inline-flex h-7 items-center gap-2 rounded-sm px-2.5 text-sm transition-colors',
+              isActive
+                ? 'bg-surface-2 text-foreground'
+                : 'text-foreground-muted hover:bg-surface-2/60 hover:text-foreground',
+            )}
           >
             <span>{tab.label}</span>
             <span
               className={cn(
-                'rounded-full px-2 py-0.5 text-xs tabular-nums',
+                'inline-flex h-4 min-w-4 items-center justify-center rounded-xs px-1 text-xs tabular-nums',
                 isActive
-                  ? 'bg-background/20 text-background'
-                  : 'bg-muted text-muted-foreground',
+                  ? 'bg-surface-3 text-foreground-subtle'
+                  : 'bg-surface-1 text-foreground-subtle',
               )}
             >
               {count}

--- a/dashboard/components/orders/order-detail.tsx
+++ b/dashboard/components/orders/order-detail.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowLeft, Play } from 'lucide-react';
+import { ChevronLeft, Play, Radio } from 'lucide-react';
 
 import { CallDuration } from '@/components/orders/call-duration';
 import { CancelOrderButton } from '@/components/orders/cancel-order-button';
@@ -21,22 +21,35 @@ import {
   orderShortId,
 } from '@/lib/schemas/order';
 
+const ACTION_STATUSES: ReadonlySet<Order['status']> = new Set([
+  'confirmed',
+  'preparing',
+  'ready',
+]);
+
 export function OrderDetail({ order }: { order: Order }) {
+  const showActionRow = ACTION_STATUSES.has(order.status);
+
   return (
-    <section className="mx-auto flex max-w-4xl flex-col gap-4 p-6">
+    <div className="mx-auto max-w-6xl p-6">
       <Header order={order} />
-      <CallerCard order={order} />
-      <ItemsCard order={order} />
-      <SubtotalCard order={order} />
-      {(order.status === 'confirmed' ||
-        order.status === 'preparing' ||
-        order.status === 'ready') && (
-        <div className="flex flex-wrap items-center gap-2 pt-2">
-          <TransitionButton order={order} />
-          <CancelOrderButton callSid={order.call_sid} />
+      <div className="mt-6 flex flex-col gap-6 min-[960px]:grid min-[960px]:grid-cols-[3fr_2fr] min-[960px]:gap-6">
+        <div className="flex flex-col gap-6">
+          <CallerCard order={order} />
+          <ItemsList order={order} />
+          <Totals order={order} />
+          {showActionRow && (
+            <div className="flex flex-wrap items-center gap-3 pt-2">
+              <TransitionButton order={order} mode="detail" />
+              <CancelOrderButton callSid={order.call_sid} />
+            </div>
+          )}
         </div>
-      )}
-    </section>
+        <div className="flex flex-col gap-6">
+          <CallSidebarCard order={order} />
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -44,14 +57,16 @@ function Header({ order }: { order: Order }) {
   return (
     <div className="flex flex-wrap items-center gap-3">
       <Button variant="ghost" size="sm" asChild>
-        <Link href="/" aria-label="Back to orders">
-          <ArrowLeft className="mr-1 h-4 w-4" />
+        <Link href="/orders" aria-label="Back to orders">
+          <ChevronLeft className="size-4" />
           Back
         </Link>
       </Button>
-      <h2 className="text-xl font-medium">Order {orderShortId(order)}</h2>
+      <h2 className="font-mono text-lg font-semibold">
+        Order {orderShortId(order)}
+      </h2>
       <StatusBadge status={order.status} />
-      <div className="ml-auto text-sm text-muted-foreground">
+      <div className="ml-auto text-sm text-foreground-muted">
         {headerTimestamp(order)}
       </div>
     </div>
@@ -119,98 +134,109 @@ function headerTimestamp(order: Order): React.ReactNode {
 
 function CallerCard({ order }: { order: Order }) {
   return (
-    <Card>
-      <div className="flex flex-wrap items-start justify-between gap-4 p-4">
-        <div>
+    <div className="rounded-md border border-border-subtle bg-surface-1 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
           <div className="font-medium">{formatPhone(order.caller_phone)}</div>
-          <div className="text-sm text-muted-foreground">
+          <div className="text-sm text-foreground-muted">
             {order.order_type ? capitalize(order.order_type) : 'Type unknown'}
           </div>
           {order.order_type === 'delivery' && order.delivery_address && (
-            <div className="mt-1 text-sm text-muted-foreground">
+            <div className="mt-1 text-sm text-foreground-muted">
               {order.delivery_address}
             </div>
           )}
         </div>
-        <div className="text-right text-sm text-muted-foreground">
-          <div>
-            <CallDuration order={order} />
-          </div>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  disabled
-                  className="mt-2"
-                  aria-label="Recording playback (coming in Phase 2)"
-                >
-                  <Play className="mr-1 h-4 w-4" />
-                  Recording
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Recording UI coming in Phase 2</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+        <div className="text-right text-sm text-foreground-muted">
+          <CallDuration order={order} />
         </div>
-      </div>
-    </Card>
-  );
-}
-
-function ItemsCard({ order }: { order: Order }) {
-  if (order.items.length === 0) {
-    return (
-      <Card>
-        <div className="p-4 text-sm text-muted-foreground">No items.</div>
-      </Card>
-    );
-  }
-
-  return (
-    <Card>
-      <div className="divide-y">
-        {order.items.map((item, idx) => (
-          <div key={idx} className="p-4">
-            <div className="flex items-baseline justify-between gap-4">
-              <div className="font-medium">{formatLineItemTitle(item)}</div>
-              <div className="tabular-nums font-medium">
-                {formatCAD(item.line_total)}
-              </div>
-            </div>
-            {item.modifications.length > 0 && (
-              <ul className="mt-2 space-y-0.5 pl-4 text-sm text-muted-foreground list-disc">
-                {item.modifications.map((mod, i) => (
-                  <li key={i}>{mod}</li>
-                ))}
-              </ul>
-            )}
-          </div>
-        ))}
-      </div>
-    </Card>
-  );
-}
-
-function SubtotalCard({ order }: { order: Order }) {
-  return (
-    <div className="rounded-xl border bg-muted/40 p-4">
-      <div className="flex items-baseline justify-between">
-        <div className="font-medium">Subtotal</div>
-        <div className="tabular-nums font-medium">
-          {formatCAD(order.subtotal)}
-        </div>
-      </div>
-      <div className="mt-1 text-xs text-muted-foreground">
-        Tax and total aren&rsquo;t computed in Phase 1.
       </div>
     </div>
   );
 }
 
-function Card({ children }: { children: React.ReactNode }) {
-  return <div className="rounded-xl border bg-card">{children}</div>;
+function ItemsList({ order }: { order: Order }) {
+  if (order.items.length === 0) {
+    return (
+      <p className="text-sm text-foreground-muted">No items.</p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col">
+      {order.items.map((item, idx) => (
+        <li
+          key={idx}
+          className="border-b border-border-subtle py-3 last:border-b-0"
+        >
+          <div className="flex items-baseline justify-between gap-4">
+            <div className="font-medium">{formatLineItemTitle(item)}</div>
+            <div className="font-mono font-medium tabular-nums">
+              {formatCAD(item.line_total)}
+            </div>
+          </div>
+          {item.modifications.length > 0 && (
+            <ul className="mt-2 list-disc space-y-0.5 pl-4 text-sm text-foreground-muted">
+              {item.modifications.map((mod, i) => (
+                <li key={i}>{mod}</li>
+              ))}
+            </ul>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Totals({ order }: { order: Order }) {
+  return (
+    <div className="rounded-md bg-surface-2 p-4">
+      <div className="flex items-baseline justify-between">
+        <div className="font-medium">Subtotal</div>
+        <div className="font-mono font-medium tabular-nums">
+          {formatCAD(order.subtotal)}
+        </div>
+      </div>
+      <p className="mt-1 text-xs italic text-foreground-subtle">
+        Tax and total aren&rsquo;t computed in this build.
+      </p>
+    </div>
+  );
+}
+
+function CallSidebarCard({ order }: { order: Order }) {
+  return (
+    <div className="rounded-md border border-border-subtle bg-surface-1 p-4">
+      <div className="flex items-center gap-2">
+        <Radio
+          className="size-3 text-foreground-faint"
+          aria-hidden
+        />
+        <span className="text-eyebrow">Call recording</span>
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <div className="text-sm text-foreground-muted">
+          <CallDuration order={order} />
+        </div>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled
+                aria-label="Recording playback (coming in Phase 2)"
+              >
+                <Play className="mr-1 size-4" />
+                Play
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Recording UI ships in PR 4 (calls)</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    </div>
+  );
 }
 
 function capitalize(s: string): string {

--- a/dashboard/components/orders/order-detail.tsx
+++ b/dashboard/components/orders/order-detail.tsx
@@ -33,7 +33,7 @@ export function OrderDetail({ order }: { order: Order }) {
   return (
     <div className="mx-auto max-w-6xl p-6">
       <Header order={order} />
-      <div className="mt-6 flex flex-col gap-6 min-[960px]:grid min-[960px]:grid-cols-[3fr_2fr] min-[960px]:gap-6">
+      <div className="mt-6 flex flex-col gap-6 min-[960px]:grid min-[960px]:grid-cols-[3fr_2fr]">
         <div className="flex flex-col gap-6">
           <CallerCard order={order} />
           <ItemsList order={order} />

--- a/dashboard/components/orders/orders-table.tsx
+++ b/dashboard/components/orders/orders-table.tsx
@@ -23,16 +23,16 @@ export function OrdersTable({
   if (orders.length === 0) return <EmptyState twilioPhone={twilioPhone} />;
 
   return (
-    <div className="overflow-hidden rounded-xl border">
+    <div className="overflow-hidden">
       <table className="w-full text-left text-sm">
-        <thead className="bg-muted/40 text-muted-foreground">
-          <tr>
+        <thead>
+          <tr className="border-b border-border-subtle text-foreground-muted">
             <Th className="w-28">Order</Th>
             <Th className="w-24">Time</Th>
             <Th>Items</Th>
-            <Th className="w-32 text-right">Subtotal</Th>
-            <Th className="w-32">Status</Th>
-            <Th className="w-36">Action</Th>
+            <Th className="w-28 text-right">Subtotal</Th>
+            <Th className="w-24">Status</Th>
+            <Th className="w-24">Action</Th>
           </tr>
         </thead>
         <tbody>
@@ -51,8 +51,8 @@ export function OrdersTable({
 
 function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
   const isLive = order.status === 'in_progress';
-  const isCancelled = order.status === 'cancelled';
-  const mutedCell = isCancelled ? 'text-muted-foreground' : '';
+  const isFaded = order.status === 'completed' || order.status === 'cancelled';
+  const fadedCell = isFaded ? 'text-foreground-faint' : '';
 
   const itemsSummary =
     order.items.length === 0
@@ -65,28 +65,24 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
     .filter(Boolean)
     .join(' · ');
 
+  const detailHref = `/orders/${encodeURIComponent(order.call_sid)}`;
+
   return (
     <tr
-      className="border-t transition-colors hover:bg-muted/40"
+      className={cn(
+        'border-b border-border-subtle transition-colors hover:bg-surface-2/40',
+        isFresh && 'animate-row-enter',
+      )}
       data-fresh={isFresh ? 'true' : undefined}
     >
-      <Td className={cn('py-3', mutedCell)}>
-        <Link
-          href={`/orders/${encodeURIComponent(order.call_sid)}`}
-          className="flex items-center gap-2 font-medium"
-        >
-          {isLive && (
-            <span
-              aria-hidden
-              className="inline-block h-1.5 w-1.5 rounded-full bg-amber-500"
-            />
-          )}
+      <Td className={cn('font-mono text-xs', fadedCell)}>
+        <Link href={detailHref} className="block">
           {orderShortId(order)}
         </Link>
       </Td>
-      <Td className={cn('text-muted-foreground', mutedCell)}>
+      <Td className="text-foreground-muted">
         <Link
-          href={`/orders/${encodeURIComponent(order.call_sid)}`}
+          href={detailHref}
           data-testid={`order-time-${order.call_sid}`}
           data-anchor-iso={timeColumnAnchor(order).toISOString()}
         >
@@ -100,31 +96,26 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
           )}
         </Link>
       </Td>
-      <Td className={mutedCell}>
-        <Link
-          href={`/orders/${encodeURIComponent(order.call_sid)}`}
-          className="block"
-        >
-          <div className={isLive ? 'italic' : ''}>
+      <Td className={fadedCell}>
+        <Link href={detailHref} className="block">
+          <div className={cn('truncate', isLive && 'italic')}>
             {isLive ? `Building… ${itemsSummary}` : itemsSummary}
           </div>
           {secondary && (
-            <div className="text-xs text-muted-foreground">{secondary}</div>
+            <div className="text-xs text-foreground-faint">{secondary}</div>
           )}
         </Link>
       </Td>
       <Td
         className={cn(
-          'text-right font-medium tabular-nums',
-          mutedCell,
+          'text-right font-mono font-medium tabular-nums',
+          fadedCell,
         )}
       >
-        <Link href={`/orders/${encodeURIComponent(order.call_sid)}`}>
-          {formatCAD(order.subtotal)}
-        </Link>
+        <Link href={detailHref}>{formatCAD(order.subtotal)}</Link>
       </Td>
       <Td>
-        <Link href={`/orders/${encodeURIComponent(order.call_sid)}`}>
+        <Link href={detailHref}>
           <StatusBadge status={order.status} />
         </Link>
       </Td>
@@ -145,7 +136,7 @@ function Th({
   return (
     <th
       className={cn(
-        'px-4 py-2 text-xs font-medium uppercase tracking-wide',
+        'px-2.5 py-2.5 text-xs font-medium uppercase tracking-wide',
         className,
       )}
     >
@@ -161,16 +152,21 @@ function Td({
   children: React.ReactNode;
   className?: string;
 }) {
-  return <td className={cn('px-4 py-3 align-top', className)}>{children}</td>;
+  return (
+    <td className={cn('px-2.5 py-2.5 align-middle', className)}>{children}</td>
+  );
 }
 
 function EmptyState({ twilioPhone }: { twilioPhone: string }) {
   const display = formatPhone(twilioPhone);
   return (
-    <div className="flex flex-col items-center justify-center rounded-xl border border-dashed py-16 text-center">
-      <PhoneIncoming className="mb-4 h-8 w-8 text-muted-foreground" />
-      <p className="text-base font-medium">Waiting for first order</p>
-      <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+    <div className="flex flex-col items-center justify-center gap-2 py-16 text-center">
+      <PhoneIncoming
+        className="size-8 text-foreground-faint"
+        aria-hidden
+      />
+      <p className="text-md font-medium">No orders yet</p>
+      <p className="max-w-sm text-sm text-foreground-muted">
         {display
           ? `Calls to ${display} will appear here in real time.`
           : 'No Twilio number is assigned to this restaurant yet — assign one to start receiving calls.'}

--- a/dashboard/components/orders/transition-button.tsx
+++ b/dashboard/components/orders/transition-button.tsx
@@ -12,11 +12,13 @@ import {
 import { Button } from '@/components/ui/button';
 import { useOptimisticStatus } from '@/components/orders/optimistic-status-context';
 import { type Order, type OrderStatus, orderShortId } from '@/lib/schemas/order';
+import { cn } from '@/lib/utils';
+
+type Mode = 'compact' | 'detail';
 
 type TransitionConfig = {
   label: string;
   pendingLabel: string;
-  variant: 'default' | 'outline';
   successMessage: string;
   targetStatus: OrderStatus;
   action: (input: { call_sid: string }) => Promise<TransitionActionResult>;
@@ -27,41 +29,49 @@ type TransitionConfig = {
  * in confirmed/preparing/ready; renders nothing for terminal or
  * not-yet-confirmed orders.
  *
+ * `mode="compact"` (default) is for table rows + the overview kitchen
+ * queue: short labels, 28px tall, secondary treatment. `mode="detail"`
+ * is for the order detail page: full labels, 36px tall, primary
+ * treatment.
+ *
  * No confirmation dialog — kitchen wants single-tap speed. Cancel
  * (which IS destructive) keeps its own dialog in CancelOrderButton.
  */
-export function TransitionButton({ order }: { order: Order }) {
-  const config = configFor(order);
+export function TransitionButton({
+  order,
+  mode = 'compact',
+}: {
+  order: Order;
+  mode?: Mode;
+}) {
+  const config = configFor(order, mode);
   if (!config) return null;
 
-  return <ActiveButton order={order} config={config} />;
+  return <ActiveButton order={order} config={config} mode={mode} />;
 }
 
-function configFor(order: Order): TransitionConfig | null {
+function configFor(order: Order, mode: Mode): TransitionConfig | null {
   switch (order.status) {
     case 'confirmed':
       return {
-        label: 'Start Preparing',
-        pendingLabel: 'Starting…',
-        variant: 'default',
+        label: mode === 'compact' ? 'Start' : 'Start preparing',
+        pendingLabel: mode === 'compact' ? 'Starting…' : 'Starting…',
         successMessage: `Order ${orderShortId(order)} is now preparing`,
         targetStatus: 'preparing',
         action: (input) => markPreparingAction(input),
       };
     case 'preparing':
       return {
-        label: 'Mark Ready',
+        label: mode === 'compact' ? 'Ready' : 'Mark ready',
         pendingLabel: 'Marking…',
-        variant: 'default',
         successMessage: `Order ${orderShortId(order)} is ready`,
         targetStatus: 'ready',
         action: (input) => markReadyAction(input),
       };
     case 'ready':
       return {
-        label: 'Mark Completed',
+        label: mode === 'compact' ? 'Done' : 'Mark completed',
         pendingLabel: 'Completing…',
-        variant: 'outline',
         successMessage: `Order ${orderShortId(order)} is completed`,
         targetStatus: 'completed',
         action: (input) => markCompletedAction(input),
@@ -76,16 +86,16 @@ function configFor(order: Order): TransitionConfig | null {
 function ActiveButton({
   order,
   config,
+  mode,
 }: {
   order: Order;
   config: TransitionConfig;
+  mode: Mode;
 }) {
   const [isPending, startTransition] = useTransition();
   const { addOptimistic, clearOptimistic } = useOptimisticStatus();
 
   function onClick() {
-    // Optimistic update: target status reflects the transition we're
-    // attempting. If the action fails, we drop the override + toast.
     addOptimistic({
       call_sid: order.call_sid,
       status: config.targetStatus,
@@ -103,12 +113,19 @@ function ActiveButton({
     });
   }
 
+  // Compact (table) = secondary look. Detail = primary look.
+  // shadcn's `secondary` variant maps `--secondary` → `--surface-2`
+  // in our globals.css; we add `border` to give the visible outline
+  // the design spec asks for ("subtle background, visible border").
+  const isCompact = mode === 'compact';
+
   return (
     <Button
-      variant={config.variant}
-      size="sm"
+      variant={isCompact ? 'secondary' : 'default'}
+      size={isCompact ? 'sm' : 'lg'}
       onClick={onClick}
       disabled={isPending}
+      className={cn(isCompact && 'border border-border')}
     >
       {isPending ? config.pendingLabel : config.label}
     </Button>

--- a/dashboard/components/orders/transition-button.tsx
+++ b/dashboard/components/orders/transition-button.tsx
@@ -55,7 +55,7 @@ function configFor(order: Order, mode: Mode): TransitionConfig | null {
     case 'confirmed':
       return {
         label: mode === 'compact' ? 'Start' : 'Start preparing',
-        pendingLabel: mode === 'compact' ? 'Starting…' : 'Starting…',
+        pendingLabel: 'Starting…',
         successMessage: `Order ${orderShortId(order)} is now preparing`,
         targetStatus: 'preparing',
         action: (input) => markPreparingAction(input),
@@ -113,10 +113,6 @@ function ActiveButton({
     });
   }
 
-  // Compact (table) = secondary look. Detail = primary look.
-  // shadcn's `secondary` variant maps `--secondary` → `--surface-2`
-  // in our globals.css; we add `border` to give the visible outline
-  // the design spec asks for ("subtle background, visible border").
   const isCompact = mode === 'compact';
 
   return (

--- a/dashboard/tests/transition-button.test.tsx
+++ b/dashboard/tests/transition-button.test.tsx
@@ -49,23 +49,23 @@ afterEach(() => {
 });
 
 it('renders nothing for in_progress orders', () => {
-  const { container } = render(<TransitionButton order={makeOrder('in_progress')} />);
+  const { container } = render(<TransitionButton mode="detail" order={makeOrder('in_progress')} />);
   expect(container).toBeEmptyDOMElement();
 });
 
 it('renders nothing for completed orders', () => {
-  const { container } = render(<TransitionButton order={makeOrder('completed')} />);
+  const { container } = render(<TransitionButton mode="detail" order={makeOrder('completed')} />);
   expect(container).toBeEmptyDOMElement();
 });
 
 it('renders nothing for cancelled orders', () => {
-  const { container } = render(<TransitionButton order={makeOrder('cancelled')} />);
+  const { container } = render(<TransitionButton mode="detail" order={makeOrder('cancelled')} />);
   expect(container).toBeEmptyDOMElement();
 });
 
 it('renders Start Preparing for confirmed orders and calls markPreparingAction on click', async () => {
   vi.mocked(markPreparingAction).mockResolvedValueOnce({ success: true });
-  render(<TransitionButton order={makeOrder('confirmed')} />);
+  render(<TransitionButton mode="detail" order={makeOrder('confirmed')} />);
 
   const button = screen.getByRole('button', { name: /start preparing/i });
   fireEvent.click(button);
@@ -80,7 +80,7 @@ it('renders Start Preparing for confirmed orders and calls markPreparingAction o
 
 it('renders Mark Ready for preparing orders and calls markReadyAction on click', async () => {
   vi.mocked(markReadyAction).mockResolvedValueOnce({ success: true });
-  render(<TransitionButton order={makeOrder('preparing')} />);
+  render(<TransitionButton mode="detail" order={makeOrder('preparing')} />);
 
   const button = screen.getByRole('button', { name: /mark ready/i });
   fireEvent.click(button);
@@ -92,7 +92,7 @@ it('renders Mark Ready for preparing orders and calls markReadyAction on click',
 
 it('renders Mark Completed for ready orders and calls markCompletedAction on click', async () => {
   vi.mocked(markCompletedAction).mockResolvedValueOnce({ success: true });
-  render(<TransitionButton order={makeOrder('ready')} />);
+  render(<TransitionButton mode="detail" order={makeOrder('ready')} />);
 
   const button = screen.getByRole('button', { name: /mark completed/i });
   fireEvent.click(button);
@@ -107,7 +107,7 @@ it('shows error toast when the action returns failure', async () => {
     success: false,
     error: 'order not found',
   });
-  render(<TransitionButton order={makeOrder('confirmed')} />);
+  render(<TransitionButton mode="detail" order={makeOrder('confirmed')} />);
 
   fireEvent.click(screen.getByRole('button', { name: /start preparing/i }));
 
@@ -129,7 +129,7 @@ it('calls the action immediately on tap (optimistic UI inflight)', async () => {
 
   const renderResult = render(
     <OptimisticStatusProvider>
-      <TransitionButton order={makeOrder('confirmed')} />
+      <TransitionButton mode="detail" order={makeOrder('confirmed')} />
     </OptimisticStatusProvider>,
   );
 
@@ -154,7 +154,7 @@ it('shows error toast on action failure (rollback handled by OrdersFeed)', async
 
   render(
     <OptimisticStatusProvider>
-      <TransitionButton order={makeOrder('confirmed')} />
+      <TransitionButton mode="detail" order={makeOrder('confirmed')} />
     </OptimisticStatusProvider>,
   );
 


### PR DESCRIPTION
## Summary

PR 2 of 4 in the design-system migration. Stages 3 + 4 — the highest-impact screens in the product (orders feed sets the standard for every other table; order detail finally puts the right-half of the screen to use).

## Stages shipped

**Stage 3 — Orders feed**
- `filter-tabs.tsx` — 7-tab row, active = `bg-surface-2` pill, count pills sit one elevation up so they contrast (`bg-surface-3` active, `bg-surface-1` inactive). **Bug fix while in there**: hrefs were still `/?status=…` from when orders lived at `/`; now point to `/orders?status=…`.
- `orders-table.tsx` — 36px compact rows, `py-2.5 px-2.5` cells, `border-border-subtle` dividers, `hover:bg-surface-2/40`, no zebra. Order column `font-mono text-xs`; Subtotal `font-mono tabular-nums` weight 500. Items truncated single-line with `Pickup · phone` meta in `text-xs text-foreground-faint`. **Faded rows** for `completed`/`cancelled` (Order/Items/Subtotal cells in `text-foreground-faint`). Killed the redundant amber dot in the Order cell — `<StatusBadge>` already pulses for live status.
- Empty state: `<PhoneIncoming>` lucide at 32px in `text-foreground-faint`, "No orders yet" + per-restaurant phone copy.
- `transition-button.tsx` — added `mode` prop. Compact (default; table + overview kitchen queue): "Start" / "Ready" / "Done", `size="sm"` 28px, secondary + border. Detail: "Start preparing" / "Mark ready" / "Mark completed", `size="lg"` 36px, primary.
- `tests/transition-button.test.tsx` — passes `mode="detail"` so the existing label assertions still match.

**Stage 4 — Order detail**
- `order-detail.tsx` — two-column grid on `>=960px` (3fr left / 2fr right), single column below. Header: back button (`<ChevronLeft>` + "Back") + mono Order ID + `<StatusBadge>` + right-aligned timestamp. Caller card on `bg-surface-1 border-border-subtle rounded-md p-4`. Items rendered as a flat `<ul>` with `border-border-subtle` separators — no nested cards. Totals on `bg-surface-2 rounded-md p-4` subtle card with the italic "Tax and total aren't computed in this build" note. Action row: `<TransitionButton mode="detail">` (primary, 36px) + `<CancelOrderButton>` (secondary + border, 36px).
- Right column: Call recording placeholder card (Radio eyebrow + Call duration + disabled Play button). Full player + transcript ship in PR 4.
- `cancel-order-button.tsx` — trigger updated to match action-row scale (`variant="secondary"`, `size="lg"`, `border-border`).

## Files changed

```
M  components/orders/cancel-order-button.tsx
M  components/orders/filter-tabs.tsx
M  components/orders/order-detail.tsx
M  components/orders/orders-table.tsx
M  components/orders/transition-button.tsx
M  tests/transition-button.test.tsx
```

6 files, +201/-157.

## Verification

- `pnpm typecheck` — clean.
- `pnpm lint` — 14 problems, **identical to PR 1 baseline** (all in files this PR doesn't touch). PR 2 introduces zero new lint issues.
- `pnpm test` — 68/68 passing. The 9 unhandled errors during teardown are pre-existing ESM/CJS interop noise from `html-encoding-sniffer` + `@exodus/bytes`, not from this PR.
- Color hygiene: zero hex/rgb/Tailwind-palette classes in any of the 5 source files this PR rewrites.

## Test plan

- [ ] Orders list on `/orders` renders with 36px rows, faded `completed`/`cancelled` rows, working filter tabs (each tab updates the URL + count pills update)
- [ ] Filter pills are visible against the active tab background (the previous `bg-surface-2` on `bg-surface-2` would have made them invisible)
- [ ] Live order shows the pulsing dot ONLY in the StatusBadge (no second dot in the Order cell)
- [ ] Empty state ("No orders yet") shows when filter has zero results
- [ ] Action button shows correctly per status: Start / Ready / Done, no button on completed/cancelled/in_progress
- [ ] Order detail at `/orders/<id>` is two-column on widescreen, single column on narrow
- [ ] Items are bare rows with separators (no nested-card chrome)
- [ ] Totals on subtle bg with italic disclaimer
- [ ] Action row: primary `Start preparing` / `Mark ready` / `Mark completed` (full label) + secondary Cancel order
- [ ] Cancel dialog still confirms before destructive action
- [ ] Light + dark mode both render correctly

## Carry-overs to PRs 3 & 4

- The `bg-amber-500` in `live-calls-widget.tsx:95` (overview) remains until Stage 5.
- The `bg-amber-50/...` banner in `(dashboard)/layout.tsx` remains for now (Stage 2 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)