### PR TITLE
dashboard(orders): link order-detail recording placeholder to /calls/<sid>

### DIFF
--- a/dashboard/components/orders/order-detail.tsx
+++ b/dashboard/components/orders/order-detail.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ChevronLeft, Play, Radio } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Radio } from 'lucide-react';
 
 import { CallDuration } from '@/components/orders/call-duration';
 import { CancelOrderButton } from '@/components/orders/cancel-order-button';
@@ -7,12 +7,6 @@ import { StatusBadge } from '@/components/orders/status-badge';
 import { TransitionButton } from '@/components/orders/transition-button';
 import { LocalTime } from '@/components/shared/local-time';
 import { Button } from '@/components/ui/button';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
 import { formatCAD } from '@/lib/formatters/money';
 import { formatPhone } from '@/lib/formatters/phone';
 import {
@@ -218,22 +212,15 @@ function CallSidebarCard({ order }: { order: Order }) {
         <div className="text-sm text-foreground-muted">
           <CallDuration order={order} />
         </div>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled
-                aria-label="Recording playback (coming in Phase 2)"
-              >
-                <Play className="mr-1 size-4" />
-                Play
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Recording UI ships in PR 4 (calls)</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Button variant="ghost" size="sm" asChild>
+          <Link
+            href={`/calls/${encodeURIComponent(order.call_sid)}`}
+            aria-label="Open call detail to play the recording and read the transcript"
+          >
+            Open call
+            <ChevronRight className="ml-1 size-4" aria-hidden />
+          </Link>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Tiny follow-up to PR 4. Replaces the still-disabled "Play" placeholder on the order-detail right column with a real link to `/calls/<order.call_sid>` — the canonical recording + transcript surface that PR 4 polished.

## What was wrong

PR 2's order-detail right column shipped a placeholder Play button:

```tsx
<Button disabled aria-label="Recording playback (coming in Phase 2)">
  <Play /> Play
</Button>
<TooltipContent>Recording UI ships in PR 4 (calls)</TooltipContent>
```

PR 4 then shipped the recording UI — but only on `/calls/<sid>`, not on the order detail. So the tooltip's promise ("ships in PR 4") was real *for the calls page*, misleading *for the order page*. User asked about this directly during PR 4 review.

Wiring the actual recording player onto the order page would mean adding a `getCallTimeline(call_sid)` fetch in the order detail RSC, which is product work outside the visual-migration scope.

## What changed

`components/orders/order-detail.tsx`:
- Drop the disabled `<Button>` + `<TooltipProvider>`/`<Tooltip>`/`<TooltipTrigger>`/`<TooltipContent>` wrapper.
- Drop `Play` import; add `ChevronRight`.
- Replace with `<Button variant="ghost" size="sm" asChild><Link href="/calls/<sid>">Open call →</Link></Button>`.
- aria-label clarifies the destination ("Open call detail to play the recording and read the transcript").

One file, +10 / -23.

## Verification

- `pnpm typecheck` clean.
- Tooltip primitives are now unused in `order-detail.tsx` — but they remain in the design system and are imported elsewhere; no unused-import warning surfaces.
- Behavior: from `/orders/<id>` right column, click "Open call →" → land on `/calls/<order.call_sid>` with `<CallRecordingPlayer>` + transcript timeline ready to play.

## Test plan

- [ ] Open an order detail (`/orders/<id>`)
- [ ] Right column shows the "Call recording" card with Radio eyebrow + Call duration + "Open call →" link
- [ ] Click "Open call →" — navigates to `/calls/<call_sid>`
- [ ] On the call detail, the audio player + transcript are functional (already covered by PR 4 testing)
- [ ] Both dark and light mode render correctly

## Stacks on top of

- PR 4 (#208) — the call-detail recording UI this links to. PR 4 doesn't have to merge first; this PR doesn't depend on PR 4's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)