### PR TITLE
chore: apply ruff format and gate CI on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Ruff lint
         run: ruff check .
 
+      - name: Ruff format check
+        run: ruff format --check .
+
       # Live-marked tests (live_llm, live_discord) are deselected — they
       # need real API keys and would either skip or burn credits in CI.
       - name: Pytest

--- a/app/dev/calls.py
+++ b/app/dev/calls.py
@@ -178,8 +178,7 @@ def summarize(call_sid: str, events: list[CallEvent]) -> CallSummary:
 def _logging_client():
     if gcp_logging is None:
         raise RuntimeError(
-            "google-cloud-logging is not installed. "
-            "Add it to requirements.txt and redeploy."
+            "google-cloud-logging is not installed. Add it to requirements.txt and redeploy."
         )
     return gcp_logging.Client()
 
@@ -194,9 +193,7 @@ def _build_filter(hours: int) -> str:
     )
 
 
-def fetch_entries(
-    *, hours: int, page_size: int = 1000, client: Any = None
-) -> Iterable[Any]:
+def fetch_entries(*, hours: int, page_size: int = 1000, client: Any = None) -> Iterable[Any]:
     """Pull recent niko service log entries that mention a call_sid.
 
     ``client`` is injectable for tests — pass any object with a
@@ -204,9 +201,7 @@ def fetch_entries(
     """
     log_client = client or _logging_client()
     filter_str = _build_filter(hours)
-    descending = (
-        gcp_logging.DESCENDING if gcp_logging is not None else "timestamp desc"
-    )
+    descending = gcp_logging.DESCENDING if gcp_logging is not None else "timestamp desc"
     return log_client.list_entries(
         filter_=filter_str,
         order_by=descending,

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -81,10 +81,7 @@ UPDATE_ORDER_TOOL: dict[str, Any] = {
                         "modifications": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": (
-                                "Customizations like 'extra cheese' or "
-                                "'no onions'."
-                            ),
+                            "description": ("Customizations like 'extra cheese' or 'no onions'."),
                         },
                     },
                     "required": ["name", "category", "quantity", "unit_price"],
@@ -253,9 +250,7 @@ def _system_cache_block(system_prompt: str) -> list[dict[str, Any]]:
     ]
 
 
-def _append_user_transcript(
-    history: list[dict[str, Any]], transcript: str
-) -> list[dict[str, Any]]:
+def _append_user_transcript(history: list[dict[str, Any]], transcript: str) -> list[dict[str, Any]]:
     """Append the caller's transcript to history with valid alternation.
 
     Anthropic requires strict user/assistant alternation. After a turn
@@ -280,8 +275,7 @@ def _append_user_transcript(
 
 
 _INVALID_ADDRESS_NOTE = (
-    "Delivery address incomplete — please ask the caller for the full "
-    "street address."
+    "Delivery address incomplete — please ask the caller for the full street address."
 )
 
 
@@ -605,7 +599,9 @@ async def stream_reply(
                     usage = getattr(msg, "usage", None) if msg is not None else None
                     if usage is not None:
                         fu_cache_read_tokens = getattr(usage, "cache_read_input_tokens", 0) or 0
-                        fu_cache_creation_tokens = getattr(usage, "cache_creation_input_tokens", 0) or 0
+                        fu_cache_creation_tokens = (
+                            getattr(usage, "cache_creation_input_tokens", 0) or 0
+                        )
                 elif etype == "content_block_start":
                     block = getattr(event, "content_block", None)
                     if getattr(block, "type", None) == "text" and fu_t_first_text_block is None:

--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -233,8 +233,7 @@ def _format_menu(restaurant: Restaurant) -> str:
         if not isinstance(items, list) or not items:
             continue
         available_items = [
-            i for i in items
-            if not (isinstance(i, dict) and i.get("available", True) is False)
+            i for i in items if not (isinstance(i, dict) and i.get("available", True) is False)
         ]
         if not available_items:
             continue
@@ -286,7 +285,7 @@ def build_system_prompt(restaurant: Restaurant) -> str:
         intro_line = "Place a pickup order from the menu below."
         delivery_handling = (
             "- If the caller asks for delivery, say something like\n"
-            "  \"We're actually pickup-only — would pickup work for you?\"\n"
+            '  "We\'re actually pickup-only — would pickup work for you?"\n'
             "  and continue from there. Do not capture a delivery address;\n"
             "  do not set order_type to delivery."
         )

--- a/app/main.py
+++ b/app/main.py
@@ -126,9 +126,7 @@ class RestaurantUpdate(BaseModel):
         if v is None or v == "":
             return v
         if not _E164.match(v):
-            raise ValueError(
-                f"fallback_phone must be E.164 (+1...), got {v!r}"
-            )
+            raise ValueError(f"fallback_phone must be E.164 (+1...), got {v!r}")
         return v
 
 
@@ -288,9 +286,7 @@ def list_orders(
     """
     if limit < 1 or limit > 200:
         raise HTTPException(status_code=400, detail="limit must be 1..200")
-    orders = order_storage.list_recent_orders(
-        restaurant_id=tenant.restaurant_id, limit=limit
-    )
+    orders = order_storage.list_recent_orders(restaurant_id=tenant.restaurant_id, limit=limit)
     return {"orders": [o.model_dump(mode="json") for o in orders]}
 
 
@@ -301,9 +297,7 @@ def _load_tenant_order(call_sid: str, tenant: Tenant) -> Order:
     belongs to a different tenant — both are indistinguishable to the
     caller, which is the desired tenant-isolation property (matches
     the pattern in /dev/calls/{call_sid})."""
-    order = order_storage.get_order(
-        call_sid=call_sid, restaurant_id=tenant.restaurant_id
-    )
+    order = order_storage.get_order(call_sid=call_sid, restaurant_id=tenant.restaurant_id)
     if order is None:
         raise HTTPException(status_code=404, detail="order not found")
     return order
@@ -409,16 +403,13 @@ def dev_list_calls(
     _require_dev_endpoints()
     if limit < 1 or limit > 200:
         raise HTTPException(status_code=400, detail="limit must be 1..200")
-    sessions = call_sessions.list_recent_sessions(
-        restaurant_id=tenant.restaurant_id, limit=limit
-    )
+    sessions = call_sessions.list_recent_sessions(restaurant_id=tenant.restaurant_id, limit=limit)
     return {
         "calls": [
             {
                 "call_sid": s.get("call_sid"),
                 "started_at": _iso(s.get("started_at")),
-                "ended_at": _iso(s.get("ended_at"))
-                or _iso(s.get("last_event_at")),
+                "ended_at": _iso(s.get("ended_at")) or _iso(s.get("last_event_at")),
                 "transcript_count": s.get("transcript_count", 0),
                 "has_error": s.get("has_error", False),
                 "status": s.get("status", "in_progress"),

--- a/app/orders/lifecycle.py
+++ b/app/orders/lifecycle.py
@@ -52,9 +52,7 @@ def persist_on_confirm(order: Order) -> Order:
     """
 
     if order.status is OrderStatus.CANCELLED:
-        raise OrderNotReadyError(
-            f"Cannot confirm order {order.call_sid!r}: status is cancelled"
-        )
+        raise OrderNotReadyError(f"Cannot confirm order {order.call_sid!r}: status is cancelled")
 
     if not order.is_ready_to_confirm():
         raise OrderNotReadyError(
@@ -127,9 +125,7 @@ def _transition(
         )
 
     now = datetime.now(timezone.utc)
-    updated = order.model_copy(
-        update={"status": target, timestamp_field: now}
-    )
+    updated = order.model_copy(update={"status": target, timestamp_field: now})
     order_storage.save_order(updated)
     return updated
 

--- a/app/sms/client.py
+++ b/app/sms/client.py
@@ -35,10 +35,7 @@ class SmsResult(BaseModel):
 def _twilio_client() -> TwilioClient:
     """Construct a Twilio client at call time so tests can patch this."""
     if not settings.twilio_account_sid or not settings.twilio_auth_token:
-        raise SmsError(
-            "Twilio credentials missing — set TWILIO_ACCOUNT_SID and "
-            "TWILIO_AUTH_TOKEN."
-        )
+        raise SmsError("Twilio credentials missing — set TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN.")
     return TwilioClient(settings.twilio_account_sid, settings.twilio_auth_token)
 
 
@@ -57,10 +54,7 @@ def send_sms(
     key. Raises ``SmsError`` on Twilio failure or missing order.
     """
     if ":" not in idempotency_key:
-        raise SmsError(
-            f"idempotency_key must be 'call_sid:template_name', "
-            f"got {idempotency_key!r}"
-        )
+        raise SmsError(f"idempotency_key must be 'call_sid:template_name', got {idempotency_key!r}")
     call_sid, template_name = idempotency_key.split(":", 1)
 
     order = order_storage.get_order(call_sid, tenant_id)

--- a/app/storage/analytics.py
+++ b/app/storage/analytics.py
@@ -37,9 +37,7 @@ def _window(now: datetime | None = None) -> _Window:
     # Compute "today" boundary in the restaurant's local timezone, then
     # convert back to UTC for the Firestore query.
     local_now = now.astimezone(_LOCAL_TZ)
-    local_today_start = local_now.replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
+    local_today_start = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
     today_start_utc = local_today_start.astimezone(timezone.utc)
     return _Window(
         today_start=today_start_utc,
@@ -85,8 +83,10 @@ def summarize_orders(*, restaurant_id: str) -> OrderSummary:
         # opportunities — confirmed, preparing, ready, completed.
         # Excludes IN_PROGRESS (call live) and CANCELLED (no revenue).
         aov_orders = [
-            o for o in seven_day
-            if o.status in {
+            o
+            for o in seven_day
+            if o.status
+            in {
                 OrderStatus.CONFIRMED,
                 OrderStatus.PREPARING,
                 OrderStatus.READY,
@@ -94,14 +94,10 @@ def summarize_orders(*, restaurant_id: str) -> OrderSummary:
             }
         ]
         if aov_orders:
-            aov = round(
-                sum(o.subtotal for o in aov_orders) / len(aov_orders), 2
-            )
+            aov = round(sum(o.subtotal for o in aov_orders) / len(aov_orders), 2)
         else:
             aov = 0.0
-        completed = sum(
-            1 for o in seven_day if o.status is OrderStatus.COMPLETED
-        )
+        completed = sum(1 for o in seven_day if o.status is OrderStatus.COMPLETED)
         # Denominator: orders that had a chance to complete — i.e. anything
         # past the in-progress (call-live) state. Cancelled orders count
         # against the rate.
@@ -117,9 +113,7 @@ def summarize_orders(*, restaurant_id: str) -> OrderSummary:
                 OrderStatus.CANCELLED,
             }
         )
-        completion_rate = (
-            completed / had_chance_to_complete if had_chance_to_complete else 0.0
-        )
+        completion_rate = completed / had_chance_to_complete if had_chance_to_complete else 0.0
     else:
         aov = 0.0
         completion_rate = 0.0

--- a/app/storage/call_sessions.py
+++ b/app/storage/call_sessions.py
@@ -67,9 +67,7 @@ def _legacy_parent(client: firestore.Client, call_sid: str):
     return client.collection(_LEGACY_COLLECTION).document(call_sid)
 
 
-def _nested_parent(
-    client: firestore.Client, restaurant_id: str, call_sid: str
-):
+def _nested_parent(client: firestore.Client, restaurant_id: str, call_sid: str):
     return (
         client.collection(_RESTAURANTS_COLLECTION)
         .document(restaurant_id)
@@ -166,9 +164,7 @@ def record_event(
         )
 
 
-def list_recent_sessions(
-    restaurant_id: str, limit: int = 50
-) -> list[dict[str, Any]]:
+def list_recent_sessions(restaurant_id: str, limit: int = 50) -> list[dict[str, Any]]:
     """Return one restaurant's parent docs ordered by ``started_at`` desc.
 
     Reads from the nested canonical path. The legacy flat collection is
@@ -185,9 +181,7 @@ def list_recent_sessions(
     return [snap.to_dict() for snap in query.stream()]
 
 
-def get_session_events(
-    call_sid: str, restaurant_id: str
-) -> Optional[list[dict[str, Any]]]:
+def get_session_events(call_sid: str, restaurant_id: str) -> Optional[list[dict[str, Any]]]:
     """Return the timeline of events for one call_sid, oldest-first.
 
     ``None`` when the parent doc doesn't exist (call_sid never tracked).
@@ -248,9 +242,7 @@ def mark_recording_ready(
         nested.update(patch)
         nested.collection(_EVENTS_SUBCOLLECTION).add(event_payload)
     except Exception:
-        logger.exception(
-            "call_sessions: mark_recording_ready failed call_sid=%s", call_sid
-        )
+        logger.exception("call_sessions: mark_recording_ready failed call_sid=%s", call_sid)
 
 
 def mark_recording_deleted(call_sid: str, restaurant_id: str) -> None:
@@ -287,9 +279,7 @@ def mark_recording_deleted(call_sid: str, restaurant_id: str) -> None:
         nested.update(patch)
         nested.collection(_EVENTS_SUBCOLLECTION).add(event_payload)
     except Exception:
-        logger.exception(
-            "call_sessions: mark_recording_deleted failed call_sid=%s", call_sid
-        )
+        logger.exception("call_sessions: mark_recording_deleted failed call_sid=%s", call_sid)
 
 
 def mark_transfer_attempted(
@@ -400,9 +390,7 @@ def update_voicemail_transcript(
         )
 
 
-def get_session(
-    call_sid: str, restaurant_id: str
-) -> Optional[dict[str, Any]]:
+def get_session(call_sid: str, restaurant_id: str) -> Optional[dict[str, Any]]:
     """Return the parent call session doc, or None if it doesn't exist."""
     client = _get_client()
     snap = _nested_parent(client, restaurant_id, call_sid).get()
@@ -429,9 +417,7 @@ def get_session_by_call_sid(call_sid: str) -> Optional[dict[str, Any]]:
             return None
         return snap.to_dict()
     except Exception:
-        logger.exception(
-            "call_sessions: get_session_by_call_sid failed call_sid=%s", call_sid
-        )
+        logger.exception("call_sessions: get_session_by_call_sid failed call_sid=%s", call_sid)
         return None
 
 
@@ -458,6 +444,4 @@ def mark_call_ended(
         _legacy_parent(client, call_sid).update(patch)
         _nested_parent(client, restaurant_id, call_sid).update(patch)
     except Exception:
-        logger.exception(
-            "call_sessions: mark_call_ended failed call_sid=%s", call_sid
-        )
+        logger.exception("call_sessions: mark_call_ended failed call_sid=%s", call_sid)

--- a/app/storage/firestore.py
+++ b/app/storage/firestore.py
@@ -78,9 +78,7 @@ def save_order(order: Order) -> str:
 
     client = _get_client()
     payload = order.model_dump(mode="python")
-    _orders_collection(client, order.restaurant_id).document(order.call_sid).set(
-        payload
-    )
+    _orders_collection(client, order.restaurant_id).document(order.call_sid).set(payload)
     return order.call_sid
 
 
@@ -92,17 +90,13 @@ def get_order(call_sid: str, restaurant_id: str) -> Optional[Order]:
     """
 
     client = _get_client()
-    snapshot = (
-        _orders_collection(client, restaurant_id).document(call_sid).get()
-    )
+    snapshot = _orders_collection(client, restaurant_id).document(call_sid).get()
     if not snapshot.exists:
         return None
     return Order.model_validate(snapshot.to_dict())
 
 
-def list_recent_orders(
-    restaurant_id: str, limit: int = 50
-) -> list[Order]:
+def list_recent_orders(restaurant_id: str, limit: int = 50) -> list[Order]:
     """Return one restaurant's recent orders, newest-first, up to ``limit``."""
 
     client = _get_client()

--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -69,7 +69,7 @@ import lameenc
 _MP3_BITRATE_KBPS = 32
 _MP3_QUALITY = 2
 _PCM_SAMPLE_RATE = 8000  # Twilio media is 8 kHz μ-law
-_PCM_CHANNELS = 1        # caller + agent summed to mono in _mix_pcm_streams
+_PCM_CHANNELS = 1  # caller + agent summed to mono in _mix_pcm_streams
 
 
 def _make_encoder() -> "lameenc.Encoder":
@@ -112,6 +112,7 @@ class RecordingUploadSession:
     the pod dies before finalize). Acceptable for v1 since instance
     death during a live WS is rare.
     """
+
     call_sid: str
     restaurant_id: str
     blob_name: str
@@ -207,9 +208,7 @@ def _mix_pcm_streams(inbound: bytes, outbound: bytes) -> bytes:
     return bytes(out)
 
 
-def _upload_blob(
-    *, blob_name: str, mp3_bytes: bytes, retention_days: int
-) -> None:
+def _upload_blob(*, blob_name: str, mp3_bytes: bytes, retention_days: int) -> None:
     """One-shot blob upload with custom_time set for per-tenant retention."""
     bucket = _get_storage_client().bucket(settings.recordings_bucket)
     blob = bucket.blob(blob_name)
@@ -248,9 +247,7 @@ def finalize_recording(
             retention_days=session.retention_days,
         )
     except Exception:
-        logger.exception(
-            "recording: finalize/upload failed call_sid=%s", session.call_sid
-        )
+        logger.exception("recording: finalize/upload failed call_sid=%s", session.call_sid)
         session.broken = True
         return ("", 0)
 
@@ -271,9 +268,7 @@ def delete_recording(*, call_sid: str, restaurant_id: str) -> None:
     try:
         blob.delete()
     except NotFound:
-        logger.info(
-            "recording: delete on missing blob (idempotent) call_sid=%s", call_sid
-        )
+        logger.info("recording: delete on missing blob (idempotent) call_sid=%s", call_sid)
 
 
 def upload_voicemail_from_twilio(
@@ -306,9 +301,7 @@ def upload_voicemail_from_twilio(
     return f"gs://{settings.recordings_bucket}/{blob_name}"
 
 
-def generate_signed_url(
-    *, call_sid: str, restaurant_id: str, ttl_minutes: int = 30
-) -> str:
+def generate_signed_url(*, call_sid: str, restaurant_id: str, ttl_minutes: int = 30) -> str:
     """Return a V4 signed GET URL for the recording blob. TTL defaults
     to 30 minutes — long enough for a typical playback session, short
     enough that a leaked URL ages out fast.
@@ -345,5 +338,3 @@ def generate_signed_url(
         service_account_email=getattr(credentials, "service_account_email", None),
         access_token=getattr(credentials, "token", None),
     )
-
-

--- a/app/storage/restaurants.py
+++ b/app/storage/restaurants.py
@@ -120,12 +120,7 @@ def get_restaurant_by_twilio_phone(e164: str) -> Optional[Restaurant]:
     if cached is not None:
         return cached
     try:
-        query = (
-            _get_client()
-            .collection(_COLLECTION)
-            .where("twilio_phone", "==", e164)
-            .limit(1)
-        )
+        query = _get_client().collection(_COLLECTION).where("twilio_phone", "==", e164).limit(1)
         docs = list(query.stream())
     except Exception:
         logger.exception("restaurants: phone lookup failed phone=%s", e164)

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -114,9 +114,7 @@ def _looks_like_goodbye(reply: str) -> bool:
     return any(pat in lower for pat in _GOODBYE_PATTERNS)
 
 
-def _bg_call_event(
-    call_sid: str | None, restaurant_id: str | None, **kwargs
-) -> None:
+def _bg_call_event(call_sid: str | None, restaurant_id: str | None, **kwargs) -> None:
     """Fire-and-forget Firestore write so the audio loop never blocks on it.
 
     The storage module catches its own exceptions, so failures here just
@@ -132,15 +130,11 @@ def _bg_call_event(
     except RuntimeError:
         return
     loop.create_task(
-        asyncio.to_thread(
-            call_sessions.record_event, call_sid, restaurant_id, **kwargs
-        )
+        asyncio.to_thread(call_sessions.record_event, call_sid, restaurant_id, **kwargs)
     )
 
 
-async def send_end_of_call_mark(
-    websocket: WebSocket, stream_sid: str | None
-) -> bool:
+async def send_end_of_call_mark(websocket: WebSocket, stream_sid: str | None) -> bool:
     """Append a named ``mark`` event to Twilio's outgoing media stream.
 
     Twilio echoes the same mark back over the WebSocket once its audio
@@ -162,9 +156,7 @@ async def send_end_of_call_mark(
     except WebSocketDisconnect:
         return False
     except Exception:
-        logger.exception(
-            "mark: failed to send end_of_call mark stream_sid=%s", stream_sid
-        )
+        logger.exception("mark: failed to send end_of_call mark stream_sid=%s", stream_sid)
         return False
 
 
@@ -199,9 +191,7 @@ async def _hang_up_after_grace(state: _CallState) -> None:
                 state.call_sid,
             )
         except Exception:
-            logger.exception(
-                "auto-hangup: WS close failed call_sid=%s", state.call_sid
-            )
+            logger.exception("auto-hangup: WS close failed call_sid=%s", state.call_sid)
 
 
 async def _hang_up_after_mark_timeout(state: _CallState) -> None:
@@ -222,8 +212,7 @@ async def _hang_up_after_mark_timeout(state: _CallState) -> None:
     if not state.pending_hangup or not state.call_sid:
         return
     logger.warning(
-        "auto-hangup: mark echo timed out after %.1fs, falling back to "
-        "grace window call_sid=%s",
+        "auto-hangup: mark echo timed out after %.1fs, falling back to grace window call_sid=%s",
         MARK_ECHO_TIMEOUT_SECONDS,
         state.call_sid,
     )
@@ -269,17 +258,17 @@ async def clear_twilio_audio(websocket: WebSocket, stream_sid: str | None) -> No
 
 @dataclass
 class _CallState:
-    call_sid:     str | None       = None
-    stream_sid:   str | None       = None
-    order:        Order | None     = None
-    history:      list[dict]       = field(default_factory=list)
-    restaurant:   Restaurant | None = None     # tenant for this call (#79)
-    system_prompt: str             = ""        # built from restaurant on start
-    llm_task:          asyncio.Task | None = None   # current LLM→TTS turn
-    silence_task:      asyncio.Task | None = None   # silence watchdog
-    hangup_task:       asyncio.Task | None = None   # pending auto-hangup (#78)
-    mark_timeout_task: asyncio.Task | None = None   # mark-echo fallback (#114)
-    pending_hangup: bool           = False     # set when goodbye mark sent (#78)
+    call_sid: str | None = None
+    stream_sid: str | None = None
+    order: Order | None = None
+    history: list[dict] = field(default_factory=list)
+    restaurant: Restaurant | None = None  # tenant for this call (#79)
+    system_prompt: str = ""  # built from restaurant on start
+    llm_task: asyncio.Task | None = None  # current LLM→TTS turn
+    silence_task: asyncio.Task | None = None  # silence watchdog
+    hangup_task: asyncio.Task | None = None  # pending auto-hangup (#78)
+    mark_timeout_task: asyncio.Task | None = None  # mark-echo fallback (#114)
+    pending_hangup: bool = False  # set when goodbye mark sent (#78)
     recording_session: "RecordingUploadSession | None" = None
     should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
     # WS reference so _hang_up_after_grace can close the connection
@@ -405,14 +394,10 @@ def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
     if state.llm_task and state.llm_task.cancelled():
         return  # barge-in — caller spoke again, no watchdog needed
     _cancel_silence_task(state)
-    state.silence_task = asyncio.get_event_loop().create_task(
-        _silence_watchdog(state, websocket)
-    )
+    state.silence_task = asyncio.get_event_loop().create_task(_silence_watchdog(state, websocket))
 
 
-async def _run_llm_tts_turn(
-    transcript: str, state: _CallState, websocket: WebSocket
-) -> None:
+async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSocket) -> None:
     turn_start = time.monotonic()
     logger.info("llm_turn start call_sid=%s transcript=%r", state.call_sid, transcript)
     _bg_call_event(
@@ -547,9 +532,7 @@ async def _run_llm_tts_turn(
                 #     The model sometimes says the right closing line
                 #     without remembering to flip status.
                 if state.order is not None and state.stream_sid:
-                    explicitly_confirmed = (
-                        state.order.status == OrderStatus.CONFIRMED
-                    )
+                    explicitly_confirmed = state.order.status == OrderStatus.CONFIRMED
                     fallback_confirmed = (
                         state.order.is_ready_to_confirm()
                         and state.order.status != OrderStatus.CANCELLED
@@ -567,9 +550,7 @@ async def _run_llm_tts_turn(
                             state.order = state.order.model_copy(
                                 update={"status": OrderStatus.CONFIRMED}
                             )
-                        sent = await send_end_of_call_mark(
-                            websocket, state.stream_sid
-                        )
+                        sent = await send_end_of_call_mark(websocket, state.stream_sid)
                         if sent:
                             state.pending_hangup = True
                             if state.mark_timeout_task and not state.mark_timeout_task.done():
@@ -596,9 +577,7 @@ async def _run_llm_tts_turn(
         raise
 
 
-async def _handle_final_transcript(
-    text: str, state: _CallState, websocket: WebSocket
-) -> None:
+async def _handle_final_transcript(text: str, state: _CallState, websocket: WebSocket) -> None:
     interrupted = bool(state.llm_task and not state.llm_task.done())
     if interrupted:
         state.llm_task.cancel()
@@ -610,9 +589,7 @@ async def _handle_final_transcript(
     # turn that never made it into history."
     if state.in_flight_transcript.strip():
         text = f"{state.in_flight_transcript} {text}".strip()
-    silence_was_active = bool(
-        state.silence_task and not state.silence_task.done()
-    )
+    silence_was_active = bool(state.silence_task and not state.silence_task.done())
     _cancel_silence_task(state)
     # Caller spoke — abort any pending auto-hangup (#78). Even if they
     # spoke during the grace window after a confirmation, we want to
@@ -623,17 +600,11 @@ async def _handle_final_transcript(
         # us pause instead of getting talked over (#74).
         await clear_twilio_audio(websocket, state.stream_sid)
     state.in_flight_transcript = text
-    state.llm_task = asyncio.create_task(
-        _run_llm_tts_turn(text, state, websocket)
-    )
-    state.llm_task.add_done_callback(
-        lambda _t: _arm_silence_watchdog(state, websocket)
-    )
+    state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
+    state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
 
 
-_UNCONFIGURED_TWIML_MESSAGE = (
-    "Sorry, this number is not currently configured. Goodbye."
-)
+_UNCONFIGURED_TWIML_MESSAGE = "Sorry, this number is not currently configured. Goodbye."
 
 
 def _resolve_restaurant_for_voice(
@@ -684,9 +655,7 @@ async def voice(request: Request) -> Response:
 
     twiml = VoiceResponse()
     if restaurant is None:
-        logger.warning(
-            "voice: no restaurant for To=%s — rejecting call", to_e164 or "(missing)"
-        )
+        logger.warning("voice: no restaurant for To=%s — rejecting call", to_e164 or "(missing)")
         twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
         twiml.hangup()
         return Response(content=str(twiml), media_type="application/xml")
@@ -764,9 +733,7 @@ async def stream_ended(request: Request) -> Response:
         session_doc = call_sessions.get_session_by_call_sid(call_sid)
         rid: str | None = (session_doc or {}).get("restaurant_id")
     except Exception:
-        logger.exception(
-            "stream_ended: session lookup failed call_sid=%s", call_sid
-        )
+        logger.exception("stream_ended: session lookup failed call_sid=%s", call_sid)
         rid = None
 
     if rid is None:
@@ -790,7 +757,10 @@ async def stream_ended(request: Request) -> Response:
         # Transfer requested but no number to dial → mark + voicemail.
         try:
             call_sessions.mark_transfer_attempted(
-                call_sid, rid, status="skipped", fallback_phone=None,
+                call_sid,
+                rid,
+                status="skipped",
+                fallback_phone=None,
             )
         except Exception:
             logger.exception(
@@ -953,7 +923,9 @@ async def voicemail_transcription(
     if transcript:
         try:
             call_sessions.update_voicemail_transcript(
-                call_sid, rid, transcript=transcript,
+                call_sid,
+                rid,
+                transcript=transcript,
             )
         except Exception:
             logger.exception(
@@ -1056,9 +1028,7 @@ async def media_stream(websocket: WebSocket) -> None:
                 state.llm_task = asyncio.create_task(
                     _run_llm_tts_turn(GREETING_TRANSCRIPT, state, websocket)
                 )
-                state.llm_task.add_done_callback(
-                    lambda _t: _arm_silence_watchdog(state, websocket)
-                )
+                state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
 
             elif event == "media":
                 payload = base64.b64decode(msg["media"]["payload"])
@@ -1075,9 +1045,7 @@ async def media_stream(websocket: WebSocket) -> None:
                     inbound_chunk = b""
                     outbound_chunk = b""
                 if state.recording_session is not None:
-                    recordings.append_chunks(
-                        state.recording_session, inbound_chunk, outbound_chunk
-                    )
+                    recordings.append_chunks(state.recording_session, inbound_chunk, outbound_chunk)
 
             elif event == "mark":
                 # Twilio echoes our outgoing marks once the audio queued
@@ -1094,9 +1062,7 @@ async def media_stream(websocket: WebSocket) -> None:
                     state.mark_timeout_task = None
                     if state.hangup_task and not state.hangup_task.done():
                         state.hangup_task.cancel()
-                    state.hangup_task = asyncio.create_task(
-                        _hang_up_after_grace(state)
-                    )
+                    state.hangup_task = asyncio.create_task(_hang_up_after_grace(state))
 
             elif event == "stop":
                 logger.info("media-stream stop call_sid=%s", state.call_sid)
@@ -1127,14 +1093,10 @@ async def media_stream(websocket: WebSocket) -> None:
             try:
                 persist_on_confirm(state.order)
                 logger.info("order confirmed call_sid=%s", state.call_sid)
-                _bg_call_event(
-                    state.call_sid, _state_rid(state), kind="order_confirmed"
-                )
+                _bg_call_event(state.call_sid, _state_rid(state), kind="order_confirmed")
                 order_confirmed = True
             except (OrderNotReadyError, Exception) as exc:
-                logger.error(
-                    "order persist failed call_sid=%s: %s", state.call_sid, exc
-                )
+                logger.error("order persist failed call_sid=%s: %s", state.call_sid, exc)
         rid_for_close = _state_rid(state)
         if state.call_sid and rid_for_close:
             try:
@@ -1154,6 +1116,7 @@ async def media_stream(websocket: WebSocket) -> None:
         # event so the action callback can branch on it.
         if state.call_sid and rid_for_close:
             from app.telephony.transfer_triggers import should_trigger_transfer
+
             transfer_reason = should_trigger_transfer(
                 consecutive_low_confidence_turns=state.consecutive_low_confidence_turns,
                 last_transcript=state.last_caller_transcript,
@@ -1195,5 +1158,3 @@ async def media_stream(websocket: WebSocket) -> None:
                 )
         if dg_conn is not None:
             await dg_conn.finish()
-
-

--- a/app/tts/client.py
+++ b/app/tts/client.py
@@ -47,8 +47,7 @@ def _api_key() -> str:
     key = settings.deepgram_api_key
     if not key:
         raise RuntimeError(
-            "DEEPGRAM_API_KEY not set — cannot call TTS. "
-            "Fetch credentials via /shared-creds."
+            "DEEPGRAM_API_KEY not set — cannot call TTS. Fetch credentials via /shared-creds."
         )
     return key
 
@@ -110,9 +109,7 @@ async def speak(
     _client = client if client is not None else _get_client()
     first_byte_fired = False
 
-    async with _client.stream(
-        "POST", url, headers=headers, params=params, json=body
-    ) as response:
+    async with _client.stream("POST", url, headers=headers, params=params, json=body) as response:
         if response.status_code != 200:
             error_body = await response.aread()
             logger.error(
@@ -122,8 +119,7 @@ async def speak(
                 error_body.decode(errors="replace")[:200],
             )
             raise RuntimeError(
-                f"Deepgram returned {response.status_code}: "
-                f"{error_body.decode(errors='replace')}"
+                f"Deepgram returned {response.status_code}: {error_body.decode(errors='replace')}"
             )
 
         async for chunk in response.aiter_bytes():
@@ -134,9 +130,7 @@ async def speak(
                 try:
                     on_first_byte()
                 except Exception:
-                    logger.exception(
-                        "tts: on_first_byte callback raised stream_sid=%s", stream_sid
-                    )
+                    logger.exception("tts: on_first_byte callback raised stream_sid=%s", stream_sid)
             payload = base64.b64encode(chunk).decode()
             try:
                 await websocket.send_json(
@@ -152,12 +146,10 @@ async def speak(
             if recording_session is not None:
                 try:
                     from app.storage import recordings as _recordings
-                    _recordings.append_chunks(
-                        recording_session, b"", chunk
-                    )
+
+                    _recordings.append_chunks(recording_session, b"", chunk)
                 except Exception:
                     logger.exception(
-                        "tts: failed to feed chunk into recording session "
-                        "stream_sid=%s",
+                        "tts: failed to feed chunk into recording session stream_sid=%s",
                         stream_sid,
                     )

--- a/bot/jarvis/agent.py
+++ b/bot/jarvis/agent.py
@@ -47,9 +47,7 @@ async def respond(
     If `tool_registry` is None or empty, this is a no-tools call (PR 2
     behavior).
     """
-    messages: list[dict[str, Any]] = list(history) + [
-        {"role": "user", "content": user_message}
-    ]
+    messages: list[dict[str, Any]] = list(history) + [{"role": "user", "content": user_message}]
 
     tools_payload: Optional[list[dict[str, Any]]] = None
     if tool_registry is not None and tool_registry.names():
@@ -76,9 +74,7 @@ async def respond(
                 yield delta
             final = await stream.get_final_message()
 
-        tool_uses = [
-            b for b in final.content if getattr(b, "type", None) == "tool_use"
-        ]
+        tool_uses = [b for b in final.content if getattr(b, "type", None) == "tool_use"]
         if not tool_uses:
             return  # done
 
@@ -108,9 +104,7 @@ async def respond(
                     {
                         "type": "tool_result",
                         "tool_use_id": tu.id,
-                        "content": json.dumps(
-                            {"error": "no tools available"}
-                        ),
+                        "content": json.dumps({"error": "no tools available"}),
                     }
                 )
         else:

--- a/bot/jarvis/events.py
+++ b/bot/jarvis/events.py
@@ -24,6 +24,7 @@ from jarvis.router import RoutingDecision, classify_incoming
 
 logger = logging.getLogger(__name__)
 
+
 # Type aliases for the injected callables. Spelled as Protocols rather
 # than Callable[...] so they can be async generators (Callable doesn't
 # express the AsyncIterator return shape cleanly).
@@ -40,9 +41,7 @@ class _AgentFn(Protocol):
 
 
 class _StreamWriterFn(Protocol):
-    async def __call__(
-        self, placeholder: Any, chunks: AsyncIterator[str]
-    ) -> str: ...
+    async def __call__(self, placeholder: Any, chunks: AsyncIterator[str]) -> str: ...
 
 
 class _MemoryProto(Protocol):
@@ -54,9 +53,7 @@ class _MemoryProto(Protocol):
         parent_channel_id: str,
         guild_id: str,
     ) -> None: ...
-    async def get_turns(
-        self, thread_id: str
-    ) -> list[dict[str, Any]]: ...
+    async def get_turns(self, thread_id: str) -> list[dict[str, Any]]: ...
     async def append_turn(
         self,
         *,
@@ -107,9 +104,7 @@ class OnMessageHandler:
         # Rate limit BEFORE thread creation — a rate-limited caller
         # shouldn't pollute the channel with empty threads.
         if self._rate_limiter is not None:
-            allowed = self._rate_limiter.check_and_record(
-                user_id=int(message.author.id)
-            )
+            allowed = self._rate_limiter.check_and_record(user_id=int(message.author.id))
             if not allowed:
                 logger.info(
                     "rate-limited user %s in channel %s",
@@ -117,9 +112,7 @@ class OnMessageHandler:
                     message.channel.id,
                 )
                 try:
-                    await message.reply(
-                        "Rate limit reached — try again in a few minutes."
-                    )
+                    await message.reply("Rate limit reached — try again in a few minutes.")
                 except Exception:  # noqa: BLE001 — best-effort notice
                     logger.exception("failed to post rate-limit reply")
                 return

--- a/bot/jarvis/github_client.py
+++ b/bot/jarvis/github_client.py
@@ -37,9 +37,7 @@ class AsyncGitHubClient:
             "User-Agent": _USER_AGENT,
         }
 
-    async def get(
-        self, path: str, params: Optional[dict[str, Any]] = None
-    ) -> Any:
+    async def get(self, path: str, params: Optional[dict[str, Any]] = None) -> Any:
         url = _BASE_URL + path
         response = await self._client.request(
             method="GET",
@@ -48,9 +46,7 @@ class AsyncGitHubClient:
             params=params,
         )
         if response.status_code >= 300:
-            raise RuntimeError(
-                f"GitHub GET {path} -> {response.status_code}: {response.text}"
-            )
+            raise RuntimeError(f"GitHub GET {path} -> {response.status_code}: {response.text}")
         return response.json()
 
     async def post(self, path: str, json: dict[str, Any]) -> Any:
@@ -62,14 +58,10 @@ class AsyncGitHubClient:
             json=json,
         )
         if response.status_code >= 300:
-            raise RuntimeError(
-                f"GitHub POST {path} -> {response.status_code}: {response.text}"
-            )
+            raise RuntimeError(f"GitHub POST {path} -> {response.status_code}: {response.text}")
         return response.json()
 
-    async def graphql(
-        self, query: str, variables: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
         url = _BASE_URL + "/graphql"
         response = await self._client.request(
             method="POST",
@@ -78,14 +70,10 @@ class AsyncGitHubClient:
             json={"query": query, "variables": variables},
         )
         if response.status_code >= 300:
-            raise RuntimeError(
-                f"GitHub GraphQL -> {response.status_code}: {response.text}"
-            )
+            raise RuntimeError(f"GitHub GraphQL -> {response.status_code}: {response.text}")
         body = response.json()
         if body.get("errors"):
-            messages = "; ".join(
-                e.get("message", "?") for e in body["errors"]
-            )
+            messages = "; ".join(e.get("message", "?") for e in body["errors"])
             raise RuntimeError(f"GitHub GraphQL errors: {messages}")
         return body.get("data") or {}
 

--- a/bot/jarvis/logging_setup.py
+++ b/bot/jarvis/logging_setup.py
@@ -25,8 +25,6 @@ def configure_logging(level: str = "INFO") -> None:
     has_ours = any(getattr(h, _HANDLER_TAG, False) for h in root.handlers)
     if not has_ours:
         handler = logging.StreamHandler()
-        handler.setFormatter(
-            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
-        )
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
         setattr(handler, _HANDLER_TAG, True)
         root.addHandler(handler)

--- a/bot/jarvis/main.py
+++ b/bot/jarvis/main.py
@@ -65,8 +65,7 @@ async def serve_http(app, port: int) -> None:
 def _build_handler(settings: Settings) -> OnMessageHandler:
     if not settings.anthropic_api_key:
         raise RuntimeError(
-            "ANTHROPIC_API_KEY is required for PR 2 chat. "
-            "Set it in .env or Secret Manager."
+            "ANTHROPIC_API_KEY is required for PR 2 chat. Set it in .env or Secret Manager."
         )
     anthropic_client = AsyncAnthropic(api_key=settings.anthropic_api_key)
     fs_kwargs = {}
@@ -75,9 +74,7 @@ def _build_handler(settings: Settings) -> OnMessageHandler:
     firestore_client = AsyncFirestoreClient(**fs_kwargs)
     memory = ThreadMemory(firestore_client)
 
-    rate_limiter = InMemoryRateLimiter(
-        max_per_window=20, window_seconds=3600.0
-    )
+    rate_limiter = InMemoryRateLimiter(max_per_window=20, window_seconds=3600.0)
 
     tool_registry: Optional[ToolRegistry] = None
     github_client = None
@@ -103,9 +100,7 @@ def _build_handler(settings: Settings) -> OnMessageHandler:
                 repo=settings.github_repo,
             )
         )
-        tool_registry.register(
-            build_search_repo_docs_tool(docs_root=Path("docs"))
-        )
+        tool_registry.register(build_search_repo_docs_tool(docs_root=Path("docs")))
         tool_registry.register(
             build_get_pr_tool(
                 github_client=github_client,
@@ -126,9 +121,7 @@ def _build_handler(settings: Settings) -> OnMessageHandler:
             )
         )
         tool_registry.register(build_get_recent_messages_tool())
-        logger.info(
-            "tool registry: %s", ", ".join(tool_registry.names())
-        )
+        logger.info("tool registry: %s", ", ".join(tool_registry.names()))
     else:
         tool_registry = chat_only_registry
         logger.info(
@@ -136,9 +129,7 @@ def _build_handler(settings: Settings) -> OnMessageHandler:
             ", ".join(tool_registry.names()),
         )
 
-    async def agent_fn(
-        *, system_prompt, history, user_message, tool_registry, tool_context
-    ):
+    async def agent_fn(*, system_prompt, history, user_message, tool_registry, tool_context):
         async for d in agent_respond(
             anthropic_client=anthropic_client,
             system_prompt=system_prompt,
@@ -203,12 +194,8 @@ async def run() -> None:
 
     app = build_app(commit_sha=settings.commit_sha)
 
-    gateway_task = asyncio.create_task(
-        bot.start(settings.discord_bot_token), name="gateway"
-    )
-    http_task = asyncio.create_task(
-        serve_http(app, settings.jarvis_http_port), name="http"
-    )
+    gateway_task = asyncio.create_task(bot.start(settings.discord_bot_token), name="gateway")
+    http_task = asyncio.create_task(serve_http(app, settings.jarvis_http_port), name="http")
 
     try:
         done, pending = await asyncio.wait(

--- a/bot/jarvis/memory.py
+++ b/bot/jarvis/memory.py
@@ -63,9 +63,7 @@ class ThreadMemory:
         data = snap.to_dict() or {}
         turns = data.get("turns", [])
         # Strip Firestore-internal fields the model doesn't need.
-        return [
-            {"role": t["role"], "content": t["content"]} for t in turns
-        ]
+        return [{"role": t["role"], "content": t["content"]} for t in turns]
 
     async def append_turn(
         self,

--- a/bot/jarvis/tools/chat.py
+++ b/bot/jarvis/tools/chat.py
@@ -44,9 +44,7 @@ def _resolve_channel(guild: Any, channel: str) -> Optional[Any]:
 
 
 def build_get_recent_messages_tool() -> ToolDescriptor:
-    async def get_recent_messages(
-        channel: str, n: int = 50, *, context: ToolContext
-    ) -> Any:
+    async def get_recent_messages(channel: str, n: int = 50, *, context: ToolContext) -> Any:
         guild = context.guild
         if guild is None:
             return {"error": "no guild context — bot is not in a guild"}
@@ -54,10 +52,7 @@ def build_get_recent_messages_tool() -> ToolDescriptor:
         target = _resolve_channel(guild, channel)
         if target is None:
             return {
-                "error": (
-                    f"channel '{channel}' not found in guild "
-                    "(use a #name or numeric id)"
-                )
+                "error": (f"channel '{channel}' not found in guild (use a #name or numeric id)")
             }
 
         clamped = _clamp_n(int(n))
@@ -70,9 +65,7 @@ def build_get_recent_messages_tool() -> ToolDescriptor:
                 {
                     "author": display or "?",
                     "content": getattr(msg, "content", "") or "",
-                    "timestamp": (
-                        created.isoformat() if created is not None else None
-                    ),
+                    "timestamp": (created.isoformat() if created is not None else None),
                 }
             )
         return out
@@ -94,15 +87,12 @@ def build_get_recent_messages_tool() -> ToolDescriptor:
                 "channel": {
                     "type": "string",
                     "description": (
-                        "Channel name (with or without leading '#') or "
-                        "numeric channel id."
+                        "Channel name (with or without leading '#') or numeric channel id."
                     ),
                 },
                 "n": {
                     "type": "integer",
-                    "description": (
-                        "How many messages to fetch (1–100, default 50)."
-                    ),
+                    "description": ("How many messages to fetch (1–100, default 50)."),
                 },
             },
             "required": ["channel"],

--- a/bot/jarvis/tools/docs.py
+++ b/bot/jarvis/tools/docs.py
@@ -31,9 +31,7 @@ def _snippet(line: str, query_lower: str) -> str:
     return ("…" if start > 0 else "") + snippet + ("…" if end < len(line) else "")
 
 
-def build_search_repo_docs_tool(
-    *, docs_root: Optional[Path]
-) -> ToolDescriptor:
+def build_search_repo_docs_tool(*, docs_root: Optional[Path]) -> ToolDescriptor:
     async def search_repo_docs(query: str) -> list[dict[str, Any]]:
         if not query:
             return []
@@ -50,9 +48,7 @@ def build_search_repo_docs_tool(
                 if q in line.lower():
                     results.append(
                         {
-                            "path": str(
-                                md_path.relative_to(docs_root)
-                            ).replace("\\", "/"),
+                            "path": str(md_path.relative_to(docs_root)).replace("\\", "/"),
                             "snippet": _snippet(line, q),
                         }
                     )

--- a/bot/jarvis/tools/github.py
+++ b/bot/jarvis/tools/github.py
@@ -21,12 +21,8 @@ def _clamp_n(n: int) -> int:
     return n
 
 
-def build_get_recent_commits_tool(
-    *, github_client: Any, repo: str
-) -> ToolDescriptor:
-    async def get_recent_commits(
-        n: int = 10, branch: str = "master"
-    ) -> list[dict[str, Any]]:
+def build_get_recent_commits_tool(*, github_client: Any, repo: str) -> ToolDescriptor:
+    async def get_recent_commits(n: int = 10, branch: str = "master") -> list[dict[str, Any]]:
         clamped = _clamp_n(n)
         raw = await github_client.get(
             f"/repos/{repo}/commits",
@@ -35,15 +31,9 @@ def build_get_recent_commits_tool(
         return [
             {
                 "sha": (c.get("sha") or "")[:8],
-                "title": (c.get("commit", {}).get("message") or "").split(
-                    "\n", 1
-                )[0],
-                "author": c.get("commit", {})
-                .get("author", {})
-                .get("name"),
-                "date": c.get("commit", {})
-                .get("author", {})
-                .get("date"),
+                "title": (c.get("commit", {}).get("message") or "").split("\n", 1)[0],
+                "author": c.get("commit", {}).get("author", {}).get("name"),
+                "date": c.get("commit", {}).get("author", {}).get("date"),
                 "url": c.get("html_url"),
             }
             for c in (raw or [])
@@ -76,9 +66,7 @@ def build_get_recent_commits_tool(
     )
 
 
-def build_get_pr_tool(
-    *, github_client: Any, repo: str
-) -> ToolDescriptor:
+def build_get_pr_tool(*, github_client: Any, repo: str) -> ToolDescriptor:
     async def get_pr(number: int) -> dict[str, Any]:
         raw = await github_client.get(f"/repos/{repo}/pulls/{number}")
         return {
@@ -113,21 +101,15 @@ def build_get_pr_tool(
     )
 
 
-def build_get_issue_tool(
-    *, github_client: Any, repo: str
-) -> ToolDescriptor:
+def build_get_issue_tool(*, github_client: Any, repo: str) -> ToolDescriptor:
     async def get_issue(number: int) -> dict[str, Any]:
         raw = await github_client.get(f"/repos/{repo}/issues/{number}")
         return {
             "title": raw.get("title"),
             "state": raw.get("state"),
             "body": raw.get("body") or "",
-            "labels": [
-                (lbl or {}).get("name") for lbl in (raw.get("labels") or [])
-            ],
-            "assignees": [
-                (a or {}).get("login") for a in (raw.get("assignees") or [])
-            ],
+            "labels": [(lbl or {}).get("name") for lbl in (raw.get("labels") or [])],
+            "assignees": [(a or {}).get("login") for a in (raw.get("assignees") or [])],
             "url": raw.get("html_url"),
         }
 
@@ -161,9 +143,7 @@ def build_open_issue_tool(
     allowed_set = set(allowed_labels)
     allowed_for_doc = ", ".join(sorted(allowed_set)) or "(none)"
 
-    async def open_issue(
-        title: str, body: str, labels: list[str] | None = None
-    ) -> dict[str, Any]:
+    async def open_issue(title: str, body: str, labels: list[str] | None = None) -> dict[str, Any]:
         requested = list(labels or [])
         accepted = [lbl for lbl in requested if lbl in allowed_set]
         dropped = [lbl for lbl in requested if lbl not in allowed_set]
@@ -208,8 +188,7 @@ def build_open_issue_tool(
                     "type": "array",
                     "items": {"type": "string"},
                     "description": (
-                        f"Optional labels. Allowed: {allowed_for_doc}. "
-                        "Other labels are dropped."
+                        f"Optional labels. Allowed: {allowed_for_doc}. Other labels are dropped."
                     ),
                 },
             },

--- a/bot/jarvis/tools/sprint.py
+++ b/bot/jarvis/tools/sprint.py
@@ -65,9 +65,7 @@ def _flatten(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def build_get_current_sprint_tool(
-    *, github_client: Any, project_id: str
-) -> ToolDescriptor:
+def build_get_current_sprint_tool(*, github_client: Any, project_id: str) -> ToolDescriptor:
     async def get_current_sprint() -> dict[str, Any]:
         data = await github_client.graphql(_QUERY, variables={"id": project_id})
         nodes = (((data or {}).get("node") or {}).get("items") or {}).get("nodes") or []
@@ -81,19 +79,13 @@ def build_get_current_sprint_tool(
         if not open_items:
             return {"selected_by": "empty", "items": []}
 
-        phases = [
-            _phase_number(i.get("phase")) for i in open_items
-        ]
+        phases = [_phase_number(i.get("phase")) for i in open_items]
         present = [p for p in phases if p is not None]
         if not present:
             return {"selected_by": "no_phase_field", "items": open_items}
 
         lowest = min(present)
-        items_at_lowest = [
-            i
-            for i, p in zip(open_items, phases)
-            if p == lowest
-        ]
+        items_at_lowest = [i for i, p in zip(open_items, phases) if p == lowest]
         return {"selected_by": "lowest_open_phase", "items": items_at_lowest}
 
     return ToolDescriptor(

--- a/bot/tests/test_agent.py
+++ b/bot/tests/test_agent.py
@@ -131,9 +131,7 @@ async def test_respond_dispatches_tool_and_loops():
     # First response: model emits a tool_use block (no text).
     final1 = FakeMessage(
         content=[
-            FakeToolUseBlock(
-                type="tool_use", id="tu_1", name="ping", input={"x": 1}
-            ),
+            FakeToolUseBlock(type="tool_use", id="tu_1", name="ping", input={"x": 1}),
         ]
     )
     # Second response: model emits the final text answer.
@@ -214,11 +212,7 @@ async def test_respond_aborts_at_max_tool_steps():
         return {"ok": True}
 
     reg = ToolRegistry()
-    reg.register(
-        ToolDescriptor(
-            name="ping", description="d", input_schema={}, fn=ping
-        )
-    )
+    reg.register(ToolDescriptor(name="ping", description="d", input_schema={}, fn=ping))
 
     chunks = []
     async for delta in respond(
@@ -241,11 +235,7 @@ async def test_respond_handles_unknown_tool_name():
     """If the model invents a tool name, the registry returns an error
     JSON and the loop continues; the model gets a chance to recover."""
     final1 = FakeMessage(
-        content=[
-            FakeToolUseBlock(
-                type="tool_use", id="tu_1", name="nope", input={}
-            )
-        ]
+        content=[FakeToolUseBlock(type="tool_use", id="tu_1", name="nope", input={})]
     )
     final2 = FakeMessage(content=[FakeTextBlock(type="text", text="sorry")])
     client, calls = _make_anthropic_with_responses(
@@ -297,9 +287,7 @@ async def test_respond_handles_text_and_tool_in_same_response():
     final1 = FakeMessage(
         content=[
             FakeTextBlock(type="text", text="checking…"),
-            FakeToolUseBlock(
-                type="tool_use", id="tu_1", name="ping", input={}
-            ),
+            FakeToolUseBlock(type="tool_use", id="tu_1", name="ping", input={}),
         ]
     )
     final2 = FakeMessage(content=[FakeTextBlock(type="text", text="done")])
@@ -314,11 +302,7 @@ async def test_respond_handles_text_and_tool_in_same_response():
         return {"ok": True}
 
     reg = ToolRegistry()
-    reg.register(
-        ToolDescriptor(
-            name="ping", description="d", input_schema={}, fn=ping
-        )
-    )
+    reg.register(ToolDescriptor(name="ping", description="d", input_schema={}, fn=ping))
 
     out = []
     async for delta in respond(

--- a/bot/tests/test_config.py
+++ b/bot/tests/test_config.py
@@ -60,5 +60,7 @@ def test_settings_missing_required_raises(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
     monkeypatch.delenv("DISCORD_GUILD_ID", raising=False)
-    with pytest.raises(Exception):  # pydantic.ValidationError; broad to avoid pinning the import path
+    with pytest.raises(
+        Exception
+    ):  # pydantic.ValidationError; broad to avoid pinning the import path
         Settings()

--- a/bot/tests/test_events.py
+++ b/bot/tests/test_events.py
@@ -48,9 +48,7 @@ class FakeChannel:
     type: str = "text"
     created_thread: FakeThread | None = None
 
-    async def create_thread(
-        self, *, name: str, message: Any | None = None
-    ) -> FakeThread:
+    async def create_thread(self, *, name: str, message: Any | None = None) -> FakeThread:
         # Real discord.py creates a thread off a message with
         # `message.create_thread(name=...)`. The events handler is
         # written against `message.create_thread`, so this fake's
@@ -68,9 +66,7 @@ class FakeMessage:
     content: str = ""
 
     async def create_thread(self, *, name: str) -> FakeThread:
-        thread = FakeThread(
-            id=self.id + 100_000, parent_id=self.channel.id, name=name
-        )
+        thread = FakeThread(id=self.id + 100_000, parent_id=self.channel.id, name=name)
         self.created_thread = thread  # type: ignore[attr-defined]
         return thread
 
@@ -230,9 +226,7 @@ async def test_history_passed_through_to_agent():
 
     captured = {}
 
-    async def capture_agent(
-        *, system_prompt, history, user_message, tool_registry, tool_context
-    ):
+    async def capture_agent(*, system_prompt, history, user_message, tool_registry, tool_context):
         captured["system_prompt"] = system_prompt
         captured["history"] = history
         captured["user_message"] = user_message

--- a/bot/tests/test_github_client.py
+++ b/bot/tests/test_github_client.py
@@ -60,9 +60,7 @@ async def test_graphql_posts_query_and_variables():
 
 
 async def test_graphql_raises_on_top_level_errors():
-    response = _make_response(
-        200, {"errors": [{"message": "Could not resolve"}], "data": None}
-    )
+    response = _make_response(200, {"errors": [{"message": "Could not resolve"}], "data": None})
     httpx_client = _make_async_client(response)
     gh = AsyncGitHubClient(token="t", httpx_client=httpx_client)
     with pytest.raises(RuntimeError, match="Could not resolve"):

--- a/bot/tests/test_logging_setup.py
+++ b/bot/tests/test_logging_setup.py
@@ -16,9 +16,7 @@ def test_configure_logging_idempotent():
     configure_logging("INFO")
     configure_logging("INFO")
     tagged = [
-        h
-        for h in logging.getLogger().handlers
-        if getattr(h, "_jarvis_stream_handler", False)
+        h for h in logging.getLogger().handlers if getattr(h, "_jarvis_stream_handler", False)
     ]
     assert len(tagged) == 1
 

--- a/bot/tests/test_main.py
+++ b/bot/tests/test_main.py
@@ -45,7 +45,8 @@ async def test_main_runs_both_subsystems_and_returns_when_one_finishes(monkeypat
     monkeypatch.setattr(main_mod, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(main_mod, "_build_handler", lambda settings: object())
     monkeypatch.setattr(
-        main_mod, "JarvisBot",
+        main_mod,
+        "JarvisBot",
         lambda *, guild_id, on_message_handler: FakeClient(),
     )
     monkeypatch.setattr(main_mod, "serve_http", fake_serve_http)
@@ -90,7 +91,8 @@ async def test_main_cancels_http_when_gateway_raises(monkeypatch):
     monkeypatch.setattr(main_mod, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(main_mod, "_build_handler", lambda settings: object())
     monkeypatch.setattr(
-        main_mod, "JarvisBot",
+        main_mod,
+        "JarvisBot",
         lambda *, guild_id, on_message_handler: ExplodingClient(),
     )
     monkeypatch.setattr(main_mod, "serve_http", fake_serve_http)

--- a/bot/tests/test_memory.py
+++ b/bot/tests/test_memory.py
@@ -110,12 +110,8 @@ async def test_append_turn_persists_via_update():
 
 
 async def test_append_turn_caps_at_max_turns():
-    existing = [
-        {"role": "user", "content": f"msg {i}"} for i in range(MAX_TURNS)
-    ]
-    client, doc_ref = _make_doc_ref_with_snapshot(
-        {"thread_id": "123", "turns": existing}
-    )
+    existing = [{"role": "user", "content": f"msg {i}"} for i in range(MAX_TURNS)]
+    client, doc_ref = _make_doc_ref_with_snapshot({"thread_id": "123", "turns": existing})
     mem = ThreadMemory(client)
     await mem.append_turn(thread_id="123", role="assistant", content="newest")
     payload = doc_ref.update.await_args.args[0]

--- a/bot/tests/test_ratelimit.py
+++ b/bot/tests/test_ratelimit.py
@@ -32,9 +32,7 @@ def test_limit_blocks_after_max():
 def test_old_entries_drop_when_window_passes():
     """Inject a clock so we can travel forward without sleeping."""
     now = [0.0]
-    rl = InMemoryRateLimiter(
-        max_per_window=2, window_seconds=10.0, clock=lambda: now[0]
-    )
+    rl = InMemoryRateLimiter(max_per_window=2, window_seconds=10.0, clock=lambda: now[0])
     assert rl.check_and_record(user_id=1) is True
     assert rl.check_and_record(user_id=1) is True
     assert rl.check_and_record(user_id=1) is False  # at limit

--- a/bot/tests/test_tools_chat.py
+++ b/bot/tests/test_tools_chat.py
@@ -82,9 +82,7 @@ async def test_resolves_channel_by_name_and_returns_messages():
 
 
 async def test_resolves_channel_with_hash_prefix():
-    chan = FakeTextChannel(
-        channel_id=11, name="blockers", messages=[FakeMessage(content="x")]
-    )
+    chan = FakeTextChannel(channel_id=11, name="blockers", messages=[FakeMessage(content="x")])
     guild = FakeGuild(text_channels=[chan])
     desc = build_get_recent_messages_tool()
     out = await desc.fn(channel="#blockers", n=5, context=_ctx_with_guild(guild))
@@ -92,9 +90,7 @@ async def test_resolves_channel_with_hash_prefix():
 
 
 async def test_resolves_channel_by_numeric_id():
-    chan = FakeTextChannel(
-        channel_id=99, name="alerts", messages=[FakeMessage(content="a")]
-    )
+    chan = FakeTextChannel(channel_id=99, name="alerts", messages=[FakeMessage(content="a")])
     guild = FakeGuild(text_channels=[chan])
     desc = build_get_recent_messages_tool()
     out = await desc.fn(channel="99", n=5, context=_ctx_with_guild(guild))
@@ -108,9 +104,7 @@ async def test_returns_error_when_no_guild():
 
 
 async def test_returns_error_when_channel_not_found():
-    chan = FakeTextChannel(
-        channel_id=10, name="general", messages=[FakeMessage(content="x")]
-    )
+    chan = FakeTextChannel(channel_id=10, name="general", messages=[FakeMessage(content="x")])
     guild = FakeGuild(text_channels=[chan])
     desc = build_get_recent_messages_tool()
     out = await desc.fn(channel="ghost", n=5, context=_ctx_with_guild(guild))
@@ -124,14 +118,10 @@ async def test_clamps_n_to_safe_range():
     guild = FakeGuild(text_channels=[chan])
     desc = build_get_recent_messages_tool()
     # n=10000 should clamp to 100 (max)
-    out_max = await desc.fn(
-        channel="general", n=10000, context=_ctx_with_guild(guild)
-    )
+    out_max = await desc.fn(channel="general", n=10000, context=_ctx_with_guild(guild))
     assert len(out_max) == 100
     # n=0 should clamp to 1
-    out_min = await desc.fn(
-        channel="general", n=0, context=_ctx_with_guild(guild)
-    )
+    out_min = await desc.fn(channel="general", n=0, context=_ctx_with_guild(guild))
     assert len(out_min) == 1
 
 

--- a/bot/tests/test_tools_github.py
+++ b/bot/tests/test_tools_github.py
@@ -33,9 +33,7 @@ async def test_get_recent_commits_returns_compact_records():
         },
     ]
     gh = _gh_with_response(raw)
-    desc = build_get_recent_commits_tool(
-        github_client=gh, repo="tsuki-works/niko"
-    )
+    desc = build_get_recent_commits_tool(github_client=gh, repo="tsuki-works/niko")
     out = await desc.fn(n=2, branch="master")
     assert len(out) == 2
     assert out[0]["sha"] == "abc123de"  # short sha
@@ -51,9 +49,7 @@ async def test_get_recent_commits_returns_compact_records():
 
 async def test_get_recent_commits_defaults_to_master_and_10():
     gh = _gh_with_response([])
-    desc = build_get_recent_commits_tool(
-        github_client=gh, repo="tsuki-works/niko"
-    )
+    desc = build_get_recent_commits_tool(github_client=gh, repo="tsuki-works/niko")
     await desc.fn()
     params = gh.get.await_args.kwargs["params"]
     assert params["sha"] == "master"
@@ -62,9 +58,7 @@ async def test_get_recent_commits_defaults_to_master_and_10():
 
 async def test_get_recent_commits_clamps_n():
     gh = _gh_with_response([])
-    desc = build_get_recent_commits_tool(
-        github_client=gh, repo="tsuki-works/niko"
-    )
+    desc = build_get_recent_commits_tool(github_client=gh, repo="tsuki-works/niko")
     # Anthropic models occasionally pass big numbers; we cap to 50.
     await desc.fn(n=10000)
     assert gh.get.await_args.kwargs["params"]["per_page"] == 50
@@ -75,9 +69,7 @@ async def test_get_recent_commits_clamps_n():
 
 async def test_get_recent_commits_descriptor_metadata():
     gh = _gh_with_response([])
-    desc = build_get_recent_commits_tool(
-        github_client=gh, repo="tsuki-works/niko"
-    )
+    desc = build_get_recent_commits_tool(github_client=gh, repo="tsuki-works/niko")
     assert desc.name == "get_recent_commits"
     assert "commit" in desc.description.lower()
     assert "n" in desc.input_schema["properties"]
@@ -229,9 +221,7 @@ async def test_open_issue_drops_labels_not_in_allowlist():
         repo="o/r",
         allowed_labels=["bug", "feature"],
     )
-    out = await desc.fn(
-        title="t", body="b", labels=["bug", "production-incident", "paid"]
-    )
+    out = await desc.fn(title="t", body="b", labels=["bug", "production-incident", "paid"])
     payload = gh.post.await_args.kwargs["json"]
     assert payload["labels"] == ["bug"]
     assert out["dropped_labels"] == ["production-incident", "paid"]
@@ -269,9 +259,7 @@ async def test_open_issue_handles_no_labels_kwarg():
 
 async def test_open_issue_descriptor_metadata():
     gh = AsyncMock()
-    desc = build_open_issue_tool(
-        github_client=gh, repo="o/r", allowed_labels=["bug"]
-    )
+    desc = build_open_issue_tool(github_client=gh, repo="o/r", allowed_labels=["bug"])
     assert desc.name == "open_issue"
     assert "open" in desc.description.lower() or "create" in desc.description.lower()
     props = desc.input_schema["properties"]

--- a/bot/tests/test_tools_registry.py
+++ b/bot/tests/test_tools_registry.py
@@ -9,8 +9,13 @@ from jarvis.tools import ToolContext, ToolDescriptor, ToolRegistry
 
 def _ctx() -> ToolContext:
     # Minimal context — no real fields needed for these tests.
-    return ToolContext(guild=None, github_client=None, github_repo="org/repo",
-                       github_project_id="PVT_x", docs_root=None)
+    return ToolContext(
+        guild=None,
+        github_client=None,
+        github_repo="org/repo",
+        github_project_id="PVT_x",
+        docs_root=None,
+    )
 
 
 async def test_register_and_as_anthropic_tools_shape():
@@ -44,7 +49,10 @@ async def test_dispatch_returns_json_string_on_success():
     reg = ToolRegistry()
     reg.register(
         ToolDescriptor(
-            name="echo", description="d", input_schema={}, fn=echo,
+            name="echo",
+            description="d",
+            input_schema={},
+            fn=echo,
         )
     )
     out = await reg.dispatch(name="echo", tool_input={"x": 3}, context=_ctx())
@@ -67,7 +75,10 @@ async def test_dispatch_catches_tool_exception():
     reg = ToolRegistry()
     reg.register(
         ToolDescriptor(
-            name="explode", description="d", input_schema={}, fn=explode,
+            name="explode",
+            description="d",
+            input_schema={},
+            fn=explode,
         )
     )
     out = await reg.dispatch(name="explode", tool_input={}, context=_ctx())
@@ -87,13 +98,14 @@ async def test_dispatch_passes_context_when_fn_accepts_it():
     reg = ToolRegistry()
     reg.register(
         ToolDescriptor(
-            name="needs_ctx", description="d", input_schema={}, fn=needs_ctx,
+            name="needs_ctx",
+            description="d",
+            input_schema={},
+            fn=needs_ctx,
             wants_context=True,
         )
     )
-    await reg.dispatch(
-        name="needs_ctx", tool_input={"x": 1}, context=_ctx()
-    )
+    await reg.dispatch(name="needs_ctx", tool_input={"x": 1}, context=_ctx())
     assert seen["repo"] == "org/repo"
 
 
@@ -105,5 +117,6 @@ async def test_register_rejects_duplicate_name():
     desc = ToolDescriptor(name="t", description="", input_schema={}, fn=fn)
     reg.register(desc)
     import pytest
+
     with pytest.raises(ValueError, match="already registered"):
         reg.register(desc)

--- a/bot/tests/test_tools_sprint.py
+++ b/bot/tests/test_tools_sprint.py
@@ -41,9 +41,7 @@ async def test_returns_in_progress_items():
         }
     }
     gh = _gh_with_response(data)
-    desc = build_get_current_sprint_tool(
-        github_client=gh, project_id="PVT_x"
-    )
+    desc = build_get_current_sprint_tool(github_client=gh, project_id="PVT_x")
     out = await desc.fn()
     assert out["selected_by"] == "in_progress"
     assert len(out["items"]) == 1
@@ -90,9 +88,7 @@ async def test_falls_back_to_lowest_open_phase_when_none_in_progress():
         }
     }
     gh = _gh_with_response(data)
-    desc = build_get_current_sprint_tool(
-        github_client=gh, project_id="PVT_x"
-    )
+    desc = build_get_current_sprint_tool(github_client=gh, project_id="PVT_x")
     out = await desc.fn()
     assert out["selected_by"] == "lowest_open_phase"
     titles = [item["title"] for item in out["items"]]
@@ -102,9 +98,7 @@ async def test_falls_back_to_lowest_open_phase_when_none_in_progress():
 
 async def test_handles_empty_board():
     gh = _gh_with_response({"node": {"items": {"nodes": []}}})
-    desc = build_get_current_sprint_tool(
-        github_client=gh, project_id="PVT_x"
-    )
+    desc = build_get_current_sprint_tool(github_client=gh, project_id="PVT_x")
     out = await desc.fn()
     assert out["selected_by"] == "empty"
     assert out["items"] == []
@@ -112,9 +106,7 @@ async def test_handles_empty_board():
 
 async def test_descriptor_metadata():
     gh = _gh_with_response({"node": {"items": {"nodes": []}}})
-    desc = build_get_current_sprint_tool(
-        github_client=gh, project_id="PVT_x"
-    )
+    desc = build_get_current_sprint_tool(github_client=gh, project_id="PVT_x")
     assert desc.name == "get_current_sprint"
     assert "sprint" in desc.description.lower()
     # No required input — the tool takes no args.

--- a/scripts/grant_tenant_claim.py
+++ b/scripts/grant_tenant_claim.py
@@ -48,9 +48,7 @@ def _ensure_app() -> None:
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--email", required=True, help="Email of the existing Firebase Auth user"
-    )
+    parser.add_argument("--email", required=True, help="Email of the existing Firebase Auth user")
     parser.add_argument(
         "--rid",
         required=True,

--- a/scripts/list_twilio_numbers.py
+++ b/scripts/list_twilio_numbers.py
@@ -54,14 +54,10 @@ def _twilio_client() -> TwilioClient:
 
 def _search(twilio: TwilioClient, area_code: str, limit: int) -> tuple[str, list]:
     """Return (country, numbers). Try CA first, fall back to US."""
-    available = twilio.available_phone_numbers("CA").local.list(
-        area_code=area_code, limit=limit
-    )
+    available = twilio.available_phone_numbers("CA").local.list(area_code=area_code, limit=limit)
     if available:
         return "CA", available
-    available = twilio.available_phone_numbers("US").local.list(
-        area_code=area_code, limit=limit
-    )
+    available = twilio.available_phone_numbers("US").local.list(area_code=area_code, limit=limit)
     return "US", available
 
 
@@ -109,12 +105,8 @@ def main() -> int:
         region = getattr(n, "region", None) or ""
         loc = f" ({locality}, {region})" if locality or region else ""
         logger.info("  %d. %s — %s%s", idx, n.phone_number, n.friendly_name, loc)
-    logger.info(
-        "\nTo provision with a specific number, pass it to provision_restaurant:"
-    )
-    logger.info(
-        "  python -m scripts.provision_restaurant ... --phone-number <E.164>"
-    )
+    logger.info("\nTo provision with a specific number, pass it to provision_restaurant:")
+    logger.info("  python -m scripts.provision_restaurant ... --phone-number <E.164>")
     return 0
 
 

--- a/scripts/migrate_to_nested_subcollections.py
+++ b/scripts/migrate_to_nested_subcollections.py
@@ -52,10 +52,7 @@ def _migrate_orders(client: firestore.Client, dry_run: bool) -> int:
         rid = data.get("restaurant_id") or DEMO_RID
         call_sid = data.get("call_sid") or snap.id
         target = (
-            client.collection("restaurants")
-            .document(rid)
-            .collection("orders")
-            .document(call_sid)
+            client.collection("restaurants").document(rid).collection("orders").document(call_sid)
         )
         if dry_run:
             logger.info("[dry-run] orders/%s → restaurants/%s/orders/%s", snap.id, rid, call_sid)
@@ -94,9 +91,7 @@ def _migrate_call_sessions(client: firestore.Client, dry_run: bool) -> tuple[int
         parents_moved += 1
 
         events_ref = (
-            client.collection("call_sessions")
-            .document(parent_snap.id)
-            .collection("events")
+            client.collection("call_sessions").document(parent_snap.id).collection("events")
         )
         for ev_snap in events_ref.stream():
             ev_data = ev_snap.to_dict() or {}

--- a/scripts/provision_restaurant.py
+++ b/scripts/provision_restaurant.py
@@ -111,14 +111,10 @@ def _backend_url() -> str:
 
 def _purchase_number(twilio: TwilioClient, area_code: str) -> str:
     """Buy a US/CA local number in ``area_code``. Returns the E.164 string."""
-    available = twilio.available_phone_numbers("CA").local.list(
-        area_code=area_code, limit=1
-    )
+    available = twilio.available_phone_numbers("CA").local.list(area_code=area_code, limit=1)
     if not available:
         # Fall back to US if the area code has no Canadian inventory.
-        available = twilio.available_phone_numbers("US").local.list(
-            area_code=area_code, limit=1
-        )
+        available = twilio.available_phone_numbers("US").local.list(area_code=area_code, limit=1)
     if not available:
         raise SystemExit(f"No numbers available in area code {area_code}")
     candidate = available[0].phone_number
@@ -140,9 +136,7 @@ def _configure_voice_webhook(twilio: TwilioClient, e164: str, backend_url: str) 
     numbers = twilio.incoming_phone_numbers.list(phone_number=e164, limit=1)
     if not numbers:
         raise SystemExit(f"twilio: number {e164} not found on this account")
-    twilio.incoming_phone_numbers(numbers[0].sid).update(
-        voice_url=voice_url, voice_method="POST"
-    )
+    twilio.incoming_phone_numbers(numbers[0].sid).update(voice_url=voice_url, voice_method="POST")
     logger.info("twilio: %s voice webhook → %s", e164, voice_url)
 
 

--- a/tests/fixtures/correction_transcripts.py
+++ b/tests/fixtures/correction_transcripts.py
@@ -34,11 +34,8 @@ class CorrectionScenario:
 
 def _assert_remove_item(final: Order) -> None:
     names = [i.name.lower() for i in final.items]
-    assert not any("coke" in n for n in names), (
-        f"Coke should be removed; items were {names}"
-    )
-    assert any("margherita" in n or "pepperoni" in n or "veggie" in n
-               for n in names), (
+    assert not any("coke" in n for n in names), f"Coke should be removed; items were {names}"
+    assert any("margherita" in n or "pepperoni" in n or "veggie" in n for n in names), (
         f"At least one pizza should remain; items were {names}"
     )
 
@@ -46,9 +43,7 @@ def _assert_remove_item(final: Order) -> None:
 def _assert_substitute_item(final: Order) -> None:
     names = [i.name.lower() for i in final.items]
     # The substitute landed (calzone present)
-    assert any("calzone" in n for n in names), (
-        f"Calzone should be present; items were {names}"
-    )
+    assert any("calzone" in n for n in names), f"Calzone should be present; items were {names}"
     # The replaced item is gone
     assert not any("margherita" in n for n in names), (
         f"Margherita should be replaced; items were {names}"
@@ -63,9 +58,7 @@ def _assert_quantity_change(final: Order) -> None:
     assert len(final.items) == 1, (
         f"Quantity change must not duplicate the line; got {len(final.items)} items"
     )
-    assert final.items[0].quantity == 2, (
-        f"Expected quantity=2; got {final.items[0].quantity}"
-    )
+    assert final.items[0].quantity == 2, f"Expected quantity=2; got {final.items[0].quantity}"
 
 
 def _assert_size_change(final: Order) -> None:
@@ -87,8 +80,7 @@ def _assert_swap_to_pickup(final: Order) -> None:
         f"Expected order_type=pickup; got {final.order_type}"
     )
     assert final.delivery_address in (None, ""), (
-        f"delivery_address should be cleared on swap-to-pickup; got "
-        f"{final.delivery_address!r}"
+        f"delivery_address should be cleared on swap-to-pickup; got {final.delivery_address!r}"
     )
 
 
@@ -98,12 +90,10 @@ def _assert_address_fix(final: Order) -> None:
     )
     assert final.delivery_address is not None, "Expected an address"
     assert "14" in final.delivery_address, (
-        f"Expected corrected address to contain '14'; got "
-        f"{final.delivery_address!r}"
+        f"Expected corrected address to contain '14'; got {final.delivery_address!r}"
     )
     assert "40" not in final.delivery_address, (
-        f"Old address number '40' should be gone; got "
-        f"{final.delivery_address!r}"
+        f"Old address number '40' should be gone; got {final.delivery_address!r}"
     )
 
 

--- a/tests/fixtures/delivery_transcripts.py
+++ b/tests/fixtures/delivery_transcripts.py
@@ -29,12 +29,10 @@ def _assert_delivery_address_complete(final: Order) -> None:
     assert final.delivery_address is not None, "Expected an address"
     addr_lower = final.delivery_address.lower()
     assert "14" in addr_lower, (
-        f"Expected captured address to contain '14'; got "
-        f"{final.delivery_address!r}"
+        f"Expected captured address to contain '14'; got {final.delivery_address!r}"
     )
     assert "spadina" in addr_lower, (
-        f"Expected captured address to contain 'Spadina'; got "
-        f"{final.delivery_address!r}"
+        f"Expected captured address to contain 'Spadina'; got {final.delivery_address!r}"
     )
 
 
@@ -42,17 +40,13 @@ def _assert_uhh_then_real(final: Order) -> None:
     assert final.order_type is OrderType.DELIVERY, (
         f"Expected order_type=delivery; got {final.order_type}"
     )
-    assert final.delivery_address is not None, (
-        "Expected an address after the re-ask"
-    )
+    assert final.delivery_address is not None, "Expected an address after the re-ask"
     addr_lower = final.delivery_address.lower()
     assert "uhh" not in addr_lower, (
-        f"'uhh' should have been rejected and replaced; got "
-        f"{final.delivery_address!r}"
+        f"'uhh' should have been rejected and replaced; got {final.delivery_address!r}"
     )
     assert "14" in addr_lower, (
-        f"Expected the corrected address to contain '14'; got "
-        f"{final.delivery_address!r}"
+        f"Expected the corrected address to contain '14'; got {final.delivery_address!r}"
     )
 
 
@@ -61,8 +55,7 @@ def _assert_pickup_only_soft_pivot(final: Order) -> None:
         f"Expected order_type=pickup; got {final.order_type}"
     )
     assert final.delivery_address in (None, ""), (
-        f"Expected no delivery_address on pickup-only flow; got "
-        f"{final.delivery_address!r}"
+        f"Expected no delivery_address on pickup-only flow; got {final.delivery_address!r}"
     )
 
 
@@ -73,9 +66,7 @@ SCENARIOS: list[CorrectionScenario] = [
     CorrectionScenario(
         id="delivery_address_complete",
         initial_turns=[],
-        correction_transcript=(
-            "I'd like a large margherita for delivery to 14 Spadina Avenue."
-        ),
+        correction_transcript=("I'd like a large margherita for delivery to 14 Spadina Avenue."),
         assert_end_state=_assert_delivery_address_complete,
     ),
     CorrectionScenario(

--- a/tests/test_auth_dependency.py
+++ b/tests/test_auth_dependency.py
@@ -52,9 +52,7 @@ def test_returns_tenant_from_bearer_token_when_no_cookie():
         "app.auth.dependency.firebase_auth.verify_id_token",
         return_value=_claims(role="tsuki_admin"),
     ) as mock:
-        tenant = current_tenant(
-            __session=None, authorization="Bearer raw-id-token"
-        )
+        tenant = current_tenant(__session=None, authorization="Bearer raw-id-token")
 
     mock.assert_called_once_with("raw-id-token")
     assert tenant.is_admin is True
@@ -62,12 +60,13 @@ def test_returns_tenant_from_bearer_token_when_no_cookie():
 
 def test_prefers_cookie_over_bearer_when_both_present():
     """Cookie wins so the dashboard's session lifetime governs."""
-    with patch(
-        "app.auth.dependency.firebase_auth.verify_session_cookie",
-        return_value=_claims(),
-    ) as cookie_mock, patch(
-        "app.auth.dependency.firebase_auth.verify_id_token"
-    ) as token_mock:
+    with (
+        patch(
+            "app.auth.dependency.firebase_auth.verify_session_cookie",
+            return_value=_claims(),
+        ) as cookie_mock,
+        patch("app.auth.dependency.firebase_auth.verify_id_token") as token_mock,
+    ):
         current_tenant(__session="cookie", authorization="Bearer raw")
 
     cookie_mock.assert_called_once()

--- a/tests/test_call_sessions_storage.py
+++ b/tests/test_call_sessions_storage.py
@@ -8,6 +8,7 @@ write hits BOTH the legacy ``call_sessions/{sid}`` and the nested
 ``restaurants/{rid}/call_sessions/{sid}`` paths. The fake here tracks
 arbitrary path segments so tests can assert both writes landed.
 """
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
@@ -242,9 +243,7 @@ def test_record_event_appends_to_both_paths(fake_client):
 
 def test_record_event_error_kind_flips_has_error(fake_client):
     call_sessions.init_call_session("CAtest", _DEMO_RID)
-    call_sessions.record_event(
-        "CAtest", _DEMO_RID, kind="error", text="500 from anthropic"
-    )
+    call_sessions.record_event("CAtest", _DEMO_RID, kind="error", text="500 from anthropic")
 
     assert fake_client.docs[_legacy_parent("CAtest")]["has_error"] is True
     assert fake_client.docs[_nested_parent(_DEMO_RID, "CAtest")]["has_error"] is True
@@ -253,9 +252,7 @@ def test_record_event_error_kind_flips_has_error(fake_client):
 def test_mark_call_ended_confirmed_status(fake_client):
     call_sessions.init_call_session("CAconfirmed", _DEMO_RID)
     end = datetime(2026, 4, 25, 22, 5, tzinfo=timezone.utc)
-    call_sessions.mark_call_ended(
-        "CAconfirmed", _DEMO_RID, confirmed=True, ended_at=end
-    )
+    call_sessions.mark_call_ended("CAconfirmed", _DEMO_RID, confirmed=True, ended_at=end)
 
     for path in (_legacy_parent("CAconfirmed"), _nested_parent(_DEMO_RID, "CAconfirmed")):
         doc = fake_client.docs[path]
@@ -325,9 +322,7 @@ def test_record_event_swallows_firestore_exceptions(fake_client):
 
     call_sessions.set_client(BoomClient())
     # No exception escaping is the assertion.
-    call_sessions.record_event(
-        "CAtest", _DEMO_RID, kind="transcript_final", text="hi"
-    )
+    call_sessions.record_event("CAtest", _DEMO_RID, kind="transcript_final", text="hi")
 
 
 def test_mark_recording_deleted_clears_url_and_emits_event(monkeypatch):
@@ -339,14 +334,17 @@ def test_mark_recording_deleted_clears_url_and_emits_event(monkeypatch):
     class FakeDoc:
         def __init__(self):
             self._collection = FakeCollection(events)
+
         def update(self, patch):
             patches.append(patch)
+
         def collection(self, _name):
             return self._collection
 
     class FakeCollection:
         def __init__(self, events):
             self._events = events
+
         def add(self, payload):
             self._events.append(payload)
 
@@ -385,13 +383,7 @@ def test_mark_transfer_attempted_writes_status_to_both_paths():
     )
 
     legacy_update = fs.collection.return_value.document.return_value.update
-    nested_update = (
-        fs.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-        .update
-    )
+    nested_update = fs.collection.return_value.document.return_value.collection.return_value.document.return_value.update
     assert legacy_update.called
     assert nested_update.called
     payload = legacy_update.call_args.args[0]
@@ -412,13 +404,7 @@ def test_mark_voicemail_left_sets_recording_url_and_transcript():
         transcript=None,
     )
 
-    nested_update = (
-        fs.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-        .update
-    )
+    nested_update = fs.collection.return_value.document.return_value.collection.return_value.document.return_value.update
     payload = nested_update.call_args.args[0]
     assert payload["voicemail_recording_url"] == "gs://bucket/path.mp3"
     assert payload["voicemail_recording_sid"] == "REabc"
@@ -436,13 +422,7 @@ def test_update_voicemail_transcript_patches_transcript():
     )
 
     legacy_update = fs.collection.return_value.document.return_value.update
-    nested_update = (
-        fs.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-        .update
-    )
+    nested_update = fs.collection.return_value.document.return_value.collection.return_value.document.return_value.update
     assert legacy_update.called
     assert nested_update.called
     legacy_payload = legacy_update.call_args.args[0]

--- a/tests/test_calls_route.py
+++ b/tests/test_calls_route.py
@@ -41,11 +41,13 @@ def test_get_call_recording_returns_302_to_signed_url(override_owner, monkeypatc
     from app.storage import call_sessions, recordings
 
     monkeypatch.setattr(
-        call_sessions, "get_session",
+        call_sessions,
+        "get_session",
         lambda call_sid, rid: {"recording_url": f"gs://niko-recordings/{rid}/CAt.mp3"},
     )
     monkeypatch.setattr(
-        recordings, "generate_signed_url",
+        recordings,
+        "generate_signed_url",
         lambda *, call_sid, restaurant_id: "https://signed.example/?sig=fake",
     )
 
@@ -58,7 +60,8 @@ def test_get_call_recording_404_when_url_missing(override_owner, monkeypatch):
     from app.storage import call_sessions
 
     monkeypatch.setattr(
-        call_sessions, "get_session",
+        call_sessions,
+        "get_session",
         lambda call_sid, rid: {"recording_url": None},
     )
     r = client.get("/calls/CAt/recording")
@@ -71,7 +74,8 @@ def test_get_call_recording_502_when_url_not_gs(override_owner, monkeypatch):
     from app.storage import call_sessions
 
     monkeypatch.setattr(
-        call_sessions, "get_session",
+        call_sessions,
+        "get_session",
         lambda call_sid, rid: {"recording_url": "https://api.twilio.com/legacy.mp3"},
     )
     r = client.get("/calls/CAt/recording", follow_redirects=False)
@@ -87,17 +91,20 @@ def test_delete_call_recording_owner_returns_204(override_owner, monkeypatch):
     from app.storage import call_sessions, recordings
 
     monkeypatch.setattr(
-        call_sessions, "get_session",
+        call_sessions,
+        "get_session",
         lambda call_sid, rid: {"recording_url": f"gs://niko-recordings/{rid}/CAt.mp3"},
     )
     deleted: list[dict] = []
     cleared: list[dict] = []
     monkeypatch.setattr(
-        recordings, "delete_recording",
+        recordings,
+        "delete_recording",
         lambda *, call_sid, restaurant_id: deleted.append({"sid": call_sid, "rid": restaurant_id}),
     )
     monkeypatch.setattr(
-        call_sessions, "mark_recording_deleted",
+        call_sessions,
+        "mark_recording_deleted",
         lambda call_sid, rid: cleared.append({"sid": call_sid, "rid": rid}),
     )
 
@@ -115,9 +122,7 @@ def test_delete_call_recording_non_owner_returns_403(override_staff):
 def test_delete_call_recording_404_when_call_missing(override_owner, monkeypatch):
     from app.storage import call_sessions
 
-    monkeypatch.setattr(
-        call_sessions, "get_session", lambda call_sid, rid: None
-    )
+    monkeypatch.setattr(call_sessions, "get_session", lambda call_sid, rid: None)
     r = client.delete("/calls/CAt/recording")
     assert r.status_code == 404
 
@@ -130,7 +135,8 @@ def test_delete_call_recording_idempotent_on_no_recording(override_owner, monkey
     from app.storage import call_sessions, recordings
 
     monkeypatch.setattr(
-        call_sessions, "get_session",
+        call_sessions,
+        "get_session",
         lambda call_sid, rid: {"recording_url": None},
     )
     monkeypatch.setattr(recordings, "delete_recording", lambda **kw: None)

--- a/tests/test_dev_calls.py
+++ b/tests/test_dev_calls.py
@@ -4,6 +4,7 @@ Hand-rolls a tiny fake matching the shape of google.cloud.logging entries —
 ``payload`` (str) + ``timestamp`` (datetime). The module is hermetic; we
 never touch the real Cloud Logging API in tests.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -72,9 +73,8 @@ def _full_call_entries(call_sid: str, base_minute: int) -> list[FakeEntry]:
 
 
 def test_parse_events_groups_by_call_sid():
-    entries = (
-        _full_call_entries("CAfirst", base_minute=10)
-        + _full_call_entries("CAsecond", base_minute=30)
+    entries = _full_call_entries("CAfirst", base_minute=10) + _full_call_entries(
+        "CAsecond", base_minute=30
     )
     grouped = dev_calls.parse_events(entries)
 
@@ -100,7 +100,9 @@ def test_parse_events_skips_lines_without_call_sid():
 
 
 def test_classify_transcript_final_extracts_text():
-    payload = "INFO:app.telephony.router:transcript [final] call_sid=CA123 text='extra olives please'"
+    payload = (
+        "INFO:app.telephony.router:transcript [final] call_sid=CA123 text='extra olives please'"
+    )
     kind, detail = dev_calls._classify(payload)
 
     assert kind == "transcript_final"
@@ -176,8 +178,7 @@ def test_summarize_call_without_stop_is_in_progress():
 
 def test_list_recent_calls_orders_newest_first():
     fake = FakeLoggingClient(
-        _full_call_entries("CAearly", base_minute=10)
-        + _full_call_entries("CAlate", base_minute=30)
+        _full_call_entries("CAearly", base_minute=10) + _full_call_entries("CAlate", base_minute=30)
     )
     summaries = dev_calls.list_recent_calls(hours=24, client=fake)
 

--- a/tests/test_firestore_storage.py
+++ b/tests/test_firestore_storage.py
@@ -38,20 +38,11 @@ def _fake_client() -> MagicMock:
 def _orders_doc(client: MagicMock, rid: str = _DEMO_RID, call_sid: str = "CAtest"):
     """Helper to address the same ``restaurants/{rid}/orders/{call_sid}`` doc
     we expect the storage module to address."""
-    return (
-        client.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-    )
+    return client.collection.return_value.document.return_value.collection.return_value.document.return_value
 
 
 def _orders_collection(client: MagicMock, rid: str = _DEMO_RID):
-    return (
-        client.collection.return_value
-        .document.return_value
-        .collection.return_value
-    )
+    return client.collection.return_value.document.return_value.collection.return_value
 
 
 def _pepperoni() -> LineItem:
@@ -80,13 +71,11 @@ def test_save_order_writes_to_nested_path():
     # then .collection("orders"), then .document(call_sid).
     client.collection.assert_called_with("restaurants")
     client.collection.return_value.document.assert_called_with(_DEMO_RID)
+    (client.collection.return_value.document.return_value.collection.assert_called_with("orders"))
     (
-        client.collection.return_value.document.return_value
-        .collection.assert_called_with("orders")
-    )
-    (
-        client.collection.return_value.document.return_value
-        .collection.return_value.document.assert_called_with("CAsave1")
+        client.collection.return_value.document.return_value.collection.return_value.document.assert_called_with(
+            "CAsave1"
+        )
     )
 
     set_call = _orders_doc(client).set
@@ -161,11 +150,7 @@ def test_list_recent_orders_queries_under_restaurant():
     snap2 = MagicMock()
     snap2.to_dict.return_value = {"call_sid": "CA2", "items": []}
 
-    query = (
-        _orders_collection(client)
-        .order_by.return_value
-        .limit.return_value
-    )
+    query = _orders_collection(client).order_by.return_value.limit.return_value
     query.stream.return_value = iter([snap1, snap2])
 
     result = storage.list_recent_orders(restaurant_id=_DEMO_RID, limit=5)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -103,9 +103,7 @@ def test_tool_use_updates_order_in_single_turn():
                 ),
             ]
         ),
-        _fake_response(
-            [FakeBlock(type="text", text="Anything else for you?")]
-        ),
+        _fake_response([FakeBlock(type="text", text="Anything else for you?")]),
     ]
 
     result = generate_reply(
@@ -185,9 +183,7 @@ def test_history_threads_user_and_assistant_turns():
 
     assert result.history[0] == {"role": "user", "content": "one pepperoni please"}
     assert result.history[1]["role"] == "assistant"
-    assert result.history[1]["content"] == [
-        {"type": "text", "text": "Sure, what size?"}
-    ]
+    assert result.history[1]["content"] == [{"type": "text", "text": "Sure, what size?"}]
 
 
 def test_text_plus_tool_use_appends_tool_result_to_history():
@@ -232,7 +228,12 @@ def test_text_plus_tool_use_appends_tool_result_to_history():
             ]
         ),
         _fake_response(
-            [FakeBlock(type="text", text="So that's one large Margarita — your total is nineteen ninety-nine. Sound right?")]
+            [
+                FakeBlock(
+                    type="text",
+                    text="So that's one large Margarita — your total is nineteen ninety-nine. Sound right?",
+                )
+            ]
         ),
     ]
 
@@ -272,7 +273,8 @@ def test_text_plus_tool_use_appends_tool_result_to_history():
     # History must continue with the follow-up assistant message after the tool_result.
     assert followup_assistant_msg is not None, "follow-up assistant message missing from history"
     assert any(
-        b.get("text", "") == "So that's one large Margarita — your total is nineteen ninety-nine. Sound right?"
+        b.get("text", "")
+        == "So that's one large Margarita — your total is nineteen ninety-nine. Sound right?"
         for b in followup_assistant_msg["content"]
     )
 
@@ -333,9 +335,7 @@ def test_tool_result_carries_post_apply_subtotal():
                 ),
             ]
         ),
-        _fake_response(
-            [FakeBlock(type="text", text="Anything else?")]
-        ),
+        _fake_response([FakeBlock(type="text", text="Anything else?")]),
     ]
 
     result = generate_reply(
@@ -602,9 +602,7 @@ def test_caller_changes_mind_replaces_items():
                 ),
             ]
         ),
-        _fake_response(
-            [FakeBlock(type="text", text="Anything else?")]
-        ),
+        _fake_response([FakeBlock(type="text", text="Anything else?")]),
     ]
 
     result = generate_reply(
@@ -760,11 +758,7 @@ async def test_stream_reply_emits_text_deltas_then_final():
         [
             _FakeAsyncStream(
                 deltas=["Hi, ", "what would you ", "like to order?"],
-                blocks=[
-                    FakeBlock(
-                        type="text", text="Hi, what would you like to order?"
-                    )
-                ],
+                blocks=[FakeBlock(type="text", text="Hi, what would you like to order?")],
             )
         ]
     )
@@ -814,9 +808,7 @@ async def test_stream_reply_applies_tool_use_to_order_state():
                             "status": "in_progress",
                         },
                     ),
-                    FakeBlock(
-                        type="text", text="One medium pepperoni for pickup."
-                    ),
+                    FakeBlock(type="text", text="One medium pepperoni for pickup."),
                 ],
             ),
             _FakeAsyncStream(
@@ -860,11 +852,7 @@ async def test_stream_reply_runs_followup_when_first_turn_is_tool_only():
             ),
             _FakeAsyncStream(
                 deltas=["Okay, ", "order cancelled."],
-                blocks=[
-                    FakeBlock(
-                        type="text", text="Okay, order cancelled."
-                    )
-                ],
+                blocks=[FakeBlock(type="text", text="Okay, order cancelled.")],
             ),
         ],
         captured_calls,
@@ -959,9 +947,12 @@ async def test_stream_reply_emits_timing_event_before_first_delta():
     assert seen_kinds == ["timing", "delta", "final"]
     assert timing_payload is not None
     # Back-compat fields must still be present (#175).
-    assert {"ttft_seconds", "tool_prefix_seconds", "cache_read_tokens", "cache_creation_tokens"} <= set(
-        timing_payload.keys()
-    )
+    assert {
+        "ttft_seconds",
+        "tool_prefix_seconds",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+    } <= set(timing_payload.keys())
     # New finer fields added in #175.
     assert {"network_prefill_seconds", "decode_seconds"} <= set(timing_payload.keys())
     assert timing_payload["ttft_seconds"] >= 0
@@ -1063,9 +1054,7 @@ def test_modifications_round_trip_into_line_item():
                 ),
             ]
         ),
-        _fake_response(
-            [FakeBlock(type="text", text="Anything else?")]
-        ),
+        _fake_response([FakeBlock(type="text", text="Anything else?")]),
     ]
 
     result = generate_reply(
@@ -1150,20 +1139,33 @@ def test_correction_remove_item_drops_it_from_order():
     only the Margherita remains."""
     order = _seed_order_with(
         [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
-            {"name": "Coke", "category": "drinks", "size": None,
-             "quantity": 1, "unit_price": 2.99},
+            {
+                "name": "Margherita",
+                "category": "pizza",
+                "size": "large",
+                "quantity": 1,
+                "unit_price": 19.99,
+            },
+            {"name": "Coke", "category": "drinks", "size": None, "quantity": 1, "unit_price": 2.99},
         ],
         order_type="pickup",
     )
 
     corrected = _apply_update(
         order,
-        {"items": [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
-        ], "order_type": "pickup", "status": "in_progress"},
+        {
+            "items": [
+                {
+                    "name": "Margherita",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 1,
+                    "unit_price": 19.99,
+                },
+            ],
+            "order_type": "pickup",
+            "status": "in_progress",
+        },
     )
 
     assert [i.name for i in corrected.items] == ["Margherita"]
@@ -1176,18 +1178,32 @@ def test_correction_substitute_item_replaces_not_appends():
     ONE item, not two."""
     order = _seed_order_with(
         [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
+            {
+                "name": "Margherita",
+                "category": "pizza",
+                "size": "large",
+                "quantity": 1,
+                "unit_price": 19.99,
+            },
         ],
         order_type="pickup",
     )
 
     corrected = _apply_update(
         order,
-        {"items": [
-            {"name": "Calzone", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 16.99},
-        ], "order_type": "pickup", "status": "in_progress"},
+        {
+            "items": [
+                {
+                    "name": "Calzone",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 1,
+                    "unit_price": 16.99,
+                },
+            ],
+            "order_type": "pickup",
+            "status": "in_progress",
+        },
     )
 
     assert len(corrected.items) == 1
@@ -1200,18 +1216,32 @@ def test_correction_quantity_change_does_not_duplicate_line():
     never two lines for the same item."""
     order = _seed_order_with(
         [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
+            {
+                "name": "Margherita",
+                "category": "pizza",
+                "size": "large",
+                "quantity": 1,
+                "unit_price": 19.99,
+            },
         ],
         order_type="pickup",
     )
 
     corrected = _apply_update(
         order,
-        {"items": [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 2, "unit_price": 19.99},
-        ], "order_type": "pickup", "status": "in_progress"},
+        {
+            "items": [
+                {
+                    "name": "Margherita",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 2,
+                    "unit_price": 19.99,
+                },
+            ],
+            "order_type": "pickup",
+            "status": "in_progress",
+        },
     )
 
     assert len(corrected.items) == 1
@@ -1224,18 +1254,32 @@ def test_correction_size_change_swaps_size_and_unit_price():
     new unit_price (the menu's price for the new size)."""
     order = _seed_order_with(
         [
-            {"name": "Margherita", "category": "pizza", "size": "medium",
-             "quantity": 1, "unit_price": 14.99},
+            {
+                "name": "Margherita",
+                "category": "pizza",
+                "size": "medium",
+                "quantity": 1,
+                "unit_price": 14.99,
+            },
         ],
         order_type="pickup",
     )
 
     corrected = _apply_update(
         order,
-        {"items": [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
-        ], "order_type": "pickup", "status": "in_progress"},
+        {
+            "items": [
+                {
+                    "name": "Margherita",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 1,
+                    "unit_price": 19.99,
+                },
+            ],
+            "order_type": "pickup",
+            "status": "in_progress",
+        },
     )
 
     assert len(corrected.items) == 1
@@ -1249,8 +1293,13 @@ def test_correction_order_type_swap_to_pickup_clears_delivery_address():
     would show a stale address on a pickup order."""
     order = _seed_order_with(
         [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
+            {
+                "name": "Margherita",
+                "category": "pizza",
+                "size": "large",
+                "quantity": 1,
+                "unit_price": 19.99,
+            },
         ],
         order_type="delivery",
         delivery_address="14 Spadina Ave",
@@ -1260,11 +1309,20 @@ def test_correction_order_type_swap_to_pickup_clears_delivery_address():
 
     corrected = _apply_update(
         order,
-        {"items": [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
-        ], "order_type": "pickup", "delivery_address": None,
-         "status": "in_progress"},
+        {
+            "items": [
+                {
+                    "name": "Margherita",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 1,
+                    "unit_price": 19.99,
+                },
+            ],
+            "order_type": "pickup",
+            "delivery_address": None,
+            "status": "in_progress",
+        },
     )
 
     assert corrected.order_type is OrderType.PICKUP
@@ -1276,8 +1334,13 @@ def test_correction_delivery_address_fix_overwrites_full_value():
     fully-corrected address — not a partial / diff."""
     order = _seed_order_with(
         [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
+            {
+                "name": "Margherita",
+                "category": "pizza",
+                "size": "large",
+                "quantity": 1,
+                "unit_price": 19.99,
+            },
         ],
         order_type="delivery",
         delivery_address="40 Main St",
@@ -1285,12 +1348,20 @@ def test_correction_delivery_address_fix_overwrites_full_value():
 
     corrected = _apply_update(
         order,
-        {"items": [
-            {"name": "Margherita", "category": "pizza", "size": "large",
-             "quantity": 1, "unit_price": 19.99},
-        ], "order_type": "delivery",
-         "delivery_address": "14 Main St",
-         "status": "in_progress"},
+        {
+            "items": [
+                {
+                    "name": "Margherita",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 1,
+                    "unit_price": 19.99,
+                },
+            ],
+            "order_type": "delivery",
+            "delivery_address": "14 Main St",
+            "status": "in_progress",
+        },
     )
 
     assert corrected.delivery_address == "14 Main St"
@@ -1308,8 +1379,13 @@ def test_correction_invalid_delivery_address_is_rejected_and_signaled():
         order,
         {
             "items": [
-                {"name": "Margherita", "category": "pizza", "size": "large",
-                 "quantity": 1, "unit_price": 19.99},
+                {
+                    "name": "Margherita",
+                    "category": "pizza",
+                    "size": "large",
+                    "quantity": 1,
+                    "unit_price": 19.99,
+                },
             ],
             "order_type": "delivery",
             "delivery_address": "14 Spadina Ave",
@@ -1329,8 +1405,13 @@ def test_correction_invalid_delivery_address_is_rejected_and_signaled():
                     name="update_order",
                     input={
                         "items": [
-                            {"name": "Margherita", "category": "pizza",
-                             "size": "large", "quantity": 1, "unit_price": 19.99},
+                            {
+                                "name": "Margherita",
+                                "category": "pizza",
+                                "size": "large",
+                                "quantity": 1,
+                                "unit_price": 19.99,
+                            },
                         ],
                         "order_type": "delivery",
                         "delivery_address": "uhh",
@@ -1339,9 +1420,7 @@ def test_correction_invalid_delivery_address_is_rejected_and_signaled():
                 ),
             ]
         ),
-        _fake_response(
-            [FakeBlock(type="text", text="Could you give me the full street address?")]
-        ),
+        _fake_response([FakeBlock(type="text", text="Could you give me the full street address?")]),
     ]
 
     result = generate_reply(
@@ -1439,12 +1518,14 @@ def test_apply_validation_passes_through_explicit_address_clears():
     from app.llm.client import _INVALID_ADDRESS_NOTE, _apply_validation
 
     # Explicit None passes through, no rejection note.
-    cleaned, notes = _apply_validation({
-        "items": [],
-        "order_type": "pickup",
-        "delivery_address": None,
-        "status": "in_progress",
-    })
+    cleaned, notes = _apply_validation(
+        {
+            "items": [],
+            "order_type": "pickup",
+            "delivery_address": None,
+            "status": "in_progress",
+        }
+    )
     assert cleaned == {
         "items": [],
         "order_type": "pickup",
@@ -1454,25 +1535,31 @@ def test_apply_validation_passes_through_explicit_address_clears():
     assert notes == []
 
     # Empty string passes through, no rejection note.
-    cleaned, notes = _apply_validation({
-        "delivery_address": "",
-    })
+    cleaned, notes = _apply_validation(
+        {
+            "delivery_address": "",
+        }
+    )
     assert cleaned == {"delivery_address": ""}
     assert notes == []
 
     # Whitespace-only passes through, no rejection note.
-    cleaned, notes = _apply_validation({
-        "delivery_address": "   ",
-    })
+    cleaned, notes = _apply_validation(
+        {
+            "delivery_address": "   ",
+        }
+    )
     assert cleaned == {"delivery_address": "   "}
     assert notes == []
 
     # Real garbage with content STILL gets rejected — verifies the
     # explicit-clear pass-through didn't accidentally weaken the
     # rejection path.
-    cleaned, notes = _apply_validation({
-        "delivery_address": "uhh",
-    })
+    cleaned, notes = _apply_validation(
+        {
+            "delivery_address": "uhh",
+        }
+    )
     assert "delivery_address" not in cleaned
     assert notes == [_INVALID_ADDRESS_NOTE]
 
@@ -1574,7 +1661,9 @@ async def test_stream_reply_followup_after_text_plus_tool_yields_both_deltas():
                 ],
             ),
             _FakeAsyncStream(
-                deltas=["So that's one Chicken Fried Rice — your total is twelve twenty-five. Sound right?"],
+                deltas=[
+                    "So that's one Chicken Fried Rice — your total is twelve twenty-five. Sound right?"
+                ],
                 blocks=[
                     FakeBlock(
                         type="text",
@@ -1598,7 +1687,10 @@ async def test_stream_reply_followup_after_text_plus_tool_yields_both_deltas():
 
     # Both delta streams must be yielded in order.
     assert "Got it, one Chicken Fried Rice coming up." in deltas
-    assert "So that's one Chicken Fried Rice — your total is twelve twenty-five. Sound right?" in deltas
+    assert (
+        "So that's one Chicken Fried Rice — your total is twelve twenty-five. Sound right?"
+        in deltas
+    )
     assert deltas.index("Got it, one Chicken Fried Rice coming up.") < deltas.index(
         "So that's one Chicken Fried Rice — your total is twelve twenty-five. Sound right?"
     )
@@ -1684,6 +1776,7 @@ async def test_stream_reply_tool_use_turn_emits_two_timing_events(monkeypatch):
     # Patch the time module reference inside client.py so asyncio's own
     # time.monotonic (used for event-loop scheduling) is not affected.
     import types as _types
+
     fake_time = _types.SimpleNamespace(monotonic=_fake_monotonic)
     monkeypatch.setattr(client_module, "time", fake_time)
 
@@ -1778,6 +1871,7 @@ async def test_stream_reply_tool_only_turn_emits_two_timing_events(monkeypatch):
     # Patch the time module reference inside client.py so asyncio's own
     # time.monotonic (used for event-loop scheduling) is not affected.
     import types as _types
+
     fake_time = _types.SimpleNamespace(monotonic=_fake_monotonic)
     monkeypatch.setattr(client_module, "time", fake_time)
 

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -79,9 +79,7 @@ _DEMO_SYSTEM_PROMPT = build_system_prompt(_DEMO_RESTAURANT)
 # Pickup-only variant: same menu, but offers_delivery=False so the
 # system prompt branches into the soft-pivot flow. Used by the
 # pickup_only_soft_pivot scenario in delivery_transcripts.py.
-_DEMO_PICKUP_ONLY_RESTAURANT = _DEMO_RESTAURANT.model_copy(
-    update={"offers_delivery": False}
-)
+_DEMO_PICKUP_ONLY_RESTAURANT = _DEMO_RESTAURANT.model_copy(update={"offers_delivery": False})
 _DEMO_PICKUP_ONLY_SYSTEM_PROMPT = build_system_prompt(_DEMO_PICKUP_ONLY_RESTAURANT)
 
 
@@ -93,7 +91,9 @@ def test_pickup_order_round_trip():
     transcript = "Hi, I'd like a large pepperoni pizza for pickup please."
 
     result = generate_reply(
-        transcript=transcript, history=[], order=order,
+        transcript=transcript,
+        history=[],
+        order=order,
         system_prompt=_DEMO_SYSTEM_PROMPT,
     )
 
@@ -103,9 +103,7 @@ def test_pickup_order_round_trip():
 
     assert len(result.reply_text) > 5, "Haiku should produce a spoken reply"
     assert result.order.call_sid == "CAintegration-pickup", "call_sid preserved"
-    assert len(result.order.items) >= 1, (
-        "Expected Haiku to record the pepperoni via update_order"
-    )
+    assert len(result.order.items) >= 1, "Expected Haiku to record the pepperoni via update_order"
 
 
 def test_greeting_does_not_mutate_order():
@@ -115,7 +113,9 @@ def test_greeting_does_not_mutate_order():
     transcript = "Hello?"
 
     result = generate_reply(
-        transcript=transcript, history=[], order=order,
+        transcript=transcript,
+        history=[],
+        order=order,
         system_prompt=_DEMO_SYSTEM_PROMPT,
     )
 
@@ -134,7 +134,9 @@ def test_off_menu_item_is_declined_without_adding():
     transcript = "Hi, can I get some sushi please?"
 
     result = generate_reply(
-        transcript=transcript, history=[], order=order,
+        transcript=transcript,
+        history=[],
+        order=order,
         system_prompt=_DEMO_SYSTEM_PROMPT,
     )
 
@@ -143,9 +145,7 @@ def test_off_menu_item_is_declined_without_adding():
     print(f"\n--- Order items ---\n{result.order.items}")
 
     assert len(result.reply_text) > 5, "Haiku should respond"
-    assert len(result.order.items) == 0, (
-        "Off-menu requests must not be added to the order"
-    )
+    assert len(result.order.items) == 0, "Off-menu requests must not be added to the order"
 
 
 def test_caller_changes_mind_replaces_pizza():
@@ -163,9 +163,9 @@ def test_caller_changes_mind_replaces_pizza():
     )
     print(f"\n--- Turn 1 reply ---\n{first.reply_text}")
     print(f"\n--- Turn 1 order ---\n{first.order.model_dump_json(indent=2)}")
-    assert any(
-        "pepperoni" in item.name.lower() for item in first.order.items
-    ), "Turn 1 should record the pepperoni"
+    assert any("pepperoni" in item.name.lower() for item in first.order.items), (
+        "Turn 1 should record the pepperoni"
+    )
 
     second = generate_reply(
         transcript="Actually, scratch that — make it a large veggie supreme instead.",
@@ -177,9 +177,7 @@ def test_caller_changes_mind_replaces_pizza():
     print(f"\n--- Turn 2 order ---\n{second.order.model_dump_json(indent=2)}")
 
     pizza_names = [item.name.lower() for item in second.order.items]
-    assert any("veggie" in name for name in pizza_names), (
-        "Turn 2 should record the veggie supreme"
-    )
+    assert any("veggie" in name for name in pizza_names), "Turn 2 should record the veggie supreme"
     assert not any("pepperoni" in name for name in pizza_names), (
         "Turn 2 should have replaced the pepperoni, not kept both"
     )
@@ -197,7 +195,9 @@ async def test_stream_reply_yields_deltas_before_final():
     final = None
 
     async for event in stream_reply(
-        transcript=transcript, history=[], order=order,
+        transcript=transcript,
+        history=[],
+        order=order,
         system_prompt=_DEMO_SYSTEM_PROMPT,
     ):
         if event.text_delta is not None:
@@ -224,6 +224,7 @@ async def test_stream_reply_yields_deltas_before_final():
 # `pytest` invocation. The module-level skipif still applies — without the
 # API key we skip even when -m live_llm is passed.
 
+
 @pytest.mark.live_llm
 @pytest.mark.parametrize(
     "scenario",
@@ -240,25 +241,33 @@ def test_caller_correction_lands_in_final_order(scenario: CorrectionScenario):
 
     for turn in scenario.initial_turns:
         result = generate_reply(
-            transcript=turn, history=history, order=order,
+            transcript=turn,
+            history=history,
+            order=order,
             system_prompt=_DEMO_SYSTEM_PROMPT,
         )
         order = result.order
         history = result.history
-        print(f"\n--- Seed turn ({scenario.id}) ---\nCaller: {turn}\n"
-              f"Haiku: {result.reply_text}\n"
-              f"Order: {order.model_dump_json(indent=2)}")
+        print(
+            f"\n--- Seed turn ({scenario.id}) ---\nCaller: {turn}\n"
+            f"Haiku: {result.reply_text}\n"
+            f"Order: {order.model_dump_json(indent=2)}"
+        )
 
     correction = scenario.correction_transcript
     result = generate_reply(
-        transcript=correction, history=history, order=order,
+        transcript=correction,
+        history=history,
+        order=order,
         system_prompt=_DEMO_SYSTEM_PROMPT,
     )
     order = result.order
 
-    print(f"\n--- Correction ({scenario.id}) ---\nCaller: {correction}\n"
-          f"Haiku: {result.reply_text}\n"
-          f"Final order: {order.model_dump_json(indent=2)}")
+    print(
+        f"\n--- Correction ({scenario.id}) ---\nCaller: {correction}\n"
+        f"Haiku: {result.reply_text}\n"
+        f"Final order: {order.model_dump_json(indent=2)}"
+    )
 
     scenario.assert_end_state(order)
 
@@ -301,9 +310,11 @@ def test_pickup_delivery_flow(scenario: CorrectionScenario):
         )
         order = result.order
         history = result.history
-        print(f"\n--- Seed turn ({scenario.id}) ---\nCaller: {turn}\n"
-              f"Haiku: {result.reply_text}\n"
-              f"Order: {order.model_dump_json(indent=2)}")
+        print(
+            f"\n--- Seed turn ({scenario.id}) ---\nCaller: {turn}\n"
+            f"Haiku: {result.reply_text}\n"
+            f"Order: {order.model_dump_json(indent=2)}"
+        )
 
     trigger = scenario.correction_transcript
     result = generate_reply(
@@ -314,8 +325,10 @@ def test_pickup_delivery_flow(scenario: CorrectionScenario):
     )
     order = result.order
 
-    print(f"\n--- Trigger ({scenario.id}) ---\nCaller: {trigger}\n"
-          f"Haiku: {result.reply_text}\n"
-          f"Final order: {order.model_dump_json(indent=2)}")
+    print(
+        f"\n--- Trigger ({scenario.id}) ---\nCaller: {trigger}\n"
+        f"Haiku: {result.reply_text}\n"
+        f"Final order: {order.model_dump_json(indent=2)}"
+    )
 
     scenario.assert_end_state(order)

--- a/tests/test_menu_api.py
+++ b/tests/test_menu_api.py
@@ -137,12 +137,14 @@ def test_post_category_rejects_underscore_prefix(client: TestClient):
 def test_patch_menu_item_409_on_rename_collision(client: TestClient):
     """PATCH that renames to an existing item's name in the same
     category must return 409."""
-    _wire({
-        "pizzas": [
-            {"name": "Margherita", "price": 12.99, "available": True},
-            {"name": "Pepperoni", "price": 15.99, "available": True},
-        ],
-    })
+    _wire(
+        {
+            "pizzas": [
+                {"name": "Margherita", "price": 12.99, "available": True},
+                {"name": "Pepperoni", "price": 15.99, "available": True},
+            ],
+        }
+    )
     resp = client.patch(
         "/restaurants/me/menu/items/pizzas/Margherita",
         json={"new_name": "Pepperoni"},
@@ -155,6 +157,7 @@ def test_post_menu_item_403_for_non_owner(client: TestClient, fake_tenant: Tenan
     import dataclasses
 
     from app.auth.dependency import current_tenant
+
     staff = dataclasses.replace(fake_tenant, role="staff")
     app.dependency_overrides[current_tenant] = lambda: staff
 

--- a/tests/test_menu_models.py
+++ b/tests/test_menu_models.py
@@ -66,11 +66,11 @@ def test_category_create_rejects_invalid_keys():
     from app.restaurants.models import CategoryCreate
 
     invalid = [
-        "Pizzas",          # uppercase
-        "fried rice",      # space
-        "fried-rice",      # hyphen
-        "_underscore",     # underscore prefix reserved for internal keys
-        "",                # empty
+        "Pizzas",  # uppercase
+        "fried rice",  # space
+        "fried-rice",  # hyphen
+        "_underscore",  # underscore prefix reserved for internal keys
+        "",  # empty
     ]
     for key in invalid:
         with pytest.raises(Exception):

--- a/tests/test_orders_lifecycle.py
+++ b/tests/test_orders_lifecycle.py
@@ -37,12 +37,7 @@ def _fake_client() -> MagicMock:
 def _order_doc(client: MagicMock):
     """Address the same ``restaurants/{rid}/orders/{call_sid}`` doc the
     storage module addresses."""
-    return (
-        client.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-    )
+    return client.collection.return_value.document.return_value.collection.return_value.document.return_value
 
 
 def _pepperoni() -> LineItem:
@@ -137,9 +132,7 @@ def test_persist_on_confirm_is_idempotent_on_already_confirmed_order():
 
     client = _fake_client()
     original_ts = datetime(2026, 4, 25, 12, 0, 0, tzinfo=timezone.utc)
-    order = _ready_pickup_order(
-        status=OrderStatus.CONFIRMED, confirmed_at=original_ts
-    )
+    order = _ready_pickup_order(status=OrderStatus.CONFIRMED, confirmed_at=original_ts)
 
     confirmed = persist_on_confirm(order)
 
@@ -248,6 +241,7 @@ def _confirmed_pickup_order(**overrides) -> Order:
 
 def test_mark_preparing_transitions_confirmed_to_preparing():
     from app.orders.lifecycle import mark_preparing
+
     client = _fake_client()
     order = _confirmed_pickup_order()
 
@@ -262,6 +256,7 @@ def test_mark_preparing_transitions_confirmed_to_preparing():
 
 def test_mark_preparing_rejects_wrong_source_state():
     from app.orders.lifecycle import OrderTransitionError, mark_preparing
+
     _fake_client()
     order = _ready_pickup_order()  # status=IN_PROGRESS
 
@@ -271,11 +266,10 @@ def test_mark_preparing_rejects_wrong_source_state():
 
 def test_mark_preparing_is_idempotent():
     from app.orders.lifecycle import mark_preparing
+
     client = _fake_client()
     original_ts = datetime(2026, 4, 28, 13, 0, 0, tzinfo=timezone.utc)
-    order = _confirmed_pickup_order(
-        status=OrderStatus.PREPARING, preparing_at=original_ts
-    )
+    order = _confirmed_pickup_order(status=OrderStatus.PREPARING, preparing_at=original_ts)
 
     updated = mark_preparing(order)
 
@@ -288,6 +282,7 @@ def test_mark_preparing_is_idempotent():
 
 def test_mark_ready_transitions_preparing_to_ready():
     from app.orders.lifecycle import mark_ready
+
     client = _fake_client()
     order = _confirmed_pickup_order(
         status=OrderStatus.PREPARING,
@@ -303,6 +298,7 @@ def test_mark_ready_transitions_preparing_to_ready():
 
 def test_mark_ready_rejects_wrong_source_state():
     from app.orders.lifecycle import OrderTransitionError, mark_ready
+
     _fake_client()
     order = _confirmed_pickup_order()  # status=CONFIRMED, not PREPARING
 
@@ -312,11 +308,10 @@ def test_mark_ready_rejects_wrong_source_state():
 
 def test_mark_ready_is_idempotent():
     from app.orders.lifecycle import mark_ready
+
     client = _fake_client()
     original_ts = datetime(2026, 4, 28, 13, 30, 0, tzinfo=timezone.utc)
-    order = _confirmed_pickup_order(
-        status=OrderStatus.READY, ready_at=original_ts
-    )
+    order = _confirmed_pickup_order(status=OrderStatus.READY, ready_at=original_ts)
 
     updated = mark_ready(order)
 
@@ -329,6 +324,7 @@ def test_mark_ready_is_idempotent():
 
 def test_mark_completed_transitions_ready_to_completed():
     from app.orders.lifecycle import mark_completed
+
     client = _fake_client()
     order = _confirmed_pickup_order(
         status=OrderStatus.READY,
@@ -344,6 +340,7 @@ def test_mark_completed_transitions_ready_to_completed():
 
 def test_mark_completed_rejects_wrong_source_state():
     from app.orders.lifecycle import OrderTransitionError, mark_completed
+
     _fake_client()
     order = _confirmed_pickup_order()  # status=CONFIRMED, not READY
 
@@ -353,11 +350,10 @@ def test_mark_completed_rejects_wrong_source_state():
 
 def test_mark_completed_is_idempotent():
     from app.orders.lifecycle import mark_completed
+
     client = _fake_client()
     original_ts = datetime(2026, 4, 28, 14, 0, 0, tzinfo=timezone.utc)
-    order = _confirmed_pickup_order(
-        status=OrderStatus.COMPLETED, completed_at=original_ts
-    )
+    order = _confirmed_pickup_order(status=OrderStatus.COMPLETED, completed_at=original_ts)
 
     updated = mark_completed(order)
 
@@ -370,6 +366,7 @@ def test_mark_completed_is_idempotent():
 
 def test_cancel_order_transitions_from_in_progress():
     from app.orders.lifecycle import cancel_order
+
     client = _fake_client()
     order = _ready_pickup_order()  # status=IN_PROGRESS
 
@@ -382,6 +379,7 @@ def test_cancel_order_transitions_from_in_progress():
 
 def test_cancel_order_transitions_from_preparing():
     from app.orders.lifecycle import cancel_order
+
     _fake_client()
     order = _confirmed_pickup_order(
         status=OrderStatus.PREPARING,
@@ -397,6 +395,7 @@ def test_cancel_order_transitions_from_preparing():
 
 def test_cancel_order_rejects_already_completed_order():
     from app.orders.lifecycle import OrderTransitionError, cancel_order
+
     _fake_client()
     order = _confirmed_pickup_order(
         status=OrderStatus.COMPLETED,
@@ -409,11 +408,10 @@ def test_cancel_order_rejects_already_completed_order():
 
 def test_cancel_order_is_idempotent():
     from app.orders.lifecycle import cancel_order
+
     client = _fake_client()
     original_ts = datetime(2026, 4, 28, 13, 0, 0, tzinfo=timezone.utc)
-    order = _confirmed_pickup_order(
-        status=OrderStatus.CANCELLED, cancelled_at=original_ts
-    )
+    order = _confirmed_pickup_order(status=OrderStatus.CANCELLED, cancelled_at=original_ts)
 
     updated = cancel_order(order)
 
@@ -429,6 +427,7 @@ def test_cancel_order_is_idempotent():
 def test_persist_on_confirm_sends_order_confirmation_sms():
     """After Firestore write, persist_on_confirm fires the SMS."""
     from unittest.mock import patch
+
     _fake_client()
     order = _ready_pickup_order(caller_phone="+15551234567")
 
@@ -447,6 +446,7 @@ def test_persist_on_confirm_skips_sms_when_no_caller_phone():
     """An order without caller_phone (rare — the call had bad caller ID)
     is still confirmable; we just don't send a confirmation SMS."""
     from unittest.mock import patch
+
     _fake_client()
     order = _ready_pickup_order(caller_phone=None)
 
@@ -462,6 +462,7 @@ def test_persist_on_confirm_swallows_sms_errors():
     from unittest.mock import patch
 
     from app.sms.exceptions import SmsError
+
     _fake_client()
     order = _ready_pickup_order(caller_phone="+15551234567")
 
@@ -475,6 +476,7 @@ def test_persist_on_confirm_swallows_non_sms_errors_too():
     """Defensive: even non-SmsError raised by send_sms (or by the
     template renderer) must not roll back the order."""
     from unittest.mock import patch
+
     _fake_client()
     order = _ready_pickup_order(caller_phone="+15551234567")
 

--- a/tests/test_orders_route.py
+++ b/tests/test_orders_route.py
@@ -66,36 +66,33 @@ def _fake_firestore_with_orders(docs: list[dict]) -> MagicMock:
 
     # Path: restaurants/{rid}/orders → order_by → limit → stream
     (
-        fake_client.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .order_by.return_value
-        .limit.return_value
-        .stream.return_value
+        fake_client.collection.return_value.document.return_value.collection.return_value.order_by.return_value.limit.return_value.stream.return_value
     ) = iter(snapshots)
     storage.set_client(fake_client)
     return fake_client
 
 
 def test_list_orders_returns_recent_orders():
-    _fake_firestore_with_orders([
-        {
-            "call_sid": "CA1",
-            "items": [
-                {
-                    "name": "Pepperoni",
-                    "category": "pizza",
-                    "size": "medium",
-                    "quantity": 1,
-                    "unit_price": 17.99,
-                    "modifications": [],
-                }
-            ],
-            "order_type": "pickup",
-            "status": "confirmed",
-        },
-        {"call_sid": "CA2", "items": []},
-    ])
+    _fake_firestore_with_orders(
+        [
+            {
+                "call_sid": "CA1",
+                "items": [
+                    {
+                        "name": "Pepperoni",
+                        "category": "pizza",
+                        "size": "medium",
+                        "quantity": 1,
+                        "unit_price": 17.99,
+                        "modifications": [],
+                    }
+                ],
+                "order_type": "pickup",
+                "status": "confirmed",
+            },
+            {"call_sid": "CA2", "items": []},
+        ]
+    )
 
     response = client.get("/orders")
 
@@ -117,11 +114,7 @@ def test_list_orders_addresses_authenticated_tenant():
 
     fake.collection.assert_called_with("restaurants")
     fake.collection.return_value.document.assert_called_with(_DEMO_RID)
-    (
-        fake.collection.return_value
-        .document.return_value
-        .collection.assert_called_with("orders")
-    )
+    (fake.collection.return_value.document.return_value.collection.assert_called_with("orders"))
 
 
 def test_list_orders_ignores_query_param_attempts_to_cross_tenant():
@@ -151,11 +144,9 @@ def test_list_orders_respects_limit_query_param():
 
     assert response.status_code == 200
     (
-        fake.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .order_by.return_value
-        .limit.assert_called_with(10)
+        fake.collection.return_value.document.return_value.collection.return_value.order_by.return_value.limit.assert_called_with(
+            10
+        )
     )
 
 
@@ -189,18 +180,8 @@ def test_seed_order_persists_when_dev_flag_on(dev_endpoints_enabled):
     # Seed orders land under the demo tenant's nested path.
     fake.collection.assert_called_with("restaurants")
     fake.collection.return_value.document.assert_called_with(_DEMO_RID)
-    (
-        fake.collection.return_value
-        .document.return_value
-        .collection.assert_called_with("orders")
-    )
-    set_call = (
-        fake.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-        .set
-    )
+    (fake.collection.return_value.document.return_value.collection.assert_called_with("orders"))
+    set_call = fake.collection.return_value.document.return_value.collection.return_value.document.return_value.set
     set_call.assert_called_once()
 
 
@@ -234,21 +215,12 @@ def _fake_firestore_with_single_order(doc: dict | None) -> MagicMock:
         snapshot.exists = False
 
     (
-        fake_client.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-        .get.return_value
+        fake_client.collection.return_value.document.return_value.collection.return_value.document.return_value.get.return_value
     ) = snapshot
 
     # Wire the list path too so the stream doesn't raise on accidental calls.
     (
-        fake_client.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .order_by.return_value
-        .limit.return_value
-        .stream.return_value
+        fake_client.collection.return_value.document.return_value.collection.return_value.order_by.return_value.limit.return_value.stream.return_value
     ) = iter([])
 
     storage.set_client(fake_client)

--- a/tests/test_recordings_storage.py
+++ b/tests/test_recordings_storage.py
@@ -20,7 +20,7 @@ def test_ulaw2lin_16_decodes_two_bytes():
     """Sanity: lookup-table decode produces 2 bytes per μ-law byte."""
     from app.storage.recordings import _ulaw2lin_16
 
-    assert len(_ulaw2lin_16(b"\xff\xff")) == 4   # 2 samples × 2 bytes
+    assert len(_ulaw2lin_16(b"\xff\xff")) == 4  # 2 samples × 2 bytes
     assert len(_ulaw2lin_16(b"")) == 0
 
 
@@ -88,7 +88,7 @@ def test_make_encoder_is_mono():
     from app.storage.recordings import _make_encoder
 
     enc = _make_encoder()
-    pcm = b"\x00" * (8000 * 2)   # 1 second of mono PCM silence
+    pcm = b"\x00" * (8000 * 2)  # 1 second of mono PCM silence
     mp3 = enc.encode(pcm)
     mp3 += enc.flush()
 
@@ -108,9 +108,7 @@ def test_begin_recording_creates_session_with_blob_name_and_retention():
     No GCS calls at begin — the upload happens at finalize."""
     from app.storage import recordings
 
-    session = recordings.begin_recording(
-        call_sid="CAtest", restaurant_id="rid1", retention_days=7
-    )
+    session = recordings.begin_recording(call_sid="CAtest", restaurant_id="rid1", retention_days=7)
 
     assert session.call_sid == "CAtest"
     assert session.restaurant_id == "rid1"
@@ -129,9 +127,7 @@ def test_begin_recording_creates_session_with_blob_name_and_retention():
 def test_append_chunks_extends_inbound_buffer():
     from app.storage import recordings
 
-    session = recordings.begin_recording(
-        call_sid="CAt", restaurant_id="rid", retention_days=90
-    )
+    session = recordings.begin_recording(call_sid="CAt", restaurant_id="rid", retention_days=90)
     recordings.append_chunks(session, b"\xff" * 8, b"")
 
     # 8 μ-law bytes → 16 PCM bytes (2 bytes per sample)
@@ -145,12 +141,10 @@ def test_append_chunks_pads_outbound_to_inbound_position():
     aligned to wall-clock time without per-chunk timestamps."""
     from app.storage import recordings
 
-    session = recordings.begin_recording(
-        call_sid="CAt", restaurant_id="rid", retention_days=90
-    )
+    session = recordings.begin_recording(call_sid="CAt", restaurant_id="rid", retention_days=90)
     # Caller silence for "100 samples" arrives first.
     recordings.append_chunks(session, b"\xff" * 100, b"")
-    assert len(session.inbound_pcm) == 200   # 100 samples × 2 bytes
+    assert len(session.inbound_pcm) == 200  # 100 samples × 2 bytes
     assert len(session.outbound_pcm) == 0
 
     # Now the agent says something — outbound chunk = 5 samples of TTS.
@@ -166,9 +160,7 @@ def test_append_chunks_pads_outbound_to_inbound_position():
 def test_append_chunks_skips_when_session_broken():
     from app.storage import recordings
 
-    session = recordings.begin_recording(
-        call_sid="CAt", restaurant_id="rid", retention_days=90
-    )
+    session = recordings.begin_recording(call_sid="CAt", restaurant_id="rid", retention_days=90)
     session.broken = True
     recordings.append_chunks(session, b"\xff" * 100, b"\x80" * 100)
 
@@ -179,9 +171,7 @@ def test_append_chunks_skips_when_session_broken():
 def test_append_chunks_handles_empty_payloads():
     from app.storage import recordings
 
-    session = recordings.begin_recording(
-        call_sid="CAt", restaurant_id="rid", retention_days=90
-    )
+    session = recordings.begin_recording(call_sid="CAt", restaurant_id="rid", retention_days=90)
     recordings.append_chunks(session, b"", b"")
 
     assert session.inbound_pcm == bytearray()
@@ -204,15 +194,19 @@ def test_finalize_recording_mixes_encodes_and_uploads(monkeypatch):
 
     fake_blob = type("FakeBlob", (), {})()
     fake_blob.custom_time = None
+
     def fake_upload(data, content_type):
         captured["data"] = data
         captured["content_type"] = content_type
+
     fake_blob.upload_from_string = fake_upload
 
     fake_bucket = type("FakeBucket", (), {})()
+
     def get_blob(name):
         captured["blob_name"] = name
         return fake_blob
+
     fake_bucket.blob = get_blob
 
     fake_client = type("FakeClient", (), {})()
@@ -220,9 +214,7 @@ def test_finalize_recording_mixes_encodes_and_uploads(monkeypatch):
 
     monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
 
-    session = recordings.begin_recording(
-        call_sid="CAt", restaurant_id="rid", retention_days=7
-    )
+    session = recordings.begin_recording(call_sid="CAt", restaurant_id="rid", retention_days=7)
     # Simulate 1 second of overlapping audio: feed the agent (outbound)
     # chunk *first*, while inbound is still empty, so the alignment
     # logic doesn't shift it. Then feed 1 second of caller audio.
@@ -246,7 +238,11 @@ def test_finalize_recording_mixes_encodes_and_uploads(monkeypatch):
     # Output is real MP3 bytes
     assert captured["data"][0] == 0xFF and (captured["data"][1] & 0xE0) == 0xE0
     # custom_time is set to now() + retention_days
-    assert before + timedelta(days=7) - timedelta(seconds=2) <= fake_blob.custom_time <= after + timedelta(days=7)
+    assert (
+        before + timedelta(days=7) - timedelta(seconds=2)
+        <= fake_blob.custom_time
+        <= after + timedelta(days=7)
+    )
 
 
 def test_finalize_recording_returns_empty_when_no_audio(monkeypatch):
@@ -255,13 +251,12 @@ def test_finalize_recording_returns_empty_when_no_audio(monkeypatch):
     from app.storage import recordings
 
     monkeypatch.setattr(
-        recordings, "_get_storage_client",
+        recordings,
+        "_get_storage_client",
         lambda: (_ for _ in ()).throw(AssertionError("must not touch GCS")),
     )
 
-    session = recordings.begin_recording(
-        call_sid="CAt", restaurant_id="rid", retention_days=90
-    )
+    session = recordings.begin_recording(call_sid="CAt", restaurant_id="rid", retention_days=90)
     url, duration = recordings.finalize_recording(session)
 
     assert url == ""
@@ -272,13 +267,12 @@ def test_finalize_recording_skips_when_broken(monkeypatch):
     from app.storage import recordings
 
     monkeypatch.setattr(
-        recordings, "_get_storage_client",
+        recordings,
+        "_get_storage_client",
         lambda: (_ for _ in ()).throw(AssertionError("must not touch GCS on broken")),
     )
 
-    session = recordings.begin_recording(
-        call_sid="CAt", restaurant_id="rid", retention_days=90
-    )
+    session = recordings.begin_recording(call_sid="CAt", restaurant_id="rid", retention_days=90)
     session.inbound_pcm.extend(b"\x00" * 100)
     session.broken = True
 
@@ -295,8 +289,10 @@ def test_finalize_recording_swallows_upload_failure(monkeypatch):
 
     fake_blob = type("FakeBlob", (), {})()
     fake_blob.custom_time = None
+
     def fake_upload(data, content_type):
         raise RuntimeError("upload exploded")
+
     fake_blob.upload_from_string = fake_upload
 
     fake_bucket = type("FakeBucket", (), {})()
@@ -307,9 +303,7 @@ def test_finalize_recording_swallows_upload_failure(monkeypatch):
 
     monkeypatch.setattr(recordings, "_get_storage_client", lambda: fake_client)
 
-    session = recordings.begin_recording(
-        call_sid="CAt", restaurant_id="rid", retention_days=90
-    )
+    session = recordings.begin_recording(call_sid="CAt", restaurant_id="rid", retention_days=90)
     session.inbound_pcm.extend(b"\x00" * 1000)
 
     url, duration = recordings.finalize_recording(session)
@@ -333,7 +327,7 @@ def test_delete_recording_calls_blob_delete(monkeypatch):
     fake_blob.delete = lambda: deleted.append("called")
 
     fake_bucket = type("FakeBucket", (), {})()
-    fake_bucket.blob = lambda name: (deleted.append(name) or fake_blob)
+    fake_bucket.blob = lambda name: deleted.append(name) or fake_blob
 
     fake_client = type("FakeClient", (), {})()
     fake_client.bucket = lambda name: fake_bucket
@@ -351,8 +345,10 @@ def test_delete_recording_idempotent_on_404(monkeypatch):
     from app.storage import recordings
 
     fake_blob = type("FakeBlob", (), {})()
+
     def raise_notfound():
         raise NotFound("gone")
+
     fake_blob.delete = raise_notfound
 
     fake_bucket = type("FakeBucket", (), {})()
@@ -386,15 +382,19 @@ def test_generate_signed_url_uses_v4_get_30min_and_iam_signblob(monkeypatch):
     captured: dict = {}
 
     fake_blob = type("FakeBlob", (), {})()
+
     def fake_signed(**kwargs):
         captured.update(kwargs)
         return "https://signed.googleapis.com/?sig=fake"
+
     fake_blob.generate_signed_url = fake_signed
 
     fake_bucket = type("FakeBucket", (), {})()
+
     def get_blob(name):
         captured["blob_name"] = name
         return fake_blob
+
     fake_bucket.blob = get_blob
 
     fake_client = type("FakeClient", (), {})()
@@ -408,8 +408,10 @@ def test_generate_signed_url_uses_v4_get_30min_and_iam_signblob(monkeypatch):
         refresh=lambda _request: None,
     )
     import google.auth as gauth_mod
+
     monkeypatch.setattr(gauth_mod, "default", lambda: (fake_creds, "niko-tsuki"))
     from google.auth.transport import requests as _gauth_req
+
     monkeypatch.setattr(_gauth_req, "Request", lambda: object())
 
     url = recordings.generate_signed_url(call_sid="CAt", restaurant_id="rid")

--- a/tests/test_restaurants_storage.py
+++ b/tests/test_restaurants_storage.py
@@ -90,29 +90,19 @@ def test_get_restaurant_caches_within_ttl():
 def test_get_restaurant_by_twilio_phone_returns_doc():
     client = _fake_client()
     snap = _fake_doc(_restaurant_payload())
-    query = (
-        client.collection.return_value
-        .where.return_value
-        .limit.return_value
-    )
+    query = client.collection.return_value.where.return_value.limit.return_value
     query.stream.return_value = iter([snap])
 
     result = storage.get_restaurant_by_twilio_phone("+16479058093")
 
     assert result is not None
     assert result.id == "niko-pizza-kitchen"
-    client.collection.return_value.where.assert_called_with(
-        "twilio_phone", "==", "+16479058093"
-    )
+    client.collection.return_value.where.assert_called_with("twilio_phone", "==", "+16479058093")
 
 
 def test_get_restaurant_by_twilio_phone_returns_none_when_no_match():
     client = _fake_client()
-    query = (
-        client.collection.return_value
-        .where.return_value
-        .limit.return_value
-    )
+    query = client.collection.return_value.where.return_value.limit.return_value
     query.stream.return_value = iter([])
 
     assert storage.get_restaurant_by_twilio_phone("+19990000000") is None
@@ -176,8 +166,8 @@ def test_get_restaurant_returns_none_when_firestore_raises(caplog):
     """A transient Firestore error must not crash the call flow — the
     router treats ``None`` as a fallback signal."""
     client = _fake_client()
-    client.collection.return_value.document.return_value.get.side_effect = (
-        RuntimeError("firestore unavailable")
+    client.collection.return_value.document.return_value.get.side_effect = RuntimeError(
+        "firestore unavailable"
     )
 
     with caplog.at_level("ERROR"):
@@ -216,8 +206,13 @@ def test_restaurant_recording_retention_default_is_90():
     from app.restaurants.models import Restaurant
 
     r = Restaurant(
-        id="x", name="X", display_phone="+1", twilio_phone="+1",
-        address="a", hours="h", menu={"pizzas": [], "sides": [], "drinks": []},
+        id="x",
+        name="X",
+        display_phone="+1",
+        twilio_phone="+1",
+        address="a",
+        hours="h",
+        menu={"pizzas": [], "sides": [], "drinks": []},
     )
     assert r.recording_retention_days == 90
 
@@ -226,8 +221,12 @@ def test_restaurant_recording_retention_accepts_override():
     from app.restaurants.models import Restaurant
 
     r = Restaurant(
-        id="x", name="X", display_phone="+1", twilio_phone="+1",
-        address="a", hours="h",
+        id="x",
+        name="X",
+        display_phone="+1",
+        twilio_phone="+1",
+        address="a",
+        hours="h",
         menu={"pizzas": [], "sides": [], "drinks": []},
         recording_retention_days=30,
     )
@@ -242,8 +241,12 @@ def test_restaurant_recording_retention_rejects_zero_or_negative():
 
     with pytest.raises(ValidationError):
         Restaurant(
-            id="x", name="X", display_phone="+1", twilio_phone="+1",
-            address="a", hours="h",
+            id="x",
+            name="X",
+            display_phone="+1",
+            twilio_phone="+1",
+            address="a",
+            hours="h",
             menu={"pizzas": [], "sides": [], "drinks": []},
             recording_retention_days=0,
         )
@@ -280,7 +283,11 @@ def test_restaurant_has_optional_hours_structured_and_fallback_phone():
         sun=DayHours(open="11:00", close="22:00", closed=True),
     )
     full = Restaurant.model_validate(
-        {**legacy_doc, "hours_structured": structured.model_dump(), "fallback_phone": "+15559999999"},
+        {
+            **legacy_doc,
+            "hours_structured": structured.model_dump(),
+            "fallback_phone": "+15559999999",
+        },
     )
     assert full.hours_structured is not None
     assert full.hours_structured.sun.closed is True

--- a/tests/test_sms_client.py
+++ b/tests/test_sms_client.py
@@ -39,12 +39,7 @@ def _fake_storage(order: Order | None) -> MagicMock:
         snapshot.exists = True
         snapshot.to_dict.return_value = order.model_dump(mode="python")
     (
-        client.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-        .get
-        .return_value
+        client.collection.return_value.document.return_value.collection.return_value.document.return_value.get.return_value
     ) = snapshot
     return client
 
@@ -115,7 +110,9 @@ def test_send_sms_short_circuits_when_record_already_exists():
 
     twilio_factory.return_value.messages.create.assert_not_called()
     assert result.sid == "SMexisting"
-    assert result.status == "sent"  # short-circuit returns "sent" since record's presence implies success
+    assert (
+        result.status == "sent"
+    )  # short-circuit returns "sent" since record's presence implies success
 
 
 def test_send_sms_writes_record_back_to_firestore_on_success():
@@ -138,13 +135,7 @@ def test_send_sms_writes_record_back_to_firestore_on_success():
         )
 
     # Confirm the doc was set with the new record under sms_sent
-    set_call = (
-        client.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-        .set
-    )
+    set_call = client.collection.return_value.document.return_value.collection.return_value.document.return_value.set
     set_call.assert_called_once()
     payload = set_call.call_args.args[0]
     assert "order_confirmation" in payload["sms_sent"]

--- a/tests/test_sms_e2e.py
+++ b/tests/test_sms_e2e.py
@@ -52,12 +52,7 @@ def test_confirm_to_sms_full_path():
     ).model_dump(mode="python")
     snapshot.to_dict.return_value = confirmed_dump
     (
-        fs_client.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .document.return_value
-        .get
-        .return_value
+        fs_client.collection.return_value.document.return_value.collection.return_value.document.return_value.get.return_value
     ) = snapshot
 
     with (

--- a/tests/test_storage_analytics.py
+++ b/tests/test_storage_analytics.py
@@ -35,11 +35,7 @@ def _wire_orders(orders: list[Order]) -> None:
         snap.to_dict.return_value = o.model_dump(mode="python")
         snapshots.append(snap)
     (
-        fs.collection.return_value
-        .document.return_value
-        .collection.return_value
-        .where.return_value
-        .stream
+        fs.collection.return_value.document.return_value.collection.return_value.where.return_value.stream
     ).return_value = iter(snapshots)
 
 

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -69,9 +69,7 @@ _STOP_MSG = {"event": "stop", "stop": {"accountSid": "ACtest", "callSid": "CAtes
 def _make_fake_stream_reply(reply="Hi, welcome to Niko's Pizza Kitchen!"):
     async def fake_stream_reply(*, transcript, history, order, **kw):
         yield StreamEvent(text_delta=reply)
-        yield StreamEvent(
-            final=LLMResponse(reply_text=reply, order=order, history=history)
-        )
+        yield StreamEvent(final=LLMResponse(reply_text=reply, order=order, history=history))
 
     return fake_stream_reply
 
@@ -95,9 +93,7 @@ def mock_pipeline(monkeypatch):
 
     monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
     monkeypatch.setattr("app.telephony.router.speak", fake_speak)
-    monkeypatch.setattr(
-        "app.telephony.router.stream_reply", _make_fake_stream_reply()
-    )
+    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
     monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
@@ -110,22 +106,18 @@ def mock_pipeline(monkeypatch):
 
 
 def test_voice_returns_xml(monkeypatch):
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
-    )
+    monkeypatch.setattr(restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None)
     response = client.post("/voice", data=_VOICE_FORM)
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/xml")
 
 
 def test_voice_twiml_contains_media_stream_no_say(monkeypatch):
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
-    )
+    monkeypatch.setattr(restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None)
     response = client.post("/voice", data=_VOICE_FORM)
     body = response.text
     assert "<Response>" in body
-    assert "<Say" not in body          # greeting is now via ElevenLabs on start event
+    assert "<Say" not in body  # greeting is now via ElevenLabs on start event
     assert "<Connect" in body
     assert "<Stream" in body
     # TestClient sets Host: testserver
@@ -136,9 +128,7 @@ def test_voice_passes_restaurant_id_as_stream_parameter(monkeypatch):
     """PR B (#79): /voice resolves the tenant by ``To`` and forwards the
     id to /media-stream via a Stream <Parameter>. Twilio echoes it back
     on the start event under ``customParameters.restaurant_id``."""
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
-    )
+    monkeypatch.setattr(restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None)
     response = client.post("/voice", data=_VOICE_FORM)
     body = response.text
     assert "<Parameter" in body
@@ -153,9 +143,7 @@ def test_voice_stream_omits_track_attribute(monkeypatch):
     trial-account interstitial. To get agent audio into the recording
     we capture TTS bytes inside ``speak()`` instead — see the WS
     handler in the same module."""
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
-    )
+    monkeypatch.setattr(restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None)
     response = client.post("/voice", data=_VOICE_FORM)
     body = response.text
     assert "<Stream " in body
@@ -194,9 +182,7 @@ def test_voice_uses_firestore_lookup_when_present(monkeypatch):
 def test_voice_rejects_unmapped_number(monkeypatch):
     """Inbound to a number with no tenant mapping plays a brief hangup
     message instead of dead air."""
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
-    )
+    monkeypatch.setattr(restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None)
     response = client.post(
         "/voice",
         data={"CallSid": "CAtest", "From": "+10000000000", "To": "+19999999999"},
@@ -246,26 +232,26 @@ def test_media_stream_begins_recording_on_start(mock_pipeline, monkeypatch):
     seeded = Restaurant(
         id="niko-pizza-kitchen",
         name="Niko",
-        display_phone="+1", twilio_phone=_DEMO_TO,
-        address="a", hours="h",
+        display_phone="+1",
+        twilio_phone=_DEMO_TO,
+        address="a",
+        hours="h",
         menu={"pizzas": [], "sides": [], "drinks": []},
         recording_retention_days=42,
     )
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant", lambda _rid: seeded
-    )
-    monkeypatch.setattr(
-        restaurants_storage, "load_or_fallback_demo", lambda _rid: seeded
-    )
+    monkeypatch.setattr(restaurants_storage, "get_restaurant", lambda _rid: seeded)
+    monkeypatch.setattr(restaurants_storage, "load_or_fallback_demo", lambda _rid: seeded)
 
     captured: list[dict] = []
 
     def fake_begin(*, call_sid, restaurant_id, retention_days):
-        captured.append({
-            "call_sid": call_sid,
-            "restaurant_id": restaurant_id,
-            "retention_days": retention_days,
-        })
+        captured.append(
+            {
+                "call_sid": call_sid,
+                "restaurant_id": restaurant_id,
+                "retention_days": retention_days,
+            }
+        )
         return MagicMock(broken=False)
 
     monkeypatch.setattr(recordings_mod, "begin_recording", fake_begin)
@@ -296,16 +282,21 @@ def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
     captured: list[tuple[bytes, bytes]] = []
 
     monkeypatch.setattr(
-        recordings_mod, "begin_recording",
+        recordings_mod,
+        "begin_recording",
         lambda *, call_sid, restaurant_id, retention_days: fake_session,
     )
     monkeypatch.setattr(
-        recordings_mod, "append_chunks",
-        lambda session, inbound_mu_law, outbound_mu_law:
-            captured.append((inbound_mu_law, outbound_mu_law)),
+        recordings_mod,
+        "append_chunks",
+        lambda session, inbound_mu_law, outbound_mu_law: captured.append(
+            (inbound_mu_law, outbound_mu_law)
+        ),
     )
     monkeypatch.setattr(
-        recordings_mod, "finalize_recording", lambda _s: ("", 0),
+        recordings_mod,
+        "finalize_recording",
+        lambda _s: ("", 0),
     )
 
     fake_dg = AsyncMock()
@@ -320,10 +311,9 @@ def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
 
     monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
     monkeypatch.setattr("app.telephony.router.speak", fake_speak)
-    monkeypatch.setattr(
-        "app.telephony.router.stream_reply", _make_fake_stream_reply()
-    )
+    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
     from app.storage import call_sessions
+
     monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
@@ -335,14 +325,32 @@ def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
     with client.websocket_connect("/media-stream") as ws:
         ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
         ws.send_text(json.dumps(_START_MSG))
-        ws.send_text(json.dumps({
-            "event": "media",
-            "media": {"track": "inbound", "chunk": "1", "timestamp": "5", "payload": inbound_payload},
-        }))
-        ws.send_text(json.dumps({
-            "event": "media",
-            "media": {"track": "outbound", "chunk": "2", "timestamp": "10", "payload": outbound_payload},
-        }))
+        ws.send_text(
+            json.dumps(
+                {
+                    "event": "media",
+                    "media": {
+                        "track": "inbound",
+                        "chunk": "1",
+                        "timestamp": "5",
+                        "payload": inbound_payload,
+                    },
+                }
+            )
+        )
+        ws.send_text(
+            json.dumps(
+                {
+                    "event": "media",
+                    "media": {
+                        "track": "outbound",
+                        "chunk": "2",
+                        "timestamp": "10",
+                        "payload": outbound_payload,
+                    },
+                }
+            )
+        )
         ws.send_text(json.dumps(_STOP_MSG))
 
     assert (b"\xff" * 8, b"") in captured
@@ -357,12 +365,14 @@ def test_media_stream_finalizes_recording_on_stop(monkeypatch):
 
     fake_session = MagicMock(broken=False)
     monkeypatch.setattr(
-        recordings_mod, "begin_recording",
+        recordings_mod,
+        "begin_recording",
         lambda *, call_sid, restaurant_id, retention_days: fake_session,
     )
     monkeypatch.setattr(recordings_mod, "append_chunks", lambda *a, **kw: None)
     monkeypatch.setattr(
-        recordings_mod, "finalize_recording",
+        recordings_mod,
+        "finalize_recording",
         lambda session: ("gs://niko-recordings/niko-pizza-kitchen/CAtest123.mp3", 12),
     )
 
@@ -383,7 +393,8 @@ def test_media_stream_finalizes_recording_on_stop(monkeypatch):
 
     captured: list[dict] = []
     monkeypatch.setattr(
-        call_sessions, "mark_recording_ready",
+        call_sessions,
+        "mark_recording_ready",
         lambda call_sid, rid, **kw: captured.append({"call_sid": call_sid, "rid": rid, **kw}),
     )
 
@@ -423,9 +434,7 @@ def test_ai_greeting_spawned_on_start(monkeypatch):
     async def recording_stream_reply(*, transcript, history, order, **kw):
         calls.append(transcript)
         yield StreamEvent(text_delta="Hello!")
-        yield StreamEvent(
-            final=LLMResponse(reply_text="Hello!", order=order, history=history)
-        )
+        yield StreamEvent(final=LLMResponse(reply_text="Hello!", order=order, history=history))
 
     monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
     monkeypatch.setattr("app.telephony.router.speak", fake_speak)
@@ -462,7 +471,15 @@ def test_stop_event_persists_ready_order(monkeypatch):
 
     ready_order = Order(
         call_sid="CAtest123",
-        items=[LineItem(name="Pepperoni", category=ItemCategory.PIZZA, size="large", quantity=1, unit_price=21.99)],
+        items=[
+            LineItem(
+                name="Pepperoni",
+                category=ItemCategory.PIZZA,
+                size="large",
+                quantity=1,
+                unit_price=21.99,
+            )
+        ],
         order_type=OrderType.PICKUP,
     )
 
@@ -630,9 +647,7 @@ async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
 
     await clear_twilio_audio(ws, "MZtest456")
 
-    ws.send_json.assert_awaited_once_with(
-        {"event": "clear", "streamSid": "MZtest456"}
-    )
+    ws.send_json.assert_awaited_once_with({"event": "clear", "streamSid": "MZtest456"})
 
 
 @pytest.mark.asyncio
@@ -651,9 +666,7 @@ async def test_clear_twilio_audio_skips_when_stream_sid_missing():
 def test_looks_like_goodbye_matches_terminal_phrases():
     from app.telephony.router import _looks_like_goodbye
 
-    assert _looks_like_goodbye(
-        "Great, your order is in — we'll have it ready for you soon!"
-    )
+    assert _looks_like_goodbye("Great, your order is in — we'll have it ready for you soon!")
     assert _looks_like_goodbye("Perfect, see you soon!")
     assert _looks_like_goodbye("Thanks for calling!")
     assert _looks_like_goodbye("Have a great day.")
@@ -663,13 +676,9 @@ def test_looks_like_goodbye_rejects_questions():
     """A reply that ends with '?' is still asking the caller something."""
     from app.telephony.router import _looks_like_goodbye
 
-    assert not _looks_like_goodbye(
-        "Got that. Anything else, or are you all set?"
-    )
+    assert not _looks_like_goodbye("Got that. Anything else, or are you all set?")
     # Even with goodbye-shaped phrasing earlier, trailing '?' = still asking.
-    assert not _looks_like_goodbye(
-        "Your order is in — does that all sound right?"
-    )
+    assert not _looks_like_goodbye("Your order is in — does that all sound right?")
 
 
 def test_looks_like_goodbye_rejects_simple_acknowledgements():
@@ -756,6 +765,7 @@ async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
 def test_looks_like_goodbye_excludes_coming_right_up():
     """'coming right up' is mid-order, not a wrap-up — must NOT trigger fallback."""
     from app.telephony.router import _looks_like_goodbye
+
     assert _looks_like_goodbye("One large Margherita coming right up.") is False
     assert _looks_like_goodbye("Two Cokes coming right up!") is False
 
@@ -763,6 +773,7 @@ def test_looks_like_goodbye_excludes_coming_right_up():
 def test_looks_like_goodbye_remaining_patterns_still_match():
     """Positive coverage so a drive-by removal of a pattern is caught."""
     from app.telephony.router import _looks_like_goodbye
+
     assert _looks_like_goodbye("Thanks for ordering, see you soon!")
     assert _looks_like_goodbye("Your order is in — we'll have it ready shortly.")
     assert _looks_like_goodbye("Thanks for calling!")
@@ -773,6 +784,7 @@ def test_looks_like_goodbye_remaining_patterns_still_match():
 def test_hangup_grace_seconds_is_five():
     """Grace window must be 5s so callers can add late items."""
     from app.telephony.router import HANGUP_GRACE_SECONDS
+
     assert HANGUP_GRACE_SECONDS == 5.0
 
 
@@ -932,9 +944,7 @@ def _make_fake_stream_reply_deltas(*deltas: str, final_text: str = ""):
     async def fake(*, transcript, history, order, **kw):
         for d in deltas:
             yield StreamEvent(text_delta=d)
-        yield StreamEvent(
-            final=LLMResponse(reply_text=final, order=order, history=history)
-        )
+        yield StreamEvent(final=LLMResponse(reply_text=final, order=order, history=history))
 
     return fake
 
@@ -1103,7 +1113,7 @@ def test_voice_twiml_includes_stream_ended_action():
 
     assert resp.status_code == 200
     body = resp.text
-    assert '<Connect' in body
+    assert "<Connect" in body
     assert 'action="/voice/stream-ended"' in body
     assert 'method="POST"' in body
 
@@ -1446,12 +1456,15 @@ def test_voicemail_recorded_uploads_and_marks_session(monkeypatch):
     from app.storage import call_sessions, recordings
 
     upload_calls: list[dict] = []
+
     def fake_upload(**kwargs):
         upload_calls.append(kwargs)
         return f"gs://test/voicemail/{kwargs['restaurant_id']}/{kwargs['call_sid']}.mp3"
 
     monkeypatch.setattr(
-        recordings, "upload_voicemail_from_twilio", fake_upload,
+        recordings,
+        "upload_voicemail_from_twilio",
+        fake_upload,
     )
     monkeypatch.setattr(settings, "twilio_account_sid", "ACfake")
     monkeypatch.setattr(settings, "twilio_auth_token", "tokenfake")
@@ -1525,13 +1538,16 @@ def test_voicemail_recorded_handles_upload_failure_gracefully(monkeypatch):
 
     def boom(**kw):
         raise RuntimeError("gcs is angry")
+
     monkeypatch.setattr(recordings, "upload_voicemail_from_twilio", boom)
     monkeypatch.setattr(settings, "twilio_account_sid", "AC")
     monkeypatch.setattr(settings, "twilio_auth_token", "tok")
 
     mark_calls = []
     monkeypatch.setattr(
-        call_sessions, "mark_voicemail_left", lambda *a, **kw: mark_calls.append(kw),
+        call_sessions,
+        "mark_voicemail_left",
+        lambda *a, **kw: mark_calls.append(kw),
     )
 
     client = TestClient(app)
@@ -1618,8 +1634,13 @@ def test_voice_routes_to_voicemail_when_after_hours(monkeypatch):
 
     closed_day = DayHours(open="00:00", close="00:00", closed=True)
     h = HoursStructured(
-        mon=closed_day, tue=closed_day, wed=closed_day, thu=closed_day,
-        fri=closed_day, sat=closed_day, sun=closed_day,
+        mon=closed_day,
+        tue=closed_day,
+        wed=closed_day,
+        thu=closed_day,
+        fri=closed_day,
+        sat=closed_day,
+        sun=closed_day,
     )
     fake = Restaurant(
         id="r1",
@@ -1723,8 +1744,8 @@ def test_voicemail_recorded_is_idempotent_on_twilio_retry(monkeypatch):
     )
 
     sessions = [
-        None,                                          # 1st call: no session yet
-        {"voicemail_recording_sid": "REabc"},          # 2nd call: already processed
+        None,  # 1st call: no session yet
+        {"voicemail_recording_sid": "REabc"},  # 2nd call: already processed
     ]
     monkeypatch.setattr(
         call_sessions,
@@ -1916,9 +1937,7 @@ async def test_run_llm_tts_turn_clears_in_flight_transcript_on_final(monkeypatch
     from app.telephony.router import _CallState, _run_llm_tts_turn
 
     async def fake_stream_reply(*, transcript, history, order, **kw):
-        yield StreamEvent(
-            final=LLMResponse(reply_text="ok", order=order, history=history)
-        )
+        yield StreamEvent(final=LLMResponse(reply_text="ok", order=order, history=history))
 
     async def fake_speak(*a, **kw):
         pass
@@ -2026,4 +2045,3 @@ async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch
             pass
 
     assert captured == ["and a coke"]
-

--- a/tests/test_tts_client.py
+++ b/tests/test_tts_client.py
@@ -2,6 +2,7 @@
 
 All tests mock httpx and WebSocket — no real API calls made.
 """
+
 import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,8 +16,10 @@ from app.tts.client import speak
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 class _AsyncStreamCtx:
     """Async context manager that returns a pre-built mock response."""
+
     def __init__(self, response):
         self._response = response
 
@@ -63,6 +66,7 @@ def _patch_settings():
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_speak_sends_media_events():
@@ -238,6 +242,7 @@ def test_get_client_returns_same_instance_across_calls():
 
 def test_get_client_constructs_with_expected_timeouts():
     import httpx
+
     c = tts_module._get_client()
     assert isinstance(c, httpx.AsyncClient)
     # httpx.Timeout exposes per-stage attributes; the values match what
@@ -318,7 +323,10 @@ async def test_speak_skips_on_first_byte_for_empty_chunks():
 
     calls: list[int] = []
     await speak(
-        "Hello", ws, stream_sid="MZ123", client=mock_client,
+        "Hello",
+        ws,
+        stream_sid="MZ123",
+        client=mock_client,
         on_first_byte=lambda: calls.append(1),
     )
     assert calls == [1]
@@ -337,7 +345,10 @@ async def test_speak_swallows_on_first_byte_exception():
 
     # Should not raise
     await speak(
-        "Hello", ws, stream_sid="MZ123", client=mock_client,
+        "Hello",
+        ws,
+        stream_sid="MZ123",
+        client=mock_client,
         on_first_byte=bad_cb,
     )
     ws.send_json.assert_called_once()

--- a/tests/test_tts_integration.py
+++ b/tests/test_tts_integration.py
@@ -9,6 +9,7 @@ Usage:
 
 Audio is saved to tts_test_output.wav (mulaw 8 kHz, decoded to PCM16).
 """
+
 import base64
 import struct
 from pathlib import Path
@@ -45,6 +46,7 @@ def _mulaw_to_pcm16(mulaw_data: bytes) -> bytes:
 def _save_audio(audio_bytes: bytes) -> Path:
     """Save audio as a WAV by decoding the raw mulaw stream to PCM16."""
     import wave
+
     path = Path("tts_test_output.wav")
     pcm = _mulaw_to_pcm16(audio_bytes)
     with wave.open(str(path), "wb") as wf:
@@ -73,9 +75,7 @@ async def test_speak_returns_audio_chunks(tts_phrase):
         assert event["streamSid"] == "TEST-STREAM-SID"
         assert len(base64.b64decode(event["media"]["payload"])) > 0
 
-    audio_bytes = b"".join(
-        base64.b64decode(e["media"]["payload"]) for e in received
-    )
+    audio_bytes = b"".join(base64.b64decode(e["media"]["payload"]) for e in received)
     output_path = _save_audio(audio_bytes)
 
     print(f"Chunks received : {len(received)}")

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -37,9 +37,7 @@ def test_health_returns_ok():
 def test_voice_returns_twiml(monkeypatch):
     """Inbound to the demo Twilio number resolves via the MENU fallback
     (Firestore returns None in unit tests) and opens a Media Stream."""
-    monkeypatch.setattr(
-        restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None
-    )
+    monkeypatch.setattr(restaurants_storage, "get_restaurant_by_twilio_phone", lambda _e164: None)
     response = client.post(
         "/voice",
         data={


### PR DESCRIPTION
## Summary

- Mechanical reformat of all backend Python files via `ruff format`. No logic changes.
- Adds a `Ruff format check` step to the backend CI job (gates future PRs on staying formatted).

## Stacked on

Built on top of #211. PR base is `chore/ci-lint-and-tests`; GitHub will auto-retarget to `master` once #211 merges.

## Test plan

- [ ] Backend CI job passes (ruff check + ruff format --check + pytest)
- [ ] Dashboard / Terraform / CodeQL jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)