### PR TITLE
chore(ci): add Dependabot and dependency-review-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "pip"
+    directory: "/bot"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(bot)"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/dashboard"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(dashboard)"
+      include: "scope"
+
+  - package-ecosystem: "terraform"
+    directory: "/infra/jarvis"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(infra)"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Toronto"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(actions)"
+      include: "scope"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary

- **Dependabot** — weekly PRs across pip (root + bot), npm (dashboard), terraform (infra/jarvis), and github-actions. Capped at 5 open PRs per ecosystem; commit-message prefixes scoped per area (`deps`, `deps(bot)`, `deps(dashboard)`, `deps(infra)`, `deps(actions)`).
- **dependency-review-action** — new workflow that runs on every PR to master, fails on moderate+ vulnerabilities, summarizes in a PR comment on failure.

## Context

Replaces #213 (closed when its base branch was deleted on #211 merge).

## Test plan

- [ ] Dependency review job appears and passes on this PR (no new vulnerable deps)
- [ ] After merge, expect Dependabot to start opening update PRs on Monday morning

🤖 Generated with [Claude Code](https://claude.com/claude-code)