### PR TITLE
fix(dashboard): single <Link> per table row in orders + kitchen queue + calls

### DIFF
--- a/dashboard/components/calls/calls-table.tsx
+++ b/dashboard/components/calls/calls-table.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { PhoneIncoming } from 'lucide-react';
 
 import { LocalTime } from '@/components/shared/local-time';
@@ -40,6 +43,8 @@ export function CallsTable({
 }
 
 function CallRow({ call }: { call: CallSummary }) {
+  const router = useRouter();
+
   const startedAt = new Date(call.started_at);
   const endedAt = new Date(call.ended_at);
   const durationSec = Math.max(
@@ -49,35 +54,45 @@ function CallRow({ call }: { call: CallSummary }) {
 
   const detailHref = `/calls/${encodeURIComponent(call.call_sid)}`;
   const status = mappedStatus(call);
+  const shortSid = call.call_sid.slice(0, 8);
 
   return (
-    <tr className="border-b border-border-subtle transition-colors hover:bg-surface-2/40">
+    <tr
+      onClick={() => {
+        // Don't navigate when the user is selecting text — call SIDs
+        // are exactly the kind of thing operators copy out of the table.
+        if (window.getSelection()?.toString()) return;
+        router.push(detailHref);
+      }}
+      className="cursor-pointer border-b border-border-subtle transition-colors hover:bg-surface-2/40"
+    >
+      {/* Cell 1 — the only <Link> in the row. The cell-1 link is the
+          single keyboard target per row; cells 2-5 are plain content
+          and the <tr> onClick handles mouse navigation. */}
       <Td>
-        <Link href={detailHref} className="inline-flex items-center gap-2">
+        <Link
+          href={detailHref}
+          aria-label={`View call ${shortSid}`}
+          className="inline-flex items-center gap-2"
+        >
           <PhoneIncoming
             className="size-3.5 text-foreground-muted"
             aria-hidden
           />
-          <span className="font-mono text-xs">
-            {call.call_sid.slice(0, 8)}…
-          </span>
+          <span className="font-mono text-xs">{shortSid}…</span>
         </Link>
       </Td>
       <Td className="text-foreground-muted">
-        <Link href={detailHref}>
-          <LocalTime date={startedAt} mode="datetime" />
-        </Link>
+        <LocalTime date={startedAt} mode="datetime" />
       </Td>
       <Td className="text-right font-mono tabular-nums">
-        <Link href={detailHref}>{formatDuration(durationSec)}</Link>
+        {formatDuration(durationSec)}
       </Td>
       <Td className="text-right font-mono tabular-nums">
-        <Link href={detailHref}>{call.transcript_count}</Link>
+        {call.transcript_count}
       </Td>
       <Td>
-        <Link href={detailHref}>
-          <StatusBadge status={status} />
-        </Link>
+        <StatusBadge status={status} />
       </Td>
     </tr>
   );

--- a/dashboard/components/orders/orders-table.tsx
+++ b/dashboard/components/orders/orders-table.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { PhoneIncoming } from 'lucide-react';
 
 import { LocalTime } from '@/components/shared/local-time';
@@ -50,6 +53,8 @@ export function OrdersTable({
 }
 
 function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
+  const router = useRouter();
+
   const isLive = order.status === 'in_progress';
   const isFaded = order.status === 'completed' || order.status === 'cancelled';
   const fadedCell = isFaded ? 'text-foreground-faint' : '';
@@ -69,20 +74,35 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
 
   return (
     <tr
+      onClick={() => {
+        // Don't navigate when the user is selecting text — kitchen
+        // staff routinely copy order IDs / phone numbers to other
+        // windows. Released drag-selection would otherwise eat them.
+        if (window.getSelection()?.toString()) return;
+        router.push(detailHref);
+      }}
       className={cn(
-        'border-b border-border-subtle transition-colors hover:bg-surface-2/40',
+        'cursor-pointer border-b border-border-subtle transition-colors hover:bg-surface-2/40',
         isFresh && 'animate-row-enter',
       )}
       data-fresh={isFresh ? 'true' : undefined}
     >
+      {/* Cell 1 — the only <Link> in the row. The cell-1 link is the
+          single keyboard target per row; cells 2-5 are plain content
+          and the <tr> onClick handles mouse navigation. <TransitionButton>
+          in cell 6 stays independently focusable and stops propagation
+          on its own click. */}
       <Td className={cn('font-mono text-xs', fadedCell)}>
-        <Link href={detailHref} className="block">
+        <Link
+          href={detailHref}
+          aria-label={`View order ${orderShortId(order)}`}
+          className="block"
+        >
           {orderShortId(order)}
         </Link>
       </Td>
       <Td className="text-foreground-muted">
-        <Link
-          href={detailHref}
+        <span
           data-testid={`order-time-${order.call_sid}`}
           data-anchor-iso={timeColumnAnchor(order).toISOString()}
         >
@@ -94,17 +114,15 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
               mode="relative"
             />
           )}
-        </Link>
+        </span>
       </Td>
       <Td className={fadedCell}>
-        <Link href={detailHref} className="block">
-          <div className={cn('truncate', isLive && 'italic')}>
-            {isLive ? `Building… ${itemsSummary}` : itemsSummary}
-          </div>
-          {secondary && (
-            <div className="text-xs text-foreground-faint">{secondary}</div>
-          )}
-        </Link>
+        <div className={cn('truncate', isLive && 'italic')}>
+          {isLive ? `Building… ${itemsSummary}` : itemsSummary}
+        </div>
+        {secondary && (
+          <div className="text-xs text-foreground-faint">{secondary}</div>
+        )}
       </Td>
       <Td
         className={cn(
@@ -112,12 +130,10 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
           fadedCell,
         )}
       >
-        <Link href={detailHref}>{formatCAD(order.subtotal)}</Link>
+        {formatCAD(order.subtotal)}
       </Td>
       <Td>
-        <Link href={detailHref}>
-          <StatusBadge status={order.status} />
-        </Link>
+        <StatusBadge status={order.status} />
       </Td>
       <Td>
         <TransitionButton order={order} />

--- a/dashboard/components/orders/transition-button.tsx
+++ b/dashboard/components/orders/transition-button.tsx
@@ -95,7 +95,14 @@ function ActiveButton({
   const [isPending, startTransition] = useTransition();
   const { addOptimistic, clearOptimistic } = useOptimisticStatus();
 
-  function onClick() {
+  function onClick(e: React.MouseEvent<HTMLButtonElement>) {
+    // Stop propagation so the row-level onClick in OrdersTable and
+    // ActiveOrdersWidget doesn't fire alongside the transition (which
+    // would BOTH transition the order AND navigate to its detail page).
+    // No-op when this button is rendered outside a clickable row
+    // (e.g. on the order detail page action row).
+    e.stopPropagation();
+
     addOptimistic({
       call_sid: order.call_sid,
       status: config.targetStatus,

--- a/dashboard/components/overview/active-orders-widget.tsx
+++ b/dashboard/components/overview/active-orders-widget.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import {
   collection,
@@ -101,6 +102,8 @@ function ActiveOrdersInner({ initial, restaurantId }: Props) {
 }
 
 function QueueRow({ order }: { order: Order }) {
+  const router = useRouter();
+
   const itemsLine =
     order.items.length === 0
       ? '—'
@@ -114,24 +117,34 @@ function QueueRow({ order }: { order: Order }) {
   const detailHref = `/orders/${encodeURIComponent(order.call_sid)}`;
 
   return (
-    <tr className="border-b border-border-subtle last:border-b-0 hover:bg-surface-2/40">
+    <tr
+      onClick={() => {
+        // Don't navigate when the user is selecting text — order IDs
+        // and item names are copy-targets for kitchen staff.
+        if (window.getSelection()?.toString()) return;
+        router.push(detailHref);
+      }}
+      className="cursor-pointer border-b border-border-subtle last:border-b-0 hover:bg-surface-2/40"
+    >
+      {/* Cell 1 — the only <Link> in the row. <TransitionButton> in
+          cell 5 stays independently focusable and stops propagation
+          on its own click. */}
       <td className="px-1 py-2 align-middle font-mono text-xs">
-        <Link href={detailHref}>{orderShortId(order)}</Link>
+        <Link
+          href={detailHref}
+          aria-label={`View order ${orderShortId(order)}`}
+        >
+          {orderShortId(order)}
+        </Link>
       </td>
       <td className="px-1 py-2 align-middle">
-        <Link href={detailHref} className="block truncate">
-          {itemsLine}
-        </Link>
+        <div className="truncate">{itemsLine}</div>
       </td>
       <td className="px-1 py-2 align-middle text-foreground-muted">
-        <Link href={detailHref}>
-          <LocalTime date={order.created_at} mode="relative" />
-        </Link>
+        <LocalTime date={order.created_at} mode="relative" />
       </td>
       <td className="px-1 py-2 align-middle">
-        <Link href={detailHref}>
-          <StatusBadge status={order.status} />
-        </Link>
+        <StatusBadge status={order.status} />
       </td>
       <td className="px-1 py-2 align-middle text-right">
         <TransitionButton order={order} />

--- a/dashboard/tests/orders-table.test.tsx
+++ b/dashboard/tests/orders-table.test.tsx
@@ -15,6 +15,13 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+// OrdersTable rows call `useRouter()` for click-to-navigate. The hook
+// throws "invariant expected app router to be mounted" outside a real
+// Next.js render tree — stub it for the unit test surface.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
 import { OrdersTable } from '@/components/orders/orders-table';
 import type { Order, OrderStatus } from '@/lib/schemas/order';
 


### PR DESCRIPTION
## Summary

Closes follow-up #3 from the post-migration cleanup queue. Each row in `OrdersTable`, `ActiveOrdersWidget` (kitchen queue), and `CallsTable` previously had **one `<Link>` per cell** — 4–5 sibling anchors per row, all pointing at the same detail href. Screen readers announced each row as several redundant links; keyboard users tabbed through every cell to reach the row's action button; each row hover triggered 4–5 `next/link` prefetches.

After this PR: **one `<Link>` per row** (with descriptive `aria-label`), plus an action button where applicable. Mouse users still get full-row click navigation.

## Pattern

**Pattern 2 across all three tables**, even calls-table which has no row-level button. Consistency wins for an internal tool, and Pattern 1's wrapping-link trick has known table-layout edge cases. Per-table read confirmed the same shape works:

| Table | Cells | Link cell | Action cell |
|---|---|---|---|
| `orders-table.tsx` | Order \| Time \| Items \| Subtotal \| Status \| Action | 1 (Order) | 6 (`<TransitionButton>`) |
| `active-orders-widget.tsx` (kitchen queue) | Order \| Items \| Time \| Status \| Action | 1 (Order) | 5 (`<TransitionButton>`) |
| `calls-table.tsx` | Call ID \| Started \| Duration \| Turns \| Status | 1 (Call ID) | none |

### Cell 1 link

```tsx
<Link
  href={detailHref}
  aria-label={`View order ${orderShortId(order)}`}
  className="block"
>
  {orderShortId(order)}   // visible content stays mono + tight
</Link>
```

The `aria-label` overrides the link's accessible name for screen readers — visible users see "F045," SR users hear "View order F045 link."

### Row click handler

```tsx
<tr
  onClick={() => {
    // Don't navigate when the user is selecting text — kitchen
    // staff routinely copy order IDs / phone numbers to other
    // windows. Released drag-selection would otherwise eat them.
    if (window.getSelection()?.toString()) return;
    router.push(detailHref);
  }}
  className="cursor-pointer ..."
>
```

The `<tr>` is **not** focusable (no `tabIndex` / `role` override). Changing the implicit `row` role would clobber screen-reader table navigation. The cell-1 link is the keyboard target; the `<tr>` onClick is mouse-only convenience.

### Action button propagation

`transition-button.tsx` gains a one-line `e.stopPropagation()` with a comment explaining the cross-component coupling:

```tsx
function onClick(e: React.MouseEvent<HTMLButtonElement>) {
  // Stop propagation so the row-level onClick in OrdersTable and
  // ActiveOrdersWidget doesn't fire alongside the transition (which
  // would BOTH transition the order AND navigate to its detail page).
  // No-op when this button is rendered outside a clickable row
  // (e.g. on the order detail page action row).
  e.stopPropagation();
  // ...
}
```

`<CancelOrderButton>` is only used on the order detail page (not in any row), so no change needed there.

## `'use client'` boundary impact

`orders-table.tsx` and `calls-table.tsx` now carry the `'use client'` directive (`useRouter` is a client hook). **Verified pre-edit**: both files are purely presentational — no `cookies()`, no `headers()`, no `<Suspense>`, no `fetch()`, no async work. They were already rendered inside Client Components (`OrdersFeed`, `CallsFeed`); the directive just makes the boundary explicit. `active-orders-widget.tsx` was already `'use client'`.

## Tests

`tests/orders-table.test.tsx` now mocks `next/navigation` alongside its existing Server Action / sonner mocks, since `useRouter` throws "invariant expected app router to be mounted" outside a real Next.js render tree.

```ts
vi.mock('next/navigation', () => ({
  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
}));
```

The 4 existing `time-anchor` assertions still pass unchanged — the `data-testid` + `data-anchor-iso` attributes migrate from the removed cell-1 `<Link>` wrappers onto a `<span>` in the Time cell; `getByTestId` returns whichever element has the testid regardless of tag.

No tests exist for `active-orders-widget` or `calls-table` (covered by manual click-through during verification).

## Verification

- `pnpm typecheck` — clean.
- `pnpm lint` — 7 problems (0 errors, 7 warnings). **Identical baseline to before this PR.** The 7 are the `use-new-order-alert` exhaustive-deps + 3 test-file unused-import warnings that PR #244 closes out separately.
- `pnpm test` — `Test Files 15 passed (15)`, `Tests 109 passed (109)`.

### Manual verification I'll do in `pnpm dev`

- [ ] **Orders feed (`/orders`)**: Tab from outside table → row 1's first-cell link, then row 1's `TransitionButton` (if visible), then row 2's link, etc. Two tab stops per row in rows with buttons; one stop per row otherwise.
- [ ] **Orders feed**: Click action button — fires the transition, does NOT navigate. Click anywhere else on row — navigates.
- [ ] **Orders feed**: Drag-select an order ID → release → no navigation; selection preserved for copy.
- [ ] **Kitchen queue (overview `/`)**: Same checks as orders feed (this widget has the same structure).
- [ ] **Calls list (`/calls`)**: Tab from outside → row 1's call-ID link, then row 2's, etc. (No action buttons, so 1 stop per row.) Click anywhere on a row → navigates to call detail.
- [ ] **All three tables**: Hover state highlights the row (`bg-surface-2/40`); cursor is `pointer` over the entire row, not just the link.
- [ ] **All three tables**: Focus ring visible on the cell-1 link (brand outline from globals).
- [ ] Both dark and light mode.

I don't have a screen reader available; VoiceOver smoke would be on the reviewer.

## Bonus: `next/link` prefetch reduction

| | Before | After |
|---|---|---|
| Prefetch requests per row hover | 4–5 | **1** |

For a 30-row orders feed on a kitchen tablet over venue wifi, that's a 4–5× reduction in network requests on a hover sweep across the table. Not the reason for the PR — but worth flagging here so a future maintainer searching for "prefetch storm" in network logs finds the trail.

## Files

```
M  components/calls/calls-table.tsx           ('use client', useRouter, cell-1 Link, row onClick)
M  components/orders/orders-table.tsx         ('use client', useRouter, cell-1 Link, row onClick, testid migrated to <span>)
M  components/orders/transition-button.tsx    (e.stopPropagation() + explanatory comment)
M  components/overview/active-orders-widget.tsx  (useRouter, cell-1 Link, row onClick)
M  tests/orders-table.test.tsx                (next/navigation mock)
```

5 files, +100/-42.

## Stacks on top of

#239 (jsdom test env restore) — already merged. This PR branches from current master, which has #239's fix, so verification of `tests/orders-table.test.tsx` was possible. No dependency on PR #244 (use-new-order-alert warnings — also still in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)