### PR TITLE
fix(dashboard): unwrap transition timestamps in order converter

### DIFF
--- a/dashboard/lib/firebase/converters.ts
+++ b/dashboard/lib/firebase/converters.ts
@@ -35,6 +35,10 @@ function normalize(raw: Record<string, unknown>): Record<string, unknown> {
     ...raw,
     created_at: unwrapTimestamp(raw.created_at),
     confirmed_at: unwrapTimestamp(raw.confirmed_at),
+    preparing_at: unwrapTimestamp(raw.preparing_at),
+    ready_at: unwrapTimestamp(raw.ready_at),
+    completed_at: unwrapTimestamp(raw.completed_at),
+    cancelled_at: unwrapTimestamp(raw.cancelled_at),
   };
 }
 
@@ -74,6 +78,10 @@ export function parseOrderFromJson(raw: unknown, contextLabel = 'api'): Order {
           ...(raw as Record<string, unknown>),
           created_at: toDate((raw as Record<string, unknown>).created_at),
           confirmed_at: toDate((raw as Record<string, unknown>).confirmed_at),
+          preparing_at: toDate((raw as Record<string, unknown>).preparing_at),
+          ready_at: toDate((raw as Record<string, unknown>).ready_at),
+          completed_at: toDate((raw as Record<string, unknown>).completed_at),
+          cancelled_at: toDate((raw as Record<string, unknown>).cancelled_at),
         }
       : raw;
 


### PR DESCRIPTION
## Summary

`normalize()` (Firestore `onSnapshot` path) and `parseOrderFromJson()` (RSC fetch path) only unwrapped `created_at` and `confirmed_at`. The four per-transition timestamps (`preparing_at`, `ready_at`, `completed_at`, `cancelled_at`) were left as raw Firestore `Timestamp` objects. They reached `z.coerce.date()` → `new Date(<Timestamp>)` → "Invalid Date", and Zod rejected with the cryptic `"expected date, received Date"` message (it's `z.date()` rejecting a Date instance whose `.getTime()` is `NaN`).

The bug only manifested on orders that had actually transitioned past `confirmed` — un-set fields are `null`, which `.nullish()` accepts. Surfaced on the kitchen-queue widget once a demo order moved to `preparing`/`ready`/`completed`.

## Fix

Extend both unwrap helpers to cover all six timestamp fields the schema declares.

```diff
 function normalize(raw) {
   return {
     ...raw,
     created_at: unwrapTimestamp(raw.created_at),
     confirmed_at: unwrapTimestamp(raw.confirmed_at),
+    preparing_at: unwrapTimestamp(raw.preparing_at),
+    ready_at: unwrapTimestamp(raw.ready_at),
+    completed_at: unwrapTimestamp(raw.completed_at),
+    cancelled_at: unwrapTimestamp(raw.cancelled_at),
   };
 }
```

(Same shape for `parseOrderFromJson`'s `withDates` block.)

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run tests/order-schema.test.ts` — 8/8 pass
- [ ] Reload `/` in dev — kitchen-queue widget no longer throws `OrderValidationError` for the demo `CA8bb389…` order
- [ ] Open an order in each status (`/orders/<id>`) — no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)