### PR TITLE
feat(dashboard): designed empty states + keyboard affordance for kitchen queue

### DIFF
--- a/dashboard/app/(dashboard)/page.tsx
+++ b/dashboard/app/(dashboard)/page.tsx
@@ -32,6 +32,8 @@ export default async function OverviewPage() {
     {
       eyebrow: 'Orders today',
       value: summary ? String(summary.today_count) : '—',
+      zeroHint:
+        summary?.today_count === 0 ? 'No orders yet today.' : undefined,
     },
     {
       eyebrow: 'Orders this week',

--- a/dashboard/components/orders/orders-feed.tsx
+++ b/dashboard/components/orders/orders-feed.tsx
@@ -141,7 +141,12 @@ function OrdersFeedInner({
 
       <FilterTabs active={statusFilter} counts={initialCounts} />
 
-      <OrdersTable orders={displayOrders} twilioPhone={twilioPhone} freshIds={freshIds} />
+      <OrdersTable
+        orders={displayOrders}
+        twilioPhone={twilioPhone}
+        statusFilter={statusFilter}
+        freshIds={freshIds}
+      />
 
       <div role="status" aria-live="polite" className="sr-only">
         {announcement}

--- a/dashboard/components/orders/orders-table.tsx
+++ b/dashboard/components/orders/orders-table.tsx
@@ -7,23 +7,49 @@ import { PhoneIncoming } from 'lucide-react';
 import { LocalTime } from '@/components/shared/local-time';
 import { StatusBadge } from '@/components/orders/status-badge';
 import { TransitionButton } from '@/components/orders/transition-button';
-import { type Order, orderShortId } from '@/lib/schemas/order';
+import {
+  type Order,
+  type OrderStatus,
+  orderShortId,
+} from '@/lib/schemas/order';
 import { formatCAD } from '@/lib/formatters/money';
 import { formatPhone } from '@/lib/formatters/phone';
 import { cn } from '@/lib/utils';
 
 const MAX_ITEMS_LINE = 48;
 
+// Typed Record so any add/remove on OrderStatus fails the build here
+// rather than silently falling back to a default string.
+const EMPTY_HEADLINE_BY_STATUS: Record<OrderStatus, string> = {
+  in_progress: 'No live orders right now',
+  confirmed: 'No confirmed orders waiting',
+  preparing: 'Nothing in the kitchen right now',
+  ready: 'Nothing ready for pickup',
+  completed: 'No completed orders yet',
+  cancelled: 'No cancelled orders',
+};
+
+const FILTER_EMPTY_HELPER =
+  'This view will update automatically as orders come in.';
+
 export function OrdersTable({
   orders,
   twilioPhone,
+  statusFilter,
   freshIds,
 }: {
   orders: Order[];
   twilioPhone: string;
+  statusFilter?: OrderStatus;
   freshIds?: ReadonlySet<string>;
 }) {
-  if (orders.length === 0) return <EmptyState twilioPhone={twilioPhone} />;
+  // All-tab + zero rows is still the "provisioning / nothing ever"
+  // surface — keep it distinct from the transient filter-empty state.
+  if (orders.length === 0 && statusFilter === undefined) {
+    return <EmptyState twilioPhone={twilioPhone} />;
+  }
+
+  const isFilterEmpty = orders.length === 0 && statusFilter !== undefined;
 
   return (
     <div className="overflow-hidden">
@@ -39,15 +65,42 @@ export function OrdersTable({
           </tr>
         </thead>
         <tbody>
-          {orders.map((order) => (
-            <OrderRow
-              key={order.call_sid}
-              order={order}
-              isFresh={freshIds?.has(order.call_sid) ?? false}
-            />
-          ))}
+          {isFilterEmpty ? (
+            <tr>
+              <td colSpan={6} className="px-2.5 py-10">
+                <FilterEmptyState status={statusFilter} />
+              </td>
+            </tr>
+          ) : (
+            orders.map((order) => (
+              <OrderRow
+                key={order.call_sid}
+                order={order}
+                isFresh={freshIds?.has(order.call_sid) ?? false}
+              />
+            ))
+          )}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+function FilterEmptyState({ status }: { status: OrderStatus }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-2 text-center">
+      <div className="flex size-14 items-center justify-center rounded-[10px] bg-surface-2">
+        <PhoneIncoming
+          className="size-6 text-foreground-muted"
+          aria-hidden
+        />
+      </div>
+      <p className="mt-3 text-base text-foreground">
+        {EMPTY_HEADLINE_BY_STATUS[status]}
+      </p>
+      <p className="mt-1.5 text-sm text-foreground-subtle">
+        {FILTER_EMPTY_HELPER}
+      </p>
     </div>
   );
 }

--- a/dashboard/components/overview/active-orders-widget.tsx
+++ b/dashboard/components/overview/active-orders-widget.tsx
@@ -124,7 +124,7 @@ function QueueRow({ order }: { order: Order }) {
         if (window.getSelection()?.toString()) return;
         router.push(detailHref);
       }}
-      className="cursor-pointer border-b border-border-subtle last:border-b-0 hover:bg-surface-2/40"
+      className="cursor-pointer border-b border-border-subtle transition-[background-color] duration-100 ease-linear last:border-b-0 hover:bg-surface-2/40 focus-within:outline focus-within:outline-brand-muted focus-within:-outline-offset-2"
     >
       {/* Cell 1 — the only <Link> in the row. <TransitionButton> in
           cell 5 stays independently focusable and stops propagation

--- a/dashboard/components/overview/kpi-strip.tsx
+++ b/dashboard/components/overview/kpi-strip.tsx
@@ -4,6 +4,12 @@ export type KpiItem = {
   eyebrow: string;
   value: string;
   caption?: string;
+  // When set, treat `value` as a designed zero state: render it
+  // smaller + muted, and append `zeroHint` as a subtitle line. The
+  // page passes this only on KPIs where "0" is meaningful (e.g.
+  // Orders today on a quiet morning) — the other KPIs have their own
+  // sensible zero/low-value renderings.
+  zeroHint?: string;
 };
 
 /**
@@ -27,19 +33,33 @@ export function KpiStrip({
         className,
       )}
     >
-      {items.map((item, i) => (
-        <div key={i} className="flex flex-1 flex-col p-4">
-          <span className="text-eyebrow">{item.eyebrow}</span>
-          <span className="mt-2 font-mono text-2xl font-semibold tabular-nums">
-            {item.value}
-          </span>
-          {item.caption ? (
-            <span className="mt-1 text-sm text-foreground-subtle">
-              {item.caption}
+      {items.map((item, i) => {
+        const isZeroState = item.zeroHint !== undefined && item.value === '0';
+        return (
+          <div key={i} className="flex flex-1 flex-col p-4">
+            <span className="text-eyebrow">{item.eyebrow}</span>
+            <span
+              className={cn(
+                'mt-2 font-mono font-semibold tabular-nums',
+                isZeroState
+                  ? 'text-xl text-foreground-muted'
+                  : 'text-2xl',
+              )}
+            >
+              {item.value}
             </span>
-          ) : null}
-        </div>
-      ))}
+            {isZeroState ? (
+              <span className="mt-1 text-sm text-foreground-subtle">
+                {item.zeroHint}
+              </span>
+            ) : item.caption ? (
+              <span className="mt-1 text-sm text-foreground-subtle">
+                {item.caption}
+              </span>
+            ) : null}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/dashboard/components/overview/live-calls-widget.tsx
+++ b/dashboard/components/overview/live-calls-widget.tsx
@@ -112,13 +112,16 @@ function CallDuration({ startedAt }: { startedAt: Date }) {
 
 function EmptyState() {
   return (
-    <div className="flex flex-col items-center justify-center gap-2 py-10 text-center">
-      <PhoneIncoming
-        className="size-8 text-foreground-faint"
-        aria-hidden
-      />
-      <p className="text-sm text-foreground-muted">
-        No callers on the line right now.
+    <div className="flex flex-col items-center justify-center py-8 text-center">
+      <div className="flex size-14 items-center justify-center rounded-[10px] bg-surface-2">
+        <PhoneIncoming
+          className="size-6 text-foreground-muted"
+          aria-hidden
+        />
+      </div>
+      <p className="mt-3 text-base text-foreground">No active calls</p>
+      <p className="mt-1.5 text-sm text-foreground-subtle">
+        Niko will surface live calls here as they come in.
       </p>
     </div>
   );

--- a/dashboard/tests/orders-table.test.tsx
+++ b/dashboard/tests/orders-table.test.tsx
@@ -104,3 +104,34 @@ describe('OrdersTable Time column', () => {
     expect(time).toHaveAttribute('data-anchor-iso', createdAt.toISOString());
   });
 });
+
+describe('OrdersTable empty states', () => {
+  it('renders the status-specific filter-empty state and keeps the table header', () => {
+    render(<OrdersTable orders={[]} twilioPhone="+14165551234" statusFilter="preparing" />);
+    // Headline is keyed off statusFilter via EMPTY_HEADLINE_BY_STATUS.
+    expect(screen.getByText('Nothing in the kitchen right now')).toBeInTheDocument();
+    expect(
+      screen.getByText('This view will update automatically as orders come in.'),
+    ).toBeInTheDocument();
+    // The table header stays mounted so the filter tabs don't jump.
+    expect(screen.getByText('Order')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    // Not the "provisioning / nothing ever" all-tab surface.
+    expect(screen.queryByText('No orders yet')).not.toBeInTheDocument();
+  });
+
+  it('uses the headline that matches the active status filter', () => {
+    render(<OrdersTable orders={[]} twilioPhone="+14165551234" statusFilter="ready" />);
+    expect(screen.getByText('Nothing ready for pickup')).toBeInTheDocument();
+    expect(screen.queryByText('Nothing in the kitchen right now')).not.toBeInTheDocument();
+  });
+
+  it('renders the all-tab provisioning empty state (no table) when there is no filter', () => {
+    render(<OrdersTable orders={[]} twilioPhone="+14165551234" />);
+    expect(screen.getByText('No orders yet')).toBeInTheDocument();
+    // The whole table (and its header) is replaced, and no filter-empty
+    // headline is shown.
+    expect(screen.queryByText('Order')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nothing in the kitchen right now')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Polish pass on the Niko dashboard. Three empty-state surfaces were reading as \"didn't load\" instead of \"intentionally empty,\" and the kitchen queue rows wired in #245 lacked a visible focus ring for keyboard nav.

No schema, Server Action, or Firestore changes. All visual decisions go through tokens from \`globals.css\`.

## Part A — Empty states

**1. Overview KPI strip — Orders today = 0**
- New optional \`zeroHint?: string\` on \`KpiItem\`. When present *and* \`value === '0'\`, render the value smaller (\`text-xl\`) and \`text-foreground-muted\`, with a \`text-sm text-foreground-subtle\` subtitle line.
- Page only sets \`zeroHint\` on Orders today (\`summary?.today_count === 0 ? 'No orders yet today.' : undefined\`). Other KPIs unchanged — they have their own meaningful low/zero renderings.
- KpiStrip stays a dumb presentational map; the page knows the semantics.

**2. Overview live calls widget**
- 56px square \`rounded-[10px]\` \`bg-surface-2\` container around \`<PhoneIncoming>\`, icon at \`text-foreground-muted\`.
- Headline \"No active calls\" at \`text-base text-foreground\`.
- Helper \"Niko will surface live calls here as they come in.\" at \`text-sm text-foreground-subtle\`.
- 12px / 6px gaps, 32px vertical padding.

**3. Orders filter tabs — empty list**
- When a filter tab has zero rows, render the same icon-container + headline + helper pattern as a \`<td colSpan={6}>\` row inside the table — the \`<thead>\` stays visible above it.
- Headlines come from a typed \`Record<OrderStatus, string>\` so adding/removing a status anywhere in the schema fails the build here.
- All-tab + zero rows still routes to the existing twilio-aware \`<EmptyState>\` — that surface answers \"are you provisioned\", not \"is this filter empty right now.\" Kept distinct on purpose.
- Helper copy is constant: \"This view will update automatically as orders come in.\"

## Part B — Kitchen queue keyboard affordance

PR #245 already wired \`tr onClick → router.push\` + cell-1 \`<Link aria-label>\` + \`TransitionButton.stopPropagation\`, so the rows are already clickable and the button already doesn't navigate. What was missing:

- \`focus-within:outline focus-within:outline-brand-muted focus-within:-outline-offset-2\` on the \`<tr>\` so the row lights up when its cell-1 link is focused via Tab.
- \`transition-[background-color] duration-100 ease-linear\` (was the default \`transition-colors\` ~150ms).

**Did not** convert the table to a list of \`<Link>\`s — wrapping \`<tr>\` in \`<a>\` is invalid HTML, and the table → list refactor would regress the a11y pattern #245 standardized for one cosmetic affordance. Inset outline (\`-outline-offset-2\`) avoids the rounded-card-corner clipping risk on first/last rows.

## Files

- \`components/overview/kpi-strip.tsx\` — \`zeroHint\` prop, conditional render
- \`app/(dashboard)/page.tsx\` — pass \`zeroHint\` only when count is 0
- \`components/overview/live-calls-widget.tsx\` — new EmptyState markup
- \`components/orders/orders-table.tsx\` — \`statusFilter?: OrderStatus\` prop, typed \`EMPTY_HEADLINE_BY_STATUS\` map, \`FilterEmptyState\` rendered as colSpan row
- \`components/orders/orders-feed.tsx\` — pass \`statusFilter\` through (already in scope as typed \`OrderStatus\`)
- \`components/overview/active-orders-widget.tsx\` — focus-within ring + 100ms linear transition

## Test plan

- [x] \`pnpm tsc --noEmit\` — clean
- [x] \`pnpm lint\` — clean (zero warnings)
- [x] \`pnpm vitest run\` — 109/109 (15 files)
- [x] \`pnpm dev\` — Turbopack ready in 386ms, no build errors
- [ ] Manual (dark + light):
  - / — KPI \"Orders today\" shows muted \`0\` + helper line when count is 0
  - / — Live calls widget shows new pattern (icon container + headline + helper)
  - /orders — click each filter tab with 0 results: inline empty renders inside the table card with header still visible above
  - / — click anywhere on a kitchen queue row except the button → /orders/{call_sid}; click the button → existing transition, no nav
  - / — Tab through the kitchen queue: each row gets a brand-muted focus ring, Enter activates the cell-1 link

🤖 Generated with [Claude Code](https://claude.com/claude-code)