### PR TITLE
fix(dashboard): legible terminal-status rows + simpler sidebar account block

### DIFF
--- a/dashboard/components/orders/orders-table.tsx
+++ b/dashboard/components/orders/orders-table.tsx
@@ -56,8 +56,6 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
   const router = useRouter();
 
   const isLive = order.status === 'in_progress';
-  const isFaded = order.status === 'completed' || order.status === 'cancelled';
-  const fadedCell = isFaded ? 'text-foreground-faint' : '';
 
   const itemsSummary =
     order.items.length === 0
@@ -92,7 +90,7 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
           and the <tr> onClick handles mouse navigation. <TransitionButton>
           in cell 6 stays independently focusable and stops propagation
           on its own click. */}
-      <Td className={cn('font-mono text-xs', fadedCell)}>
+      <Td className="font-mono text-xs text-foreground-muted">
         <Link
           href={detailHref}
           aria-label={`View order ${orderShortId(order)}`}
@@ -116,7 +114,7 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
           )}
         </span>
       </Td>
-      <Td className={fadedCell}>
+      <Td>
         <div className={cn('truncate', isLive && 'italic')}>
           {isLive ? `Building… ${itemsSummary}` : itemsSummary}
         </div>
@@ -124,12 +122,7 @@ function OrderRow({ order, isFresh }: { order: Order; isFresh: boolean }) {
           <div className="text-xs text-foreground-faint">{secondary}</div>
         )}
       </Td>
-      <Td
-        className={cn(
-          'text-right font-mono font-medium tabular-nums',
-          fadedCell,
-        )}
-      >
+      <Td className="text-right font-mono font-medium tabular-nums">
         {formatCAD(order.subtotal)}
       </Td>
       <Td>

--- a/dashboard/components/shared/user-menu.tsx
+++ b/dashboard/components/shared/user-menu.tsx
@@ -58,19 +58,14 @@ export function UserMenu({ restaurantName, userEmail, buildSha }: Props) {
         )}
         aria-label="Account menu"
       >
-        <Avatar className="size-8 shrink-0">
-          <AvatarFallback className="bg-brand-muted text-foreground text-xs font-medium">
+        <Avatar className="size-7 shrink-0 border border-border">
+          <AvatarFallback className="bg-surface-2 text-foreground text-xs font-medium">
             {initials}
           </AvatarFallback>
         </Avatar>
-        <div className="flex min-w-0 flex-1 flex-col leading-tight">
-          <span className="truncate font-medium">{restaurantName}</span>
-          {userEmail ? (
-            <span className="truncate text-xs text-foreground-muted group-hover/user-menu:text-foreground/80 group-data-[state=open]/user-menu:text-foreground/80">
-              {userEmail}
-            </span>
-          ) : null}
-        </div>
+        <span className="min-w-0 flex-1 truncate font-medium">
+          {restaurantName}
+        </span>
         <ChevronsUpDown className="size-4 shrink-0 opacity-60" aria-hidden />
       </DropdownMenuTrigger>
 
@@ -83,7 +78,7 @@ export function UserMenu({ restaurantName, userEmail, buildSha }: Props) {
         <DropdownMenuLabel className="flex flex-col gap-0.5">
           <span className="truncate font-medium">{restaurantName}</span>
           {userEmail ? (
-            <span className="truncate text-xs font-normal text-muted-foreground">
+            <span className="truncate text-sm font-normal text-foreground-muted">
               {userEmail}
             </span>
           ) : null}
@@ -166,13 +161,9 @@ function ThemeSubMenu() {
 }
 
 function computeInitials(restaurantName: string, userEmail: string): string {
-  const fromName = restaurantName
-    .trim()
-    .split(/\s+/)
-    .filter((w) => w.length > 0)
-    .slice(0, 2)
-    .map((w) => w[0]?.toUpperCase() ?? '')
-    .join('');
-  if (fromName) return fromName;
-  return userEmail.charAt(0).toUpperCase() || '?';
+  const trimmedName = restaurantName.trim();
+  if (trimmedName) return trimmedName[0].toUpperCase();
+  const trimmedEmail = userEmail.trim();
+  if (trimmedEmail) return trimmedEmail[0].toUpperCase();
+  return '?';
 }


### PR DESCRIPTION
## Summary

Two visual fixes. No functional changes, no schema work. Status visuals continue to flow through `<StatusBadge>`.

## Part A — Stop muting completed/cancelled rows

Terminal-state rows were rendering ID + items + subtotal in `text-foreground-faint`, reading as "row is disabled" rather than "row is finished." The status pill is already carrying the terminal-state signal — the row body should stay legible for audit trail / refund lookup work.

Per discussion with reviewer: the muting mechanism is removed for **both** completed and cancelled. Splitting two terminal statuses on visual treatment doesn't have a real design rationale ("why is cancelled muted but completed isn't?" — the answer "brief said completed" isn't a design rationale). Status pills carry status; row bodies stay legible; no exceptions.

- Delete `isFaded` / `fadedCell` entirely.
- Order ID column: `text-foreground-muted` across all statuses (one consistent treatment).
- Items + subtotal columns: inherit foreground for every status.
- Hover, status pill, action button: unchanged. The action button on terminal rows was already absent — `configFor` in transition-button.tsx returns `null` for completed/cancelled.

## Part B — Sidebar account block

Trigger row was crammed in 200px: avatar + name + truncated email + chevron. Email at this position is low-value and ugly when truncated.

- Trigger row: avatar + name + chevron only. Single row, ~44px tall.
- Avatar: 32px → 28px (`size-7`), `bg-brand-muted` → `bg-surface-2`, with a 1px `border border-border` hairline.
  - **Why the border:** light-mode ΔL between `--surface-1` (sidebar bg) and `--surface-2` (avatar bg) is 0.02 — below the perceptible threshold. Dark-mode ΔL is 0.04, marginal. Border guarantees the circle is visible regardless of theme without bumping the surface step.
- `computeInitials`: single uppercase letter (was up to 2). Handles empty / whitespace-only `restaurantName` via fallback chain → email first char → `'?'`.
- Email moves into the menu's `DropdownMenuLabel` at `text-sm text-foreground-muted` (information preserved, just out of the always-visible sidebar).
- Menu contents (theme submenu, sign out, build SHA): unchanged.

## Files

- `components/orders/orders-table.tsx` — \`OrderRow\`: drop muting, ID gets unconditional \`text-foreground-muted\`
- `components/shared/user-menu.tsx` — trigger row collapse, avatar restyle + border, single-letter initials, menu email at \`text-sm text-foreground-muted\`

## Test plan

- [x] \`pnpm tsc --noEmit\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm vitest run\` — 109/109 (15 files)
- [ ] Manual (dark + light):
  - /orders — completed rows (e.g. #0B69, #FDD1) at full legibility, only the status pill indicates completion. Hover works.
  - /orders — cancelled rows same treatment.
  - Any page — sidebar account block shows just \"Restaurant\" + chevron, no email. Avatar circle visible against the sidebar in both themes.
  - Click sidebar account → menu opens, email visible at top in \`text-sm text-foreground-muted\`.
  - \"Restaurant\" → avatar shows \`R\`. Empty / whitespace-only name → first letter of email; if both empty → \`?\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)