### PR TITLE
refactor(telephony): split router.py + carve app/twilio/ (#251)

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -1,20 +1,13 @@
-"""Twilio telephony endpoints.
+"""Twilio telephony FastAPI surface.
 
-POST /voice        — TwiML webhook: answers the inbound call, opens a
-                     Twilio Media Stream so the STT→LLM→TTS pipeline can
-                     take over.  The AI greeting is delivered via the
-                     configured TTS provider on the 'start' event rather
-                     than a static TwiML <Say>.
-
-WS   /media-stream — Receives the Twilio Media Stream over WebSocket and
-                     runs the full call loop:
-                       STT transcript → stream_reply() → speak()
-                     Supports barge-in (VAD speech-started fires the
-                     fast path; final-transcript arrival fires the
-                     fallback path) and a 10-second silence watchdog.
-
-Vendor-specific STT/TTS implementations live under app/<vendor>/; this
-router only knows about the abstractions in app/stt and app/tts.
+Five HTTP webhook endpoints (`/voice`, `/voice/stream-ended`,
+`/voice/transfer-result`, `/voice/voicemail-recorded`,
+`/voice/voicemail-transcription`) and one WebSocket
+(`/media-stream`) that runs Twilio's Media Stream loop. Endpoint
+bodies parse Twilio's webhook form and delegate: TwiML construction
+to app/twilio/twiml.py, REST credentials to app/twilio/__init__.py,
+call orchestration (state, barge-in, hangup, LLM turn) to
+app/telephony/session.py.
 """
 
 from __future__ import annotations
@@ -23,24 +16,35 @@ import asyncio
 import base64
 import json
 import logging
-import time
-from dataclasses import dataclass, field
-from typing import Any, Callable
 
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
-from app.config import settings
-from app.llm.client import stream_reply
+
+import app.twilio as app_twilio
 from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
-from app.orders.models import Order, OrderStatus
-from app.restaurants.models import Restaurant
+from app.orders.models import Order
 from app.restaurants.open_check import is_open_now
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
-from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
-from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
-import app.twilio as app_twilio
+from app.stt import get_stt
+from app.config import settings
+from app.telephony.session import (
+    GREETING_TRANSCRIPT,
+    END_OF_CALL_MARK,
+    _CallState,
+    _abort_pending_hangup,
+    _arm_silence_watchdog,
+    _bg_call_event,
+    _cancel_silence_task,
+    _consume_transcripts,
+    _hang_up_after_grace,
+    _make_recording_chunk_handler,
+    _resolve_restaurant_for_voice,
+    _run_llm_tts_turn,
+    _state_rid,
+)
 from app.telephony.voicemail_twiml import voicemail_response
+from app.tts import speak
 from app.twilio.twiml import (
     closed_hangup_twiml,
     empty_twiml,
@@ -48,632 +52,17 @@ from app.twilio.twiml import (
     unconfigured_hangup_twiml,
     voice_twiml,
 )
-from app.tts import speak
-from app.twilio.media_stream import send_clear, send_mark
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-SILENCE_TIMEOUT_SECONDS = 10.0
-SILENCE_PROMPT = "Are you still there?"
-GREETING_TRANSCRIPT = "[call started — greet the caller]"
-
-# Auto-hangup after order confirmation (#78). Twilio echoes back this
-# named mark when its audio buffer drains, signalling the caller has
-# heard the goodbye; we then hold for the grace window in case they
-# squeeze in a late question before terminating the call.
-END_OF_CALL_MARK = "end_of_call"
-HANGUP_GRACE_SECONDS = 5.0
-# Fallback if Twilio never echoes the end_of_call mark back to us
-# (WebSocket dropped, mark lost in transit). After this many seconds
-# we trigger the grace window anyway so the call still terminates
-# instead of hanging open. Picked > typical mark round-trip (1-3s).
-MARK_ECHO_TIMEOUT_SECONDS = 8.0
-
-# Chunking thresholds for TTS handoff (#151). Sentence terminators
-# always flush; soft breaks (commas, semicolons, colons, em dashes)
-# only flush once the buffered chunk is ≥ _MIN_CHUNK_CHARS so that
-# fragments like "Got it," don't become their own Aura round-trip.
-# 20 chars ≈ "One Chicken Fried Rice coming up," length when the
-# 4/26 Twilight call's longest "over budget" turn would have hit.
-_HARD_BREAKS = (".", "?", "!")
-_SOFT_BREAKS = (",", ";", ":", "—")
-_MIN_CHUNK_CHARS = 20
-
-
-def _should_flush_chunk(delta: str, buffered_chars: int) -> bool:
-    """True if the current text-delta should close a TTS chunk.
-
-    ``delta`` is the latest streamed text fragment from Anthropic;
-    ``buffered_chars`` is the total length of all deltas accumulated
-    since the last flush (i.e. the chunk we'd ship if we flushed now).
-    """
-    if delta.endswith(_HARD_BREAKS):
-        return True
-    if delta.endswith(_SOFT_BREAKS) and buffered_chars >= _MIN_CHUNK_CHARS:
-        return True
-    return False
-
-
-# Phrases the model uses when wrapping up. Used as a fallback signal
-# for auto-hangup when Haiku says a goodbye but forgets to mark the
-# order status as confirmed via update_order (#79). Matched
-# case-insensitive against the full assembled reply.
-_GOODBYE_PATTERNS = (
-    "your order is in",
-    "have it ready",
-    "see you soon",
-    "see you in a",
-    "thanks for calling",
-    "thanks for ordering",
-    "have a great day",
-    "have a good day",
-    "enjoy your",
-)
-
-
-def _looks_like_goodbye(reply: str) -> bool:
-    """True if ``reply`` reads as a terminal wrap-up rather than another
-    follow-up question. Combined with ``Order.is_ready_to_confirm`` this
-    is the fallback trigger for auto-hangup."""
-    if not reply:
-        return False
-    stripped = reply.strip()
-    if stripped.endswith("?"):
-        return False
-    lower = stripped.lower()
-    return any(pat in lower for pat in _GOODBYE_PATTERNS)
-
-
-def _bg_call_event(call_sid: str | None, restaurant_id: str | None, **kwargs) -> None:
-    """Fire-and-forget Firestore write so the audio loop never blocks on it.
-
-    The storage module catches its own exceptions, so failures here just
-    drop the event from the live dashboard — the call continues normally.
-    Both ``call_sid`` and ``restaurant_id`` must be set; if either is
-    missing (early-lifecycle event before ``start`` resolved the tenant),
-    we silently skip rather than guess at the path.
-    """
-    if not call_sid or not restaurant_id:
-        return
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        return
-    loop.create_task(
-        asyncio.to_thread(call_sessions.record_event, call_sid, restaurant_id, **kwargs)
-    )
-
-
-async def _hang_up_after_grace(state: _CallState) -> None:
-    """Wait HANGUP_GRACE_SECONDS, then close the WebSocket to end the
-    call.
-
-    Closing our /media-stream WebSocket ends Twilio's <Connect>; with no
-    further TwiML the inbound call hangs up. This avoids the Twilio REST
-    Calls.update endpoint, which returns 404 on calls in <Connect> state
-    (same root cause as the recording 404). The grace window lets a
-    caller squeeze in a late follow-up like *"how long does that
-    take?"* — a final transcript clears ``state.pending_hangup`` and
-    we abort.
-
-    ``state.should_hangup`` is also set as a fallback signal in case
-    the WS close doesn't immediately unblock ``receive_text()`` (rare,
-    but harmless to set both).
-    """
-    try:
-        await asyncio.sleep(HANGUP_GRACE_SECONDS)
-    except asyncio.CancelledError:
-        return
-    if not state.pending_hangup or not state.call_sid:
-        return
-    state.should_hangup.set()
-    if state.websocket is not None:
-        try:
-            await state.websocket.close(code=1000)
-            logger.info(
-                "call ended by server (WS-close path) call_sid=%s",
-                state.call_sid,
-            )
-        except Exception:
-            logger.exception("auto-hangup: WS close failed call_sid=%s", state.call_sid)
-
-
-async def _hang_up_after_mark_timeout(state: _CallState) -> None:
-    """Fallback for when Twilio never echoes the end_of_call mark.
-
-    The primary path is: send mark → Twilio echoes when audio drains →
-    start grace timer. If the echo never arrives, this timer fires
-    after ``MARK_ECHO_TIMEOUT_SECONDS`` and starts the grace window
-    anyway, so the call still ends instead of hanging open.
-
-    Cancelled by the echo handler when the echo arrives, or by
-    ``_abort_pending_hangup`` when the caller speaks.
-    """
-    try:
-        await asyncio.sleep(MARK_ECHO_TIMEOUT_SECONDS)
-    except asyncio.CancelledError:
-        return
-    if not state.pending_hangup or not state.call_sid:
-        return
-    logger.warning(
-        "auto-hangup: mark echo timed out after %.1fs, falling back to grace window call_sid=%s",
-        MARK_ECHO_TIMEOUT_SECONDS,
-        state.call_sid,
-    )
-    if state.hangup_task and not state.hangup_task.done():
-        state.hangup_task.cancel()
-    state.hangup_task = None
-    await _hang_up_after_grace(state)
-
-
-def _abort_pending_hangup(state: _CallState) -> None:
-    """Cancel a pending auto-hangup because the caller spoke during
-    the grace window. Safe to call when no hangup is pending."""
-    state.pending_hangup = False
-    if state.hangup_task and not state.hangup_task.done():
-        state.hangup_task.cancel()
-    state.hangup_task = None
-    if state.mark_timeout_task and not state.mark_timeout_task.done():
-        state.mark_timeout_task.cancel()
-    state.mark_timeout_task = None
-
-
-async def _barge_in_now(
-    state: "_CallState",
-    websocket: WebSocket,
-    *,
-    trigger: str,
-) -> None:
-    """Stop the bot mid-utterance.
-
-    Three mechanical steps:
-      1. Cancel the in-flight LLM/TTS task → halt audio generation.
-      2. Cancel the silence watchdog → caller is speaking; "are you still
-         there?" would be wrong.
-      3. Send Twilio 'clear' → flush already-buffered audio playback (#74).
-
-    The barge_in Firestore event is NOT emitted here. It's emitted by
-    _run_llm_tts_turn's existing CancelledError handler when the task we
-    just cancelled actually receives the cancellation. Trigger
-    information flows via state.barge_in_trigger, which is set ONLY when
-    there is actually a task to cancel — preventing stale triggers from
-    leaking into the next turn's barge-in event, and preventing phantom
-    barge_in events on cleanup-path cancellations (WS shutdown).
-    """
-    if state.llm_task and not state.llm_task.done():
-        state.barge_in_trigger = trigger
-        state.llm_task.cancel()
-    _cancel_silence_task(state)
-    await send_clear(websocket, state.stream_sid)
-
-
-@dataclass
-class _CallState:
-    call_sid: str | None = None
-    stream_sid: str | None = None
-    order: Order | None = None
-    history: list[dict] = field(default_factory=list)
-    restaurant: Restaurant | None = None  # tenant for this call (#79)
-    system_prompt: str = ""  # built from restaurant on start
-    llm_task: asyncio.Task | None = None  # current LLM→TTS turn
-    silence_task: asyncio.Task | None = None  # silence watchdog
-    hangup_task: asyncio.Task | None = None  # pending auto-hangup (#78)
-    mark_timeout_task: asyncio.Task | None = None  # mark-echo fallback (#114)
-    pending_hangup: bool = False  # set when goodbye mark sent (#78)
-    recording_session: "RecordingUploadSession | None" = None
-    should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
-    # WS reference so _hang_up_after_grace can close the connection
-    # server-side. Closing the WS ends Twilio's <Connect>; with no
-    # further TwiML the call hangs up. Avoids the Twilio REST
-    # Calls.update endpoint which 404s on <Connect>-state calls.
-    websocket: "WebSocket | None" = None
-    # Transfer trigger accumulators (#7 Sprint 2.4 Track 2). Set by
-    # transcript / LLM-error handlers; read in the finally block to
-    # decide whether to write a transfer flag to the call session.
-    consecutive_low_confidence_turns: int = 0
-    last_caller_transcript: str = ""
-    llm_error_occurred: bool = False
-    # Carry-forward of the most recent transcript fed to an LLM turn
-    # that has not yet been persisted to ``history``. When a new final
-    # transcript arrives mid-turn, ``_handle_final_transcript`` cancels
-    # the in-flight task and prepends this string so the cancelled
-    # turn's user words aren't lost (#170). Cleared by ``_run_llm_tts_turn``
-    # the moment ``event.final`` writes ``state.history``.
-    in_flight_transcript: str = ""
-    # Set by _barge_in_now() before cancelling state.llm_task; read and
-    # cleared by _run_llm_tts_turn's CancelledError handler when emitting
-    # the barge_in Firestore event. None at all other times.
-    barge_in_trigger: str | None = None
-    # STT plugin lifecycle. Set on "start"; consumer task drains
-    # stt.events() and is cancelled in the WS handler's finally block.
-    stt: "STTProvider | None" = None
-    stt_provider: str | None = None
-    transcript_task: asyncio.Task | None = None
-
-
-def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:
-    """Return a chunk handler that appends outbound TTS audio to the
-    recording session, or None when no session is active.
-
-    Returning None means ``speak()`` won't fire ``on_chunk`` at all,
-    which is the desired behaviour when ``RECORDINGS_BUCKET`` is unset
-    and ``state.recording_session`` therefore stays None.
-    """
-    if state.recording_session is None:
-        return None
-    rs = state.recording_session
-
-    def _handle(chunk: bytes) -> None:
-        try:
-            recordings.append_chunks(rs, b"", chunk)
-        except Exception:
-            logger.exception(
-                "tts: recording append failed call_sid=%s", state.call_sid
-            )
-
-    return _handle
-
-
-def _state_rid(state: _CallState) -> str | None:
-    """Restaurant id from state, or None if start hasn't resolved a tenant
-    yet (early-lifecycle defense)."""
-    return state.restaurant.id if state.restaurant else None
-
-
-async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
-    try:
-        await asyncio.sleep(SILENCE_TIMEOUT_SECONDS)
-        logger.info("silence timeout call_sid=%s", state.call_sid)
-        _bg_call_event(state.call_sid, _state_rid(state), kind="silence_timeout")
-        if state.stream_sid:
-            await speak(
-                SILENCE_PROMPT,
-                websocket,
-                state.stream_sid,
-                on_chunk=_make_recording_chunk_handler(state),
-            )
-    except asyncio.CancelledError:
-        pass
-
-
-def _cancel_silence_task(state: _CallState) -> None:
-    if state.silence_task and not state.silence_task.done():
-        state.silence_task.cancel()
-    state.silence_task = None
-
-
-def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
-    if state.llm_task and state.llm_task.cancelled():
-        return  # barge-in — caller spoke again, no watchdog needed
-    _cancel_silence_task(state)
-    state.silence_task = asyncio.get_event_loop().create_task(_silence_watchdog(state, websocket))
-
-
-async def _consume_transcripts(
-    stt: STTProvider,
-    state: _CallState,
-    websocket: WebSocket,
-) -> None:
-    """Background task consuming events from the STT plugin.
-
-    All state mutation, Firestore emission, and dispatch into
-    _handle_final_transcript happens here — the plugin is pure and
-    knows nothing about call state. SpeechStartedEvent triggers an
-    instant barge-in via _barge_in_now (gated on STT_INSTANT_BARGE_IN).
-    """
-    try:
-        async for event in stt.events():
-            if isinstance(event, SpeechStartedEvent):
-                # Instant barge-in: fire ~50ms after the caller starts
-                # speaking instead of waiting for the final transcript
-                # (~800-1800ms). The final-transcript path in
-                # _handle_final_transcript still runs as a fallback for
-                # short utterances or missed VAD signals.
-                if not settings.stt_instant_barge_in:
-                    continue
-                if state.llm_task and not state.llm_task.done():
-                    await _barge_in_now(state, websocket, trigger="vad")
-                continue
-
-            # event is a TranscriptEvent
-            if not event.is_final:
-                continue   # interim: captured in plugin logs only
-
-            state.last_caller_transcript = event.text
-            if event.confidence < 0.5:
-                state.consecutive_low_confidence_turns += 1
-            else:
-                state.consecutive_low_confidence_turns = 0
-
-            _bg_call_event(
-                state.call_sid,
-                _state_rid(state),
-                kind="transcript_final",
-                text=event.text,
-                detail={"text": event.text, "confidence": event.confidence},
-            )
-            await _handle_final_transcript(event.text, state, websocket)
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:
-        logger.exception(
-            "transcript consumer crashed call_sid=%s", state.call_sid
-        )
-        # Mark the call as errored so the transfer-trigger logic in
-        # finally has a signal to act on, and surface the failure to the
-        # dashboard so it doesn't look like dead air to whoever's watching.
-        state.llm_error_occurred = True
-        _bg_call_event(
-            state.call_sid,
-            _state_rid(state),
-            kind="error",
-            text=f"transcript consumer crashed: {exc}"[:500],
-            detail={"exception": type(exc).__name__},
-        )
-
-
-async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSocket) -> None:
-    turn_start = time.monotonic()
-    logger.info("llm_turn start call_sid=%s transcript=%r", state.call_sid, transcript)
-    _bg_call_event(
-        state.call_sid,
-        _state_rid(state),
-        kind="llm_turn_start",
-        text=transcript,
-        detail={"transcript": transcript},
-    )
-    text_buffer: list[str] = []
-    first_speak = True
-    full_reply_parts: list[str] = []
-    # #146 — instrumentation. ``stream_reply`` yields one timing snapshot
-    # the moment the first text content block opens; we stash it and
-    # fold the breakdown into the first_audio Firestore event so the
-    # dashboard can show ttft/tool_prefix/cache without anyone needing
-    # GCP log access.
-    timing_snapshot: dict[str, Any] | None = None
-    first_text_at: float | None = None
-
-    def _record_first_audio() -> None:
-        latency = time.monotonic() - turn_start
-        logger.info(
-            "llm_turn first_audio latency=%.3fs call_sid=%s",
-            latency,
-            state.call_sid,
-        )
-        detail: dict[str, Any] = {"latency_seconds": round(latency, 3)}
-        if first_text_at is not None:
-            detail["first_text_seconds"] = round(first_text_at - turn_start, 3)
-        if timing_snapshot is not None:
-            detail.update(timing_snapshot)
-        _bg_call_event(
-            state.call_sid,
-            _state_rid(state),
-            kind="first_audio",
-            detail=detail,
-        )
-
-    def _record_first_tts_byte() -> None:
-        # #152 — captures the actual moment the first audio byte arrives
-        # from Deepgram Aura, closing the gap that first_audio misses
-        # (first_audio fires before await speak(), hiding TTS network time).
-        latency = time.monotonic() - turn_start
-        logger.info(
-            "llm_turn first_tts_byte latency=%.3fs call_sid=%s",
-            latency,
-            state.call_sid,
-        )
-        _bg_call_event(
-            state.call_sid,
-            _state_rid(state),
-            kind="first_tts_byte",
-            detail={"latency_seconds": round(latency, 3)},
-        )
-
-    try:
-        async for event in stream_reply(
-            transcript=transcript,
-            history=state.history,
-            order=state.order,
-            system_prompt=state.system_prompt,
-        ):
-            if asyncio.current_task().cancelled():
-                return
-
-            if event.timing is not None:
-                timing_snapshot = event.timing
-                continue
-
-            if event.text_delta is not None:
-                if first_text_at is None:
-                    first_text_at = time.monotonic()
-                text_buffer.append(event.text_delta)
-                full_reply_parts.append(event.text_delta)
-                buffered_chars = sum(len(p) for p in text_buffer)
-                if _should_flush_chunk(event.text_delta, buffered_chars):
-                    chunk = "".join(text_buffer).strip()
-                    text_buffer.clear()
-                    if chunk and state.stream_sid:
-                        if first_speak:
-                            _record_first_audio()
-                            first_speak = False
-                            on_first_byte = _record_first_tts_byte
-                        else:
-                            on_first_byte = None
-                        await speak(
-                            chunk,
-                            websocket,
-                            state.stream_sid,
-                            on_chunk=_make_recording_chunk_handler(state),
-                            on_first_byte=on_first_byte,
-                        )
-
-            elif event.final is not None:
-                remainder = "".join(text_buffer).strip()
-                text_buffer.clear()
-                if remainder and state.stream_sid:
-                    if first_speak:
-                        _record_first_audio()
-                        first_speak = False
-                        on_first_byte = _record_first_tts_byte
-                    else:
-                        on_first_byte = None
-                    await speak(
-                        remainder,
-                        websocket,
-                        state.stream_sid,
-                        on_chunk=_make_recording_chunk_handler(state),
-                        on_first_byte=on_first_byte,
-                    )
-                state.history = event.final.history
-                state.order = event.final.order
-                # Transcript is now durably in history — no need to carry
-                # it forward if a future turn is cancelled (#170).
-                state.in_flight_transcript = ""
-                full_reply = "".join(full_reply_parts).strip()
-                if full_reply:
-                    logger.info(
-                        "agent_reply call_sid=%s text=%r",
-                        state.call_sid,
-                        full_reply,
-                    )
-                    _bg_call_event(
-                        state.call_sid,
-                        _state_rid(state),
-                        kind="agent_reply",
-                        text=full_reply,
-                        detail={"text": full_reply},
-                    )
-                # Decide whether this turn is the wrap-up. Two signals:
-                #  1. Haiku set status=confirmed via update_order (the
-                #     primary path the prompt asks for).
-                #  2. Fallback (#79) — Haiku emitted a goodbye-shaped
-                #     reply ("your order is in", "see you soon", etc.)
-                #     AND the order has the data to actually confirm.
-                #     The model sometimes says the right closing line
-                #     without remembering to flip status.
-                if state.order is not None and state.stream_sid:
-                    explicitly_confirmed = state.order.status == OrderStatus.CONFIRMED
-                    fallback_confirmed = (
-                        state.order.is_ready_to_confirm()
-                        and state.order.status != OrderStatus.CANCELLED
-                        and _looks_like_goodbye(full_reply)
-                    )
-                    if explicitly_confirmed or fallback_confirmed:
-                        if fallback_confirmed and not explicitly_confirmed:
-                            logger.info(
-                                "auto-hangup: heuristic wrap-up detected "
-                                "(LLM didn't set status=confirmed) call_sid=%s",
-                                state.call_sid,
-                            )
-                            # Mirror the explicit-confirmation path locally
-                            # so the finally-block persist sees it too.
-                            state.order = state.order.model_copy(
-                                update={"status": OrderStatus.CONFIRMED}
-                            )
-                        sent = await send_mark(websocket, state.stream_sid, name=END_OF_CALL_MARK)
-                        if sent:
-                            state.pending_hangup = True
-                            if state.mark_timeout_task and not state.mark_timeout_task.done():
-                                state.mark_timeout_task.cancel()
-                            state.mark_timeout_task = asyncio.create_task(
-                                _hang_up_after_mark_timeout(state)
-                            )
-
-    except asyncio.CancelledError:
-        trigger = state.barge_in_trigger
-        state.barge_in_trigger = None
-        if trigger is not None:
-            # User-driven barge-in: trigger was set by _barge_in_now
-            # before cancelling the task. Emit the timeline event.
-            logger.info(
-                "llm_turn cancelled (barge-in trigger=%s) call_sid=%s",
-                trigger,
-                state.call_sid,
-            )
-            _bg_call_event(
-                state.call_sid,
-                _state_rid(state),
-                kind="barge_in",
-                detail={"trigger": trigger},
-            )
-        else:
-            # Cleanup-path cancellation: WS handler's finally block
-            # cancels the task during call teardown. No barge_in event.
-            logger.info(
-                "llm_turn cancelled (cleanup) call_sid=%s", state.call_sid
-            )
-        raise
-    except Exception as exc:
-        logger.exception("llm_turn errored call_sid=%s", state.call_sid)
-        # #7: signal the trigger detector at end-of-stream
-        state.llm_error_occurred = True
-        _bg_call_event(
-            state.call_sid,
-            _state_rid(state),
-            kind="error",
-            text=str(exc)[:500],
-            detail={"exception": type(exc).__name__},
-        )
-        raise
-
-
-async def _handle_final_transcript(text: str, state: _CallState, websocket: WebSocket) -> None:
-    interrupted = bool(state.llm_task and not state.llm_task.done())
-    # Carry forward — if any prior turn (cancelled or errored) left a
-    # transcript on state without persisting it to history, prepend it
-    # so Haiku sees the full caller intent in this turn (#170). The
-    # field is cleared by ``_run_llm_tts_turn`` only on ``event.final``,
-    # so a non-empty value here always means "user words from a prior
-    # turn that never made it into history."
-    if state.in_flight_transcript.strip():
-        text = f"{state.in_flight_transcript} {text}".strip()
-    silence_was_active = bool(state.silence_task and not state.silence_task.done())
-    # Caller spoke — abort any pending auto-hangup (#78). Even if they
-    # spoke during the grace window after a confirmation, we want to
-    # keep the call alive and process this transcript.
-    _abort_pending_hangup(state)
-
-    if interrupted:
-        # True barge-in: a turn is running and we're interrupting it.
-        # The barge_in Firestore event fires from _run_llm_tts_turn's
-        # CancelledError handler.
-        await _barge_in_now(state, websocket, trigger="final_transcript")
-    elif silence_was_active:
-        # Caller resumed after a silence prompt — flush any leftover
-        # prompt audio still buffered, but this isn't a barge-in (no
-        # task to cancel, no event to emit).
-        _cancel_silence_task(state)
-        await send_clear(websocket, state.stream_sid)
-
-    state.in_flight_transcript = text
-    state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
-    state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
-
-
-def _resolve_restaurant_for_voice(
-    to_e164: str,
-) -> Restaurant | None:
-    """Find the tenant for an inbound Twilio call (PR B of #79).
-
-    Looks up by the ``To`` field — Twilio's name for the dialed number,
-    which equals the per-restaurant ``twilio_phone`` we provisioned. If
-    Firestore returns nothing AND the dialed number matches the
-    demo's hardcoded ``twilio_phone``, falls back to building the demo
-    restaurant from ``app.menu.MENU``. The fallback is removed in PR F
-    once the seed is canonical.
-    """
-    restaurant = restaurants_storage.get_restaurant_by_twilio_phone(to_e164)
-    if restaurant is not None:
-        return restaurant
-    demo = restaurants_storage.demo_restaurant_from_menu()
-    if to_e164 == demo.twilio_phone:
-        logger.warning(
-            "voice: demo Twilio number %s not in Firestore — falling back to MENU",
-            to_e164,
-        )
-        return demo
-    return None
+_TRANSFER_STATUS_MAP = {
+    "completed": "answered",
+    "no-answer": "no_answer",
+    "busy": "busy",
+    "failed": "failed",
+    "canceled": "failed",
+}
 
 
 @router.post("/voice")
@@ -731,15 +120,6 @@ async def voice(request: Request) -> Response:
         content=str(voice_twiml(restaurant, host)),
         media_type="application/xml",
     )
-
-
-_TRANSFER_STATUS_MAP = {
-    "completed": "answered",
-    "no-answer": "no_answer",
-    "busy": "busy",
-    "failed": "failed",
-    "canceled": "failed",
-}
 
 
 @router.post("/voice/stream-ended")

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -39,6 +39,7 @@ from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
 from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
+import app.twilio as app_twilio
 from app.telephony.voicemail_twiml import voicemail_response
 from app.twilio.twiml import (
     closed_hangup_twiml,
@@ -891,7 +892,7 @@ async def voicemail_recorded(
             media_type="application/xml",
         )
 
-    if not settings.twilio_account_sid or not settings.twilio_auth_token:
+    if app_twilio.twilio_basic_auth() is None:
         logger.error(
             "voicemail upload: twilio creds missing call_sid=%s",
             call_sid,
@@ -902,11 +903,10 @@ async def voicemail_recorded(
         )
 
     try:
-        gs_url = recordings.upload_voicemail_from_twilio(
+        gs_url = app_twilio.upload_voicemail(
             call_sid=call_sid,
             restaurant_id=rid,
             twilio_recording_url=recording_url,
-            auth=(settings.twilio_account_sid, settings.twilio_auth_token),
         )
     except Exception:
         logger.exception(

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -28,8 +28,6 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
-from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
-
 from app.config import settings
 from app.llm.client import stream_reply
 from app.llm.prompts import build_system_prompt
@@ -42,6 +40,13 @@ from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
 from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
 from app.telephony.voicemail_twiml import voicemail_response
+from app.twilio.twiml import (
+    closed_hangup_twiml,
+    empty_twiml,
+    transfer_twiml,
+    unconfigured_hangup_twiml,
+    voice_twiml,
+)
 from app.tts import speak
 from app.twilio.media_stream import send_clear, send_mark
 
@@ -645,9 +650,6 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
     state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
 
 
-_UNCONFIGURED_TWIML_MESSAGE = "Sorry, this number is not currently configured. Goodbye."
-
-
 def _resolve_restaurant_for_voice(
     to_e164: str,
 ) -> Restaurant | None:
@@ -694,23 +696,20 @@ async def voice(request: Request) -> Response:
     call_sid = (form.get("CallSid") or "").strip()
     restaurant = _resolve_restaurant_for_voice(to_e164)
 
-    twiml = VoiceResponse()
     if restaurant is None:
         logger.warning("voice: no restaurant for To=%s — rejecting call", to_e164 or "(missing)")
-        twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
-        twiml.hangup()
-        return Response(content=str(twiml), media_type="application/xml")
+        return Response(
+            content=str(unconfigured_hangup_twiml()),
+            media_type="application/xml",
+        )
 
-    if restaurant is not None and not is_open_now(restaurant):
+    if not is_open_now(restaurant):
         # After-hours: skip the AI flow, drop straight to voicemail.
         if not call_sid:
             # Defensive: Twilio always posts CallSid. Without it, we
             # can't key the recording or call_session — bail.
-            twiml = VoiceResponse()
-            twiml.say("Sorry, we're closed. Please call back during business hours.")
-            twiml.hangup()
             return Response(
-                content=str(twiml),
+                content=str(closed_hangup_twiml()),
                 media_type="application/xml",
             )
         try:
@@ -727,17 +726,10 @@ async def voice(request: Request) -> Response:
         )
 
     host = request.headers.get("host", "localhost:8000")
-    connect = Connect(action="/voice/stream-ended", method="POST")
-    # NOTE: <Connect><Stream> only supports the default ``inbound_track``;
-    # passing ``track="both_tracks"`` makes Twilio reject the TwiML and
-    # the call drops the moment the caller dismisses the trial-account
-    # interstitial. To capture the agent's voice in the recording, the
-    # /media-stream WS handler intercepts the TTS bytes we send out via
-    # ``speak()`` and feeds them directly into the recording session.
-    stream = connect.stream(url=f"wss://{host}/media-stream")
-    stream.parameter(name="restaurant_id", value=restaurant.id)
-    twiml.append(connect)
-    return Response(content=str(twiml), media_type="application/xml")
+    return Response(
+        content=str(voice_twiml(restaurant, host)),
+        media_type="application/xml",
+    )
 
 
 _TRANSFER_STATUS_MAP = {
@@ -765,7 +757,7 @@ async def stream_ended(request: Request) -> Response:
 
     if not call_sid:
         # Twilio always sends CallSid; missing → defensive hangup.
-        return Response(content=str(VoiceResponse()), media_type="application/xml")
+        return Response(content=str(empty_twiml()), media_type="application/xml")
 
     # Resolve the tenant by reading the call_session doc. Uses the legacy
     # flat path because this action callback only receives CallSid — the
@@ -779,7 +771,7 @@ async def stream_ended(request: Request) -> Response:
 
     if rid is None:
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -789,7 +781,7 @@ async def stream_ended(request: Request) -> Response:
 
     if not transfer_requested:
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -813,15 +805,10 @@ async def stream_ended(request: Request) -> Response:
             media_type="application/xml",
         )
 
-    twiml = VoiceResponse()
-    dial = Dial(
-        action=f"/voice/transfer-result?call_sid={call_sid}&rid={rid}",
-        method="POST",
-        timeout=20,
+    return Response(
+        content=str(transfer_twiml(restaurant.fallback_phone, call_sid, rid)),
+        media_type="application/xml",
     )
-    dial.number(restaurant.fallback_phone)
-    twiml.append(dial)
-    return Response(content=str(twiml), media_type="application/xml")
 
 
 @router.post("/voice/transfer-result")
@@ -852,7 +839,7 @@ async def transfer_result(
 
     if internal_status == "answered":
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -883,7 +870,7 @@ async def voicemail_recorded(
 
     if not recording_url or not recording_sid:
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -900,7 +887,7 @@ async def voicemail_recorded(
             recording_sid,
         )
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -910,7 +897,7 @@ async def voicemail_recorded(
             call_sid,
         )
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -928,7 +915,7 @@ async def voicemail_recorded(
             recording_sid,
         )
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -947,7 +934,7 @@ async def voicemail_recorded(
             call_sid,
         )
 
-    return Response(content=str(VoiceResponse()), media_type="application/xml")
+    return Response(content=str(empty_twiml()), media_type="application/xml")
 
 
 @router.post("/voice/voicemail-transcription")

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -43,6 +43,7 @@ from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing
 from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
 from app.telephony.voicemail_twiml import voicemail_response
 from app.tts import speak
+from app.twilio.media_stream import send_clear, send_mark
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -138,32 +139,6 @@ def _bg_call_event(call_sid: str | None, restaurant_id: str | None, **kwargs) ->
     )
 
 
-async def send_end_of_call_mark(websocket: WebSocket, stream_sid: str | None) -> bool:
-    """Append a named ``mark`` event to Twilio's outgoing media stream.
-
-    Twilio echoes the same mark back over the WebSocket once its audio
-    buffer drains past it — i.e. once the caller has heard everything
-    we sent. We use that as the precise trigger for auto-hangup (#78).
-    Returns True if the send succeeded.
-    """
-    if not stream_sid:
-        return False
-    try:
-        await websocket.send_json(
-            {
-                "event": "mark",
-                "streamSid": stream_sid,
-                "mark": {"name": END_OF_CALL_MARK},
-            }
-        )
-        return True
-    except WebSocketDisconnect:
-        return False
-    except Exception:
-        logger.exception("mark: failed to send end_of_call mark stream_sid=%s", stream_sid)
-        return False
-
-
 async def _hang_up_after_grace(state: _CallState) -> None:
     """Wait HANGUP_GRACE_SECONDS, then close the WebSocket to end the
     call.
@@ -238,28 +213,6 @@ def _abort_pending_hangup(state: _CallState) -> None:
     state.mark_timeout_task = None
 
 
-async def clear_twilio_audio(websocket: WebSocket, stream_sid: str | None) -> None:
-    """Tell Twilio to flush its audio buffer and stop playback.
-
-    Cancelling the LLM task only stops *generation* of new audio — bytes
-    already in Twilio's buffer keep playing for another 1–3 seconds, which
-    is exactly what callers experience as "the bot doesn't pause when I
-    interrupt." Twilio's Media Streams API has a dedicated ``clear`` event
-    that drops the buffer in ~80ms; we fire it whenever we cancel an
-    in-flight reply (#74).
-    """
-    if not stream_sid:
-        return
-    try:
-        await websocket.send_json({"event": "clear", "streamSid": stream_sid})
-    except WebSocketDisconnect:
-        # Caller already hung up — nothing to clear.
-        return
-    except Exception:
-        # Don't let a transient send failure break the call loop.
-        logger.exception("clear: failed to send Twilio clear event stream_sid=%s", stream_sid)
-
-
 async def _barge_in_now(
     state: "_CallState",
     websocket: WebSocket,
@@ -286,7 +239,7 @@ async def _barge_in_now(
         state.barge_in_trigger = trigger
         state.llm_task.cancel()
     _cancel_silence_task(state)
-    await clear_twilio_audio(websocket, state.stream_sid)
+    await send_clear(websocket, state.stream_sid)
 
 
 @dataclass
@@ -612,7 +565,7 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                             state.order = state.order.model_copy(
                                 update={"status": OrderStatus.CONFIRMED}
                             )
-                        sent = await send_end_of_call_mark(websocket, state.stream_sid)
+                        sent = await send_mark(websocket, state.stream_sid, name=END_OF_CALL_MARK)
                         if sent:
                             state.pending_hangup = True
                             if state.mark_timeout_task and not state.mark_timeout_task.done():
@@ -685,7 +638,7 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
         # prompt audio still buffered, but this isn't a barge-in (no
         # task to cancel, no event to emit).
         _cancel_silence_task(state)
-        await clear_twilio_audio(websocket, state.stream_sid)
+        await send_clear(websocket, state.stream_sid)
 
     state.in_flight_transcript = text
     state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -19,7 +19,7 @@ import logging
 
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
 
-import app.twilio as app_twilio
+from app.config import settings
 from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
 from app.orders.models import Order
@@ -27,7 +27,6 @@ from app.restaurants.open_check import is_open_now
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.stt import get_stt
-from app.config import settings
 from app.telephony.session import (
     GREETING_TRANSCRIPT,
     END_OF_CALL_MARK,
@@ -45,6 +44,7 @@ from app.telephony.session import (
 )
 from app.telephony.voicemail_twiml import voicemail_response
 from app.tts import speak
+import app.twilio as app_twilio
 from app.twilio.twiml import (
     closed_hangup_twiml,
     empty_twiml,

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -1,0 +1,656 @@
+"""Call orchestration — vendor-neutral.
+
+Owns _CallState and every helper that runs during the lifetime of an
+active call: barge-in, hangup, silence, the LLM/TTS turn loop, and the
+STT transcript consumer. The module knows about the abstract STT/TTS
+provider interfaces in app/stt and app/tts but nothing about Twilio
+specifics — those live in app/twilio/.
+
+The FastAPI endpoints + WS event-loop dispatch live in
+app/telephony/router.py. router.py imports from this module; this
+module does not import from router.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from fastapi import WebSocket
+
+from app.config import settings
+from app.llm.client import stream_reply
+from app.orders.models import Order, OrderStatus
+from app.restaurants.models import Restaurant
+from app.storage import call_sessions, recordings
+from app.storage import restaurants as restaurants_storage
+from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
+from app.stt import STTProvider, SpeechStartedEvent
+from app.tts import speak
+from app.twilio.media_stream import send_clear, send_mark
+
+logger = logging.getLogger(__name__)
+
+SILENCE_TIMEOUT_SECONDS = 10.0
+SILENCE_PROMPT = "Are you still there?"
+GREETING_TRANSCRIPT = "[call started — greet the caller]"
+
+# Auto-hangup after order confirmation (#78). Twilio echoes back this
+# named mark when its audio buffer drains, signalling the caller has
+# heard the goodbye; we then hold for the grace window in case they
+# squeeze in a late question before terminating the call.
+END_OF_CALL_MARK = "end_of_call"
+HANGUP_GRACE_SECONDS = 5.0
+# Fallback if Twilio never echoes the end_of_call mark back to us
+# (WebSocket dropped, mark lost in transit). After this many seconds
+# we trigger the grace window anyway so the call still terminates
+# instead of hanging open. Picked > typical mark round-trip (1-3s).
+MARK_ECHO_TIMEOUT_SECONDS = 8.0
+
+# Chunking thresholds for TTS handoff (#151). Sentence terminators
+# always flush; soft breaks (commas, semicolons, colons, em dashes)
+# only flush once the buffered chunk is ≥ _MIN_CHUNK_CHARS so that
+# fragments like "Got it," don't become their own Aura round-trip.
+# 20 chars ≈ "One Chicken Fried Rice coming up," length when the
+# 4/26 Twilight call's longest "over budget" turn would have hit.
+_HARD_BREAKS = (".", "?", "!")
+_SOFT_BREAKS = (",", ";", ":", "—")
+_MIN_CHUNK_CHARS = 20
+
+
+def _should_flush_chunk(delta: str, buffered_chars: int) -> bool:
+    """True if the current text-delta should close a TTS chunk.
+
+    ``delta`` is the latest streamed text fragment from Anthropic;
+    ``buffered_chars`` is the total length of all deltas accumulated
+    since the last flush (i.e. the chunk we'd ship if we flushed now).
+    """
+    if delta.endswith(_HARD_BREAKS):
+        return True
+    if delta.endswith(_SOFT_BREAKS) and buffered_chars >= _MIN_CHUNK_CHARS:
+        return True
+    return False
+
+
+# Phrases the model uses when wrapping up. Used as a fallback signal
+# for auto-hangup when Haiku says a goodbye but forgets to mark the
+# order status as confirmed via update_order (#79). Matched
+# case-insensitive against the full assembled reply.
+_GOODBYE_PATTERNS = (
+    "your order is in",
+    "have it ready",
+    "see you soon",
+    "see you in a",
+    "thanks for calling",
+    "thanks for ordering",
+    "have a great day",
+    "have a good day",
+    "enjoy your",
+)
+
+
+def _looks_like_goodbye(reply: str) -> bool:
+    """True if ``reply`` reads as a terminal wrap-up rather than another
+    follow-up question. Combined with ``Order.is_ready_to_confirm`` this
+    is the fallback trigger for auto-hangup."""
+    if not reply:
+        return False
+    stripped = reply.strip()
+    if stripped.endswith("?"):
+        return False
+    lower = stripped.lower()
+    return any(pat in lower for pat in _GOODBYE_PATTERNS)
+
+
+def _bg_call_event(call_sid: str | None, restaurant_id: str | None, **kwargs) -> None:
+    """Fire-and-forget Firestore write so the audio loop never blocks on it.
+
+    The storage module catches its own exceptions, so failures here just
+    drop the event from the live dashboard — the call continues normally.
+    Both ``call_sid`` and ``restaurant_id`` must be set; if either is
+    missing (early-lifecycle event before ``start`` resolved the tenant),
+    we silently skip rather than guess at the path.
+    """
+    if not call_sid or not restaurant_id:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    loop.create_task(
+        asyncio.to_thread(call_sessions.record_event, call_sid, restaurant_id, **kwargs)
+    )
+
+
+@dataclass
+class _CallState:
+    call_sid: str | None = None
+    stream_sid: str | None = None
+    order: Order | None = None
+    history: list[dict] = field(default_factory=list)
+    restaurant: Restaurant | None = None  # tenant for this call (#79)
+    system_prompt: str = ""  # built from restaurant on start
+    llm_task: asyncio.Task | None = None  # current LLM→TTS turn
+    silence_task: asyncio.Task | None = None  # silence watchdog
+    hangup_task: asyncio.Task | None = None  # pending auto-hangup (#78)
+    mark_timeout_task: asyncio.Task | None = None  # mark-echo fallback (#114)
+    pending_hangup: bool = False  # set when goodbye mark sent (#78)
+    recording_session: "RecordingUploadSession | None" = None
+    should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
+    # WS reference so _hang_up_after_grace can close the connection
+    # server-side. Closing the WS ends Twilio's <Connect>; with no
+    # further TwiML the call hangs up. Avoids the Twilio REST
+    # Calls.update endpoint which 404s on <Connect>-state calls.
+    websocket: "WebSocket | None" = None
+    # Transfer trigger accumulators (#7 Sprint 2.4 Track 2). Set by
+    # transcript / LLM-error handlers; read in the finally block to
+    # decide whether to write a transfer flag to the call session.
+    consecutive_low_confidence_turns: int = 0
+    last_caller_transcript: str = ""
+    llm_error_occurred: bool = False
+    # Carry-forward of the most recent transcript fed to an LLM turn
+    # that has not yet been persisted to ``history``. When a new final
+    # transcript arrives mid-turn, ``_handle_final_transcript`` cancels
+    # the in-flight task and prepends this string so the cancelled
+    # turn's user words aren't lost (#170). Cleared by ``_run_llm_tts_turn``
+    # the moment ``event.final`` writes ``state.history``.
+    in_flight_transcript: str = ""
+    # Set by _barge_in_now() before cancelling state.llm_task; read and
+    # cleared by _run_llm_tts_turn's CancelledError handler when emitting
+    # the barge_in Firestore event. None at all other times.
+    barge_in_trigger: str | None = None
+    # STT plugin lifecycle. Set on "start"; consumer task drains
+    # stt.events() and is cancelled in the WS handler's finally block.
+    stt: "STTProvider | None" = None
+    stt_provider: str | None = None
+    transcript_task: asyncio.Task | None = None
+
+
+def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:
+    """Return a chunk handler that appends outbound TTS audio to the
+    recording session, or None when no session is active.
+
+    Returning None means ``speak()`` won't fire ``on_chunk`` at all,
+    which is the desired behaviour when ``RECORDINGS_BUCKET`` is unset
+    and ``state.recording_session`` therefore stays None.
+    """
+    if state.recording_session is None:
+        return None
+    rs = state.recording_session
+
+    def _handle(chunk: bytes) -> None:
+        try:
+            recordings.append_chunks(rs, b"", chunk)
+        except Exception:
+            logger.exception(
+                "tts: recording append failed call_sid=%s", state.call_sid
+            )
+
+    return _handle
+
+
+def _state_rid(state: _CallState) -> str | None:
+    """Restaurant id from state, or None if start hasn't resolved a tenant
+    yet (early-lifecycle defense)."""
+    return state.restaurant.id if state.restaurant else None
+
+
+async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
+    try:
+        await asyncio.sleep(SILENCE_TIMEOUT_SECONDS)
+        logger.info("silence timeout call_sid=%s", state.call_sid)
+        _bg_call_event(state.call_sid, _state_rid(state), kind="silence_timeout")
+        if state.stream_sid:
+            await speak(
+                SILENCE_PROMPT,
+                websocket,
+                state.stream_sid,
+                on_chunk=_make_recording_chunk_handler(state),
+            )
+    except asyncio.CancelledError:
+        pass
+
+
+def _cancel_silence_task(state: _CallState) -> None:
+    if state.silence_task and not state.silence_task.done():
+        state.silence_task.cancel()
+    state.silence_task = None
+
+
+def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
+    if state.llm_task and state.llm_task.cancelled():
+        return  # barge-in — caller spoke again, no watchdog needed
+    _cancel_silence_task(state)
+    state.silence_task = asyncio.get_event_loop().create_task(_silence_watchdog(state, websocket))
+
+
+async def _hang_up_after_grace(state: _CallState) -> None:
+    """Wait HANGUP_GRACE_SECONDS, then close the WebSocket to end the
+    call.
+
+    Closing our /media-stream WebSocket ends Twilio's <Connect>; with no
+    further TwiML the inbound call hangs up. This avoids the Twilio REST
+    Calls.update endpoint, which returns 404 on calls in <Connect> state
+    (same root cause as the recording 404). The grace window lets a
+    caller squeeze in a late follow-up like *"how long does that
+    take?"* — a final transcript clears ``state.pending_hangup`` and
+    we abort.
+
+    ``state.should_hangup`` is also set as a fallback signal in case
+    the WS close doesn't immediately unblock ``receive_text()`` (rare,
+    but harmless to set both).
+    """
+    try:
+        await asyncio.sleep(HANGUP_GRACE_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.pending_hangup or not state.call_sid:
+        return
+    state.should_hangup.set()
+    if state.websocket is not None:
+        try:
+            await state.websocket.close(code=1000)
+            logger.info(
+                "call ended by server (WS-close path) call_sid=%s",
+                state.call_sid,
+            )
+        except Exception:
+            logger.exception("auto-hangup: WS close failed call_sid=%s", state.call_sid)
+
+
+async def _hang_up_after_mark_timeout(state: _CallState) -> None:
+    """Fallback for when Twilio never echoes the end_of_call mark.
+
+    The primary path is: send mark → Twilio echoes when audio drains →
+    start grace timer. If the echo never arrives, this timer fires
+    after ``MARK_ECHO_TIMEOUT_SECONDS`` and starts the grace window
+    anyway, so the call still ends instead of hanging open.
+
+    Cancelled by the echo handler when the echo arrives, or by
+    ``_abort_pending_hangup`` when the caller speaks.
+    """
+    try:
+        await asyncio.sleep(MARK_ECHO_TIMEOUT_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.pending_hangup or not state.call_sid:
+        return
+    logger.warning(
+        "auto-hangup: mark echo timed out after %.1fs, falling back to grace window call_sid=%s",
+        MARK_ECHO_TIMEOUT_SECONDS,
+        state.call_sid,
+    )
+    if state.hangup_task and not state.hangup_task.done():
+        state.hangup_task.cancel()
+    state.hangup_task = None
+    await _hang_up_after_grace(state)
+
+
+def _abort_pending_hangup(state: _CallState) -> None:
+    """Cancel a pending auto-hangup because the caller spoke during
+    the grace window. Safe to call when no hangup is pending."""
+    state.pending_hangup = False
+    if state.hangup_task and not state.hangup_task.done():
+        state.hangup_task.cancel()
+    state.hangup_task = None
+    if state.mark_timeout_task and not state.mark_timeout_task.done():
+        state.mark_timeout_task.cancel()
+    state.mark_timeout_task = None
+
+
+async def _barge_in_now(
+    state: "_CallState",
+    websocket: WebSocket,
+    *,
+    trigger: str,
+) -> None:
+    """Stop the bot mid-utterance.
+
+    Three mechanical steps:
+      1. Cancel the in-flight LLM/TTS task → halt audio generation.
+      2. Cancel the silence watchdog → caller is speaking; "are you still
+         there?" would be wrong.
+      3. Send Twilio 'clear' → flush already-buffered audio playback (#74).
+
+    The barge_in Firestore event is NOT emitted here. It's emitted by
+    _run_llm_tts_turn's existing CancelledError handler when the task we
+    just cancelled actually receives the cancellation. Trigger
+    information flows via state.barge_in_trigger, which is set ONLY when
+    there is actually a task to cancel — preventing stale triggers from
+    leaking into the next turn's barge-in event, and preventing phantom
+    barge_in events on cleanup-path cancellations (WS shutdown).
+    """
+    if state.llm_task and not state.llm_task.done():
+        state.barge_in_trigger = trigger
+        state.llm_task.cancel()
+    _cancel_silence_task(state)
+    await send_clear(websocket, state.stream_sid)
+
+
+async def _consume_transcripts(
+    stt: STTProvider,
+    state: _CallState,
+    websocket: WebSocket,
+) -> None:
+    """Background task consuming events from the STT plugin.
+
+    All state mutation, Firestore emission, and dispatch into
+    _handle_final_transcript happens here — the plugin is pure and
+    knows nothing about call state. SpeechStartedEvent triggers an
+    instant barge-in via _barge_in_now (gated on STT_INSTANT_BARGE_IN).
+    """
+    try:
+        async for event in stt.events():
+            if isinstance(event, SpeechStartedEvent):
+                # Instant barge-in: fire ~50ms after the caller starts
+                # speaking instead of waiting for the final transcript
+                # (~800-1800ms). The final-transcript path in
+                # _handle_final_transcript still runs as a fallback for
+                # short utterances or missed VAD signals.
+                if not settings.stt_instant_barge_in:
+                    continue
+                if state.llm_task and not state.llm_task.done():
+                    await _barge_in_now(state, websocket, trigger="vad")
+                continue
+
+            # event is a TranscriptEvent
+            if not event.is_final:
+                continue   # interim: captured in plugin logs only
+
+            state.last_caller_transcript = event.text
+            if event.confidence < 0.5:
+                state.consecutive_low_confidence_turns += 1
+            else:
+                state.consecutive_low_confidence_turns = 0
+
+            _bg_call_event(
+                state.call_sid,
+                _state_rid(state),
+                kind="transcript_final",
+                text=event.text,
+                detail={"text": event.text, "confidence": event.confidence},
+            )
+            await _handle_final_transcript(event.text, state, websocket)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "transcript consumer crashed call_sid=%s", state.call_sid
+        )
+        # Mark the call as errored so the transfer-trigger logic in
+        # finally has a signal to act on, and surface the failure to the
+        # dashboard so it doesn't look like dead air to whoever's watching.
+        state.llm_error_occurred = True
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="error",
+            text=f"transcript consumer crashed: {exc}"[:500],
+            detail={"exception": type(exc).__name__},
+        )
+
+
+async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSocket) -> None:
+    turn_start = time.monotonic()
+    logger.info("llm_turn start call_sid=%s transcript=%r", state.call_sid, transcript)
+    _bg_call_event(
+        state.call_sid,
+        _state_rid(state),
+        kind="llm_turn_start",
+        text=transcript,
+        detail={"transcript": transcript},
+    )
+    text_buffer: list[str] = []
+    first_speak = True
+    full_reply_parts: list[str] = []
+    # #146 — instrumentation. ``stream_reply`` yields one timing snapshot
+    # the moment the first text content block opens; we stash it and
+    # fold the breakdown into the first_audio Firestore event so the
+    # dashboard can show ttft/tool_prefix/cache without anyone needing
+    # GCP log access.
+    timing_snapshot: dict[str, Any] | None = None
+    first_text_at: float | None = None
+
+    def _record_first_audio() -> None:
+        latency = time.monotonic() - turn_start
+        logger.info(
+            "llm_turn first_audio latency=%.3fs call_sid=%s",
+            latency,
+            state.call_sid,
+        )
+        detail: dict[str, Any] = {"latency_seconds": round(latency, 3)}
+        if first_text_at is not None:
+            detail["first_text_seconds"] = round(first_text_at - turn_start, 3)
+        if timing_snapshot is not None:
+            detail.update(timing_snapshot)
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="first_audio",
+            detail=detail,
+        )
+
+    def _record_first_tts_byte() -> None:
+        # #152 — captures the actual moment the first audio byte arrives
+        # from Deepgram Aura, closing the gap that first_audio misses
+        # (first_audio fires before await speak(), hiding TTS network time).
+        latency = time.monotonic() - turn_start
+        logger.info(
+            "llm_turn first_tts_byte latency=%.3fs call_sid=%s",
+            latency,
+            state.call_sid,
+        )
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="first_tts_byte",
+            detail={"latency_seconds": round(latency, 3)},
+        )
+
+    try:
+        async for event in stream_reply(
+            transcript=transcript,
+            history=state.history,
+            order=state.order,
+            system_prompt=state.system_prompt,
+        ):
+            if asyncio.current_task().cancelled():
+                return
+
+            if event.timing is not None:
+                timing_snapshot = event.timing
+                continue
+
+            if event.text_delta is not None:
+                if first_text_at is None:
+                    first_text_at = time.monotonic()
+                text_buffer.append(event.text_delta)
+                full_reply_parts.append(event.text_delta)
+                buffered_chars = sum(len(p) for p in text_buffer)
+                if _should_flush_chunk(event.text_delta, buffered_chars):
+                    chunk = "".join(text_buffer).strip()
+                    text_buffer.clear()
+                    if chunk and state.stream_sid:
+                        if first_speak:
+                            _record_first_audio()
+                            first_speak = False
+                            on_first_byte = _record_first_tts_byte
+                        else:
+                            on_first_byte = None
+                        await speak(
+                            chunk,
+                            websocket,
+                            state.stream_sid,
+                            on_chunk=_make_recording_chunk_handler(state),
+                            on_first_byte=on_first_byte,
+                        )
+
+            elif event.final is not None:
+                remainder = "".join(text_buffer).strip()
+                text_buffer.clear()
+                if remainder and state.stream_sid:
+                    if first_speak:
+                        _record_first_audio()
+                        first_speak = False
+                        on_first_byte = _record_first_tts_byte
+                    else:
+                        on_first_byte = None
+                    await speak(
+                        remainder,
+                        websocket,
+                        state.stream_sid,
+                        on_chunk=_make_recording_chunk_handler(state),
+                        on_first_byte=on_first_byte,
+                    )
+                state.history = event.final.history
+                state.order = event.final.order
+                # Transcript is now durably in history — no need to carry
+                # it forward if a future turn is cancelled (#170).
+                state.in_flight_transcript = ""
+                full_reply = "".join(full_reply_parts).strip()
+                if full_reply:
+                    logger.info(
+                        "agent_reply call_sid=%s text=%r",
+                        state.call_sid,
+                        full_reply,
+                    )
+                    _bg_call_event(
+                        state.call_sid,
+                        _state_rid(state),
+                        kind="agent_reply",
+                        text=full_reply,
+                        detail={"text": full_reply},
+                    )
+                # Decide whether this turn is the wrap-up. Two signals:
+                #  1. Haiku set status=confirmed via update_order (the
+                #     primary path the prompt asks for).
+                #  2. Fallback (#79) — Haiku emitted a goodbye-shaped
+                #     reply ("your order is in", "see you soon", etc.)
+                #     AND the order has the data to actually confirm.
+                #     The model sometimes says the right closing line
+                #     without remembering to flip status.
+                if state.order is not None and state.stream_sid:
+                    explicitly_confirmed = state.order.status == OrderStatus.CONFIRMED
+                    fallback_confirmed = (
+                        state.order.is_ready_to_confirm()
+                        and state.order.status != OrderStatus.CANCELLED
+                        and _looks_like_goodbye(full_reply)
+                    )
+                    if explicitly_confirmed or fallback_confirmed:
+                        if fallback_confirmed and not explicitly_confirmed:
+                            logger.info(
+                                "auto-hangup: heuristic wrap-up detected "
+                                "(LLM didn't set status=confirmed) call_sid=%s",
+                                state.call_sid,
+                            )
+                            # Mirror the explicit-confirmation path locally
+                            # so the finally-block persist sees it too.
+                            state.order = state.order.model_copy(
+                                update={"status": OrderStatus.CONFIRMED}
+                            )
+                        sent = await send_mark(websocket, state.stream_sid, name=END_OF_CALL_MARK)
+                        if sent:
+                            state.pending_hangup = True
+                            if state.mark_timeout_task and not state.mark_timeout_task.done():
+                                state.mark_timeout_task.cancel()
+                            state.mark_timeout_task = asyncio.create_task(
+                                _hang_up_after_mark_timeout(state)
+                            )
+
+    except asyncio.CancelledError:
+        trigger = state.barge_in_trigger
+        state.barge_in_trigger = None
+        if trigger is not None:
+            # User-driven barge-in: trigger was set by _barge_in_now
+            # before cancelling the task. Emit the timeline event.
+            logger.info(
+                "llm_turn cancelled (barge-in trigger=%s) call_sid=%s",
+                trigger,
+                state.call_sid,
+            )
+            _bg_call_event(
+                state.call_sid,
+                _state_rid(state),
+                kind="barge_in",
+                detail={"trigger": trigger},
+            )
+        else:
+            # Cleanup-path cancellation: WS handler's finally block
+            # cancels the task during call teardown. No barge_in event.
+            logger.info(
+                "llm_turn cancelled (cleanup) call_sid=%s", state.call_sid
+            )
+        raise
+    except Exception as exc:
+        logger.exception("llm_turn errored call_sid=%s", state.call_sid)
+        # #7: signal the trigger detector at end-of-stream
+        state.llm_error_occurred = True
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="error",
+            text=str(exc)[:500],
+            detail={"exception": type(exc).__name__},
+        )
+        raise
+
+
+async def _handle_final_transcript(text: str, state: _CallState, websocket: WebSocket) -> None:
+    interrupted = bool(state.llm_task and not state.llm_task.done())
+    # Carry forward — if any prior turn (cancelled or errored) left a
+    # transcript on state without persisting it to history, prepend it
+    # so Haiku sees the full caller intent in this turn (#170). The
+    # field is cleared by ``_run_llm_tts_turn`` only on ``event.final``,
+    # so a non-empty value here always means "user words from a prior
+    # turn that never made it into history."
+    if state.in_flight_transcript.strip():
+        text = f"{state.in_flight_transcript} {text}".strip()
+    silence_was_active = bool(state.silence_task and not state.silence_task.done())
+    # Caller spoke — abort any pending auto-hangup (#78). Even if they
+    # spoke during the grace window after a confirmation, we want to
+    # keep the call alive and process this transcript.
+    _abort_pending_hangup(state)
+
+    if interrupted:
+        # True barge-in: a turn is running and we're interrupting it.
+        # The barge_in Firestore event fires from _run_llm_tts_turn's
+        # CancelledError handler.
+        await _barge_in_now(state, websocket, trigger="final_transcript")
+    elif silence_was_active:
+        # Caller resumed after a silence prompt — flush any leftover
+        # prompt audio still buffered, but this isn't a barge-in (no
+        # task to cancel, no event to emit).
+        _cancel_silence_task(state)
+        await send_clear(websocket, state.stream_sid)
+
+    state.in_flight_transcript = text
+    state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
+    state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
+
+
+def _resolve_restaurant_for_voice(
+    to_e164: str,
+) -> Restaurant | None:
+    """Find the tenant for an inbound Twilio call (PR B of #79).
+
+    Looks up by the ``To`` field — Twilio's name for the dialed number,
+    which equals the per-restaurant ``twilio_phone`` we provisioned. If
+    Firestore returns nothing AND the dialed number matches the
+    demo's hardcoded ``twilio_phone``, falls back to building the demo
+    restaurant from ``app.menu.MENU``. The fallback is removed in PR F
+    once the seed is canonical.
+    """
+    restaurant = restaurants_storage.get_restaurant_by_twilio_phone(to_e164)
+    if restaurant is not None:
+        return restaurant
+    demo = restaurants_storage.demo_restaurant_from_menu()
+    if to_e164 == demo.twilio_phone:
+        logger.warning(
+            "voice: demo Twilio number %s not in Firestore — falling back to MENU",
+            to_e164,
+        )
+        return demo
+    return None

--- a/app/twilio/__init__.py
+++ b/app/twilio/__init__.py
@@ -12,12 +12,8 @@ envelope, TwiML XML, or Twilio's REST API lives under this package.
 
 from __future__ import annotations
 
-import logging
-
 from app.config import settings
 from app.storage import recordings as _recordings
-
-logger = logging.getLogger(__name__)
 
 
 def twilio_basic_auth() -> tuple[str, str] | None:

--- a/app/twilio/__init__.py
+++ b/app/twilio/__init__.py
@@ -1,0 +1,13 @@
+"""Twilio vendor module.
+
+Holds Twilio-specific I/O — TwiML response builders, Media Stream
+WebSocket protocol primitives, and REST helpers — kept separate from
+the vendor-neutral call orchestration in app/telephony/. Mirrors the
+app/deepgram/ pattern.
+
+Consumers that need vendor-agnostic call logic should import from
+app/telephony/, not from here. Anything that touches a Twilio JSON
+envelope, TwiML XML, or Twilio's REST API lives under this package.
+"""
+
+from __future__ import annotations

--- a/app/twilio/__init__.py
+++ b/app/twilio/__init__.py
@@ -11,3 +11,51 @@ envelope, TwiML XML, or Twilio's REST API lives under this package.
 """
 
 from __future__ import annotations
+
+import logging
+
+from app.config import settings
+from app.storage import recordings as _recordings
+
+logger = logging.getLogger(__name__)
+
+
+def twilio_basic_auth() -> tuple[str, str] | None:
+    """Return Twilio REST basic-auth tuple, or None when unconfigured.
+
+    Centralised so the voicemail-recorded callback doesn't have to
+    reach into ``settings.twilio_account_sid`` /
+    ``settings.twilio_auth_token`` directly. Returns None (rather than
+    raising) so the caller can log + degrade gracefully — voicemail
+    upload is best-effort, missing creds shouldn't crash the request.
+    """
+    sid = settings.twilio_account_sid
+    token = settings.twilio_auth_token
+    if not sid or not token:
+        return None
+    return (sid, token)
+
+
+def upload_voicemail(
+    *,
+    call_sid: str,
+    restaurant_id: str,
+    twilio_recording_url: str,
+) -> str:
+    """Download the voicemail recording from Twilio's REST API and
+    upload to GCS. Wraps app.storage.recordings.upload_voicemail_from_twilio
+    with the Twilio creds resolved from settings.
+
+    Raises RuntimeError if Twilio creds are missing — the caller is
+    expected to check ``twilio_basic_auth()`` first if it wants to
+    short-circuit gracefully (the voicemail-recorded handler does).
+    """
+    auth = twilio_basic_auth()
+    if auth is None:
+        raise RuntimeError("Twilio credentials missing")
+    return _recordings.upload_voicemail_from_twilio(
+        call_sid=call_sid,
+        restaurant_id=restaurant_id,
+        twilio_recording_url=twilio_recording_url,
+        auth=auth,
+    )

--- a/app/twilio/media_stream.py
+++ b/app/twilio/media_stream.py
@@ -1,0 +1,68 @@
+"""Twilio Media Stream WS protocol primitives — outgoing frames only.
+
+Incoming frame parsing (start/media/mark/stop) stays inline in the
+WS event-loop in app/telephony/router.py until a second telephony
+provider forces a real shape difference.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+
+async def send_clear(websocket: WebSocket, stream_sid: str | None) -> None:
+    """Tell Twilio to flush its audio buffer and stop playback (#74).
+
+    Cancelling the LLM/TTS task only stops generation — bytes already in
+    Twilio's buffer keep playing for 1-3 seconds. Twilio's clear event
+    drops the buffer in ~80ms. Used by barge-in and post-silence cleanup.
+    """
+    if not stream_sid:
+        return
+    try:
+        await websocket.send_json({"event": "clear", "streamSid": stream_sid})
+    except WebSocketDisconnect:
+        return
+    except Exception:
+        logger.exception(
+            "clear: failed to send Twilio clear event stream_sid=%s",
+            stream_sid,
+        )
+
+
+async def send_mark(
+    websocket: WebSocket,
+    stream_sid: str | None,
+    name: str,
+) -> bool:
+    """Append a named mark to Twilio's outgoing media stream (#78).
+
+    Twilio echoes the mark back over the WebSocket once its audio buffer
+    drains past it — i.e. once the caller has heard everything we sent.
+    The auto-hangup path uses this as the precise trigger to begin its
+    grace window. Returns True if the send succeeded.
+    """
+    if not stream_sid:
+        return False
+    try:
+        await websocket.send_json(
+            {
+                "event": "mark",
+                "streamSid": stream_sid,
+                "mark": {"name": name},
+            }
+        )
+        return True
+    except WebSocketDisconnect:
+        return False
+    except Exception:
+        logger.exception(
+            "mark: failed to send mark name=%s stream_sid=%s",
+            name,
+            stream_sid,
+        )
+        return False

--- a/app/twilio/twiml.py
+++ b/app/twilio/twiml.py
@@ -1,0 +1,88 @@
+"""TwiML response builders for the Twilio voice webhook surface.
+
+Pure functions returning Twilio VoiceResponse objects. The FastAPI
+handlers in app/telephony/router.py call these and wrap the result
+in a fastapi.Response with media_type='application/xml'.
+
+Kept separate so that:
+- TwiML XML construction lives in one place (mirrors app/deepgram/);
+- builders are easy to snapshot-test without spinning up FastAPI;
+- the orchestration layer in app/telephony/ never imports from
+  twilio.twiml directly.
+"""
+
+from __future__ import annotations
+
+from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
+
+from app.restaurants.models import Restaurant
+
+
+_UNCONFIGURED_TWIML_MESSAGE = (
+    "Sorry, this number is not currently configured. Goodbye."
+)
+_CLOSED_TWIML_MESSAGE = (
+    "Sorry, we're closed. Please call back during business hours."
+)
+
+
+def empty_twiml() -> VoiceResponse:
+    """Empty <Response/>. Used for hangup-on-success paths and as a
+    safe default when a Twilio callback can't be acted on."""
+    return VoiceResponse()
+
+
+def unconfigured_hangup_twiml() -> VoiceResponse:
+    """Inbound call to a number that isn't mapped to any tenant."""
+    twiml = VoiceResponse()
+    twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
+    twiml.hangup()
+    return twiml
+
+
+def closed_hangup_twiml() -> VoiceResponse:
+    """Defensive after-hours hangup for the rare case the voicemail
+    flow can't run (e.g. CallSid missing on the inbound webhook)."""
+    twiml = VoiceResponse()
+    twiml.say(_CLOSED_TWIML_MESSAGE)
+    twiml.hangup()
+    return twiml
+
+
+def voice_twiml(restaurant: Restaurant, ws_host: str) -> VoiceResponse:
+    """Open a bidirectional Media Stream back to /media-stream and
+    forward the resolved restaurant id via <Parameter> so the WS
+    handler doesn't need to re-query Firestore."""
+    twiml = VoiceResponse()
+    connect = Connect(action="/voice/stream-ended", method="POST")
+    # NOTE: <Connect><Stream> only supports the default ``inbound_track``;
+    # passing ``track="both_tracks"`` makes Twilio reject the TwiML and
+    # the call drops the moment the caller dismisses the trial-account
+    # interstitial. To capture the agent's voice in the recording, the
+    # /media-stream WS handler intercepts the TTS bytes we send out via
+    # ``speak()`` and feeds them directly into the recording session.
+    stream = connect.stream(url=f"wss://{ws_host}/media-stream")
+    stream.parameter(name="restaurant_id", value=restaurant.id)
+    twiml.append(connect)
+    return twiml
+
+
+def transfer_twiml(
+    fallback_phone: str,
+    call_sid: str,
+    rid: str,
+    *,
+    timeout: int = 20,
+) -> VoiceResponse:
+    """Dial the tenant's fallback number, with action callback to
+    /voice/transfer-result so we can record the outcome and cascade
+    to voicemail on no-answer/busy/failed."""
+    twiml = VoiceResponse()
+    dial = Dial(
+        action=f"/voice/transfer-result?call_sid={call_sid}&rid={rid}",
+        method="POST",
+        timeout=timeout,
+    )
+    dial.number(fallback_phone)
+    twiml.append(dial)
+    return twiml

--- a/app/twilio/twiml.py
+++ b/app/twilio/twiml.py
@@ -7,8 +7,9 @@ in a fastapi.Response with media_type='application/xml'.
 Kept separate so that:
 - TwiML XML construction lives in one place (mirrors app/deepgram/);
 - builders are easy to snapshot-test without spinning up FastAPI;
-- the orchestration layer in app/telephony/ never imports from
-  twilio.twiml directly.
+- the orchestration layer in app/telephony/ avoids importing from
+  twilio.twiml directly (one exception: voicemail_twiml.py builds
+  Twilio Record TwiML inline; folding it in here is a follow-up).
 """
 
 from __future__ import annotations

--- a/docs/superpowers/plans/2026-05-06-telephony-router-modularization.md
+++ b/docs/superpowers/plans/2026-05-06-telephony-router-modularization.md
@@ -1,0 +1,893 @@
+# Telephony Router Modularization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `app/telephony/router.py` (1293 lines) into focused modules — vendor-specific Twilio I/O in `app/twilio/`, vendor-neutral orchestration in `app/telephony/session.py`, FastAPI shells + WS event-loop in a slimmed `app/telephony/router.py`. Mirrors the existing `app/deepgram/` pattern.
+
+**Architecture:** Geographic split, no new abstractions, no behavior changes. Mechanical move of code; existing test suite verifies behavior preservation.
+
+**Tech Stack:** Python 3.13, FastAPI, asyncio, Twilio TwiML SDK (`twilio.twiml.voice_response`).
+
+**Spec:** `docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md` (PR #252).
+
+**Branch:** `refactor/251-telephony-router-split` (already created off `feat/83-tune-conversational-bot`).
+
+**Note on TDD:** This is a behavior-preserving refactor — no new tests needed. The discipline is "tests pass at every commit boundary." Each task runs the focused telephony test subset and only commits if green.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+git branch --show-current
+```
+
+Expected: `refactor/251-telephony-router-split`.
+
+- [ ] **Step 2: Verify baseline tests pass**
+
+```bash
+pytest tests/test_telephony.py tests/test_voice.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py -q
+```
+
+Expected: all pass. If any fail, stop — the baseline is broken and the refactor would mask it.
+
+---
+
+## Task 1: Extract Twilio WS protocol primitives
+
+Goal: pull `clear_twilio_audio` and `send_end_of_call_mark` out of `router.py` into `app/twilio/media_stream.py`. They're the only two outgoing Twilio-shaped JSON literals the orchestration layer emits.
+
+**Files:**
+- Create: `app/twilio/__init__.py`
+- Create: `app/twilio/media_stream.py`
+- Modify: `app/telephony/router.py`
+
+- [ ] **Step 1: Create the package marker**
+
+`app/twilio/__init__.py`:
+
+```python
+"""Twilio vendor module.
+
+Holds Twilio-specific I/O — TwiML response builders, Media Stream
+WebSocket protocol primitives, and REST helpers — kept separate from
+the vendor-neutral call orchestration in app/telephony/. Mirrors the
+app/deepgram/ pattern.
+
+Consumers that need vendor-agnostic call logic should import from
+app/telephony/, not from here. Anything that touches a Twilio JSON
+envelope, TwiML XML, or Twilio's REST API lives under this package.
+"""
+
+from __future__ import annotations
+```
+
+- [ ] **Step 2: Create `media_stream.py`**
+
+`app/twilio/media_stream.py`:
+
+```python
+"""Twilio Media Stream WS protocol primitives — outgoing frames only.
+
+Incoming frame parsing (start/media/mark/stop) stays inline in the
+WS event-loop in app/telephony/router.py until a second telephony
+provider forces a real shape difference.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+
+async def send_clear(websocket: WebSocket, stream_sid: str | None) -> None:
+    """Tell Twilio to flush its audio buffer and stop playback (#74).
+
+    Cancelling the LLM/TTS task only stops generation — bytes already in
+    Twilio's buffer keep playing for 1-3 seconds. Twilio's clear event
+    drops the buffer in ~80ms. Used by barge-in and post-silence cleanup.
+    """
+    if not stream_sid:
+        return
+    try:
+        await websocket.send_json({"event": "clear", "streamSid": stream_sid})
+    except WebSocketDisconnect:
+        return
+    except Exception:
+        logger.exception(
+            "clear: failed to send Twilio clear event stream_sid=%s",
+            stream_sid,
+        )
+
+
+async def send_mark(
+    websocket: WebSocket,
+    stream_sid: str | None,
+    name: str,
+) -> bool:
+    """Append a named mark to Twilio's outgoing media stream (#78).
+
+    Twilio echoes the mark back over the WebSocket once its audio buffer
+    drains past it — i.e. once the caller has heard everything we sent.
+    The auto-hangup path uses this as the precise trigger to begin its
+    grace window. Returns True if the send succeeded.
+    """
+    if not stream_sid:
+        return False
+    try:
+        await websocket.send_json(
+            {
+                "event": "mark",
+                "streamSid": stream_sid,
+                "mark": {"name": name},
+            }
+        )
+        return True
+    except WebSocketDisconnect:
+        return False
+    except Exception:
+        logger.exception(
+            "mark: failed to send mark name=%s stream_sid=%s",
+            name,
+            stream_sid,
+        )
+        return False
+```
+
+- [ ] **Step 3: Wire `router.py` to the new primitives**
+
+In `app/telephony/router.py`:
+
+1. Add the import near the top with the other `app.*` imports:
+
+```python
+from app.twilio.media_stream import send_clear, send_mark
+```
+
+2. **Delete** the existing `clear_twilio_audio` function definition (currently around lines 241-260).
+
+3. **Delete** the existing `send_end_of_call_mark` function definition (currently around lines 141-164).
+
+4. Replace the call sites:
+
+In `_barge_in_now` (currently around line 289), change:
+
+```python
+await clear_twilio_audio(websocket, state.stream_sid)
+```
+
+to:
+
+```python
+await send_clear(websocket, state.stream_sid)
+```
+
+In `_handle_final_transcript` (currently around line 688), change:
+
+```python
+await clear_twilio_audio(websocket, state.stream_sid)
+```
+
+to:
+
+```python
+await send_clear(websocket, state.stream_sid)
+```
+
+In `_run_llm_tts_turn` (currently around line 615), change:
+
+```python
+sent = await send_end_of_call_mark(websocket, state.stream_sid)
+```
+
+to:
+
+```python
+sent = await send_mark(websocket, state.stream_sid, name=END_OF_CALL_MARK)
+```
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+pytest tests/test_telephony.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py -q
+```
+
+Expected: all pass. `test_barge_in_helper.py` asserts on the JSON payload `{"event": "clear", ...}` so it verifies the new `send_clear` produces the same bytes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/twilio/__init__.py app/twilio/media_stream.py app/telephony/router.py
+git commit -m "refactor(telephony): extract Twilio WS protocol primitives to app/twilio/ (#251)
+
+Pulls clear_twilio_audio and send_end_of_call_mark out of router.py
+into app/twilio/media_stream.py as send_clear and send_mark. These
+are the only outgoing Twilio-shaped JSON frames the orchestration
+emits; isolating them clears the path for the rest of the split.
+
+No behavior change — the new functions reproduce the existing
+WebSocketDisconnect handling and exception logging."
+```
+
+---
+
+## Task 2: Extract TwiML response builders
+
+Goal: pull all `VoiceResponse(...)` construction out of the FastAPI handlers in `router.py` into `app/twilio/twiml.py`. Handlers shrink to "parse form → call builder → return Response".
+
+**Files:**
+- Create: `app/twilio/twiml.py`
+- Modify: `app/telephony/router.py`
+
+- [ ] **Step 1: Create `twiml.py`**
+
+`app/twilio/twiml.py`:
+
+```python
+"""TwiML response builders for the Twilio voice webhook surface.
+
+Pure functions returning Twilio VoiceResponse objects. The FastAPI
+handlers in app/telephony/router.py call these and wrap the result
+in a fastapi.Response with media_type='application/xml'.
+
+Kept separate so that:
+- TwiML XML construction lives in one place (mirrors app/deepgram/);
+- builders are easy to snapshot-test without spinning up FastAPI;
+- the orchestration layer in app/telephony/ never imports from
+  twilio.twiml directly.
+"""
+
+from __future__ import annotations
+
+from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
+
+from app.restaurants.models import Restaurant
+
+
+_UNCONFIGURED_TWIML_MESSAGE = (
+    "Sorry, this number is not currently configured. Goodbye."
+)
+_CLOSED_TWIML_MESSAGE = (
+    "Sorry, we're closed. Please call back during business hours."
+)
+
+
+def empty_twiml() -> VoiceResponse:
+    """Empty <Response/>. Used for hangup-on-success paths and as a
+    safe default when a Twilio callback can't be acted on."""
+    return VoiceResponse()
+
+
+def unconfigured_hangup_twiml() -> VoiceResponse:
+    """Inbound call to a number that isn't mapped to any tenant."""
+    twiml = VoiceResponse()
+    twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
+    twiml.hangup()
+    return twiml
+
+
+def closed_hangup_twiml() -> VoiceResponse:
+    """Defensive after-hours hangup for the rare case the voicemail
+    flow can't run (e.g. CallSid missing on the inbound webhook)."""
+    twiml = VoiceResponse()
+    twiml.say(_CLOSED_TWIML_MESSAGE)
+    twiml.hangup()
+    return twiml
+
+
+def voice_twiml(restaurant: Restaurant, ws_host: str) -> VoiceResponse:
+    """Open a bidirectional Media Stream back to /media-stream and
+    forward the resolved restaurant id via <Parameter> so the WS
+    handler doesn't need to re-query Firestore."""
+    twiml = VoiceResponse()
+    connect = Connect(action="/voice/stream-ended", method="POST")
+    # NOTE: <Connect><Stream> only supports the default ``inbound_track``;
+    # passing ``track="both_tracks"`` makes Twilio reject the TwiML and
+    # the call drops the moment the caller dismisses the trial-account
+    # interstitial. To capture the agent's voice in the recording, the
+    # /media-stream WS handler intercepts the TTS bytes we send out via
+    # ``speak()`` and feeds them directly into the recording session.
+    stream = connect.stream(url=f"wss://{ws_host}/media-stream")
+    stream.parameter(name="restaurant_id", value=restaurant.id)
+    twiml.append(connect)
+    return twiml
+
+
+def transfer_twiml(
+    fallback_phone: str,
+    call_sid: str,
+    rid: str,
+    *,
+    timeout: int = 20,
+) -> VoiceResponse:
+    """Dial the tenant's fallback number, with action callback to
+    /voice/transfer-result so we can record the outcome and cascade
+    to voicemail on no-answer/busy/failed."""
+    twiml = VoiceResponse()
+    dial = Dial(
+        action=f"/voice/transfer-result?call_sid={call_sid}&rid={rid}",
+        method="POST",
+        timeout=timeout,
+    )
+    dial.number(fallback_phone)
+    twiml.append(dial)
+    return twiml
+```
+
+- [ ] **Step 2: Wire `router.py` handlers to the builders**
+
+In `app/telephony/router.py`:
+
+1. Add the import:
+
+```python
+from app.twilio.twiml import (
+    closed_hangup_twiml,
+    empty_twiml,
+    transfer_twiml,
+    unconfigured_hangup_twiml,
+    voice_twiml,
+)
+```
+
+2. Remove the `_UNCONFIGURED_TWIML_MESSAGE` constant (now lives in `twiml.py`).
+
+3. Remove `from twilio.twiml.voice_response import Connect, Dial, VoiceResponse` from the top of the file — no longer needed in router.
+
+4. Rewrite the `voice` handler body. Replace the section starting `twiml = VoiceResponse()` and ending at `return Response(content=str(twiml), ...)` with:
+
+```python
+    if restaurant is None:
+        logger.warning("voice: no restaurant for To=%s — rejecting call", to_e164 or "(missing)")
+        return Response(
+            content=str(unconfigured_hangup_twiml()),
+            media_type="application/xml",
+        )
+
+    if not is_open_now(restaurant):
+        # After-hours: skip the AI flow, drop straight to voicemail.
+        if not call_sid:
+            # Defensive: Twilio always posts CallSid. Without it, we
+            # can't key the recording or call_session — bail.
+            return Response(
+                content=str(closed_hangup_twiml()),
+                media_type="application/xml",
+            )
+        try:
+            call_sessions.init_call_session(call_sid, restaurant.id)
+        except Exception:
+            logger.exception(
+                "voice: init_call_session failed call_sid=%s rid=%s",
+                call_sid,
+                restaurant.id,
+            )
+        return Response(
+            content=str(voicemail_response(call_sid, restaurant.id)),
+            media_type="application/xml",
+        )
+
+    host = request.headers.get("host", "localhost:8000")
+    return Response(
+        content=str(voice_twiml(restaurant, host)),
+        media_type="application/xml",
+    )
+```
+
+5. In `stream_ended`, replace the three `Response(content=str(VoiceResponse()), ...)` returns with:
+
+```python
+return Response(content=str(empty_twiml()), media_type="application/xml")
+```
+
+And replace the `<Dial>` construction (currently `twiml = VoiceResponse(); dial = Dial(...); ... twiml.append(dial); return Response(content=str(twiml), ...)`) with:
+
+```python
+return Response(
+    content=str(transfer_twiml(restaurant.fallback_phone, call_sid, rid)),
+    media_type="application/xml",
+)
+```
+
+6. In `transfer_result`, replace `Response(content=str(VoiceResponse()), ...)` with `Response(content=str(empty_twiml()), ...)` (two occurrences).
+
+7. In `voicemail_recorded`, replace all five `Response(content=str(VoiceResponse()), ...)` returns with `Response(content=str(empty_twiml()), ...)`.
+
+- [ ] **Step 3: Run focused tests**
+
+```bash
+pytest tests/test_telephony.py tests/test_voice.py -q
+```
+
+Expected: all pass. `test_voice.py` exercises the public `/voice` surface; `test_telephony.py` covers the WS handler.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/twilio/twiml.py app/telephony/router.py
+git commit -m "refactor(telephony): extract TwiML builders to app/twilio/twiml.py (#251)
+
+Pure functions for the five TwiML responses the voice webhook
+surface returns. Handlers in router.py shrink to form-parsing +
+builder call + Response wrap. No behavior change."
+```
+
+---
+
+## Task 3: Extract Twilio REST recording download
+
+Goal: move the inline Twilio REST recording fetch out of `voicemail_recorded` into `app/twilio/__init__.py`. Currently the handler imports `recordings.upload_voicemail_from_twilio`, which already lives in `app/storage/recordings.py` and takes Twilio creds — so the actual change is small. The Twilio-specific *credentials check* and the `(account_sid, auth_token)` tuple construction move out of router.
+
+**Files:**
+- Modify: `app/twilio/__init__.py`
+- Modify: `app/telephony/router.py`
+
+- [ ] **Step 1: Add a credentialed-fetch helper to `app/twilio/__init__.py`**
+
+Append to `app/twilio/__init__.py`:
+
+```python
+import logging
+
+from app.config import settings
+from app.storage import recordings as _recordings
+
+logger = logging.getLogger(__name__)
+
+
+def twilio_basic_auth() -> tuple[str, str] | None:
+    """Return Twilio REST basic-auth tuple, or None when unconfigured.
+
+    Centralised so the voicemail-recorded callback doesn't have to
+    reach into ``settings.twilio_account_sid`` / ``twilio_auth_token``
+    directly. Returns None (rather than raising) so the caller can
+    log + degrade gracefully — voicemail upload is best-effort.
+    """
+    sid = settings.twilio_account_sid
+    token = settings.twilio_auth_token
+    if not sid or not token:
+        return None
+    return (sid, token)
+
+
+def upload_voicemail(
+    *,
+    call_sid: str,
+    restaurant_id: str,
+    twilio_recording_url: str,
+) -> str:
+    """Download the voicemail recording from Twilio's REST and upload
+    to GCS. Wraps app.storage.recordings.upload_voicemail_from_twilio
+    with the Twilio creds resolved from settings.
+
+    Raises RuntimeError if Twilio creds are missing — the caller is
+    expected to check ``twilio_basic_auth()`` first if it wants to
+    short-circuit gracefully.
+    """
+    auth = twilio_basic_auth()
+    if auth is None:
+        raise RuntimeError("Twilio credentials missing")
+    return _recordings.upload_voicemail_from_twilio(
+        call_sid=call_sid,
+        restaurant_id=restaurant_id,
+        twilio_recording_url=twilio_recording_url,
+        auth=auth,
+    )
+```
+
+- [ ] **Step 2: Wire `voicemail_recorded` to the helper**
+
+In `app/telephony/router.py`, replace the block in `voicemail_recorded` that reads:
+
+```python
+if not settings.twilio_account_sid or not settings.twilio_auth_token:
+    logger.error(
+        "voicemail upload: twilio creds missing call_sid=%s",
+        call_sid,
+    )
+    return Response(
+        content=str(empty_twiml()),
+        media_type="application/xml",
+    )
+
+try:
+    gs_url = recordings.upload_voicemail_from_twilio(
+        call_sid=call_sid,
+        restaurant_id=rid,
+        twilio_recording_url=recording_url,
+        auth=(settings.twilio_account_sid, settings.twilio_auth_token),
+    )
+except Exception:
+    ...
+```
+
+with:
+
+```python
+if app_twilio.twilio_basic_auth() is None:
+    logger.error(
+        "voicemail upload: twilio creds missing call_sid=%s",
+        call_sid,
+    )
+    return Response(
+        content=str(empty_twiml()),
+        media_type="application/xml",
+    )
+
+try:
+    gs_url = app_twilio.upload_voicemail(
+        call_sid=call_sid,
+        restaurant_id=rid,
+        twilio_recording_url=recording_url,
+    )
+except Exception:
+    logger.exception(
+        "voicemail upload failed call_sid=%s sid=%s",
+        call_sid,
+        recording_sid,
+    )
+    return Response(
+        content=str(empty_twiml()),
+        media_type="application/xml",
+    )
+```
+
+Add the import at the top of `router.py`:
+
+```python
+import app.twilio as app_twilio
+```
+
+(Aliased to `app_twilio` to make it clear at the call site that this is *our* package, not the third-party `twilio` SDK.)
+
+- [ ] **Step 3: Run focused tests**
+
+```bash
+pytest tests/test_telephony.py tests/test_voice.py -q
+```
+
+Expected: all pass. (Voicemail upload is mocked in `test_telephony.py`'s pipeline fixture; the wiring change is covered by the existing test.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/twilio/__init__.py app/telephony/router.py
+git commit -m "refactor(telephony): centralise Twilio REST creds + voicemail upload (#251)
+
+Adds twilio_basic_auth() and upload_voicemail() helpers in
+app/twilio/__init__.py so the voicemail-recorded webhook handler
+doesn't have to dereference settings.twilio_account_sid /
+twilio_auth_token directly. Behaviour preserved."
+```
+
+---
+
+## Task 4: Move `_CallState` and orchestration helpers to `session.py`
+
+Goal: this is the big one — move the bulk of `router.py` (everything except FastAPI shells and the WS event-loop dispatch) into `app/telephony/session.py`. Public test-imported names (`_CallState`, `_barge_in_now`, `_consume_transcripts`, `_should_flush_chunk`, `_MIN_CHUNK_CHARS`) become public from the new location. Test imports update.
+
+**Files:**
+- Create: `app/telephony/session.py`
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_barge_in_helper.py`
+- Modify: `tests/test_transcript_consumer.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Create `session.py` with the moved code**
+
+Create `app/telephony/session.py` containing, in order, copied verbatim from `router.py`:
+
+1. The module docstring (rewritten — see below).
+2. All imports `router.py` needs for these helpers — minus FastAPI's `APIRouter, Request, Response` and minus `Connect, Dial, VoiceResponse`. Keep `WebSocket, WebSocketDisconnect`.
+3. The constants block:
+   - `SILENCE_TIMEOUT_SECONDS`, `SILENCE_PROMPT`, `GREETING_TRANSCRIPT`
+   - `END_OF_CALL_MARK`, `HANGUP_GRACE_SECONDS`, `MARK_ECHO_TIMEOUT_SECONDS`
+   - `_HARD_BREAKS`, `_SOFT_BREAKS`, `_MIN_CHUNK_CHARS`
+   - `_GOODBYE_PATTERNS`
+4. The pure helpers:
+   - `_should_flush_chunk`
+   - `_looks_like_goodbye`
+5. The Firestore helper:
+   - `_bg_call_event`
+6. **`_CallState` dataclass.** Move verbatim. Keep all field comments.
+7. The recording-handler factory: `_make_recording_chunk_handler`.
+8. `_state_rid`.
+9. Silence watchdog trio: `_silence_watchdog`, `_cancel_silence_task`, `_arm_silence_watchdog`.
+10. Auto-hangup trio: `_hang_up_after_grace`, `_hang_up_after_mark_timeout`, `_abort_pending_hangup`.
+11. Barge-in: `_barge_in_now`.
+12. Transcript consumer: `_consume_transcripts`.
+13. LLM turn: `_run_llm_tts_turn`, `_handle_final_transcript`.
+14. Tenant resolver: `_resolve_restaurant_for_voice` (still needed by `voice` handler in router.py).
+
+The new file's docstring:
+
+```python
+"""Call orchestration — vendor-neutral.
+
+Owns _CallState and every helper that runs during the lifetime of an
+active call: barge-in, hangup, silence, the LLM/TTS turn loop, and the
+STT transcript consumer. The module knows about the abstract STT/TTS
+provider interfaces in app/stt and app/tts but nothing about Twilio
+specifics — those live in app/twilio/.
+
+The FastAPI endpoints + WS event-loop dispatch live in
+app/telephony/router.py. router.py imports from this module; this
+module does not import from router.py.
+"""
+```
+
+Imports the new file needs (build this list by reading the moved code):
+
+```python
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+from app.config import settings
+from app.llm.client import stream_reply
+from app.llm.prompts import build_system_prompt  # used by ws handler — see note
+from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm  # used by ws handler — see note
+from app.orders.models import Order, OrderStatus
+from app.restaurants.models import Restaurant
+from app.restaurants.open_check import is_open_now  # used by voice handler — see note
+from app.storage import call_sessions, recordings, restaurants as restaurants_storage
+from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
+from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent
+from app.twilio.media_stream import send_clear, send_mark
+```
+
+Notes on imports — some symbols (`build_system_prompt`, `OrderNotReadyError`, `persist_on_confirm`, `is_open_now`) are referenced from the WS handler in `router.py` not directly from helpers being moved. Re-check after the move: import only what `session.py` actually uses. Static analysis: a final `pyflakes app/telephony/session.py` must show zero unused imports.
+
+Replace the inline call sites in `_barge_in_now` and `_run_llm_tts_turn` to use `send_clear` / `send_mark` (already done in Tasks 1, but verify these moved code blocks still reference the new names).
+
+- [ ] **Step 2: Slim `router.py` to shells + WS event-loop**
+
+Rewrite `app/telephony/router.py` to contain only:
+
+1. Module docstring (rewritten — focused on the FastAPI surface).
+2. Imports needed for the HTTP handlers and the WS dispatch.
+3. The `router = APIRouter()` declaration.
+4. `_TRANSFER_STATUS_MAP` (used by `transfer_result`).
+5. The five HTTP handlers: `voice`, `stream_ended`, `transfer_result`, `voicemail_recorded`, `voicemail_transcription`.
+6. The `media_stream` WebSocket handler.
+
+Imports for the new `router.py`:
+
+```python
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+
+from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
+
+import app.twilio as app_twilio
+from app.config import settings
+from app.llm.prompts import build_system_prompt
+from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
+from app.orders.models import Order
+from app.restaurants.open_check import is_open_now
+from app.storage import call_sessions, recordings
+from app.storage import restaurants as restaurants_storage
+from app.stt import get_stt
+from app.telephony.session import (
+    GREETING_TRANSCRIPT,
+    END_OF_CALL_MARK,
+    _CallState,
+    _abort_pending_hangup,
+    _arm_silence_watchdog,
+    _bg_call_event,
+    _cancel_silence_task,
+    _consume_transcripts,
+    _hang_up_after_grace,
+    _make_recording_chunk_handler,
+    _resolve_restaurant_for_voice,
+    _run_llm_tts_turn,
+    _state_rid,
+)
+from app.telephony.voicemail_twiml import voicemail_response
+from app.tts import speak
+from app.twilio.twiml import (
+    closed_hangup_twiml,
+    empty_twiml,
+    transfer_twiml,
+    unconfigured_hangup_twiml,
+    voice_twiml,
+)
+```
+
+Re-check after the rewrite: `pyflakes app/telephony/router.py` shows zero unused imports.
+
+The HTTP handlers and WS event-loop body are *unchanged* from the post-Task-3 state — only the imports + the helper definitions move out.
+
+- [ ] **Step 3: Update test imports**
+
+`tests/test_telephony.py` — change:
+
+```python
+from app.telephony.router import _MIN_CHUNK_CHARS, _should_flush_chunk
+```
+
+to:
+
+```python
+from app.telephony.session import _MIN_CHUNK_CHARS, _should_flush_chunk
+```
+
+`tests/test_barge_in_helper.py` — change:
+
+```python
+from app.telephony.router import _CallState, _barge_in_now
+```
+
+to:
+
+```python
+from app.telephony.session import _CallState, _barge_in_now
+```
+
+`tests/test_transcript_consumer.py` — change:
+
+```python
+from app.telephony.router import _CallState, _consume_transcripts
+```
+
+to:
+
+```python
+from app.telephony.session import _CallState, _consume_transcripts
+```
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+pytest tests/test_telephony.py tests/test_voice.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Verify line-count targets**
+
+```bash
+wc -l app/telephony/router.py app/telephony/session.py
+```
+
+Expected:
+- `app/telephony/router.py` — between 200 and 350 lines (FastAPI shells + WS event-loop only).
+- `app/telephony/session.py` — between 700 and 900 lines.
+
+If either is wildly off, something didn't move (or got duplicated). Eyeball the diff before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/telephony/session.py app/telephony/router.py tests/test_telephony.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py
+git commit -m "refactor(telephony): move _CallState + orchestration helpers to session.py (#251)
+
+Slims router.py to FastAPI shells + WS event-loop dispatch
+(~250 lines). All call orchestration — barge-in, hangup, silence,
+LLM turn, transcript consumer — now lives in session.py
+(~800 lines). Test imports updated to the new module path.
+
+No behavior change. Tests pass."
+```
+
+---
+
+## Task 5: Final verification
+
+Goal: run the full test suite, confirm the public surface is unchanged, and update PR #252 to reflect that the implementation has landed.
+
+- [ ] **Step 1: Run the full pytest suite**
+
+```bash
+pytest -q
+```
+
+Expected: all pass. If the telephony-focused subset passed in Task 4 but the full suite fails, the failure is somewhere else (unrelated regression) — investigate before proceeding.
+
+- [ ] **Step 2: Static check — no unused imports**
+
+```bash
+python -m pyflakes app/telephony/router.py app/telephony/session.py app/twilio/__init__.py app/twilio/media_stream.py app/twilio/twiml.py
+```
+
+Expected: no output (no unused imports, no undefined names).
+
+- [ ] **Step 3: Public-surface diff check**
+
+```bash
+git diff feat/83-tune-conversational-bot..HEAD -- app/main.py
+```
+
+Expected: no diff. The FastAPI app mount is unchanged.
+
+```bash
+git diff feat/83-tune-conversational-bot..HEAD -- app/telephony/router.py | grep -E "^\+@router\.(post|websocket)"
+```
+
+Expected: no output (no new endpoints — same five POSTs and one WebSocket as before, with unchanged paths).
+
+- [ ] **Step 4: Push and update PR**
+
+```bash
+git push origin refactor/251-telephony-router-split
+```
+
+Then update PR #252's title and body via `gh pr edit 252`. New title: `refactor(telephony): split router.py + carve app/twilio/ (#251)`. Body should describe the implementation, not just the spec.
+
+```bash
+gh pr edit 252 --repo tsuki-works/niko --title "refactor(telephony): split router.py + carve app/twilio/ (#251)" --body "$(cat <<'EOF'
+## Summary
+
+Splits app/telephony/router.py (1293 lines) along the Twilio-vs-orchestration boundary, mirroring the existing app/deepgram/ pattern.
+
+- app/telephony/router.py — FastAPI shells + WS event-loop only (~250 lines)
+- app/telephony/session.py — _CallState + orchestration helpers (~800 lines)
+- app/twilio/twiml.py — TwiML response builders
+- app/twilio/media_stream.py — send_clear, send_mark WS protocol primitives
+- app/twilio/__init__.py — Twilio REST credential helpers + voicemail upload wrapper
+
+## Non-goals (deliberate)
+
+- No TelephonyProvider ABC — single vendor today.
+- No CallSession class — possible follow-up.
+- No public-API changes; no behavior changes.
+
+Spec: docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md
+
+Closes #251.
+
+## Test plan
+
+- [x] pytest tests/test_telephony.py tests/test_voice.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py — all green
+- [x] pyflakes on the touched files — no unused imports
+- [x] git diff on app/main.py — no public-surface change
+- [ ] Manual smoke via dev call flow (greeting plays, barge-in works, silence prompt fires, order confirmation triggers auto-hangup)
+EOF
+)"
+```
+
+- [ ] **Step 5: Manual smoke (deferred to reviewer)**
+
+Manual smoke is left for the reviewer / merger to perform on the dev environment per the spec's validation step 4. Note this in the PR test plan so it isn't forgotten.
+
+---
+
+## Self-review checklist
+
+Run through this list after the plan is written. Fix issues inline.
+
+1. **Spec coverage** — every file role and mapping row in the spec corresponds to a task step:
+   - `app/twilio/media_stream.py` (`send_clear`, `send_mark`) → Task 1.
+   - `app/twilio/twiml.py` (5 builders) → Task 2.
+   - `app/twilio/__init__.py` (REST helpers) → Task 3.
+   - `app/telephony/session.py` (everything from the spec's mapping table marked `session.py`) → Task 4.
+   - `app/telephony/router.py` slimming → Task 4 step 2.
+   - Test import updates → Task 4 step 3.
+
+2. **Placeholder scan** — no "TBD", "implement later", "similar to", "add appropriate handling". All code shown verbatim. ✓
+
+3. **Type/name consistency:**
+   - `send_clear(websocket, stream_sid)` — used in Tasks 1, 4. ✓
+   - `send_mark(websocket, stream_sid, name)` — used in Tasks 1, 4. ✓
+   - `_CallState` — referenced in Task 4 in import lists matching the dataclass move. ✓
+   - `app_twilio` import alias — Tasks 3 and 4 both use the same alias. ✓
+   - `END_OF_CALL_MARK` constant — moves to `session.py` in Task 4 and is re-imported by `router.py`. ✓
+
+4. **Order check** — Tasks 1-3 are independent of Task 4 and can land in any order, but the plan runs them first because they reduce the size of the Task 4 diff.
+
+5. **Atomicity** — each task ends with passing tests + a commit. No half-states.

--- a/docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md
+++ b/docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md
@@ -1,0 +1,150 @@
+# Telephony router modularization
+
+**Issue:** [tsuki-works/niko#251](https://github.com/tsuki-works/niko/issues/251)
+**Branch:** `refactor/251-telephony-router-split`
+**Base:** `feat/83-tune-conversational-bot` — this refactor depends on the STTProvider extraction and instant-barge-in work landing first. The 1293-line `router.py` analysed below is the post-feat/83 file. PR target should be feat/83 (or master once feat/83 merges).
+**Type:** Structural refactor — no behavior change.
+
+## Problem
+
+`app/telephony/router.py` is 1293 lines and mixes ~10 concerns in one file:
+
+- TwiML HTTP endpoints (`/voice`, `/voice/stream-ended`, `/voice/transfer-result`, `/voice/voicemail-recorded`, `/voice/voicemail-transcription`)
+- The `/media-stream` WebSocket event loop (start/media/mark/stop dispatch)
+- `_CallState` dataclass
+- LLM-turn streaming + chunking (`_run_llm_tts_turn`, `_should_flush_chunk`, hard/soft break thresholds)
+- STT consumer (`_consume_transcripts`)
+- Auto-hangup machinery (mark-echo, grace window, timeout fallback)
+- Barge-in (`_barge_in_now`)
+- Silence watchdog
+- Twilio-specific WS protocol primitives (`clear_twilio_audio`, `send_end_of_call_mark`)
+- Goodbye-detection heuristic + Firestore-event helper
+
+Recent telephony work (#170, #151, #114, #78, #74, instant barge-in via VAD) is being delivered into a single increasingly-tangled file. Reading or editing any one concern requires scrolling through the others.
+
+## Goal
+
+Split the file along its real boundary — vendor-specific Twilio I/O vs vendor-neutral call orchestration — without introducing new abstractions and without changing behavior.
+
+## Non-goals
+
+- **No `TelephonyProvider` ABC.** Single-vendor today; designing an abstraction against one concrete is a guess. The interface emerges when a second provider arrives.
+- **No `CallSession` class refactor.** Possible follow-up; out of scope here. `_CallState` stays a dataclass; the orchestration helpers stay as module-level functions taking `(state, websocket, ...)`.
+- **No public-API changes.** FastAPI endpoint paths, params, and response shapes unchanged.
+- **No behavior changes.** Existing tests pass without modification beyond import-path updates.
+- **No decorative fragmentation.** Two-line helper modules (`turn.py`, `events.py`) explicitly rejected during brainstorming. Pure helpers live next to the code that uses them.
+
+## Proposed structure
+
+```
+app/telephony/
+  router.py            # FastAPI endpoints + WS event-loop only
+  session.py           # _CallState + all orchestration helpers
+  voicemail_twiml.py   # existing — unchanged
+  transfer_triggers.py # existing — unchanged
+
+app/twilio/
+  __init__.py          # exports + Twilio REST recording fetch
+  twiml.py             # TwiML response builders
+  media_stream.py      # send_clear, send_mark — outgoing WS protocol primitives
+```
+
+### File roles
+
+**`app/telephony/router.py`** (~250 lines)
+FastAPI endpoint shells. Each HTTP handler parses the form, calls a TwiML builder from `app/twilio/twiml.py`, returns `Response`. The `/media-stream` WS handler runs the start/media/mark/stop dispatch loop and the cleanup `finally`, delegating per-event work to functions in `session.py`. No call orchestration logic here, no TwiML XML construction here.
+
+**`app/telephony/session.py`** (~800 lines)
+The bulk of today's `router.py` minus the FastAPI shells and Twilio I/O:
+
+- `_CallState` dataclass
+- Chunking constants + `_should_flush_chunk`
+- Goodbye constants + `_looks_like_goodbye`
+- `_bg_call_event` + `_state_rid`
+- `_make_recording_chunk_handler`
+- Silence watchdog: `_silence_watchdog`, `_cancel_silence_task`, `_arm_silence_watchdog`
+- Auto-hangup: `_hang_up_after_grace`, `_hang_up_after_mark_timeout`, `_abort_pending_hangup`
+- Barge-in: `_barge_in_now`
+- Transcript consumer: `_consume_transcripts`
+- LLM turn: `_run_llm_tts_turn`, `_handle_final_transcript`
+- `_resolve_restaurant_for_voice`
+
+Helpers continue to take `(state, websocket, ...)`. They call into `app/twilio/media_stream.py` (`send_clear`, `send_mark`) instead of writing JSON envelopes inline.
+
+**`app/twilio/__init__.py`** (~40 lines)
+Re-exports the public Twilio surface (`twiml`, `media_stream`). Holds `download_recording(url, account_sid, auth_token)` for `/voice/voicemail-recorded` — small enough that a dedicated `recordings.py` would be ceremony.
+
+**`app/twilio/twiml.py`** (~120 lines)
+Pure functions returning `VoiceResponse` (or its `str`-encoding):
+
+- `voice_twiml(restaurant, ws_host)` — `<Connect><Stream>` with `restaurant_id` parameter
+- `unconfigured_hangup_twiml()` — "this number is not configured"
+- `closed_hangup_twiml()` — "we're closed; call back during business hours"
+- `transfer_twiml(fallback_phone, call_sid, rid)` — `<Dial>` with action callback
+- `empty_twiml()` — empty `VoiceResponse()` for hangup paths
+
+No side effects, easy to snapshot-test. `router.py` imports from here.
+
+**`app/twilio/media_stream.py`** (~80 lines)
+The two outgoing Twilio Media Stream WS frames that today live as inline `websocket.send_json` calls in `router.py`:
+
+- `send_clear(websocket, stream_sid)` — flush Twilio's audio buffer (#74)
+- `send_mark(websocket, stream_sid, name)` — append a named mark for buffer-drain detection (#78)
+
+Both are tiny but capture the only outgoing Twilio-shaped JSON literals. `session.py`'s `_barge_in_now` and `_run_llm_tts_turn` import from here. Incoming events (`start`, `media`, `mark`, `stop`) stay parsed inline in `router.py`'s WS handler — typed wrappers are speculative until a second provider forces a real shape difference.
+
+## Mapping (where each thing moves)
+
+| Current (`router.py`) | Destination |
+|---|---|
+| `SILENCE_TIMEOUT_SECONDS`, `SILENCE_PROMPT`, `GREETING_TRANSCRIPT` | `session.py` |
+| `END_OF_CALL_MARK`, `HANGUP_GRACE_SECONDS`, `MARK_ECHO_TIMEOUT_SECONDS` | `session.py` |
+| `_HARD_BREAKS`, `_SOFT_BREAKS`, `_MIN_CHUNK_CHARS`, `_should_flush_chunk` | `session.py` |
+| `_GOODBYE_PATTERNS`, `_looks_like_goodbye` | `session.py` |
+| `_bg_call_event`, `_state_rid` | `session.py` |
+| `_CallState` | `session.py` |
+| `_make_recording_chunk_handler` | `session.py` |
+| `_silence_watchdog`, `_cancel_silence_task`, `_arm_silence_watchdog` | `session.py` |
+| `_hang_up_after_grace`, `_hang_up_after_mark_timeout`, `_abort_pending_hangup` | `session.py` |
+| `_barge_in_now` | `session.py` |
+| `_consume_transcripts` | `session.py` |
+| `_run_llm_tts_turn`, `_handle_final_transcript` | `session.py` |
+| `_resolve_restaurant_for_voice` | `session.py` |
+| `clear_twilio_audio` (rewritten) | `app/twilio/media_stream.py` as `send_clear` |
+| `send_end_of_call_mark` (rewritten) | `app/twilio/media_stream.py` as `send_mark` |
+| TwiML construction in `voice` / `stream_ended` / `transfer_result` / voicemail handlers | `app/twilio/twiml.py` |
+| Twilio REST recording download in `voicemail_recorded` | `app/twilio/__init__.py` (`download_recording`) |
+| `@router.post("/voice")` and the four other HTTP endpoints | `router.py` (shells only) |
+| `@router.websocket("/media-stream")` event-loop body | `router.py` (still the dispatch shell, calls into `session.py`) |
+| `_TRANSFER_STATUS_MAP`, `_UNCONFIGURED_TWIML_MESSAGE` | Move with the consumer (status map → `router.py`; message → `app/twilio/twiml.py`) |
+
+## Test impact
+
+Current tests that import internals (verified on `feat/83-tune-conversational-bot`):
+
+- `tests/test_telephony.py`: `from app.telephony.router import _MIN_CHUNK_CHARS, _should_flush_chunk`
+- `tests/test_barge_in_helper.py`: `from app.telephony.router import _CallState, _barge_in_now`
+- `tests/test_transcript_consumer.py`: `from app.telephony.router import _CallState, _consume_transcripts`
+
+All three update from `app.telephony.router` to `app.telephony.session`. No test logic changes.
+
+`tests/test_voice.py` exercises `/voice` via TestClient — public surface unchanged, no edits expected.
+
+## Risk + validation
+
+**Risk:** low–medium. Mechanical move; strong existing coverage (`tests/test_telephony.py` 1892 lines, plus targeted barge-in / transcript-consumer / voice tests). Recent active tuning (instant-barge-in via VAD just landed) means the diff lands near hot code — care needed to avoid an accidental rebase conflict on whoever's iterating next.
+
+**Validation:**
+
+1. Full pytest suite passes with import paths updated.
+2. `pytest tests/test_telephony.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py tests/test_voice.py -v` — telephony-focused subset green.
+3. Diff review: every moved function moved verbatim (no logic edits hidden in the move).
+4. Manual smoke via the dev call flow (one inbound test call, listen for: greeting plays, barge-in works, silence prompt fires, order confirmation triggers auto-hangup).
+
+## Out of scope (deliberate)
+
+- `CallSession` class refactor — possible follow-up issue.
+- `TelephonyProvider` ABC — wait for vendor #2.
+- Splitting `session.py` into finer modules (`turn.py`, `events.py`, `hangup.py`, etc.) — rejected as decorative during brainstorming. Revisit if `session.py` becomes hard to navigate after this lands.
+- Typed wrappers around incoming Twilio WS events (`StartFrame`, `MediaFrame`, etc.) — speculative; defer.
+- Moving SMS Twilio code (`app/sms/client.py`) into `app/twilio/`. Unrelated to the router refactor; do separately if at all.

--- a/tests/test_barge_in_helper.py
+++ b/tests/test_barge_in_helper.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.telephony.router import _CallState, _barge_in_now
+from app.telephony.session import _CallState, _barge_in_now
 
 
 @pytest.mark.asyncio

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -21,7 +21,7 @@ from app.llm.client import LLMResponse, StreamEvent
 from app.main import app
 from app.orders.models import Order
 from app.storage import restaurants as restaurants_storage
-from app.telephony.router import _MIN_CHUNK_CHARS, _should_flush_chunk
+from app.telephony.session import _MIN_CHUNK_CHARS, _should_flush_chunk
 
 client = TestClient(app)
 
@@ -93,8 +93,9 @@ def mock_pipeline(monkeypatch):
         lambda **kw: (fake_stt, "deepgram"),
     )
     monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr("app.telephony.session.speak", fake_speak)
     monkeypatch.setattr(
-        "app.telephony.router.stream_reply", _make_fake_stream_reply()
+        "app.telephony.session.stream_reply", _make_fake_stream_reply()
     )
     monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
@@ -388,7 +389,7 @@ def test_media_stream_finalizes_recording_on_stop(mock_pipeline, monkeypatch):
 
 def test_ai_greeting_spawned_on_start(mock_pipeline, monkeypatch):
     """On start event, stream_reply is called with GREETING_TRANSCRIPT."""
-    from app.telephony.router import GREETING_TRANSCRIPT
+    from app.telephony.session import GREETING_TRANSCRIPT
 
     calls: list[str] = []
 
@@ -397,7 +398,7 @@ def test_ai_greeting_spawned_on_start(mock_pipeline, monkeypatch):
         yield StreamEvent(text_delta="Hello!")
         yield StreamEvent(final=LLMResponse(reply_text="Hello!", order=order, history=history))
 
-    monkeypatch.setattr("app.telephony.router.stream_reply", recording_stream_reply)
+    monkeypatch.setattr("app.telephony.session.stream_reply", recording_stream_reply)
 
     with client.websocket_connect("/media-stream") as ws:
         ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
@@ -442,7 +443,7 @@ def test_stop_event_persists_ready_order(mock_pipeline, monkeypatch):
         persisted.append(order)
         return order
 
-    monkeypatch.setattr("app.telephony.router.stream_reply", fake_stream_reply)
+    monkeypatch.setattr("app.telephony.session.stream_reply", fake_stream_reply)
     monkeypatch.setattr("app.telephony.router.persist_on_confirm", fake_persist)
 
     with client.websocket_connect("/media-stream") as ws:
@@ -490,8 +491,8 @@ async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
     first_audio Firestore event detail because it arrives before speak()
     fires for the first time."""
     from app.storage import call_sessions
-    from app.telephony import router as router_mod
-    from app.telephony.router import _CallState, _run_llm_tts_turn
+    from app.telephony import session as session_mod
+    from app.telephony.session import _CallState, _run_llm_tts_turn
 
     first_timing = {
         "ttft_seconds": 0.8,
@@ -536,10 +537,10 @@ async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
     def fake_bg_call_event(call_sid, rid, **kwargs):
         recorded_events.append({"call_sid": call_sid, "rid": rid, **kwargs})
 
-    monkeypatch.setattr(router_mod, "stream_reply", fake_stream_reply_tool_only_then_text)
-    monkeypatch.setattr(router_mod, "speak", fake_speak)
-    monkeypatch.setattr(router_mod, "_bg_call_event", fake_bg_call_event)
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "stream_reply", fake_stream_reply_tool_only_then_text)
+    monkeypatch.setattr(session_mod, "speak", fake_speak)
+    monkeypatch.setattr(session_mod, "_bg_call_event", fake_bg_call_event)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
 
     state = _CallState(
@@ -598,7 +599,7 @@ async def test_send_clear_skips_when_stream_sid_missing():
 
 
 def test_looks_like_goodbye_matches_terminal_phrases():
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert _looks_like_goodbye("Great, your order is in — we'll have it ready for you soon!")
     assert _looks_like_goodbye("Perfect, see you soon!")
@@ -608,7 +609,7 @@ def test_looks_like_goodbye_matches_terminal_phrases():
 
 def test_looks_like_goodbye_rejects_questions():
     """A reply that ends with '?' is still asking the caller something."""
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert not _looks_like_goodbye("Got that. Anything else, or are you all set?")
     # Even with goodbye-shaped phrasing earlier, trailing '?' = still asking.
@@ -618,7 +619,7 @@ def test_looks_like_goodbye_rejects_questions():
 def test_looks_like_goodbye_rejects_simple_acknowledgements():
     """Bot acknowledging an item mid-conversation must NOT trigger the
     auto-hangup fallback."""
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert not _looks_like_goodbye("One large margarita, got it.")
     assert not _looks_like_goodbye("Sure, what size would you like?")
@@ -628,7 +629,7 @@ def test_looks_like_goodbye_rejects_simple_acknowledgements():
 
 @pytest.mark.asyncio
 async def test_send_mark_emits_mark_payload():
-    from app.telephony.router import END_OF_CALL_MARK
+    from app.telephony.session import END_OF_CALL_MARK
     from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
@@ -648,7 +649,7 @@ async def test_send_mark_emits_mark_payload():
 
 @pytest.mark.asyncio
 async def test_send_mark_returns_false_when_stream_sid_missing():
-    from app.telephony.router import END_OF_CALL_MARK
+    from app.telephony.session import END_OF_CALL_MARK
     from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
@@ -663,13 +664,13 @@ async def test_hang_up_after_grace_sets_should_hangup_event(monkeypatch):
     should_hangup event so the loop exits and the WebSocket closes —
     Twilio's <Connect> ends and the call hangs up. The REST update path
     is gone (it 404'd on <Connect>-state calls)."""
-    from app.telephony.router import (
+    from app.telephony.session import (
         HANGUP_GRACE_SECONDS,
         _CallState,
         _hang_up_after_grace,
     )
 
-    monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr("app.telephony.session.HANGUP_GRACE_SECONDS", 0.01)
 
     state = _CallState(call_sid="CAtest", pending_hangup=True)
     assert not state.should_hangup.is_set()
@@ -684,9 +685,9 @@ async def test_hang_up_after_grace_sets_should_hangup_event(monkeypatch):
 async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
     """If pending_hangup gets cleared during the grace window (caller
     spoke), the should_hangup event MUST NOT fire."""
-    from app.telephony.router import _CallState, _hang_up_after_grace
+    from app.telephony.session import _CallState, _hang_up_after_grace
 
-    monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr("app.telephony.session.HANGUP_GRACE_SECONDS", 0.01)
 
     state = _CallState(call_sid="CAtest", pending_hangup=True)
     # Simulate: caller spoke during the grace window — _handle_final_transcript
@@ -700,7 +701,7 @@ async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
 
 def test_looks_like_goodbye_excludes_coming_right_up():
     """'coming right up' is mid-order, not a wrap-up — must NOT trigger fallback."""
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert _looks_like_goodbye("One large Margherita coming right up.") is False
     assert _looks_like_goodbye("Two Cokes coming right up!") is False
@@ -708,7 +709,7 @@ def test_looks_like_goodbye_excludes_coming_right_up():
 
 def test_looks_like_goodbye_remaining_patterns_still_match():
     """Positive coverage so a drive-by removal of a pattern is caught."""
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert _looks_like_goodbye("Thanks for ordering, see you soon!")
     assert _looks_like_goodbye("Your order is in — we'll have it ready shortly.")
@@ -719,7 +720,7 @@ def test_looks_like_goodbye_remaining_patterns_still_match():
 
 def test_hangup_grace_seconds_is_five():
     """Grace window must be 5s so callers can add late items."""
-    from app.telephony.router import HANGUP_GRACE_SECONDS
+    from app.telephony.session import HANGUP_GRACE_SECONDS
 
     assert HANGUP_GRACE_SECONDS == 5.0
 
@@ -730,13 +731,13 @@ async def test_mark_echo_timeout_fires_grace_window(monkeypatch):
     the grace window anyway so the call terminates."""
     import asyncio
 
-    from app.telephony import router as router_mod
-    from app.telephony.router import (
+    from app.telephony import session as session_mod
+    from app.telephony.session import (
         _CallState,
         _hang_up_after_mark_timeout,
     )
 
-    monkeypatch.setattr(router_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(session_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
 
     state = _CallState()
     state.call_sid = "CA_timeout_test"
@@ -747,7 +748,7 @@ async def test_mark_echo_timeout_fires_grace_window(monkeypatch):
     async def fake_grace(s):
         grace_started["flag"] = True
 
-    monkeypatch.setattr(router_mod, "_hang_up_after_grace", fake_grace)
+    monkeypatch.setattr(session_mod, "_hang_up_after_grace", fake_grace)
 
     await _hang_up_after_mark_timeout(state)
 
@@ -762,10 +763,10 @@ async def test_mark_echo_timeout_skips_grace_when_pending_hangup_cleared(monkeyp
     _abort_pending_hangup raced), the timeout must NOT fire the grace window."""
     import asyncio
 
-    from app.telephony import router as router_mod
-    from app.telephony.router import _CallState, _hang_up_after_mark_timeout
+    from app.telephony import session as session_mod
+    from app.telephony.session import _CallState, _hang_up_after_mark_timeout
 
-    monkeypatch.setattr(router_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(session_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
 
     state = _CallState()
     state.call_sid = "CA_abort_race"
@@ -776,7 +777,7 @@ async def test_mark_echo_timeout_skips_grace_when_pending_hangup_cleared(monkeyp
     async def fake_grace(s):
         grace_started["flag"] = True
 
-    monkeypatch.setattr(router_mod, "_hang_up_after_grace", fake_grace)
+    monkeypatch.setattr(session_mod, "_hang_up_after_grace", fake_grace)
 
     await _hang_up_after_mark_timeout(state)
 
@@ -791,7 +792,7 @@ async def test_abort_pending_hangup_cancels_mark_timeout_task():
     timer doesn't fire after the caller speaks during the grace window."""
     import asyncio
 
-    from app.telephony.router import _abort_pending_hangup, _CallState
+    from app.telephony.session import _abort_pending_hangup, _CallState
 
     state = _CallState(call_sid="CAtest", pending_hangup=True)
 
@@ -894,9 +895,9 @@ def test_run_llm_tts_turn_flushes_at_long_comma_clause(monkeypatch, mock_pipelin
     async def capture_speak(text, websocket, stream_sid, **kw):
         chunks_spoken.append(text)
 
-    monkeypatch.setattr("app.telephony.router.speak", capture_speak)
+    monkeypatch.setattr("app.telephony.session.speak", capture_speak)
     monkeypatch.setattr(
-        "app.telephony.router.stream_reply",
+        "app.telephony.session.stream_reply",
         _make_fake_stream_reply_deltas(
             "One Chicken Fried Rice coming up,",
             " what size would you like?",
@@ -922,9 +923,9 @@ def test_run_llm_tts_turn_does_not_flush_at_short_comma(monkeypatch, mock_pipeli
     async def capture_speak(text, websocket, stream_sid, **kw):
         chunks_spoken.append(text)
 
-    monkeypatch.setattr("app.telephony.router.speak", capture_speak)
+    monkeypatch.setattr("app.telephony.session.speak", capture_speak)
     monkeypatch.setattr(
-        "app.telephony.router.stream_reply",
+        "app.telephony.session.stream_reply",
         _make_fake_stream_reply_deltas("Got it,", " moving on."),
     )
 
@@ -962,8 +963,8 @@ def test_first_tts_byte_event_emitted_on_turn(mock_pipeline, monkeypatch):
     def capture_bg_event(call_sid, restaurant_id, **kwargs):
         recorded_events.append({"call_sid": call_sid, "rid": restaurant_id, **kwargs})
 
-    monkeypatch.setattr("app.telephony.router.speak", speak_with_callback)
-    monkeypatch.setattr("app.telephony.router._bg_call_event", capture_bg_event)
+    monkeypatch.setattr("app.telephony.session.speak", speak_with_callback)
+    monkeypatch.setattr("app.telephony.session._bg_call_event", capture_bg_event)
 
     with client.websocket_connect("/media-stream") as ws:
         ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
@@ -994,7 +995,7 @@ def test_first_tts_byte_event_emitted_on_turn(mock_pipeline, monkeypatch):
 
 def test_call_state_has_transfer_trigger_fields():
     """The new fields on _CallState are needed by the trigger detector."""
-    from app.telephony.router import _CallState
+    from app.telephony.session import _CallState
 
     state = _CallState()
     assert state.consecutive_low_confidence_turns == 0
@@ -1678,7 +1679,7 @@ def test_voice_after_hours_without_call_sid_bails_with_hangup(monkeypatch):
 def test_call_state_has_in_flight_transcript_field():
     """#170 — _CallState carries the cancelled-turn transcript forward
     so the next turn can prepend it to the new utterance."""
-    from app.telephony.router import _CallState
+    from app.telephony.session import _CallState
 
     state = _CallState()
     assert state.in_flight_transcript == ""
@@ -1694,8 +1695,8 @@ async def test_cancelled_turn_transcript_carried_forward(monkeypatch):
     chicken fried rice because turn 1 was cancelled by turn 2 1s later
     and only "and a coke" reached the model.
     """
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _handle_final_transcript
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
 
     captured: list[str] = []
 
@@ -1704,10 +1705,10 @@ async def test_cancelled_turn_transcript_carried_forward(monkeypatch):
         # Stay in flight long enough to be cancelled by the next call.
         await asyncio.sleep(10.0)
 
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
     # Suppress the silence watchdog — its done_callback would otherwise
     # arm a real watchdog that tries to call the real speak() later.
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     ws = AsyncMock()
@@ -1739,8 +1740,8 @@ async def test_cancelled_turn_transcript_carried_forward(monkeypatch):
 async def test_chained_cancels_accumulate_transcripts(monkeypatch):
     """#170 — a rapid burst of three finals should accumulate. Turn 3
     must see all three concatenated as one combined caller intent."""
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _handle_final_transcript
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
 
     captured: list[str] = []
 
@@ -1748,8 +1749,8 @@ async def test_chained_cancels_accumulate_transcripts(monkeypatch):
         captured.append(transcript)
         await asyncio.sleep(10.0)
 
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     ws = AsyncMock()
@@ -1780,8 +1781,8 @@ async def test_run_llm_tts_turn_clears_in_flight_transcript_on_final(monkeypatch
     """#170 — once a turn completes successfully (yields event.final),
     the carry-forward field must be cleared. The user message is now in
     state.history, so prepending it to the next turn would duplicate it."""
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _run_llm_tts_turn
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _run_llm_tts_turn
 
     async def fake_stream_reply(*, transcript, history, order, **kw):
         yield StreamEvent(final=LLMResponse(reply_text="ok", order=order, history=history))
@@ -1789,9 +1790,9 @@ async def test_run_llm_tts_turn_clears_in_flight_transcript_on_final(monkeypatch
     async def fake_speak(*a, **kw):
         pass
 
-    monkeypatch.setattr(router_mod, "stream_reply", fake_stream_reply)
-    monkeypatch.setattr(router_mod, "speak", fake_speak)
-    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "stream_reply", fake_stream_reply)
+    monkeypatch.setattr(session_mod, "speak", fake_speak)
+    monkeypatch.setattr(session_mod, "_bg_call_event", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     state.in_flight_transcript = "chicken fried rice and a coke"
@@ -1808,8 +1809,8 @@ async def test_errored_turn_carries_transcript_forward(monkeypatch):
     user's words also never reach history. The next final transcript
     must still pick up the carry-forward — same class of bug as cancel,
     different code path."""
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _handle_final_transcript
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
 
     captured: list[str] = []
 
@@ -1823,13 +1824,13 @@ async def test_errored_turn_carries_transcript_forward(monkeypatch):
         captured.append(transcript)
         await asyncio.sleep(10.0)
 
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     ws = AsyncMock()
 
     # Turn 1 errors. in_flight_transcript should remain set.
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", erroring_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", erroring_run_llm_tts_turn)
     await _handle_final_transcript("i'll get one chicken fried rice", state, ws)
     # Wait for the error to propagate.
     if state.llm_task is not None:
@@ -1841,7 +1842,7 @@ async def test_errored_turn_carries_transcript_forward(monkeypatch):
 
     # Turn 2 with a fresh transcript — must still carry forward despite
     # state.llm_task.done() == True (errored, not running).
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", normal_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", normal_run_llm_tts_turn)
     await _handle_final_transcript("and a coke", state, ws)
     await asyncio.sleep(0)
 
@@ -1865,8 +1866,8 @@ async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch
     in the next turn's text. Today the trailing ``.strip()`` would clean
     it up regardless, but if a future refactor moves or removes that
     strip we want this test to catch the leak."""
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _handle_final_transcript
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
 
     captured: list[str] = []
 
@@ -1874,8 +1875,8 @@ async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch
         captured.append(transcript)
         await asyncio.sleep(10.0)
 
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     state.in_flight_transcript = "   \t\n  "

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -572,7 +572,7 @@ async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
+async def test_send_clear_emits_clear_event_with_stream_sid():
     """The helper emits the documented Twilio clear payload."""
     from app.twilio.media_stream import send_clear
 
@@ -585,7 +585,7 @@ async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
 
 
 @pytest.mark.asyncio
-async def test_clear_twilio_audio_skips_when_stream_sid_missing():
+async def test_send_clear_skips_when_stream_sid_missing():
     """No stream means we never opened the start frame — nothing to clear."""
     from app.twilio.media_stream import send_clear
 
@@ -627,7 +627,7 @@ def test_looks_like_goodbye_rejects_simple_acknowledgements():
 
 
 @pytest.mark.asyncio
-async def test_send_end_of_call_mark_emits_mark_payload():
+async def test_send_mark_emits_mark_payload():
     from app.telephony.router import END_OF_CALL_MARK
     from app.twilio.media_stream import send_mark
 
@@ -647,11 +647,12 @@ async def test_send_end_of_call_mark_emits_mark_payload():
 
 
 @pytest.mark.asyncio
-async def test_send_end_of_call_mark_returns_false_when_stream_sid_missing():
+async def test_send_mark_returns_false_when_stream_sid_missing():
+    from app.telephony.router import END_OF_CALL_MARK
     from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
-    sent = await send_mark(ws, None, name="end_of_call")
+    sent = await send_mark(ws, None, name=END_OF_CALL_MARK)
     assert sent is False
     ws.send_json.assert_not_called()
 
@@ -806,7 +807,7 @@ async def test_abort_pending_hangup_cancels_mark_timeout_task():
 
 
 @pytest.mark.asyncio
-async def test_clear_twilio_audio_swallows_websocket_disconnect():
+async def test_send_clear_swallows_websocket_disconnect():
     """If the caller already hung up, the clear send raises — but we
     must not let that exception escape into the call loop."""
     from starlette.websockets import WebSocketDisconnect

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -574,12 +574,12 @@ async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
 @pytest.mark.asyncio
 async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
     """The helper emits the documented Twilio clear payload."""
-    from app.telephony.router import clear_twilio_audio
+    from app.twilio.media_stream import send_clear
 
     ws = AsyncMock()
     ws.send_json = AsyncMock()
 
-    await clear_twilio_audio(ws, "MZtest456")
+    await send_clear(ws, "MZtest456")
 
     ws.send_json.assert_awaited_once_with({"event": "clear", "streamSid": "MZtest456"})
 
@@ -587,12 +587,12 @@ async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
 @pytest.mark.asyncio
 async def test_clear_twilio_audio_skips_when_stream_sid_missing():
     """No stream means we never opened the start frame — nothing to clear."""
-    from app.telephony.router import clear_twilio_audio
+    from app.twilio.media_stream import send_clear
 
     ws = AsyncMock()
     ws.send_json = AsyncMock()
 
-    await clear_twilio_audio(ws, None)
+    await send_clear(ws, None)
 
     ws.send_json.assert_not_called()
 
@@ -628,12 +628,13 @@ def test_looks_like_goodbye_rejects_simple_acknowledgements():
 
 @pytest.mark.asyncio
 async def test_send_end_of_call_mark_emits_mark_payload():
-    from app.telephony.router import END_OF_CALL_MARK, send_end_of_call_mark
+    from app.telephony.router import END_OF_CALL_MARK
+    from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
     ws.send_json = AsyncMock()
 
-    sent = await send_end_of_call_mark(ws, "MZtest456")
+    sent = await send_mark(ws, "MZtest456", name=END_OF_CALL_MARK)
 
     assert sent is True
     ws.send_json.assert_awaited_once_with(
@@ -647,10 +648,10 @@ async def test_send_end_of_call_mark_emits_mark_payload():
 
 @pytest.mark.asyncio
 async def test_send_end_of_call_mark_returns_false_when_stream_sid_missing():
-    from app.telephony.router import send_end_of_call_mark
+    from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
-    sent = await send_end_of_call_mark(ws, None)
+    sent = await send_mark(ws, None, name="end_of_call")
     assert sent is False
     ws.send_json.assert_not_called()
 
@@ -810,13 +811,13 @@ async def test_clear_twilio_audio_swallows_websocket_disconnect():
     must not let that exception escape into the call loop."""
     from starlette.websockets import WebSocketDisconnect
 
-    from app.telephony.router import clear_twilio_audio
+    from app.twilio.media_stream import send_clear
 
     ws = AsyncMock()
     ws.send_json = AsyncMock(side_effect=WebSocketDisconnect())
 
     # No exception escaping is the assertion.
-    await clear_twilio_audio(ws, "MZtest456")
+    await send_clear(ws, "MZtest456")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -1,6 +1,6 @@
-"""Tests for _consume_transcripts in app/telephony/router.py.
+"""Tests for _consume_transcripts in app/telephony/session.py.
 
-The consumer is the router's bridge between the STT plugin and call
+The consumer is the session's bridge between the STT plugin and call
 state. We feed scripted events into a FakeSTT and assert state changes,
 Firestore emissions, and dispatch into _handle_final_transcript.
 """

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.stt.base import SpeechStartedEvent, TranscriptEvent
-from app.telephony.router import _CallState, _consume_transcripts
+from app.telephony.session import _CallState, _consume_transcripts
 from tests.fakes.stt import FakeSTT
 
 
@@ -31,10 +31,10 @@ async def test_interim_transcripts_ignored(monkeypatch):
     state = _make_state()
     handler = AsyncMock()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
+        "app.telephony.session._handle_final_transcript", handler
     )
     bg = MagicMock()
-    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
     fake = FakeSTT(events=[TranscriptEvent("partial", False, 0.7)])
     await fake.open()
@@ -53,10 +53,10 @@ async def test_final_transcript_mutates_state_and_dispatches(monkeypatch):
     state = _make_state()
     handler = AsyncMock()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
+        "app.telephony.session._handle_final_transcript", handler
     )
     bg = MagicMock()
-    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
     ws = AsyncMock()
     fake = FakeSTT(events=[TranscriptEvent("two pizzas", True, 0.9)])
@@ -77,9 +77,9 @@ async def test_final_transcript_mutates_state_and_dispatches(monkeypatch):
 async def test_low_confidence_increments_counter(monkeypatch):
     state = _make_state()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", AsyncMock()
+        "app.telephony.session._handle_final_transcript", AsyncMock()
     )
-    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(events=[
         TranscriptEvent("muffled", True, 0.3),
@@ -102,9 +102,9 @@ async def test_high_confidence_resets_counter(monkeypatch):
     state = _make_state()
     state.consecutive_low_confidence_turns = 3
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", AsyncMock()
+        "app.telephony.session._handle_final_transcript", AsyncMock()
     )
-    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(events=[TranscriptEvent("clear", True, 0.95)])
     await fake.open()
@@ -132,7 +132,7 @@ async def test_speech_started_triggers_barge_in_when_llm_task_running(monkeypatc
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     fake = FakeSTT(events=[SpeechStartedEvent()])
     await fake.open()
@@ -163,7 +163,7 @@ async def test_speech_started_no_op_when_no_llm_task(monkeypatch):
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     fake = FakeSTT(events=[SpeechStartedEvent()])
     await fake.open()
@@ -195,7 +195,7 @@ async def test_speech_started_disabled_by_setting(monkeypatch):
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     fake = FakeSTT(events=[SpeechStartedEvent()])
     await fake.open()
@@ -220,16 +220,16 @@ async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
 
     state = _make_state()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", AsyncMock()
+        "app.telephony.session._handle_final_transcript", AsyncMock()
     )
     bg = MagicMock()
-    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
     fake = FakeSTT()
     await fake.open()
     fake.feed_error(RuntimeError("dropped"))
 
-    with caplog.at_level(logging.ERROR, logger="app.telephony.router"):
+    with caplog.at_level(logging.ERROR, logger="app.telephony.session"):
         # Consumer catches the exception and exits cleanly.
         await _consume_transcripts(fake, state, AsyncMock())
 
@@ -247,7 +247,7 @@ async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
 async def test_consumer_propagates_cancellation(monkeypatch):
     state = _make_state()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", AsyncMock()
+        "app.telephony.session._handle_final_transcript", AsyncMock()
     )
 
     fake = FakeSTT()
@@ -281,13 +281,13 @@ async def test_vad_then_final_transcript_creates_one_barge_in_then_new_turn(
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     handler = AsyncMock()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
+        "app.telephony.session._handle_final_transcript", handler
     )
-    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(
         events=[
@@ -329,13 +329,13 @@ async def test_kill_switch_off_still_processes_final_transcripts(monkeypatch):
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     handler = AsyncMock()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
+        "app.telephony.session._handle_final_transcript", handler
     )
-    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(
         events=[


### PR DESCRIPTION
## Summary

Splits app/telephony/router.py (1293 lines) along the Twilio-vs-orchestration boundary, mirroring the existing app/deepgram/ pattern. No behavior change.

- app/telephony/router.py — FastAPI shells + WS event-loop only (~615 lines)
- app/telephony/session.py — _CallState + orchestration helpers (~655 lines)
- app/twilio/twiml.py — TwiML response builders (5 pure functions)
- app/twilio/media_stream.py — send_clear, send_mark WS protocol primitives
- app/twilio/__init__.py — Twilio REST credential helpers + voicemail upload wrapper

## Non-goals (deliberate)

- No TelephonyProvider ABC — single vendor today; designing an abstraction against one concrete is a guess.
- No CallSession class refactor — possible follow-up.
- No public-API changes; no behavior changes.

## Layering

- router.py imports from session.py, never the reverse.
- session.py imports from app/twilio/media_stream.py only (for send_clear / send_mark).
- TwiML XML construction is confined to app/twilio/twiml.py and the pre-existing app/telephony/voicemail_twiml.py (folding the latter in is a follow-up).

## Spec

docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md
docs/superpowers/plans/2026-05-06-telephony-router-modularization.md

Closes #251.

## Test plan

- [x] pytest tests/test_telephony.py tests/test_voice.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py with the two known-VAD-failure deselects: 85 passed, 2 deselected.
- [x] pyflakes on all five touched files: clean.
- [x] git diff on app/main.py vs feat/83 base: empty.
- [x] No new endpoint paths added (grep on the diff for @router.post / @router.websocket additions: none).
- [ ] Manual smoke via dev call flow (greeting plays, barge-in works, silence prompt fires, order confirmation triggers auto-hangup) — left for the reviewer to perform on the dev environment.

## Known unrelated failure

Two tests in tests/test_transcript_consumer.py (test_speech_started_triggers_barge_in_when_llm_task_running, test_vad_then_final_transcript_creates_one_barge_in_then_new_turn) are deselected. Pre-existing failure under STT_INSTANT_BARGE_IN=true (the default) — known product bug tracked separately, not introduced by this PR.