### PR TITLE
fix(bot): jobs - poll wait_until_ready through initial RuntimeError

### DIFF
--- a/bot/jarvis/main.py
+++ b/bot/jarvis/main.py
@@ -251,10 +251,24 @@ async def run() -> None:
         # Fake gateways in tests don't expose wait_until_ready — guard so
         # those tests don't AttributeError here.
         if hasattr(bot, "wait_until_ready"):
-            try:
-                await bot.wait_until_ready()
-            except Exception:  # noqa: BLE001
-                logger.exception("wait_until_ready raised; scheduler disabled")
+            # bot.start() is running concurrently; it hasn't yet initialised
+            # the client's _ready event so wait_until_ready() raises
+            # RuntimeError("Client has not been properly initialised") if we
+            # call it too early. Poll until login has progressed past that
+            # gate, then await readiness normally.
+            ready_ok = False
+            for _ in range(100):  # ~10s of 100ms ticks
+                try:
+                    await bot.wait_until_ready()
+                    ready_ok = True
+                    break
+                except RuntimeError:
+                    await asyncio.sleep(0.1)
+                except Exception:  # noqa: BLE001
+                    logger.exception("wait_until_ready raised; scheduler disabled")
+                    return
+            if not ready_ok:
+                logger.error("gateway never became ready; scheduler disabled")
                 return
         try:
             validate_manifest(JOBS)
@@ -267,11 +281,13 @@ async def run() -> None:
         await self_reporter.boot(commit_sha=settings.commit_sha, job_count=len(sched.get_jobs()))
         bot._scheduler = sched  # type: ignore[attr-defined]
 
-    scheduler_task = asyncio.create_task(start_scheduler_after_ready(), name="scheduler-startup")
-
     app = build_app(commit_sha=settings.commit_sha)
 
+    # Start the gateway BEFORE the scheduler poller so bot.start() has a chance
+    # to begin login (sets the internal _ready event) before
+    # start_scheduler_after_ready() calls wait_until_ready().
     gateway_task = asyncio.create_task(bot.start(settings.discord_bot_token), name="gateway")
+    scheduler_task = asyncio.create_task(start_scheduler_after_ready(), name="scheduler-startup")
     http_task = asyncio.create_task(serve_http(app, settings.jarvis_http_port), name="http")
 
     try:


### PR DESCRIPTION
## What

Hotfix for the race condition that left the scheduler disabled in production after the v1 deploy (commit 76f8dd5).

The scheduler-startup task was created before the gateway task, so `wait_until_ready()` ran before `bot.start()` had initialised the client's `_ready` event — discord.py raises `RuntimeError("Client has not been properly initialised")` in that window, and our blanket `except Exception` swallowed it.

## Symptom

Production journal:
\`\`\`
ERROR __main__ wait_until_ready raised; scheduler disabled
RuntimeError: Client has not been properly initialised. Please use the login method or asynchronous context manager before calling this method
\`\`\`

The bot stayed online (gateway + chat work fine), but **no scheduled jobs ran** — `🟢 Jarvis online` self-report never fired.

## Fix

1. **Reorder** so `gateway_task` is created before `scheduler_task` — gives `bot.start()` a chance to begin login first.
2. **Poll on RuntimeError** for up to 10s (100×100ms) before giving up — handles the small window even after reorder.

Backwards-compatible with the existing test fakes (they don't have `wait_until_ready`, so the `hasattr` guard skips this whole path).

## Test plan

- [x] `pytest bot/tests/test_main.py` — 4 passed
- [ ] Deploy + observe \`🟢 Jarvis online · scheduler: 7 jobs\` in #jarvis

🤖 Generated with [Claude Code](https://claude.com/claude-code)