### PR TITLE
fix(bot): jobs - detect commit_sha via git when env unset

### DIFF
--- a/bot/jarvis/main.py
+++ b/bot/jarvis/main.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import subprocess
 from pathlib import Path
 from typing import Any, Optional
 
@@ -68,6 +69,29 @@ logger = logging.getLogger(__name__)
 # community markers (good first issue, help wanted) are deliberately
 # omitted — those are for human triage, not bot-filed issues.
 _OPEN_ISSUE_LABEL_ALLOWLIST = ["bug", "enhancement", "documentation", "question"]
+
+
+def _detect_commit_sha() -> str:
+    """Return `git rev-parse HEAD` of the bot's repo, or "" on failure.
+
+    Used as a fallback when `Settings.commit_sha` (env `COMMIT_SHA`) is
+    unset — covers the fast-deploy path (`git pull && systemctl restart`)
+    that doesn't re-run `infra/jarvis/startup.sh` and so doesn't refresh
+    `/etc/jarvis/env`.
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+        return result.stdout.strip()
+    except Exception:  # noqa: BLE001 — best-effort; absence is non-fatal
+        return ""
 
 
 async def serve_http(app, port: int) -> None:
@@ -208,7 +232,8 @@ def _build_clients(settings: Settings) -> tuple[Any, Any, Any]:
 async def run() -> None:
     settings: Settings = get_settings()
     configure_logging(settings.jarvis_log_level)
-    logger.info("jarvis starting commit_sha=%s", settings.commit_sha or "(unset)")
+    commit_sha = settings.commit_sha or _detect_commit_sha()
+    logger.info("jarvis starting commit_sha=%s", commit_sha or "(unset)")
 
     anthropic_client, firestore_client, github_client = _build_clients(settings)
 
@@ -274,14 +299,14 @@ async def run() -> None:
             validate_manifest(JOBS)
         except Exception:  # noqa: BLE001
             logger.exception("manifest validation failed; scheduler disabled")
-            await self_reporter.boot(commit_sha=settings.commit_sha, job_count=0)
+            await self_reporter.boot(commit_sha=commit_sha, job_count=0)
             return
         sched = build_scheduler(executor, JOBS)
         sched.start()
-        await self_reporter.boot(commit_sha=settings.commit_sha, job_count=len(sched.get_jobs()))
+        await self_reporter.boot(commit_sha=commit_sha, job_count=len(sched.get_jobs()))
         bot._scheduler = sched  # type: ignore[attr-defined]
 
-    app = build_app(commit_sha=settings.commit_sha)
+    app = build_app(commit_sha=commit_sha)
 
     # Start the gateway BEFORE the scheduler poller so bot.start() has a chance
     # to begin login (sets the internal _ready event) before

--- a/bot/tests/test_main.py
+++ b/bot/tests/test_main.py
@@ -163,3 +163,22 @@ def test_main_imports_jobs_subsystem_without_error():
     assert "pr_review_nudge" in KIND_REGISTRY
     assert "digest_via_agent" in KIND_REGISTRY
     assert "stuck_in_progress" in KIND_REGISTRY
+
+
+def test_detect_commit_sha_returns_repo_head_or_empty():
+    """_detect_commit_sha returns a 40-char hex SHA when run inside a git
+    checkout, and "" when git fails. We assume the test environment is a
+    git checkout — assert the SHA shape, not a specific value."""
+    sha = main_mod._detect_commit_sha()
+    # Either a real SHA or empty (e.g., test env without git) — both fine.
+    assert sha == "" or (len(sha) == 40 and all(c in "0123456789abcdef" for c in sha))
+
+
+def test_detect_commit_sha_swallows_subprocess_failure(monkeypatch):
+    import subprocess as sp
+
+    def boom(*args, **kwargs):
+        raise sp.CalledProcessError(returncode=128, cmd=args[0])
+
+    monkeypatch.setattr(main_mod.subprocess, "run", boom)
+    assert main_mod._detect_commit_sha() == ""


### PR DESCRIPTION
## Why

The boot self-report shows `commit \`unknown\`` in `#jarvis` because:
- `infra/jarvis/jarvis.service` reads `/etc/jarvis/env` for environment.
- `infra/jarvis/startup.sh` writes that file but doesn't include `COMMIT_SHA`.
- The fast-deploy path (`git pull && pip install && systemctl restart`) skips `startup.sh` entirely, so even if we added it there, fast-deploys would stay stale.

## Fix

Add `_detect_commit_sha()` to `bot/jarvis/main.py` — a small helper that runs `git rev-parse HEAD` on the bot's own repo and returns the SHA (or `""` on failure). Used as a fallback in `run()` when `Settings.commit_sha` is empty.

`Settings.commit_sha` (env `COMMIT_SHA`) still wins if explicitly set — useful for staging or test overrides — but in production the bot now self-resolves to the actual deployed SHA without depending on deploy-script choreography.

## Test plan

- [x] `pytest bot/tests/test_main.py` — 6 passed (including 2 new tests for `_detect_commit_sha`)
- [x] `ruff check` clean
- [ ] After merge + redeploy: \`🟢 Jarvis online · commit \`<7-char SHA>\` · scheduler: 7 jobs\` in #jarvis

🤖 Generated with [Claude Code](https://claude.com/claude-code)