### PR TITLE
Migrate STT to Deepgram Flux English mono with per-tenant keyterms (#257)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,26 @@
 # Anthropic — Claude Haiku 4.5
 ANTHROPIC_API_KEY=
 
-# Deepgram — streaming STT (Nova-2) and TTS (Aura)
+# Deepgram — streaming STT (Flux English mono) and TTS (Aura)
 DEEPGRAM_API_KEY=
 DEEPGRAM_TTS_MODEL=aura-2-thalia-en
+
+# STT model. Flux English mono is the default (#257). Multi-language
+# support would be flux-general-multi at a small cost premium.
+STT_MODEL=flux-general-en
+
+# Optional debug-override for the per-tenant keyterm list. When set
+# to a non-empty comma-separated list, REPLACES the menu-derived
+# keyterms entirely — used to A/B specific term lists without
+# redeploying. Production should leave this blank.
+STT_KEYTERMS=
+
+# Instant barge-in. When true (default), the bot stops speaking as
+# soon as Flux fires StartOfTurn (~50-200ms after the caller begins
+# speaking). Flip to false if real-call data shows StartOfTurn
+# misfiring on coughs / background noise — the final-transcript
+# barge-in path absorbs the fallback case.
+STT_INSTANT_BARGE_IN=true
 
 # Twilio — Voice webhook + trial number
 TWILIO_ACCOUNT_SID=

--- a/app/config.py
+++ b/app/config.py
@@ -34,23 +34,26 @@ class Settings(BaseSettings):
     # STT provider selector. Today only "deepgram" is implemented.
     stt_provider: str = "deepgram"
 
-    # Deepgram live STT options. Defaults match what was inline in
-    # router.py before the plugin extraction; tuning is done by env var
-    # rather than code change.
-    stt_model: str = "nova-2"
-    stt_endpointing_ms: int = 800
-    stt_utterance_end_ms: int = 1000
-    # Comma-separated keyterms. Only sent to Deepgram when non-empty,
-    # and only respected by models that support keyterm prompting
-    # (Nova-3 and later). Parsed lazily in app/deepgram/stt.py.
+    # Deepgram live STT options. Migrated to Flux English mono in #257.
+    # Flux owns turn detection natively (prosody-aware, ~260ms confirmed
+    # end-of-turn) so the Nova-2 endpointing knobs were removed; if Flux
+    # turn-detection ever needs tuning, expose `eager_eot_threshold` /
+    # `eot_threshold` / `eot_timeout_ms` here, all per the v2 connect API.
+    stt_model: str = "flux-general-en"
+    # Comma-separated debug-override keyterms. When non-empty, REPLACES
+    # the per-tenant heuristic output entirely (used to A/B test what
+    # Flux does with a specific term list). Empty in production —
+    # session.py computes keyterms from each restaurant's menu.
     stt_keyterms: str = ""
 
-    # Instant barge-in via Deepgram VAD speech-started events. When True
-    # (default), a barge-in fires ~50ms after the caller begins speaking
-    # instead of waiting for the final transcript (~800-1800ms). Flip to
-    # False if VAD turns out to misfire on coughs or background noise on
-    # a real call — the existing final-transcript barge-in path absorbs
-    # the fallback case with no other code changes.
+    # Instant barge-in. When True (default), a barge-in fires as soon as
+    # the STT provider signals "user started speaking" (Flux fires
+    # `TurnInfo.event="StartOfTurn"` on the first frame of detected
+    # speech) instead of waiting for the confirmed final transcript.
+    # Flip to False if the start-of-turn signal turns out to misfire
+    # on coughs or background noise on real calls — the
+    # final-transcript path in _handle_final_transcript absorbs the
+    # fallback case with no other code changes.
     stt_instant_barge_in: bool = True
 
     twilio_account_sid: Optional[str] = None

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -2,8 +2,8 @@
 
 Implements the STTProvider contract from app/stt/base.py. Uses
 ``AsyncDeepgramClient.listen.v2.connect`` (Flux v2 API) and translates
-Flux's ``ListenV2TurnInfo`` events into the vendor-neutral common-named
-events the consumer expects.
+Flux's wire messages into the vendor-neutral common-named events the
+consumer expects.
 
 Translation map (Flux ``TurnInfo.event`` → common-named event):
 
@@ -20,12 +20,21 @@ session-loop consumer drops them in this PR. They exist on the wire
 so a follow-up speculative-drafting PR can wire them in without
 changing the protocol.
 
-Lifecycle: ``open()`` enters the v2 connect context, registers a
-background reader task that drains ``recv()`` into an internal queue,
-and returns. ``send()`` forwards Twilio mulaw bytes via
-``send_media``. ``events()`` is an async generator yielding STTEvents
-until ``close()``. ``close()`` cancels the reader, sends close-stream,
-and exits the context manager.
+A note on the SDK's wire format: ``deepgram-sdk`` 7.1's
+``recv()`` returns Union-typed messages by passing the JSON to
+``construct_type(Union[...], ...)``, which does NOT pick a Union
+discriminator and falls through to the raw dict. So in practice every
+message arrives as a ``dict`` with a ``type`` field. ``_translate``
+routes on that field for dicts, and keeps an ``isinstance``
+fallback in case a future SDK revision starts returning concrete
+Pydantic models.
+
+Lifecycle: ``open()`` enters the v2 connect context and starts a
+background reader task that drains ``recv()`` into an internal queue.
+``send()`` forwards Twilio mulaw bytes via ``send_media``.
+``events()`` is an async generator yielding STTEvents until
+``close()``. ``close()`` cancels the reader, sends close-stream, and
+exits the context manager.
 """
 
 from __future__ import annotations
@@ -87,28 +96,32 @@ def _resolve_keyterms(
     return None
 
 
-def _confidence_from_words(turn_info: ListenV2TurnInfo) -> float:
+def _confidence_from_words_payload(words: Any) -> float:
     """Average word-level confidence as a single transcript confidence.
 
-    Flux exposes per-word confidence (Nova-2 only exposed per-utterance).
-    Averaging gives the consumer a single 0-1 value to drive the
-    consecutive-low-confidence transfer-trigger heuristic.
-
-    Falls back to end-of-turn confidence when the words list is empty,
-    and to 1.0 (worst-case-visible) if neither is present.
+    Accepts either a list of pydantic ``ListenV2TurnInfoWordsItem``
+    instances (attribute access) or a list of plain dicts (key access),
+    which is what Flux's ``recv()`` returns when ``construct_type``
+    falls through to the raw JSON path. Returns 1.0 as the
+    worst-case-visible default when no per-word confidence is
+    available — picking 0.0 would mask genuine low-confidence turns.
     """
-    words = getattr(turn_info, "words", None) or []
-    if words:
-        try:
-            return sum(float(w.confidence) for w in words) / len(words)
-        except (AttributeError, TypeError, ValueError):
-            pass
-    eot = getattr(turn_info, "end_of_turn_confidence", None)
-    if eot is not None:
-        try:
-            return float(eot)
-        except (TypeError, ValueError):
-            pass
+    if not words:
+        return 1.0
+    try:
+        confs: list[float] = []
+        for w in words:
+            if isinstance(w, dict):
+                c = w.get("confidence")
+            else:
+                c = getattr(w, "confidence", None)
+            if c is None:
+                continue
+            confs.append(float(c))
+        if confs:
+            return sum(confs) / len(confs)
+    except (TypeError, ValueError):
+        pass
     return 1.0
 
 
@@ -168,55 +181,99 @@ class DeepgramSTT:
         ``recv()`` blocks until the next message; the background task
         translates each one into a common-named event and enqueues it
         for the consumer. The task ends when the connection closes
-        (recv raises) or when ``close()`` cancels it.
+        (``recv`` raises) or when ``close()`` cancels it. The
+        ``msg_count`` in the cancelled/crashed logs gives the postmortem
+        a quick read on how many wire messages were actually delivered.
         """
+        msg_count = 0
         try:
             while True:
                 msg = await self._conn.recv()
+                msg_count += 1
                 self._translate(msg)
         except asyncio.CancelledError:
+            logger.info(
+                "deepgram reader cancelled call_sid=%s msg_count=%d",
+                self._call_sid,
+                msg_count,
+            )
             raise
         except Exception as exc:
             logger.exception(
-                "deepgram reader crashed call_sid=%s", self._call_sid
+                "deepgram reader crashed call_sid=%s msg_count=%d",
+                self._call_sid,
+                msg_count,
             )
             self._queue.put_nowait(_ErrorBox(exc))
 
     def _translate(self, msg: Any) -> None:
         """Translate one Flux wire message into a common-named event.
 
-        Drops messages that have no consumer-visible meaning (Connected
-        is lifecycle; unknown TurnInfo.event values are no-ops).
+        The SDK's ``recv()`` returns ``dict`` for typed messages because
+        ``construct_type`` on a Union doesn't pick a discriminator and
+        falls through to returning the raw JSON dict. We route on the
+        ``type`` field of the dict and keep the Pydantic-class
+        ``isinstance`` branches as a safety net for any future SDK
+        version that does parse Union members into concrete classes.
         """
-        if isinstance(msg, ListenV2Connected):
-            logger.info(
-                "deepgram connected call_sid=%s request_id=%s",
+        # Normalize: extract a ``type`` discriminator from either a
+        # dict or a typed model.
+        if isinstance(msg, dict):
+            msg_type = msg.get("type")
+            getter = msg.get
+        elif isinstance(
+            msg,
+            (
+                ListenV2Connected,
+                ListenV2TurnInfo,
+                ListenV2ConfigureFailure,
+                ListenV2FatalError,
+            ),
+        ):
+            msg_type = getattr(msg, "type", None) or type(msg).__name__.replace(
+                "ListenV2", ""
+            )
+
+            def getter(key, default=None, _msg=msg):
+                return getattr(_msg, key, default)
+        else:
+            logger.debug(
+                "deepgram unknown message type=%s call_sid=%s",
+                type(msg).__name__,
                 self._call_sid,
-                getattr(msg, "request_id", "?"),
             )
             return
 
-        if isinstance(msg, ListenV2TurnInfo):
-            event = getattr(msg, "event", "")
-            text = (getattr(msg, "transcript", "") or "").strip()
+        if msg_type == "Connected":
+            logger.info(
+                "deepgram connected call_sid=%s request_id=%s",
+                self._call_sid,
+                getter("request_id", "?"),
+            )
+            return
+
+        if msg_type == "TurnInfo":
+            event = getter("event", "")
+            text = (getter("transcript", "") or "").strip()
 
             if event == "StartOfTurn":
                 logger.info(
                     "speech_started call_sid=%s turn=%s",
                     self._call_sid,
-                    getattr(msg, "turn_index", "?"),
+                    getter("turn_index", "?"),
                 )
                 self._queue.put_nowait(SpeechStartedEvent())
                 return
 
             if event == "Update":
                 # Interim transcript. Skip empty payloads — Flux
-                # occasionally sends "" mid-turn (e.g. on barge-in or
-                # silence) and an empty transcript downstream confuses
-                # logging and the low-confidence counter.
+                # streams an "Update" event every ~250ms with a
+                # rolling end_of_turn_confidence even when there's
+                # no speech yet, and an empty transcript downstream
+                # confuses logging and the low-confidence counter.
                 if not text:
                     return
-                confidence = _confidence_from_words(msg)
+                confidence = _confidence_from_words_payload(getter("words", []))
                 logger.info(
                     "transcript [interim] call_sid=%s text=%r",
                     self._call_sid,
@@ -231,7 +288,7 @@ class DeepgramSTT:
                 logger.info(
                     "eager_eot call_sid=%s turn=%s",
                     self._call_sid,
-                    getattr(msg, "turn_index", "?"),
+                    getter("turn_index", "?"),
                 )
                 self._queue.put_nowait(EarlyTurnEndEvent())
                 return
@@ -240,20 +297,18 @@ class DeepgramSTT:
                 logger.info(
                     "turn_resumed call_sid=%s turn=%s",
                     self._call_sid,
-                    getattr(msg, "turn_index", "?"),
+                    getter("turn_index", "?"),
                 )
                 self._queue.put_nowait(TurnResumedEvent())
                 return
 
             if event == "EndOfTurn":
                 if not text:
-                    # Confirmed turn-end with no transcript. Skipping
-                    # would leave the consumer waiting forever for a
-                    # final, so emit an empty final the consumer can
-                    # drop in its own logic. (Twilio call recording
-                    # has produced empty finals on dead-air calls.)
+                    # Confirmed turn-end with no transcript — caller
+                    # said nothing recognizable. Drop; the consumer
+                    # has nothing to act on.
                     return
-                confidence = _confidence_from_words(msg)
+                confidence = _confidence_from_words_payload(getter("words", []))
                 logger.info(
                     "transcript [final] call_sid=%s text=%r",
                     self._call_sid,
@@ -274,20 +329,21 @@ class DeepgramSTT:
             )
             return
 
-        if isinstance(msg, (ListenV2ConfigureFailure, ListenV2FatalError)):
+        if msg_type in ("ConfigureFailure", "FatalError"):
             logger.error(
-                "deepgram error call_sid=%s msg=%s", self._call_sid, msg
+                "deepgram error call_sid=%s msg_type=%s msg=%s",
+                self._call_sid,
+                msg_type,
+                msg,
             )
             self._queue.put_nowait(
                 _ErrorBox(RuntimeError(f"deepgram error: {msg}"))
             )
             return
 
-        # Some other shape — keep going. The SDK occasionally surfaces
-        # raw protocol frames; logging is enough.
         logger.debug(
-            "deepgram unknown message type=%s call_sid=%s",
-            type(msg).__name__,
+            "deepgram unknown message type=%r call_sid=%s",
+            msg_type,
             self._call_sid,
         )
 

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -1,8 +1,31 @@
-"""Deepgram Nova live STT implementation.
+"""Deepgram Flux live STT implementation.
 
-Implements the STTProvider contract from app/stt/base.py. Bridges
-Deepgram SDK's callback-based API onto the async-iterator interface
-the router consumer expects, via one internal asyncio.Queue.
+Implements the STTProvider contract from app/stt/base.py. Uses
+``AsyncDeepgramClient.listen.v2.connect`` (Flux v2 API) and translates
+Flux's ``ListenV2TurnInfo`` events into the vendor-neutral common-named
+events the consumer expects.
+
+Translation map (Flux ``TurnInfo.event`` → common-named event):
+
+    | TurnInfo.event   | Common-named             |
+    |------------------|--------------------------|
+    | "Update"         | TranscriptEvent(is_final=False)
+    | "StartOfTurn"    | SpeechStartedEvent
+    | "EagerEndOfTurn" | EarlyTurnEndEvent
+    | "TurnResumed"    | TurnResumedEvent
+    | "EndOfTurn"      | TranscriptEvent(is_final=True)
+
+``EarlyTurnEndEvent`` and ``TurnResumedEvent`` are emitted but the
+session-loop consumer drops them in this PR. They exist on the wire
+so a follow-up speculative-drafting PR can wire them in without
+changing the protocol.
+
+Lifecycle: ``open()`` enters the v2 connect context, registers a
+background reader task that drains ``recv()`` into an internal queue,
+and returns. ``send()`` forwards Twilio mulaw bytes via
+``send_media``. ``events()`` is an async generator yielding STTEvents
+until ``close()``. ``close()`` cancels the reader, sends close-stream,
+and exits the context manager.
 """
 
 from __future__ import annotations
@@ -10,13 +33,25 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Optional
+from typing import Any, AsyncIterator, Optional, Sequence
 
-from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
+from deepgram import AsyncDeepgramClient
+from deepgram.listen.v2.types import (
+    ListenV2ConfigureFailure,
+    ListenV2Connected,
+    ListenV2FatalError,
+    ListenV2TurnInfo,
+)
 
 from app.config import settings
 from app.deepgram import _api_key
-from app.stt.base import STTEvent, SpeechStartedEvent, TranscriptEvent
+from app.stt.base import (
+    EarlyTurnEndEvent,
+    SpeechStartedEvent,
+    STTEvent,
+    TranscriptEvent,
+    TurnResumedEvent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,88 +61,251 @@ _CLOSED = object()
 
 @dataclass(frozen=True)
 class _ErrorBox:
-    # Deepgram's SDK sometimes passes a plain str to the error callback
-    # (e.g., for protocol-level WS closures) and sometimes an Exception;
-    # we accept either and let the consumer's RuntimeError carry it.
     error: Any
 
 
-def _parse_keyterms(raw: str) -> Optional[list[str]]:
-    """Split STT_KEYTERMS env var into a list, or None when empty."""
-    items = [t.strip() for t in raw.split(",") if t.strip()]
-    return items or None
+def _resolve_keyterms(
+    constructor_keyterms: Optional[Sequence[str]],
+) -> Optional[list[str]]:
+    """Return the keyterm list to send to Flux, or None.
+
+    Precedence:
+      1. STT_KEYTERMS env var (when non-empty) — debug override that
+         REPLACES the heuristic output entirely. Used to A/B specific
+         lists without redeploying.
+      2. The list passed by the caller (computed per-tenant by
+         app.restaurants.keyterms.compute_keyterms).
+      3. None — Flux runs in pure open-domain mode.
+    """
+    env_override = settings.stt_keyterms.strip()
+    if env_override:
+        items = [t.strip() for t in env_override.split(",") if t.strip()]
+        return items or None
+    if constructor_keyterms:
+        items = [t for t in constructor_keyterms if t and t.strip()]
+        return items or None
+    return None
+
+
+def _confidence_from_words(turn_info: ListenV2TurnInfo) -> float:
+    """Average word-level confidence as a single transcript confidence.
+
+    Flux exposes per-word confidence (Nova-2 only exposed per-utterance).
+    Averaging gives the consumer a single 0-1 value to drive the
+    consecutive-low-confidence transfer-trigger heuristic.
+
+    Falls back to end-of-turn confidence when the words list is empty,
+    and to 1.0 (worst-case-visible) if neither is present.
+    """
+    words = getattr(turn_info, "words", None) or []
+    if words:
+        try:
+            return sum(float(w.confidence) for w in words) / len(words)
+        except (AttributeError, TypeError, ValueError):
+            pass
+    eot = getattr(turn_info, "end_of_turn_confidence", None)
+    if eot is not None:
+        try:
+            return float(eot)
+        except (TypeError, ValueError):
+            pass
+    return 1.0
 
 
 class DeepgramSTT:
-    """Live Deepgram Nova STT provider.
+    """Live Deepgram Flux STT provider.
 
-    Lifecycle: ``open()`` opens the live WS and registers SDK callbacks
-    that translate Deepgram events into STTEvents on an internal queue.
-    ``send()`` forwards Twilio media-stream payloads. ``events()`` is an
-    async generator that yields TranscriptEvent and SpeechStartedEvent
-    objects until ``close()`` is called.
+    Constructor accepts an optional ``keyterms`` list — typically the
+    output of ``app.restaurants.keyterms.compute_keyterms`` for the
+    active tenant. When the ``STT_KEYTERMS`` env var is non-empty it
+    REPLACES this list (debug override).
     """
 
-    def __init__(self, *, call_sid: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        *,
+        call_sid: Optional[str] = None,
+        keyterms: Optional[Sequence[str]] = None,
+    ) -> None:
         self._call_sid = call_sid
+        self._keyterms_arg: Optional[list[str]] = (
+            list(keyterms) if keyterms else None
+        )
+        self._client: Any = None
+        self._cm: Any = None
         self._conn: Any = None
+        self._reader: Optional[asyncio.Task] = None
         self._queue: asyncio.Queue = asyncio.Queue()
 
     async def open(self) -> None:
-        dg = DeepgramClient(_api_key())
-        self._conn = dg.listen.asynclive.v("1")
-        self._conn.on(LiveTranscriptionEvents.Transcript, self._on_transcript)
-        self._conn.on(
-            LiveTranscriptionEvents.SpeechStarted, self._on_speech_started
-        )
-        self._conn.on(LiveTranscriptionEvents.Error, self._on_error)
+        # Eager api-key check so the call fails before we hand off to
+        # the SDK with a confusing error message.
+        api_key = _api_key()
 
-        keyterms = _parse_keyterms(settings.stt_keyterms)
+        keyterms = _resolve_keyterms(self._keyterms_arg)
 
-        # endpointing + utterance_end_ms together control how aggressively
-        # Deepgram closes a turn. We picked 800/1000 after a 2026-04-26
-        # Twilight test call where endpointing=300 fired ~7 false barge-ins
-        # in 3 minutes — every micro-pause mid-sentence ("i would like to"
-        # <breath> "have") was treated as a turn ending, and the AI kept
-        # saying "take your time" because it thought the caller had spoken.
-        # 800ms is Deepgram's recommended value for conversational flow;
-        # utterance_end_ms=1000 layers a prosody-aware end-of-utterance
-        # signal on top so we wait for "actually finished" instead of just
-        # "stopped making noise".
-        options = LiveOptions(
+        self._client = AsyncDeepgramClient(api_key=api_key)
+        self._cm = self._client.listen.v2.connect(
             model=settings.stt_model,
             encoding="mulaw",
             sample_rate=8000,
-            channels=1,
-            interim_results=True,
-            endpointing=settings.stt_endpointing_ms,
-            utterance_end_ms=settings.stt_utterance_end_ms,
-            vad_events=True,
             keyterm=keyterms,
         )
-        started = await self._conn.start(options)
-        if not started:
-            raise RuntimeError(
-                f"Deepgram connection failed to start call_sid={self._call_sid}"
+        try:
+            self._conn = await self._cm.__aenter__()
+        except Exception:
+            # Connect itself failed (network, auth, malformed args).
+            # Re-raise so the caller can decide whether to fall back to
+            # voicemail or end the call cleanly.
+            self._cm = None
+            raise
+
+        self._reader = asyncio.create_task(self._read_loop())
+
+    async def _read_loop(self) -> None:
+        """Drain Flux messages into the internal queue.
+
+        ``recv()`` blocks until the next message; the background task
+        translates each one into a common-named event and enqueues it
+        for the consumer. The task ends when the connection closes
+        (recv raises) or when ``close()`` cancels it.
+        """
+        try:
+            while True:
+                msg = await self._conn.recv()
+                self._translate(msg)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.exception(
+                "deepgram reader crashed call_sid=%s", self._call_sid
             )
+            self._queue.put_nowait(_ErrorBox(exc))
+
+    def _translate(self, msg: Any) -> None:
+        """Translate one Flux wire message into a common-named event.
+
+        Drops messages that have no consumer-visible meaning (Connected
+        is lifecycle; unknown TurnInfo.event values are no-ops).
+        """
+        if isinstance(msg, ListenV2Connected):
+            logger.info(
+                "deepgram connected call_sid=%s request_id=%s",
+                self._call_sid,
+                getattr(msg, "request_id", "?"),
+            )
+            return
+
+        if isinstance(msg, ListenV2TurnInfo):
+            event = getattr(msg, "event", "")
+            text = (getattr(msg, "transcript", "") or "").strip()
+
+            if event == "StartOfTurn":
+                logger.info(
+                    "speech_started call_sid=%s turn=%s",
+                    self._call_sid,
+                    getattr(msg, "turn_index", "?"),
+                )
+                self._queue.put_nowait(SpeechStartedEvent())
+                return
+
+            if event == "Update":
+                # Interim transcript. Skip empty payloads — Flux
+                # occasionally sends "" mid-turn (e.g. on barge-in or
+                # silence) and an empty transcript downstream confuses
+                # logging and the low-confidence counter.
+                if not text:
+                    return
+                confidence = _confidence_from_words(msg)
+                logger.info(
+                    "transcript [interim] call_sid=%s text=%r",
+                    self._call_sid,
+                    text,
+                )
+                self._queue.put_nowait(
+                    TranscriptEvent(text=text, is_final=False, confidence=confidence)
+                )
+                return
+
+            if event == "EagerEndOfTurn":
+                logger.info(
+                    "eager_eot call_sid=%s turn=%s",
+                    self._call_sid,
+                    getattr(msg, "turn_index", "?"),
+                )
+                self._queue.put_nowait(EarlyTurnEndEvent())
+                return
+
+            if event == "TurnResumed":
+                logger.info(
+                    "turn_resumed call_sid=%s turn=%s",
+                    self._call_sid,
+                    getattr(msg, "turn_index", "?"),
+                )
+                self._queue.put_nowait(TurnResumedEvent())
+                return
+
+            if event == "EndOfTurn":
+                if not text:
+                    # Confirmed turn-end with no transcript. Skipping
+                    # would leave the consumer waiting forever for a
+                    # final, so emit an empty final the consumer can
+                    # drop in its own logic. (Twilio call recording
+                    # has produced empty finals on dead-air calls.)
+                    return
+                confidence = _confidence_from_words(msg)
+                logger.info(
+                    "transcript [final] call_sid=%s text=%r",
+                    self._call_sid,
+                    text,
+                )
+                self._queue.put_nowait(
+                    TranscriptEvent(text=text, is_final=True, confidence=confidence)
+                )
+                return
+
+            # Unknown event — log and drop. New Flux versions may add
+            # event types we haven't taught the translator about; we'd
+            # rather no-op than crash the call.
+            logger.debug(
+                "deepgram unknown turn_info event=%r call_sid=%s",
+                event,
+                self._call_sid,
+            )
+            return
+
+        if isinstance(msg, (ListenV2ConfigureFailure, ListenV2FatalError)):
+            logger.error(
+                "deepgram error call_sid=%s msg=%s", self._call_sid, msg
+            )
+            self._queue.put_nowait(
+                _ErrorBox(RuntimeError(f"deepgram error: {msg}"))
+            )
+            return
+
+        # Some other shape — keep going. The SDK occasionally surfaces
+        # raw protocol frames; logging is enough.
+        logger.debug(
+            "deepgram unknown message type=%s call_sid=%s",
+            type(msg).__name__,
+            self._call_sid,
+        )
 
     async def send(self, audio: bytes) -> None:
         if self._conn is None:
             return
         try:
-            await self._conn.send(audio)
+            await self._conn.send_media(audio)
         except Exception:
-            # Connection-level send failure: log and continue. The next
-            # transcript will be incomplete; the silence watchdog absorbs
-            # the resulting gap.
+            # Connection-level send failure: log and continue. The
+            # next transcript will be incomplete; the silence
+            # watchdog absorbs the resulting gap.
             logger.exception(
                 "deepgram send failed call_sid=%s — call continues",
                 self._call_sid,
             )
 
     def events(self) -> AsyncIterator[STTEvent]:
-        # Plain def: callers want to "async for" on the result, not "await"
-        # it first. The actual generator lives in _events_impl below.
         return self._events_impl()
 
     async def _events_impl(self) -> AsyncIterator[STTEvent]:
@@ -116,61 +314,44 @@ class DeepgramSTT:
             if item is _CLOSED:
                 return
             if isinstance(item, _ErrorBox):
-                # Preserve cause when the SDK passed an actual exception so
-                # production tracebacks chain back to the original failure.
-                # Tests sometimes pass a plain string — guard with isinstance.
-                cause = item.error if isinstance(item.error, BaseException) else None
+                cause = (
+                    item.error if isinstance(item.error, BaseException) else None
+                )
                 raise RuntimeError(f"deepgram error: {item.error}") from cause
             yield item
 
     async def close(self) -> None:
+        # Stop the reader first so it doesn't see the close-stream
+        # turn-around as a crash and enqueue a spurious _ErrorBox.
+        if self._reader and not self._reader.done():
+            self._reader.cancel()
+            try:
+                await self._reader
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception(
+                    "deepgram reader cleanup failed call_sid=%s",
+                    self._call_sid,
+                )
+
         if self._conn is not None:
             try:
-                await self._conn.finish()
+                await self._conn.send_close_stream()
+            except Exception:
+                # Socket already gone — exit the context manager
+                # anyway so resources are released.
+                logger.debug(
+                    "deepgram send_close_stream failed (likely already closed) call_sid=%s",
+                    self._call_sid,
+                )
+
+        if self._cm is not None:
+            try:
+                await self._cm.__aexit__(None, None, None)
             except Exception:
                 logger.exception(
                     "deepgram finish failed call_sid=%s", self._call_sid
                 )
+
         self._queue.put_nowait(_CLOSED)
-
-    # SDK callbacks ---------------------------------------------------
-    async def _on_transcript(self, _dg_handle: Any, result: Any, **_kwargs: Any) -> None:
-        # Deepgram passes the connection handle as the first arg to bound
-        # handlers in addition to self; we ignore it.
-        alt = result.channel.alternatives[0]
-        text = alt.transcript.strip()
-        if not text:
-            return
-        # Replace None with 1.0 (not 0.0) so callers see worst-case
-        # misheard turns explicitly when Deepgram does provide confidence.
-        raw_confidence = getattr(alt, "confidence", 1.0)
-        confidence = 1.0 if raw_confidence is None else raw_confidence
-
-        is_final = bool(result.is_final)
-        label = "final" if is_final else "interim"
-        logger.info(
-            "transcript [%s] call_sid=%s text=%r", label, self._call_sid, text
-        )
-
-        self._queue.put_nowait(
-            TranscriptEvent(text=text, is_final=is_final, confidence=confidence)
-        )
-
-    async def _on_speech_started(
-        self, _dg_handle: Any, _event: Any = None, **_kwargs: Any
-    ) -> None:
-        # Deepgram's SDK calls _on_transcript and _on_error with
-        # (handle, payload), but SpeechStarted is invoked with just
-        # (handle) — no second positional arg. The `_event=None` default
-        # tolerates both shapes. Removing the default crashes the live
-        # SDK at runtime even though the unit test passes (the test was
-        # explicitly supplying a second arg, hiding the real SDK calling
-        # convention).
-        logger.info("speech_started call_sid=%s", self._call_sid)
-        self._queue.put_nowait(SpeechStartedEvent())
-
-    async def _on_error(self, _dg_handle: Any, error: Any, **_kwargs: Any) -> None:
-        # Deepgram passes the connection handle as the first arg to bound
-        # handlers in addition to self; we ignore it.
-        logger.error("deepgram error call_sid=%s error=%s", self._call_sid, error)
-        self._queue.put_nowait(_ErrorBox(error))

--- a/app/restaurants/keyterms.py
+++ b/app/restaurants/keyterms.py
@@ -1,0 +1,124 @@
+"""Per-tenant keyterm computation for Deepgram Flux STT.
+
+Flux exposes a ``keyterm`` parameter on its v2 connect API that biases
+recognition toward menu-specific vocabulary. Without it, every call is
+open-domain English and items like "Coke" or "Pepper Shrimp" lose to
+acoustically-similar everyday phrases ("smoke", "pepper soup").
+
+Deepgram caps the keyterm payload at 500 tokens across all terms per
+request. Token here means a sub-word vocabulary unit; we approximate
+it with ``ceil(word_count * 1.3)`` because the tokenizer is not
+public. The 50-token safety margin under the 500 cap absorbs the
+heuristic's slop.
+
+This module is intentionally a pure function over a menu dict. No
+Firestore reads, no settings reads, no logging — the caller owns
+all of that. Keeps the heuristic deterministic and trivially testable.
+"""
+
+from __future__ import annotations
+
+from math import ceil
+from typing import Any
+
+# Items the model recognizes reliably without keyterm bias. Lowercase
+# substrings; if a menu item's name contains one of these, we skip it
+# to save token budget for items that actually need biasing. The list
+# is intentionally short — when in doubt, include the term and let
+# Flux's tokenizer absorb a few wasted tokens.
+_COMMON_SAFE_TERMS = frozenset(
+    {
+        "french fries",
+        "chicken wings",
+        "caesar salad",
+        "garlic bread",
+        "ice cream",
+        "spring roll",
+        "shrimp roll",
+        "vegetable spring roll",
+        "fried rice",
+    }
+)
+
+# Conservative token estimate. Deepgram's tokenizer isn't public; a
+# 1.3x word multiplier slightly overestimates so the safety margin
+# accommodates terms with sub-word splits like "Bánh Mì".
+_TOKENS_PER_WORD = 1.3
+
+# Target budget. Flux's hard cap is 500 tokens; the 50-token margin
+# protects against heuristic underestimation.
+_TOKEN_BUDGET = 450
+
+
+def _estimate_tokens(term: str) -> int:
+    """Rough sub-word token count. Always returns at least 1."""
+    words = term.split()
+    if not words:
+        return 0
+    return max(1, ceil(len(words) * _TOKENS_PER_WORD))
+
+
+def _is_common_safe_term(name: str) -> bool:
+    """True iff the name contains a substring the model recognizes
+    reliably without bias. Substring match avoids forcing the safe
+    list to enumerate every variant ('Spicy French Fries' is also
+    safe because it contains 'french fries')."""
+    name_lower = name.lower()
+    return any(safe in name_lower for safe in _COMMON_SAFE_TERMS)
+
+
+def compute_keyterms(menu: dict[str, Any], restaurant_name: str) -> list[str]:
+    """Build a Flux keyterm list for one restaurant.
+
+    Returns ``restaurant_name`` first (always — the caller may say it
+    when greeting), then menu item names in menu order, skipping items
+    in the common-safe set and items that duplicate something already
+    included (case-insensitive). Stops at the first item whose addition
+    would push the running token estimate over the budget — remaining
+    items get no bias on this call.
+
+    Pathological input where ``restaurant_name`` alone exceeds budget:
+    return only ``[restaurant_name]`` — the caller is responsible for
+    deciding whether that's acceptable. Returning an empty list would
+    mean *no* bias at all, which is worse.
+    """
+    name_tokens = _estimate_tokens(restaurant_name)
+    if name_tokens >= _TOKEN_BUDGET:
+        # Name alone exceeds the budget. Return as-is and let the
+        # caller log/triage; producing an empty list would silently
+        # drop biasing for the caller-spoken restaurant name.
+        return [restaurant_name]
+
+    terms: list[str] = [restaurant_name]
+    used_tokens = name_tokens
+    seen: set[str] = {restaurant_name.lower()}
+
+    for category_key, items in menu.items():
+        if isinstance(category_key, str) and category_key.startswith("_"):
+            # Reserved keys like _category_order. Skip — they aren't
+            # category lists and would crash isinstance(items, list).
+            continue
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            name = (item.get("name") or "").strip()
+            if not name:
+                continue
+            name_lower = name.lower()
+            if name_lower in seen:
+                continue
+            if _is_common_safe_term(name):
+                continue
+            cost = _estimate_tokens(name)
+            if used_tokens + cost > _TOKEN_BUDGET:
+                # We've hit the budget — stop emitting. Any items we
+                # haven't reached yet simply don't get biased on this
+                # call. The caller can decide whether to log this.
+                return terms
+            terms.append(name)
+            used_tokens += cost
+            seen.add(name_lower)
+
+    return terms

--- a/app/stt/__init__.py
+++ b/app/stt/__init__.py
@@ -6,9 +6,9 @@ TranscriptEvent`` instead of reaching into ``app.stt.base``.
 
 from app.stt.base import (
     EarlyTurnEndEvent,
+    SpeechStartedEvent,
     STTEvent,
     STTProvider,
-    SpeechStartedEvent,
     TranscriptEvent,
     TurnResumedEvent,
 )

--- a/app/stt/__init__.py
+++ b/app/stt/__init__.py
@@ -24,12 +24,22 @@ __all__ = [
 ]
 
 
-def get_stt(*, call_sid: str | None = None) -> tuple["STTProvider", str]:
+def get_stt(
+    *,
+    call_sid: str | None = None,
+    keyterms: "list[str] | None" = None,
+) -> tuple["STTProvider", str]:
     """Return the configured STT provider plus its name.
 
-    The name is returned alongside the provider so the caller (the router
-    consumer) can include ``provider`` metadata in events when desired,
-    without the plugin needing to know its own name.
+    ``keyterms`` (when provided) is forwarded to providers that support
+    biased recognition; the Deepgram Flux provider uses it to pre-bias
+    against the active tenant's menu vocabulary. Providers that don't
+    support keyterms ignore the argument — callers can always pass it
+    safely.
+
+    The provider name is returned alongside the provider so the caller
+    (the router consumer) can include ``provider`` metadata in events
+    when desired, without the plugin needing to know its own name.
     """
     from app.config import settings
 
@@ -37,5 +47,5 @@ def get_stt(*, call_sid: str | None = None) -> tuple["STTProvider", str]:
     if name == "deepgram":
         from app.deepgram.stt import DeepgramSTT
 
-        return DeepgramSTT(call_sid=call_sid), name
+        return DeepgramSTT(call_sid=call_sid, keyterms=keyterms), name
     raise ValueError(f"Unknown STT provider: {name}")

--- a/app/stt/__init__.py
+++ b/app/stt/__init__.py
@@ -5,17 +5,21 @@ TranscriptEvent`` instead of reaching into ``app.stt.base``.
 """
 
 from app.stt.base import (
+    EarlyTurnEndEvent,
     STTEvent,
     STTProvider,
     SpeechStartedEvent,
     TranscriptEvent,
+    TurnResumedEvent,
 )
 
 __all__ = [
+    "EarlyTurnEndEvent",
     "STTEvent",
     "STTProvider",
     "SpeechStartedEvent",
     "TranscriptEvent",
+    "TurnResumedEvent",
     "get_stt",
 ]
 

--- a/app/stt/base.py
+++ b/app/stt/base.py
@@ -32,7 +32,30 @@ class TranscriptEvent:
     confidence: float
 
 
-STTEvent = Union[TranscriptEvent, SpeechStartedEvent]
+@dataclass(frozen=True)
+class EarlyTurnEndEvent:
+    """The provider speculates the caller's turn is ending. A consumer
+    that wants minimal-latency replies may use this to start drafting
+    speculatively; a ``TurnResumedEvent`` will follow if the caller
+    keeps talking. Providers without prosody-aware turn detection (e.g.
+    Whisper) never emit this event — consumers must treat it as
+    advisory and tolerate its absence."""
+
+
+@dataclass(frozen=True)
+class TurnResumedEvent:
+    """The caller resumed speaking after an ``EarlyTurnEndEvent``. A
+    consumer that started speculative work in response to the eager
+    end should cancel it. Providers that do not emit
+    ``EarlyTurnEndEvent`` will likewise never emit this event."""
+
+
+STTEvent = Union[
+    TranscriptEvent,
+    SpeechStartedEvent,
+    EarlyTurnEndEvent,
+    TurnResumedEvent,
+]
 
 
 class STTProvider(Protocol):

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -23,6 +23,7 @@ from app.config import settings
 from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
 from app.orders.models import Order
+from app.restaurants.keyterms import compute_keyterms
 from app.restaurants.open_check import is_open_now
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
@@ -419,7 +420,24 @@ async def media_stream(websocket: WebSocket) -> None:
                         kind="start",
                         detail={"stream_sid": state.stream_sid or ""},
                     )
-                state.stt, state.stt_provider = get_stt(call_sid=state.call_sid)
+                # Compute per-tenant keyterms from the loaded menu and
+                # log them once so the call audit has a record of what
+                # was biased. Empty list when the menu is unusably thin
+                # — the heuristic always includes the restaurant name
+                # at minimum, so the list is never literally empty.
+                keyterms = compute_keyterms(
+                    state.restaurant.menu, state.restaurant.name
+                )
+                logger.info(
+                    "keyterms call_sid=%s rid=%s n=%d preview=%r",
+                    state.call_sid,
+                    state.restaurant.id,
+                    len(keyterms),
+                    keyterms[:5],
+                )
+                state.stt, state.stt_provider = get_stt(
+                    call_sid=state.call_sid, keyterms=keyterms
+                )
                 try:
                     await state.stt.open()
                 except Exception:

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -19,6 +19,7 @@ import logging
 
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
 
+import app.twilio as app_twilio
 from app.config import settings
 from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
@@ -29,12 +30,12 @@ from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.stt import get_stt
 from app.telephony.session import (
-    GREETING_TRANSCRIPT,
     END_OF_CALL_MARK,
-    _CallState,
+    GREETING_TRANSCRIPT,
     _abort_pending_hangup,
     _arm_silence_watchdog,
     _bg_call_event,
+    _CallState,
     _cancel_silence_task,
     _consume_transcripts,
     _hang_up_after_grace,
@@ -45,7 +46,6 @@ from app.telephony.session import (
 )
 from app.telephony.voicemail_twiml import voicemail_response
 from app.tts import speak
-import app.twilio as app_twilio
 from app.twilio.twiml import (
     closed_hangup_twiml,
     empty_twiml,

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -30,8 +30,8 @@ from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
 from app.stt import (
     EarlyTurnEndEvent,
-    STTProvider,
     SpeechStartedEvent,
+    STTProvider,
     TranscriptEvent,
     TurnResumedEvent,
 )

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -28,7 +28,13 @@ from app.restaurants.models import Restaurant
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
-from app.stt import STTProvider, SpeechStartedEvent
+from app.stt import (
+    EarlyTurnEndEvent,
+    STTProvider,
+    SpeechStartedEvent,
+    TranscriptEvent,
+    TurnResumedEvent,
+)
 from app.tts import speak
 from app.twilio.media_stream import send_clear, send_mark
 
@@ -345,35 +351,58 @@ async def _consume_transcripts(
     try:
         async for event in stt.events():
             if isinstance(event, SpeechStartedEvent):
-                # Instant barge-in: fire ~50ms after the caller starts
-                # speaking instead of waiting for the final transcript
-                # (~800-1800ms). The final-transcript path in
-                # _handle_final_transcript still runs as a fallback for
-                # short utterances or missed VAD signals.
+                # Instant barge-in: fire as soon as the STT provider
+                # reports the caller began speaking (Flux:
+                # TurnInfo.event="StartOfTurn") instead of waiting for
+                # the confirmed final transcript. The final-transcript
+                # path in _handle_final_transcript still runs as a
+                # fallback for short utterances or missed VAD signals.
                 if not settings.stt_instant_barge_in:
                     continue
                 if state.llm_task and not state.llm_task.done():
                     await _barge_in_now(state, websocket, trigger="vad")
                 continue
 
-            # event is a TranscriptEvent
-            if not event.is_final:
-                continue   # interim: captured in plugin logs only
+            if isinstance(event, (EarlyTurnEndEvent, TurnResumedEvent)):
+                # Speculative end-of-turn signals from Flux. The
+                # speculative-drafting work that consumes them lives
+                # in a separate follow-up PR; for now we drop them
+                # to keep behavior identical to today.
+                continue
 
-            state.last_caller_transcript = event.text
-            if event.confidence < 0.5:
-                state.consecutive_low_confidence_turns += 1
-            else:
-                state.consecutive_low_confidence_turns = 0
+            if isinstance(event, TranscriptEvent):
+                if not event.is_final:
+                    continue  # interim: captured in plugin logs only
 
-            _bg_call_event(
+                state.last_caller_transcript = event.text
+                if event.confidence < 0.5:
+                    state.consecutive_low_confidence_turns += 1
+                else:
+                    state.consecutive_low_confidence_turns = 0
+
+                _bg_call_event(
+                    state.call_sid,
+                    _state_rid(state),
+                    kind="transcript_final",
+                    text=event.text,
+                    detail={
+                        "text": event.text,
+                        "confidence": event.confidence,
+                    },
+                )
+                await _handle_final_transcript(
+                    event.text, state, websocket
+                )
+                continue
+
+            # Unknown event type — providers may extend the event union
+            # in the future. Log once and keep going rather than crash
+            # the call.
+            logger.debug(
+                "stt: unknown event type=%s call_sid=%s",
+                type(event).__name__,
                 state.call_sid,
-                _state_rid(state),
-                kind="transcript_final",
-                text=event.text,
-                detail={"text": event.text, "confidence": event.confidence},
             )
-            await _handle_final_transcript(event.text, state, websocket)
     except asyncio.CancelledError:
         raise
     except Exception as exc:

--- a/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-investigation.md
+++ b/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-investigation.md
@@ -1,0 +1,222 @@
+# Deepgram Flux STT — Investigation Summary
+
+**Date:** 2026-05-06
+**Author:** Sandeep (with Claude, research-only session — no code changes)
+**Status:** Direction agreed; not yet implemented. Hand off to next agent for spec → plan → implementation.
+
+---
+
+## Context
+
+Real-world STT errors on recent calls (no logs retained, anecdotal from Sandeep):
+- "**coke**" misheard as "**smoke**"
+- "**pepper shrimp**" misheard as "**pepper soup**"
+
+These are textbook acoustic-confusability cases on phone audio (mulaw 8 kHz band-limits to ~3.4 kHz, sibilants degrade). The root cause is that our STT has no language-model prior for "this is a restaurant ordering call for *this menu*" — it picks the more common everyday English phrase over the menu term.
+
+We did a research/thinking session to evaluate what Deepgram offers to fix this and improve the voice-agent stack overall. Scope was deliberately Deepgram-only (sticking with our incumbent vendor).
+
+## Current state (what `niko` ships today)
+
+`app/deepgram/stt.py` + `app/config.py:40-46`:
+
+| Setting | Value |
+|---|---|
+| Model | `nova-2` |
+| Endpoint | `wss://api.deepgram.com/v1/listen` (`dg.listen.asynclive.v("1")`) |
+| Encoding | mulaw, 8 kHz mono (Twilio media-stream native) |
+| `interim_results` | true |
+| `endpointing_ms` | 800 (silence-based turn end) |
+| `utterance_end_ms` | 1000 (prosody-aware end-of-utterance) |
+| `vad_events` | true → drives `SpeechStartedEvent` for instant barge-in |
+| `keyterm` | env-driven, **empty by default** |
+
+Turn-taking and barge-in live in `app/telephony/router.py` as a hand-rolled state machine layered on top of those Deepgram parameters and events.
+
+### Critical bug-in-spirit
+
+**Nova-2 silently ignores the `keyterm` parameter.** Keyterm prompting is Nova-3+ only (config.py:45 even comments this). The plumbing is wired but the model selection means it's a no-op. So today we have *no* mechanism to bias recognition toward menu vocabulary — every call is open-domain English.
+
+## What's on the table from Deepgram
+
+| Feature | What it does | Verdict for niko |
+|---|---|---|
+| **Nova-3 mono** | Newer model, supports keyterm prompting | Solves menu accuracy; doesn't change turn-taking latency |
+| **Nova-3 multi** | 45+ languages, code-switching | Nice-to-have; defer unless tenant needs it |
+| **Flux mono (`flux-general-en`)** | Nova-3-quality STT + native turn detection (~260 ms) + native barge-in | **Chosen path** |
+| **Flux multi (`flux-general-multi`)** | Flux + ~10 languages | Defer — not enough language coverage to justify cost premium today |
+| **`numerals=true`** | "two" → "2" in transcripts | Cheap orthogonal win, applicable on any model |
+| **`smart_format=true`** | Auto-format prices, phone numbers, addresses | Tradeoff vs LLM word-form parsing; A/B later |
+| **Word-level timestamps** | Per-word start/end | Could enable mid-word TTS interrupt; nice-to-have |
+| **Pre-recorded Listen API** | Post-call summarization, sentiment, topic detection | Future dashboard feature; not on critical path |
+| **Diarization** | Speaker separation | Overkill for 1:1 phone calls |
+| **Redaction** | PII/PCI redaction | Only if/when we take card numbers by phone |
+| **Voice Agent API** | Full STT+LLM+TTS bundle | **Reject** — conflicts with our menu-validation LLM and order state machine |
+| **Self-hosted Deepgram** | On-prem deployment | Not relevant at our scale |
+
+## Decision
+
+**Migrate STT from Nova-2 live to Deepgram Flux English mono (`flux-general-en`) with per-tenant keyterm prompting sourced from each restaurant's menu JSON.**
+
+### Why Flux over Nova-3 + keyterms
+
+1. **Flux mono and Nova-3 mono are priced the same.** No premium for Flux's bundled features at the mono tier.
+2. **Native turn detection** at ~260 ms vs our 800–1800 ms hand-rolled approach — meaningful per-turn latency win.
+3. **Native barge-in handling** via `EagerEndOfTurn` / `TurnResumed` events — replaces the custom `vad_events` + `SpeechStartedEvent` plumbing in `router.py`.
+4. **`EagerEndOfTurn`** lets us start drafting the LLM reply *before* the turn fully ends, with `TurnResumed` to cancel the draft if the caller resumes speaking.
+5. **Same recognition quality** as Nova-3 (Flux uses Nova-3 accuracy level), so menu accuracy via keyterms is preserved.
+
+### Why not stay on Nova-2
+
+- Keyterms silently ignored → no fix for `coke→smoke` / `pepper shrimp→pepper soup`.
+- Nova-2 is not on Deepgram's current published pricing page — likely on a deprecation track.
+- We're paying maintenance cost on a model with no forward roadmap.
+
+### Why not Voice Agent API
+
+We have non-trivial menu validation, order-state, and Firestore logic between transcript and LLM. Delegating all of that to a bundled agent would force our prompts and tool-use into Deepgram's orchestration shape — not a tradeoff we want.
+
+## Critical constraint: keyterm token cap
+
+> **"Maximum 500 tokens across all keyterms per request. Exceeding returns: `Keyterm limit exceeded.`"**
+
+Token ≠ word. A "token" is a vocabulary unit (word or sub-word piece). Working heuristic:
+- "Coke" ≈ 1 token
+- "Pepper Shrimp" ≈ 2 tokens
+- "Stir Fry Mixed Vegetables with Tofu" ≈ 6–7 tokens
+- Proper nouns ("Bánh Mì", "Basha") may be more if Deepgram's tokenizer doesn't know them
+
+### Fit check against existing menus
+
+| Menu | Items | Est. tokens | Fits 500-cap? |
+|---|---|---|---|
+| Niko's Pizza demo (`app/menu.py`) | 12 | ~40 | ✅ trivial |
+| Twilight (`restaurants/twilight-family-restaurant.json`) | ~80 | ~370 | ✅ tight but ok |
+| Hypothetical 250-item menu | 250+ | ~1200+ | ❌ needs prioritization |
+
+### Prioritization strategy when cap is hit
+
+When a menu exceeds 500 tokens, rank what to keep:
+
+1. **Acoustically confusable items** (English-collision potential): Pepper Shrimp, Coke, Wonton, Lo-Mein, Chow Mein.
+2. **Proper-noun dishes the model has likely never seen**: Basha, Bánh Mì, Horchata, Tikka Masala.
+3. **Restaurant name** (caller may say it).
+4. **Brand drink names** (Coke, Sprite, etc.).
+5. **Common modifiers**: "extra spicy", "no", "side of", "half", "whole".
+6. **Skip** items the model gets right cold (French Fries, Chicken Wings, Caesar Salad).
+7. **Skip duplicates** — if "Pepper Shrimp" is in, "Pepper Shrimp Fried Rice" probably isn't needed (bigram already biased).
+
+This is a pure function: `(menu_dict, restaurant_name) → list[str]` capped at 500 tokens. Natural home: `app/restaurants/keyterms.py`.
+
+## Pricing summary
+
+Two AI-summary sources during this session disagreed on absolute numbers but agreed on relative ordering. **Verify in a browser before commitment.**
+
+| Tier | Source A ($/min PAYG) | Source B ($/min PAYG) |
+|---|---|---|
+| Nova-2 streaming | not on page | $0.0058 |
+| Nova-3 mono streaming | $0.0048 | $0.0077 |
+| Nova-3 multi streaming | $0.0058 | $0.0092 |
+| **Flux mono streaming** | **$0.0065** | **$0.0077** |
+| Flux multi streaming | $0.0078 | — |
+
+Either way:
+- Flux mono ≈ Nova-3 mono (same tier or near it).
+- Flux is pennies/call premium over Nova-2 even in the more expensive estimate.
+- Free $200 credit (no expiration) easily covers an A/B test before committing.
+- Aura-2 TTS at $0.030/1k chars often costs more per call than STT — TTS, not STT, dominates the per-call Deepgram bill.
+
+## Implementation surface (sketch — for the next agent to refine)
+
+### SDK shape
+
+Today (`app/deepgram/stt.py:57-58`):
+```python
+dg = DeepgramClient(_api_key())
+self._conn = dg.listen.asynclive.v("1")
+self._conn.on(LiveTranscriptionEvents.Transcript, self._on_transcript)
+# ... start(options), send(audio), finish()
+```
+
+Flux:
+```python
+from deepgram import AsyncDeepgramClient
+from deepgram.core.events import EventType
+from deepgram.listen.v2.types import ListenV2TurnInfo
+
+client = AsyncDeepgramClient()  # picks up DEEPGRAM_API_KEY from env
+
+async with client.listen.v2.connect(
+    model="flux-general-en",
+    encoding="mulaw",
+    sample_rate=8000,
+    keyterm=[...],  # per-tenant, ≤500 tokens
+) as connection:
+    connection.on(EventType.MESSAGE, on_message)
+    # events: Connected, TurnInfo, EagerEndOfTurn, TurnResumed, Close
+```
+
+Package: `deepgram-sdk` (already in `requirements.txt`). **Verify minimum version exposes `AsyncDeepgramClient` and `listen.v2`** — current code uses the older `DeepgramClient` façade.
+
+### Files that change
+
+| File | Change |
+|---|---|
+| `app/deepgram/stt.py` | Rewrite for Flux (`AsyncDeepgramClient.listen.v2.connect`, new event vocabulary) |
+| `app/stt/base.py` | Extend `STTProvider` protocol — add `EndOfTurnEvent`, `EagerEndOfTurnEvent`, `TurnResumedEvent` |
+| `app/telephony/router.py` | Delegate turn detection + barge-in to Flux events; remove or deprecate the hand-rolled state machine layered on `endpointing_ms` / `utterance_end_ms` / `SpeechStartedEvent` |
+| `app/config.py` | Add `stt_provider="deepgram-flux"` option (or similar). Deprecate or remove `stt_endpointing_ms` / `stt_utterance_end_ms` once Flux owns turn detection |
+| `app/restaurants/keyterms.py` | **New.** Pure function `(menu_dict, restaurant_name) → list[str]` capped at 500 tokens, with confusability-based prioritization |
+| `app/restaurants/menu_writes.py` | Optionally compute and cache keyterm list at menu-write time (vs. recomputing per-call) |
+| `tests/test_stt_deepgram.py` | New tests for Flux event handling; keep backward-compat tests for Nova-2 path during rollout if we keep it env-flagged |
+| `tests/` (new) | Test for `app/restaurants/keyterms.py` — token-budget ranking, edge cases |
+| `requirements.txt` | Possibly bump `deepgram-sdk` minimum version |
+| `.env.example` | Document `STT_PROVIDER=deepgram-flux` and any new env vars |
+
+### Rollout plan (suggested)
+
+1. Land the Flux provider behind an env flag (`STT_PROVIDER=deepgram-flux` vs current `deepgram`).
+2. Run both side-by-side on a small fraction of calls; compare:
+   - Menu-term recognition accuracy (the original `coke→smoke` motivation)
+   - End-of-turn latency
+   - Barge-in correctness (false barge-ins, missed barge-ins)
+   - Call duration / TTFT
+3. If green, flip default and remove the Nova-2 path.
+
+## Open questions for the next agent
+
+1. **Live pricing verification** — pull Deepgram's pricing page directly in a browser; resolve the discrepancy between session sources.
+2. **Deepgram tokenizer for keyterm budget** — is there a public way to count tokens, or do we use a conservative heuristic (~1.3 × word count)? `tiktoken` is closer than word-counting but still not exact.
+3. **Flux keyterm cap behavior** — does Flux truncate, error, or silently drop terms when we exceed 500 tokens? (Sandeep's note says it errors; verify.)
+4. **`flux-general-multi` language list** — explicit list of the ~10 languages, mapped against our pilot tenant demand.
+5. **`EagerEndOfTurn` semantics** — exactly when does Flux fire it, and how often does it cancel via `TurnResumed`? (i.e., what fraction of LLM drafts are wasted?) Worth measuring on real calls.
+6. **`deepgram-sdk` min version** — does our current pinned version expose `AsyncDeepgramClient` and `listen.v2`? Check via `pip show deepgram` and the SDK changelog.
+7. **Numerals + smart_format** — should we also turn these on as part of the migration, or hold them as separate experiments?
+8. **Where keyterm computation lives** — at menu-write time (cached on the restaurant doc) or at call-open time (computed in router)? Cache is simpler at runtime; recomputation is simpler at code-change time. Lean: cache at menu-write, recompute on menu update.
+
+## What to keep doing in `router.py` (Flux does NOT do)
+
+- LLM orchestration (Anthropic Claude calls, prompt assembly).
+- Order state machine (item parsing, validation against menu, totals).
+- Firestore writes (call session, order lifecycle, recordings).
+- Twilio integration (TwiML, recording status callbacks, transfer triggers).
+- TTS (Deepgram Aura-2 today — separate product, no Flux change).
+- The fallback case where Flux's turn detection misfires — keep a watchdog timer as defense-in-depth.
+
+## What's settled vs. what's open
+
+**Settled:**
+- Direction is Flux English mono.
+- Per-tenant keyterms from menu JSON.
+- 500-token cap is the design constraint.
+- Voice Agent API is rejected.
+- Nova-2 is the past, not the present.
+
+**Open / needs next-session attention:**
+- All eight items in "Open questions" above.
+- Spec → plan → implementation sequence (this doc is the spec input, not a plan).
+- Whether to bundle `numerals=true` into the same migration or split it.
+
+---
+
+*Hand-off note for the next agent: This is a research summary, not an implementation plan. Use it as input to write a proper spec (and then plan) under `docs/superpowers/specs/` and `docs/superpowers/plans/` following the niko convention. The eight open questions above should be answered before plan-writing starts.*

--- a/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-migration-design.md
+++ b/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-migration-design.md
@@ -9,7 +9,9 @@
 
 ## Summary
 
-Migrate live STT from Deepgram Nova-2 to Deepgram Flux English mono (`flux-general-en`) with per-tenant keyterm prompting computed from each restaurant's menu. Hard cutover — no Nova-2 fallback path is preserved. Bundled with `numerals=true`. `smart_format` stays off.
+Migrate live STT from Deepgram Nova-2 to Deepgram Flux English mono (`flux-general-en`) with per-tenant keyterm prompting computed from each restaurant's menu. Hard cutover — no Nova-2 fallback path is preserved.
+
+> **SDK probe correction (2026-05-06, post-spec):** Flux v2's `connect()` does **not** accept `numerals` or `smart_format` — those are Nova-only. Whatever digit/word formatting Flux produces natively is what we ship. The original "migration + numerals" decision is moot at the API level. `smart_format` was already out of scope.
 
 Flux's prosody-aware turn detection replaces Nova-2's silence-based endpointing, dropping confirmed-final transcript latency from 800–1800ms to ~260ms. Keyterm prompting (silently no-op'd on Nova-2) becomes the mechanism that fixes anecdotal misrecognitions like "coke→smoke" and "pepper shrimp→pepper soup."
 
@@ -39,7 +41,7 @@ Each links back to a question debated during brainstorming.
 | # | Decision | Why |
 |---|---|---|
 | D1 | **Hard cutover.** Replace `app/deepgram/stt.py` outright; delete Nova-2 model selection. Revert path is `git revert`. | Nova-2 is a dead end; one live tenant; 4-person team — dual-provider maintenance cost outweighs A/B safety. |
-| D2 | **Migration + `numerals=true`.** `smart_format=false`. | Numerals are zero-risk for our pipeline (LLM handles either form natively). `smart_format` reshapes more transcript surface and offers no measurable benefit since we don't regex-parse transcripts. |
+| D2 | ~~Migration + `numerals=true`~~. **Superseded by SDK probe:** Flux v2 has no `numerals` flag. Ship Flux's native formatting as-is. `smart_format` similarly out of scope. | Flux's connect signature exposes only `keyterm`, `language_hint`, and EOT thresholds — no Nova-style formatting flags. |
 | D3 | **In-memory keyterm computation at call-open.** Pure function `compute_keyterms(menu, restaurant_name) -> list[str]`; result is logged then handed to Flux's `connect(keyterm=[...])`. No Firestore field, no menu schema change. | Persistence is only valuable when something else reads it; nothing does today. The dashboard PR that introduces an editor is the right place to introduce the schema. |
 | D4 | **Auto-detect heuristic in code, no per-item menu tags.** Restaurant name is auto-included. | Heuristic deploys instantly across all tenants; menu schema stays untouched; Twilight needs no backfill. The investigation doc's prioritization rules drive the heuristic. |
 | D5 | **Common-named events at the protocol layer, vendor translation inside the provider.** `app/stt/base.py` grows from 2 to 4 event types. Flux provider emits all four; Whisper (future) emits two. | Keeps the protocol vendor-neutral; Flux jargon (`EagerEndOfTurn`) does not appear at the seam. |
@@ -87,7 +89,7 @@ async for event in stt.events():
 | `Connected` | (none — lifecycle) | Provider state only. |
 | `TurnInfo(end_of_turn=False)` | `TranscriptEvent(is_final=False)` | Interim, logged only by consumer. |
 | `TurnInfo(end_of_turn=True)` | `TranscriptEvent(is_final=True)` | The committed turn-end. THIS is what triggers `_handle_final_transcript`. |
-| First-speech indication (TBD which Flux signal) | `SpeechStartedEvent` | Fast barge-in path. Implementation-time research item — see "Open items." |
+| `TurnInfo(event="StartOfTurn")` | `SpeechStartedEvent` | Fast barge-in path. (Resolved post-probe: Flux signals turn start via `TurnInfo.event="StartOfTurn"`.) |
 | `EagerEndOfTurn` | `EarlyTurnEndEvent` | Emitted; consumer drops. |
 | `TurnResumed` | `TurnResumedEvent` | Emitted; consumer drops. |
 | `Close` | (none — lifecycle) | Provider state only. |
@@ -100,7 +102,7 @@ async for event in stt.events():
 | `app/stt/base.py` | Add `EarlyTurnEndEvent` and `TurnResumedEvent` dataclasses. Widen `STTEvent` union from 2 to 4 members. Update the docstring on `STTProvider`. |
 | `app/restaurants/keyterms.py` | **NEW.** Pure function `compute_keyterms(menu: dict, restaurant_name: str) -> list[str]`. Heuristic ranks confusables, proper-noun dishes, brand drinks, and common modifiers; restaurant name always included. Capped well under 500 tokens (target ≤450 tokens — 50-token safety margin). See "Keyterm computation" below. |
 | `app/telephony/session.py` | Two changes: (1) call `compute_keyterms` and pass the result into Flux; (2) add the trailing `continue` in the event loop to defensively drop `EarlyTurnEndEvent` / `TurnResumedEvent`. |
-| `app/config.py` | Set `stt_model` default to `flux-general-en`. **Remove** `stt_endpointing_ms` and `stt_utterance_end_ms` (Flux owns turn detection — these have no analog). Keep `stt_keyterms` as a debug override: when non-empty, **replaces** the heuristic output entirely. (Augment-mode is YAGNI; revisit if a tenant-level use case appears.) Add `stt_numerals: bool = True`. |
+| `app/config.py` | Set `stt_model` default to `flux-general-en`. **Remove** `stt_endpointing_ms` and `stt_utterance_end_ms` (Flux owns turn detection — these have no analog). Keep `stt_keyterms` as a debug override: when non-empty, **replaces** the heuristic output entirely. (Augment-mode is YAGNI; revisit if a tenant-level use case appears.) ~~Add `stt_numerals: bool = True`.~~ Per probe correction, no numerals setting. |
 | `requirements.txt` | Bump `deepgram-sdk` minimum version to whatever first exposes `AsyncDeepgramClient` and `listen.v2`. **Verification needed in plan** — current pin is `>=3.0,<4.0` and the local install is 3.11.0; Flux v2 surface likely requires v4. |
 | `tests/test_stt_deepgram.py` | Update fixtures and translation tests for the Flux SDK shape. Add tests for emission of `EarlyTurnEndEvent` and `TurnResumedEvent`. |
 | `tests/test_keyterms.py` | **NEW.** Token-budget cap, restaurant-name inclusion, prioritization edge cases. |
@@ -230,8 +232,8 @@ These need to be resolved during plan-writing or implementation, not before.
 
 | # | Item | Resolution path |
 |---|---|---|
-| O1 | **Which Flux event maps to `SpeechStartedEvent`.** Flux's published event list is `Connected, TurnInfo, EagerEndOfTurn, TurnResumed, Close`. There may be no dedicated "user-speaking-now" event; if so, the first interim `TurnInfo` becomes the trigger (~150-250ms delay vs Nova-2's ~50ms VAD). This may degrade barge-in responsiveness. | Implementation-time empirical check. If degraded beyond acceptable, evaluate whether Flux supports a `vad_events`-equivalent or whether to layer a server-side VAD. |
-| O2 | **`deepgram-sdk` minimum version.** Current pin: `>=3.0,<4.0`; local install: 3.11.0. The investigation cites `AsyncDeepgramClient` and `listen.v2` — likely v4. | Plan: verify via `pip show` + SDK changelog, bump the pin in `requirements.txt`. |
+| O1 | ~~Which Flux event maps to `SpeechStartedEvent`.~~ **Resolved by probe: `TurnInfo.event="StartOfTurn"` fires when a turn begins.** Latency vs Nova-2 VAD's ~50ms still needs measurement on real calls. | Resolved at the API surface; latency comparison is post-merge measurement. |
+| O2 | ~~`deepgram-sdk` minimum version.~~ **Resolved by probe: bump to `>=7.1,<8.0`.** v3 didn't expose `AsyncDeepgramClient`. | Resolved. |
 | O3 | **`Keyterm limit exceeded` error vs silent truncation.** Spec assumes Flux errors. Should be confirmed empirically; if Flux truncates instead, the safety margin is less critical. | Implementation-time. Either way, the conservative budget covers both. |
 | O4 | **Token-counting heuristic accuracy.** `word_count * 1.3` is approximate. | Plan to gate against a small empirical check on Twilight's menu (estimated tokens vs Flux's reported behavior). |
 | O5 | **Pricing verification.** Investigation flagged conflicting per-minute estimates from two summarizer sources; should be confirmed at Deepgram's pricing page before merge so we know the actual per-call delta. | Out-of-band; not a blocker for the plan. |

--- a/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-migration-design.md
+++ b/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-migration-design.md
@@ -1,0 +1,267 @@
+# Deepgram Flux STT Migration — Design
+
+**Date:** 2026-05-06
+**Author:** Sandeep (with Claude)
+**Status:** Spec — ready for plan-writing
+**Companion doc:** [`2026-05-06-deepgram-flux-stt-investigation.md`](./2026-05-06-deepgram-flux-stt-investigation.md) (research summary)
+
+---
+
+## Summary
+
+Migrate live STT from Deepgram Nova-2 to Deepgram Flux English mono (`flux-general-en`) with per-tenant keyterm prompting computed from each restaurant's menu. Hard cutover — no Nova-2 fallback path is preserved. Bundled with `numerals=true`. `smart_format` stays off.
+
+Flux's prosody-aware turn detection replaces Nova-2's silence-based endpointing, dropping confirmed-final transcript latency from 800–1800ms to ~260ms. Keyterm prompting (silently no-op'd on Nova-2) becomes the mechanism that fixes anecdotal misrecognitions like "coke→smoke" and "pepper shrimp→pepper soup."
+
+The existing `STTProvider` protocol in `app/stt/base.py` is widened with two new vendor-neutral event types (`EarlyTurnEndEvent`, `TurnResumedEvent`) so Flux's speculation signals are exposed through the seam — but **this PR's consumer drops them.** Speculative LLM drafting on `EarlyTurnEndEvent` is a separate follow-up PR (see "Out of scope").
+
+## Goals
+
+1. Eliminate the menu-vocabulary recognition gap on Twilight calls.
+2. Replace Nova-2 (no published forward roadmap) with a current-tier Deepgram model.
+3. Reduce confirmed-final transcript latency.
+4. Ship a vendor-neutral protocol shape that scales to a future Whisper or other provider.
+
+## Non-goals
+
+- Speculative LLM drafting on `EarlyTurnEndEvent` / cancellation on `TurnResumedEvent`. Events are exposed; consumer ignores them.
+- Dashboard-driven keyterm editing.
+- Persisting computed keyterms to Firestore.
+- `smart_format=true` rollout.
+- Word-level timestamps, diarization, redaction, pre-recorded Listen API.
+- Voice Agent API (rejected in the investigation — conflicts with our menu validation + order state machine).
+- Multi-tenant token-budget squeeze (no live tenant exceeds 500 tokens; revisit when one does).
+
+## Settled design decisions
+
+Each links back to a question debated during brainstorming.
+
+| # | Decision | Why |
+|---|---|---|
+| D1 | **Hard cutover.** Replace `app/deepgram/stt.py` outright; delete Nova-2 model selection. Revert path is `git revert`. | Nova-2 is a dead end; one live tenant; 4-person team — dual-provider maintenance cost outweighs A/B safety. |
+| D2 | **Migration + `numerals=true`.** `smart_format=false`. | Numerals are zero-risk for our pipeline (LLM handles either form natively). `smart_format` reshapes more transcript surface and offers no measurable benefit since we don't regex-parse transcripts. |
+| D3 | **In-memory keyterm computation at call-open.** Pure function `compute_keyterms(menu, restaurant_name) -> list[str]`; result is logged then handed to Flux's `connect(keyterm=[...])`. No Firestore field, no menu schema change. | Persistence is only valuable when something else reads it; nothing does today. The dashboard PR that introduces an editor is the right place to introduce the schema. |
+| D4 | **Auto-detect heuristic in code, no per-item menu tags.** Restaurant name is auto-included. | Heuristic deploys instantly across all tenants; menu schema stays untouched; Twilight needs no backfill. The investigation doc's prioritization rules drive the heuristic. |
+| D5 | **Common-named events at the protocol layer, vendor translation inside the provider.** `app/stt/base.py` grows from 2 to 4 event types. Flux provider emits all four; Whisper (future) emits two. | Keeps the protocol vendor-neutral; Flux jargon (`EagerEndOfTurn`) does not appear at the seam. |
+| D6 | **Consumer ignores `EarlyTurnEndEvent` / `TurnResumedEvent` in this PR.** Events are emitted by the Flux module and silently swallowed by the session loop. | Speculative drafting needs measurement (how often `EagerEndOfTurn` is right vs `TurnResumed`-cancelled) and a careful UX design (handling half-spoken bot replies that get cancelled). Ship the migration first; speculate second. |
+
+## Architecture
+
+### Event flow
+
+`session.py:344-376`'s consumer loop sees the same two events it sees today (`SpeechStartedEvent`, `TranscriptEvent`) and adds one defensive branch:
+
+```python
+async for event in stt.events():
+    if isinstance(event, SpeechStartedEvent):
+        if state.llm_task and not state.llm_task.done():
+            await _barge_in_now(state, websocket, trigger="vad")
+        continue
+
+    if isinstance(event, TranscriptEvent):
+        if not event.is_final:
+            continue
+        # final transcript → LLM+TTS pipeline
+        await _handle_final_transcript(event.text, state, websocket)
+        continue
+
+    # EarlyTurnEndEvent, TurnResumedEvent — fired by Flux,
+    # consumed in a future speculative-drafting PR
+    continue
+```
+
+### Per-call lifecycle
+
+| Phase | Action | Source |
+|---|---|---|
+| WS `start` | Load `Restaurant`; build prompt; **compute keyterms**; open Flux connection. | `session.py` (existing call-start path; new call to `compute_keyterms`) |
+| Per audio frame | Forward mulaw bytes. | `state.stt.send(audio)` |
+| Per Flux event | Translate to common-named event; enqueue. | `app/deepgram/stt.py` (rewrite) |
+| Per common-named event | Branch and react (or drop). | `session.py` consumer (one new defensive `continue`) |
+| WS `stop` | `state.stt.close()` (Flux connection torn down). | `session.py` (existing) |
+
+### Translation map (Flux wire → common-named event)
+
+| Flux event | Translated to | Notes |
+|---|---|---|
+| `Connected` | (none — lifecycle) | Provider state only. |
+| `TurnInfo(end_of_turn=False)` | `TranscriptEvent(is_final=False)` | Interim, logged only by consumer. |
+| `TurnInfo(end_of_turn=True)` | `TranscriptEvent(is_final=True)` | The committed turn-end. THIS is what triggers `_handle_final_transcript`. |
+| First-speech indication (TBD which Flux signal) | `SpeechStartedEvent` | Fast barge-in path. Implementation-time research item — see "Open items." |
+| `EagerEndOfTurn` | `EarlyTurnEndEvent` | Emitted; consumer drops. |
+| `TurnResumed` | `TurnResumedEvent` | Emitted; consumer drops. |
+| `Close` | (none — lifecycle) | Provider state only. |
+
+### Files that change
+
+| File | Change |
+|---|---|
+| `app/deepgram/stt.py` | **Rewrite.** Switch from `DeepgramClient.listen.asynclive.v("1")` (callback-based v1) to `AsyncDeepgramClient.listen.v2.connect(...)` (async-context-manager v2). Translate Flux events into the common-named protocol. Drop the silence-based-endpointing knobs (Flux owns turn detection). Keep the internal queue + async iterator façade so the consumer interface is unchanged. |
+| `app/stt/base.py` | Add `EarlyTurnEndEvent` and `TurnResumedEvent` dataclasses. Widen `STTEvent` union from 2 to 4 members. Update the docstring on `STTProvider`. |
+| `app/restaurants/keyterms.py` | **NEW.** Pure function `compute_keyterms(menu: dict, restaurant_name: str) -> list[str]`. Heuristic ranks confusables, proper-noun dishes, brand drinks, and common modifiers; restaurant name always included. Capped well under 500 tokens (target ≤450 tokens — 50-token safety margin). See "Keyterm computation" below. |
+| `app/telephony/session.py` | Two changes: (1) call `compute_keyterms` and pass the result into Flux; (2) add the trailing `continue` in the event loop to defensively drop `EarlyTurnEndEvent` / `TurnResumedEvent`. |
+| `app/config.py` | Set `stt_model` default to `flux-general-en`. **Remove** `stt_endpointing_ms` and `stt_utterance_end_ms` (Flux owns turn detection — these have no analog). Keep `stt_keyterms` as a debug override: when non-empty, **replaces** the heuristic output entirely. (Augment-mode is YAGNI; revisit if a tenant-level use case appears.) Add `stt_numerals: bool = True`. |
+| `requirements.txt` | Bump `deepgram-sdk` minimum version to whatever first exposes `AsyncDeepgramClient` and `listen.v2`. **Verification needed in plan** — current pin is `>=3.0,<4.0` and the local install is 3.11.0; Flux v2 surface likely requires v4. |
+| `tests/test_stt_deepgram.py` | Update fixtures and translation tests for the Flux SDK shape. Add tests for emission of `EarlyTurnEndEvent` and `TurnResumedEvent`. |
+| `tests/test_keyterms.py` | **NEW.** Token-budget cap, restaurant-name inclusion, prioritization edge cases. |
+| `tests/test_telephony_router.py` (or session-tests) | Add a defensive case that asserts `EarlyTurnEndEvent` / `TurnResumedEvent` events flow through the consumer loop without behavioral effect. |
+| `.env.example` | Document new defaults: `STT_MODEL=flux-general-en`. Remove `STT_ENDPOINTING_MS`, `STT_UTTERANCE_END_MS`. Add `STT_NUMERALS=true`. |
+
+### Files explicitly NOT touched
+
+- `app/stt/__init__.py` — selector seam already accommodates one provider; no second provider added.
+- `app/telephony/router.py` — orchestration, barge-in, LLM/TTS turn loop are unchanged.
+- `app/restaurants/menu_writes.py`, `app/restaurants/models.py` — no menu schema or storage change.
+- `app/llm/prompts.py` — no prompt change. Numeral form ("two" vs "2") is invisible to Claude.
+- `restaurants/*.json` — no per-tenant data migration.
+- `app/tts/*` — Aura-2 unchanged.
+
+## Keyterm computation
+
+### Contract
+
+```python
+# app/restaurants/keyterms.py
+def compute_keyterms(
+    menu: dict,
+    restaurant_name: str,
+) -> list[str]:
+    """Return a prioritized list of terms to bias Flux recognition toward,
+    capped under the 500-token Deepgram limit (target ≤450 tokens for a
+    50-token safety margin).
+
+    Always includes restaurant_name first. Then ranks menu items by:
+      1. Acoustically confusable items (Coke, Pepper Shrimp, Wonton, Lo Mein, ...)
+      2. Proper-noun dishes the model is unlikely to know (Basha, Bánh Mì, ...)
+      3. Brand drink names
+      4. Common modifiers ("extra spicy", "no", "side of", "half", "whole")
+    Skips items the model gets right cold (French Fries, Chicken Wings, ...).
+    Skips redundant n-grams (if "Pepper Shrimp" is included, "Pepper Shrimp
+    Fried Rice" is not).
+    """
+```
+
+### Token-budget heuristic
+
+We do not have access to Deepgram's tokenizer. Approximate token count as `ceil(word_count * 1.3)` — slightly conservative vs typical sub-word tokenizers. The plan should validate the heuristic against a few menus and decide whether to swap to `tiktoken`'s `cl100k_base` (closer but still inexact) or stick with the simpler estimate.
+
+The function returns at the first term whose inclusion would push the running total over the safety budget. If `restaurant_name` alone exceeds budget — pathological — return only `[restaurant_name]` and log a warning.
+
+### Logging
+
+At call-start, log one line listing the keyterms passed to Flux (restaurant_id, term count, total estimated tokens, first 5 terms). This is the only audit surface until persistence ships.
+
+### Failure mode
+
+If Flux returns `Keyterm limit exceeded` on `connect`, the connection attempt fails. Rather than dropping the call, the provider retries `connect` once *without* the `keyterm` parameter, logs the budget miss with the offending term count for post-hoc fix-up, and proceeds in transcript-only mode. The conservative 50-token safety margin should make this path nearly unreachable; if we see it in production it means the heuristic underestimates tokens and needs tuning.
+
+## Behavior parity walkthrough
+
+Time-ordered for a representative call. Times are illustrative.
+
+### Phase A — connection setup
+
+| t | Event | Action |
+|---|---|---|
+| 0 | Twilio WS `start` | Router loads Restaurant + builds prompt. |
+| +5ms | (in-process) | `compute_keyterms(menu, name)` → list, logged. |
+| +10ms | Flux `Connected` | Flux WS open with `numerals=true, keyterm=[...]`. |
+| +50ms | (greeting TTS) | Bot speaks. |
+
+### Phase B — caller's first turn ("Hi, can I get a pepper shrimp?")
+
+| t | Flux | Common-named | Consumer |
+|---|---|---|---|
+| 0 | first-speech signal | `SpeechStartedEvent` | Bot not mid-response → no barge-in. |
+| 200ms | `TurnInfo(is_final=False)` | `TranscriptEvent(is_final=False)` | Interim — drop. |
+| 600ms | `TurnInfo(is_final=False)` | `TranscriptEvent(is_final=False)` | Interim — drop. |
+| 1100ms | `EagerEndOfTurn` | `EarlyTurnEndEvent` | **This PR: drop.** |
+| 1360ms | `TurnInfo(end_of_turn=true, text="...pepper shrimp?")` | `TranscriptEvent(is_final=True)` | **Trigger `_handle_final_transcript`** → LLM+TTS. |
+
+Confirmed-final latency end-of-speech to LLM trigger: ~260ms (vs 800–1800ms today).
+
+### Phase C — caller barges in mid-bot ("Yeah, and one... uhh... coke please.")
+
+| t | Flux | Common-named | Consumer |
+|---|---|---|---|
+| 0 | first-speech signal | `SpeechStartedEvent` | Bot IS mid-response → `_barge_in_now(trigger="vad")`. |
+| 250ms | `TurnInfo(is_final=False)` | `TranscriptEvent(is_final=False)` | Interim — drop. |
+| 600ms | `EagerEndOfTurn` (caller hesitated) | `EarlyTurnEndEvent` | **Drop.** |
+| 850ms | `TurnResumed` (caller continued) | `TurnResumedEvent` | **Drop.** |
+| 1400ms | `TurnInfo(is_final=False)` | `TranscriptEvent(is_final=False)` | Interim — drop. |
+| 1900ms | `TurnInfo(end_of_turn=true)` | `TranscriptEvent(is_final=True)` | Trigger `_handle_final_transcript`. |
+
+Net: barge-in path identical to today. Speculation-relevant events flow through but are silently dropped.
+
+### Acceptance signals
+
+A successful migration shows, on real Twilight calls:
+- Final-transcript latency (caller-stop → `_handle_final_transcript`) drops below 500ms p50.
+- Mishearings of menu items in Twilight's keyterm list are anecdotally absent or rare.
+- Barge-in continues to fire promptly mid-bot-response (within the same envelope as today).
+- No new error classes in call logs (`Keyterm limit exceeded`, malformed Flux events, SDK version errors).
+
+## Testing
+
+Unit:
+- `app/restaurants/keyterms.py`: token-budget cap, restaurant-name always-first invariant, edge cases (empty menu, all-confusables menu, single-item menu, name longer than budget).
+- `app/deepgram/stt.py`: each Flux event type translates to the expected common-named event; `EarlyTurnEndEvent` and `TurnResumedEvent` are emitted; lifecycle events are silently consumed.
+- `app/stt/base.py`: dataclasses immutable, `STTEvent` union members.
+
+Integration / end-to-end:
+- `app/telephony/session.py` consumer loop drops `EarlyTurnEndEvent` and `TurnResumedEvent` without side effects; barge-in path on `SpeechStartedEvent` unchanged; `_handle_final_transcript` trigger on `TranscriptEvent(is_final=True)` unchanged.
+- A simulated call delivering all four event types in time order produces the same observable behavior the consumer produces today.
+
+## Rollout
+
+Single PR. Hard cutover. Land on `master`, deploy to the running service, watch the next Twilight call.
+
+Monitoring during the first day of live calls:
+- Final-transcript latency.
+- `Keyterm limit exceeded` errors in logs.
+- Recognition accuracy on Twilight's known confusables (`coke`, `pepper shrimp`, `lo mein`, `wonton`, `basha`).
+- Barge-in latency / false barge-ins / missed barge-ins.
+
+If quality regresses, `git revert` is the rollback. There is no env flag to flip.
+
+## Open items / risks
+
+These need to be resolved during plan-writing or implementation, not before.
+
+| # | Item | Resolution path |
+|---|---|---|
+| O1 | **Which Flux event maps to `SpeechStartedEvent`.** Flux's published event list is `Connected, TurnInfo, EagerEndOfTurn, TurnResumed, Close`. There may be no dedicated "user-speaking-now" event; if so, the first interim `TurnInfo` becomes the trigger (~150-250ms delay vs Nova-2's ~50ms VAD). This may degrade barge-in responsiveness. | Implementation-time empirical check. If degraded beyond acceptable, evaluate whether Flux supports a `vad_events`-equivalent or whether to layer a server-side VAD. |
+| O2 | **`deepgram-sdk` minimum version.** Current pin: `>=3.0,<4.0`; local install: 3.11.0. The investigation cites `AsyncDeepgramClient` and `listen.v2` — likely v4. | Plan: verify via `pip show` + SDK changelog, bump the pin in `requirements.txt`. |
+| O3 | **`Keyterm limit exceeded` error vs silent truncation.** Spec assumes Flux errors. Should be confirmed empirically; if Flux truncates instead, the safety margin is less critical. | Implementation-time. Either way, the conservative budget covers both. |
+| O4 | **Token-counting heuristic accuracy.** `word_count * 1.3` is approximate. | Plan to gate against a small empirical check on Twilight's menu (estimated tokens vs Flux's reported behavior). |
+| O5 | **Pricing verification.** Investigation flagged conflicting per-minute estimates from two summarizer sources; should be confirmed at Deepgram's pricing page before merge so we know the actual per-call delta. | Out-of-band; not a blocker for the plan. |
+
+## Out of scope (follow-up work)
+
+These are explicitly downstream PRs and should not be merged into this migration:
+
+1. **Speculative LLM drafting** on `EarlyTurnEndEvent`, with cancellation on `TurnResumedEvent`. Requires its own UX spec for the "bot heard half a word and got cancelled" failure mode.
+2. **Dashboard keyterm editor.** When the dashboard ships, this PR introduces both the Firestore schema for keyterms and the UI to edit them. Migration of existing tenants follows.
+3. **`smart_format=true` experiment.** Run as a flagged A/B once a measurement harness exists.
+4. **Multi-tenant token-budget squeeze.** When a real tenant onboards with a >500-token-equivalent menu, layer tighter prioritization or per-item tagging on top.
+5. **Whisper (or other) STT provider.** When the time comes, the `app/stt/base.py` protocol is already vendor-neutral; the new provider implements `STTProvider` and only emits `SpeechStartedEvent` + `TranscriptEvent`.
+
+## What's settled vs. what's open
+
+**Settled (this spec is decisive):**
+- Hard cutover to `flux-general-en`.
+- `numerals=true`; `smart_format=false`.
+- Common-named protocol with 4 event types; consumer uses 2.
+- Auto-detect heuristic, in-memory at call-open, no persistence.
+- No speculative drafting in this PR.
+
+**Open (resolved during plan/implementation):**
+- O1 — which Flux event seeds `SpeechStartedEvent`.
+- O2 — `deepgram-sdk` version bump.
+- O3 — Flux behavior on keyterm budget exceed.
+- O4 — token-counting heuristic precision.
+- O5 — pricing verification (out-of-band).
+
+---
+
+*Hand-off note: this is the spec. Plan-writing should produce step-by-step implementation tasks under `docs/superpowers/plans/2026-05-XX-deepgram-flux-stt-migration-plan.md` following the niko convention. Open items O1–O4 should be resolved as the first plan tasks; O5 is out-of-band and does not block.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ anthropic>=0.98.1,<1.0
 google-cloud-firestore>=2.0,<3.0
 google-cloud-logging>=3.0,<4.0
 firebase-admin>=7.4.0,<8.0
-deepgram-sdk>=3.0,<4.0
+deepgram-sdk>=7.1,<8.0
 httpx>=0.27,<1.0
 tzdata>=2024.1

--- a/tests/test_provider_selector.py
+++ b/tests/test_provider_selector.py
@@ -54,3 +54,37 @@ def test_get_stt_raises_for_unknown_provider(monkeypatch):
 
     with pytest.raises(ValueError, match="Unknown STT provider"):
         get_stt(call_sid="CAtest")
+
+
+def test_get_stt_forwards_keyterms_to_deepgram_provider(monkeypatch):
+    """The selector must thread ``keyterms`` into DeepgramSTT so the
+    per-tenant heuristic output reaches Flux on connect. A regression
+    here would silently drop the menu bias on every call."""
+    monkeypatch.setattr(settings, "stt_provider", "deepgram")
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    from app.stt import get_stt
+
+    provider, _name = get_stt(
+        call_sid="CAtest",
+        keyterms=["Twilight Family Restaurant", "Pepper Shrimp"],
+    )
+    # DeepgramSTT exposes the resolved list via its private attribute;
+    # the selector test pins that the constructor argument flowed
+    # through unchanged.
+    assert provider._keyterms_arg == [
+        "Twilight Family Restaurant",
+        "Pepper Shrimp",
+    ]
+
+
+def test_get_stt_default_keyterms_is_none(monkeypatch):
+    """Callers who don't provide keyterms get a clean default — no
+    accidental empty-list shenanigans, no global state."""
+    monkeypatch.setattr(settings, "stt_provider", "deepgram")
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    from app.stt import get_stt
+
+    provider, _name = get_stt(call_sid="CAtest")
+    assert provider._keyterms_arg is None

--- a/tests/test_restaurants_keyterms.py
+++ b/tests/test_restaurants_keyterms.py
@@ -1,0 +1,170 @@
+"""Tests for compute_keyterms — the per-tenant Flux keyterm builder.
+
+The function is a pure dict-in / list-out transform; tests cover the
+contract from the spec: restaurant name always first, common-safe
+items skipped, duplicates dropped, token budget honored, edge cases
+on malformed input.
+"""
+
+from __future__ import annotations
+
+import json
+from math import ceil
+from pathlib import Path
+
+from app.restaurants.keyterms import compute_keyterms
+
+
+def _estimate_tokens(text: str) -> int:
+    """Mirror of the production heuristic for budget assertions."""
+    words = text.split()
+    return max(1, ceil(len(words) * 1.3)) if words else 0
+
+
+def test_includes_restaurant_name_first_with_empty_menu() -> None:
+    assert compute_keyterms({}, "Twilight Family Restaurant") == [
+        "Twilight Family Restaurant"
+    ]
+
+
+def test_walks_menu_in_category_order() -> None:
+    menu = {
+        "appetizers": [
+            {"name": "Pepper Shrimp", "price": 16.25},
+            {"name": "Sweet Chilli Shrimp", "price": 16.25},
+        ],
+        "soups": [
+            {"name": "Wonton Soup", "price": 8.0},
+        ],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert keyterms[0] == "Twilight"
+    assert "Pepper Shrimp" in keyterms
+    assert "Sweet Chilli Shrimp" in keyterms
+    assert "Wonton Soup" in keyterms
+
+
+def test_skips_common_safe_items() -> None:
+    """French Fries is a model-cold-recognized item — wastes budget."""
+    menu = {
+        "appetizers": [
+            {"name": "French Fries", "price": 7.25},
+            {"name": "Spicy French Fries", "price": 7.50},
+            {"name": "Pepper Shrimp", "price": 16.25},
+        ],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert "French Fries" not in keyterms
+    assert "Spicy French Fries" not in keyterms
+    assert "Pepper Shrimp" in keyterms
+
+
+def test_skips_underscore_reserved_keys() -> None:
+    """_category_order is a list of strings, not a category. Don't
+    crash on it; don't include its strings as 'menu items'."""
+    menu = {
+        "_category_order": ["appetizers", "soups"],
+        "appetizers": [{"name": "Pepper Shrimp", "price": 16.25}],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert "Pepper Shrimp" in keyterms
+    assert "appetizers" not in keyterms
+    assert "soups" not in keyterms
+
+
+def test_drops_duplicates_case_insensitive() -> None:
+    """Same item appears in two categories or two casings — include once."""
+    menu = {
+        "category_a": [{"name": "Pepper Shrimp", "price": 16.25}],
+        "category_b": [{"name": "pepper shrimp", "price": 16.25}],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    pepper_count = sum(1 for k in keyterms if k.lower() == "pepper shrimp")
+    assert pepper_count == 1
+
+
+def test_skips_items_without_a_name() -> None:
+    menu = {
+        "appetizers": [
+            {"price": 5.0},  # no name
+            {"name": "", "price": 5.0},  # empty name
+            {"name": "   ", "price": 5.0},  # whitespace name
+            {"name": "Pepper Shrimp", "price": 16.25},
+        ],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert keyterms == ["Twilight", "Pepper Shrimp"]
+
+
+def test_skips_non_dict_menu_items_and_non_list_categories() -> None:
+    """Defensive: Firestore can return surprising shapes. Don't crash."""
+    menu = {
+        "appetizers": [
+            "this is not a dict",
+            {"name": "Pepper Shrimp", "price": 16.25},
+            42,
+        ],
+        "garbage_category": "this is not a list",
+        "another_garbage": 123,
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert "Pepper Shrimp" in keyterms
+    # Non-dict items contribute nothing; the function does not crash.
+
+
+def test_token_budget_honored_on_large_menu() -> None:
+    """Build a menu wide enough to exceed the budget; verify the
+    function returns early and stays under cap."""
+    items = [
+        {"name": f"Special Dish Number {i} With Extra Words", "price": 10.0}
+        for i in range(200)
+    ]
+    menu = {"specials": items}
+    keyterms = compute_keyterms(menu, "Big Place")
+
+    total_tokens = sum(_estimate_tokens(t) for t in keyterms)
+    assert total_tokens <= 450, (
+        f"keyterms exceed token budget: {total_tokens} > 450"
+    )
+    # Should have stopped short of all 200 items.
+    assert len(keyterms) < 201
+    assert keyterms[0] == "Big Place"
+
+
+def test_pathological_long_restaurant_name_returns_name_only() -> None:
+    """If the restaurant name alone exceeds the budget, the menu items
+    are skipped. Returning an empty list would silently drop biasing
+    for the caller-spoken name."""
+    long_name = " ".join(["Very"] * 400)
+    menu = {"appetizers": [{"name": "Pepper Shrimp", "price": 16.25}]}
+    keyterms = compute_keyterms(menu, long_name)
+    assert keyterms == [long_name]
+
+
+def test_twilight_real_menu_fits_under_budget() -> None:
+    """Regression: the live tenant's menu must fit comfortably. If
+    this fires, the heuristic needs tightening before the migration
+    can ship."""
+    menu_path = (
+        Path(__file__).parent.parent
+        / "restaurants"
+        / "twilight-family-restaurant.json"
+    )
+    if not menu_path.exists():
+        # Local dev environments may not have the tenant fixture.
+        return
+    with menu_path.open(encoding="utf-8") as f:
+        menu = json.load(f)
+    keyterms = compute_keyterms(menu, "Twilight Family Restaurant")
+    total_tokens = sum(_estimate_tokens(t) for t in keyterms)
+    assert keyterms[0] == "Twilight Family Restaurant"
+    assert total_tokens <= 450
+    # Sanity: we should be biasing dozens of items, not just the name.
+    assert len(keyterms) > 5
+
+
+def test_output_preserves_original_casing() -> None:
+    """Don't lowercase or title-case names — they go on the wire as-is."""
+    menu = {"appetizers": [{"name": "PePPer Shrimp"}]}
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert "PePPer Shrimp" in keyterms

--- a/tests/test_stt_base_events.py
+++ b/tests/test_stt_base_events.py
@@ -14,8 +14,8 @@ import pytest
 
 from app.stt.base import (
     EarlyTurnEndEvent,
-    STTEvent,
     SpeechStartedEvent,
+    STTEvent,
     TranscriptEvent,
     TurnResumedEvent,
 )

--- a/tests/test_stt_base_events.py
+++ b/tests/test_stt_base_events.py
@@ -1,0 +1,62 @@
+"""Tests for the vendor-neutral event dataclasses in app.stt.base.
+
+These events are the contract between STT providers and consumers.
+Pinning their shape protects both Flux's translation and any future
+provider (Whisper) that needs to emit them.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import get_args
+
+import pytest
+
+from app.stt.base import (
+    EarlyTurnEndEvent,
+    STTEvent,
+    SpeechStartedEvent,
+    TranscriptEvent,
+    TurnResumedEvent,
+)
+
+
+def test_early_turn_end_event_is_frozen() -> None:
+    e = EarlyTurnEndEvent()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.some_attr = "x"  # type: ignore[attr-defined]
+
+
+def test_turn_resumed_event_is_frozen() -> None:
+    e = TurnResumedEvent()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.some_attr = "x"  # type: ignore[attr-defined]
+
+
+def test_stt_event_union_includes_all_four_types() -> None:
+    members = set(get_args(STTEvent))
+    assert members == {
+        TranscriptEvent,
+        SpeechStartedEvent,
+        EarlyTurnEndEvent,
+        TurnResumedEvent,
+    }
+
+
+def test_early_and_resumed_events_have_no_payload_fields() -> None:
+    """These events are pure signals — they carry no payload. Pinning
+    that here so a future-PR field addition is a deliberate, reviewed
+    change rather than an accidental drift."""
+    assert dataclasses.fields(EarlyTurnEndEvent) == ()
+    assert dataclasses.fields(TurnResumedEvent) == ()
+
+
+def test_existing_event_shapes_unchanged() -> None:
+    """Regression guard. The migration must not silently change the
+    field set on the two pre-existing event types."""
+    assert {f.name for f in dataclasses.fields(SpeechStartedEvent)} == {"at"}
+    assert {f.name for f in dataclasses.fields(TranscriptEvent)} == {
+        "text",
+        "is_final",
+        "confidence",
+    }

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -1,104 +1,166 @@
-"""Tests for app/deepgram/stt.py — DeepgramSTT plugin.
+"""Tests for app/deepgram/stt.py — DeepgramSTT plugin (Flux v2).
 
 The Deepgram SDK is the only thing mocked; everything else exercises
-real plugin code (queue plumbing, callback wiring, options building).
+real plugin code (queue plumbing, event translation, lifecycle).
+Tests stub the v2 connect path so we never hit a network — translation
+correctness is the contract this file pins.
 """
 
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.stt.base import TranscriptEvent
+from app.stt.base import (
+    EarlyTurnEndEvent,
+    SpeechStartedEvent,
+    TranscriptEvent,
+    TurnResumedEvent,
+)
 
 
 @pytest.fixture(autouse=True)
 def _set_api_key(monkeypatch):
     """Every test needs the api key set so _api_key() doesn't raise."""
     from app.config import settings
+
     monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
 
 
+def _make_turn_info(*, event: str, transcript: str = "", confidence: float = 0.95):
+    """Build a real ListenV2TurnInfo. Constructing the SDK's pydantic
+    model rather than ducking it with a MagicMock makes isinstance
+    checks inside the translator behave like production."""
+    from deepgram.listen.v2.types import (
+        ListenV2TurnInfo,
+        ListenV2TurnInfoWordsItem,
+    )
+
+    words = (
+        [
+            ListenV2TurnInfoWordsItem(word=w, confidence=confidence)
+            for w in transcript.split()
+        ]
+        if transcript
+        else []
+    )
+    return ListenV2TurnInfo(
+        request_id="req-test",
+        sequence_id=0,
+        event=event,
+        turn_index=0,
+        audio_window_start=0.0,
+        audio_window_end=1.0,
+        transcript=transcript,
+        words=words,
+        end_of_turn_confidence=confidence,
+    )
+
+
 @pytest.fixture
-def fake_deepgram_client(monkeypatch):
-    """Replace DeepgramClient inside app.deepgram.stt with a fake."""
+def fake_v2_connection(monkeypatch):
+    """Replace AsyncDeepgramClient inside app.deepgram.stt with a fake
+    whose listen.v2.connect(...) returns an async-context-manager that
+    yields a connection mock with controllable recv()/send_media()."""
     fake_conn = AsyncMock()
-    fake_conn.send = AsyncMock()
-    fake_conn.finish = AsyncMock()
-    fake_conn.start = AsyncMock(return_value=True)
-    fake_conn._handlers = {}
+    fake_conn.send_media = AsyncMock()
+    fake_conn.send_close_stream = AsyncMock()
+    fake_conn._recv_queue: asyncio.Queue = asyncio.Queue()
 
-    def fake_on(event, handler):
-        fake_conn._handlers[event] = handler
+    async def fake_recv():
+        return await fake_conn._recv_queue.get()
 
-    fake_conn.on = MagicMock(side_effect=fake_on)
+    fake_conn.recv = fake_recv
 
+    fake_cm = AsyncMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=fake_conn)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
+
+    fake_v2 = MagicMock()
+    fake_v2.connect = MagicMock(return_value=fake_cm)
     fake_listen = MagicMock()
-    fake_listen.asynclive.v = MagicMock(return_value=fake_conn)
+    fake_listen.v2 = fake_v2
     fake_client = MagicMock()
     fake_client.listen = fake_listen
 
     monkeypatch.setattr(
-        "app.deepgram.stt.DeepgramClient",
+        "app.deepgram.stt.AsyncDeepgramClient",
         MagicMock(return_value=fake_client),
     )
+    # Expose the connect mock so tests can introspect call args.
+    fake_conn._connect_mock = fake_v2.connect
     return fake_conn
 
 
 @pytest.mark.asyncio
-async def test_open_starts_connection_with_configured_options(
-    fake_deepgram_client, monkeypatch,
+async def test_open_calls_v2_connect_with_configured_options(
+    fake_v2_connection, monkeypatch
 ):
     from app.config import settings
     from app.deepgram.stt import DeepgramSTT
 
-    monkeypatch.setattr(settings, "stt_model", "nova-3")
-    monkeypatch.setattr(settings, "stt_endpointing_ms", 600)
-    monkeypatch.setattr(settings, "stt_utterance_end_ms", 1200)
-    monkeypatch.setattr(settings, "stt_keyterms", "tikka,naan")
+    monkeypatch.setattr(settings, "stt_model", "flux-general-en")
+    monkeypatch.setattr(settings, "stt_keyterms", "")  # no env override
 
-    stt = DeepgramSTT(call_sid="CAtest")
+    stt = DeepgramSTT(
+        call_sid="CAtest",
+        keyterms=["Twilight Family Restaurant", "Pepper Shrimp"],
+    )
     await stt.open()
-
-    fake_deepgram_client.start.assert_awaited_once()
-    options = fake_deepgram_client.start.await_args.args[0]
-    assert options.model == "nova-3"
-    assert options.endpointing == 600
-    assert options.utterance_end_ms == 1200
-    assert options.keyterm == ["tikka", "naan"]
-    assert options.encoding == "mulaw"
-    assert options.sample_rate == 8000
+    try:
+        connect_call = fake_v2_connection._connect_mock.call_args
+        assert connect_call.kwargs["model"] == "flux-general-en"
+        assert connect_call.kwargs["encoding"] == "mulaw"
+        assert connect_call.kwargs["sample_rate"] == 8000
+        assert connect_call.kwargs["keyterm"] == [
+            "Twilight Family Restaurant",
+            "Pepper Shrimp",
+        ]
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_keyterms_empty_string_yields_none(fake_deepgram_client, monkeypatch):
+async def test_env_keyterms_override_replaces_constructor_list(
+    fake_v2_connection, monkeypatch
+):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "stt_keyterms", "alpha, beta , gamma")
+
+    stt = DeepgramSTT(
+        call_sid="CAtest", keyterms=["Twilight", "Pepper Shrimp"]
+    )
+    await stt.open()
+    try:
+        kwargs = fake_v2_connection._connect_mock.call_args.kwargs
+        assert kwargs["keyterm"] == ["alpha", "beta", "gamma"]
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_no_keyterms_passes_none(fake_v2_connection, monkeypatch):
     from app.config import settings
     from app.deepgram.stt import DeepgramSTT
 
     monkeypatch.setattr(settings, "stt_keyterms", "")
 
-    stt = DeepgramSTT(call_sid="CAtest")
+    stt = DeepgramSTT(call_sid="CAtest")  # no keyterms arg
     await stt.open()
-
-    options = fake_deepgram_client.start.await_args.args[0]
-    assert options.keyterm is None
-
-
-@pytest.mark.asyncio
-async def test_open_raises_when_start_returns_false(fake_deepgram_client):
-    from app.deepgram.stt import DeepgramSTT
-
-    fake_deepgram_client.start = AsyncMock(return_value=False)
-    stt = DeepgramSTT(call_sid="CAtest")
-    with pytest.raises(RuntimeError, match="failed to start"):
-        await stt.open()
+    try:
+        kwargs = fake_v2_connection._connect_mock.call_args.kwargs
+        assert kwargs["keyterm"] is None
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_open_raises_when_api_key_missing(monkeypatch, fake_deepgram_client):
+async def test_open_raises_when_api_key_missing(monkeypatch, fake_v2_connection):
     from app.config import settings
     from app.deepgram.stt import DeepgramSTT
 
@@ -109,145 +171,184 @@ async def test_open_raises_when_api_key_missing(monkeypatch, fake_deepgram_clien
 
 
 @pytest.mark.asyncio
-async def test_send_forwards_audio_to_sdk(fake_deepgram_client):
+async def test_send_forwards_audio_to_send_media(fake_v2_connection):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
-    await stt.send(b"\x01\x02\x03")
-
-    fake_deepgram_client.send.assert_awaited_once_with(b"\x01\x02\x03")
+    try:
+        await stt.send(b"\x01\x02\x03")
+        fake_v2_connection.send_media.assert_awaited_once_with(b"\x01\x02\x03")
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_send_swallows_sdk_exceptions(fake_deepgram_client, caplog):
+async def test_send_swallows_sdk_exceptions(fake_v2_connection, caplog):
     import logging
+
     from app.deepgram.stt import DeepgramSTT
 
-    fake_deepgram_client.send = AsyncMock(side_effect=RuntimeError("dropped"))
-    stt = DeepgramSTT(call_sid="CAtest")
-    await stt.open()
-
-    with caplog.at_level(logging.ERROR, logger="app.deepgram.stt"):
-        await stt.send(b"x")
-
-    assert any(
-        "deepgram send failed" in rec.message for rec in caplog.records
-    ), "expected the swallowed-error log line"
-
-
-@pytest.mark.asyncio
-async def test_transcript_callback_emits_events_in_order(fake_deepgram_client):
-    from deepgram import LiveTranscriptionEvents
-    from app.deepgram.stt import DeepgramSTT
-
-    stt = DeepgramSTT(call_sid="CAtest")
-    await stt.open()
-
-    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
-
-    def make_result(text: str, is_final: bool, confidence: float):
-        alt = SimpleNamespace(transcript=text, confidence=confidence)
-        channel = SimpleNamespace(alternatives=[alt])
-        return SimpleNamespace(channel=channel, is_final=is_final)
-
-    await handler(stt, make_result("hi", False, 0.7))
-    await handler(stt, make_result("hello", True, 0.95))
-
-    received = []
-    async def consume():
-        async for event in stt.events():
-            received.append(event)
-
-    task = asyncio.create_task(consume())
-    await asyncio.sleep(0)
-    await stt.close()
-    await task
-
-    assert received == [
-        TranscriptEvent("hi", False, 0.7),
-        TranscriptEvent("hello", True, 0.95),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_transcript_callback_skips_empty_text(fake_deepgram_client):
-    from deepgram import LiveTranscriptionEvents
-    from app.deepgram.stt import DeepgramSTT
-
-    stt = DeepgramSTT(call_sid="CAtest")
-    await stt.open()
-    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
-
-    alt = SimpleNamespace(transcript="   ", confidence=0.9)
-    result = SimpleNamespace(
-        channel=SimpleNamespace(alternatives=[alt]),
-        is_final=True,
+    fake_v2_connection.send_media = AsyncMock(
+        side_effect=RuntimeError("dropped")
     )
-    await handler(stt, result)
-
-    received = []
-    async def consume():
-        async for event in stt.events():
-            received.append(event)
-
-    task = asyncio.create_task(consume())
-    await asyncio.sleep(0)
-    await stt.close()
-    await task
-
-    assert received == []
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        with caplog.at_level(logging.ERROR, logger="app.deepgram.stt"):
+            await stt.send(b"x")
+        assert any(
+            "deepgram send failed" in rec.message for rec in caplog.records
+        ), "expected the swallowed-error log line"
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_transcript_callback_normalizes_none_confidence(fake_deepgram_client):
-    """Deepgram occasionally returns confidence=None; we replace with 1.0
-    rather than 0.0 (which would mask worst-case misheard turns)."""
-    from deepgram import LiveTranscriptionEvents
+async def test_translates_start_of_turn_to_speech_started(
+    fake_v2_connection
+):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
-    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
-
-    alt = SimpleNamespace(transcript="ok", confidence=None)
-    result = SimpleNamespace(
-        channel=SimpleNamespace(alternatives=[alt]),
-        is_final=True,
-    )
-    await handler(stt, result)
-
-    received = []
-    async def consume():
-        async for event in stt.events():
-            received.append(event)
-
-    task = asyncio.create_task(consume())
-    await asyncio.sleep(0)
-    await stt.close()
-    await task
-
-    assert len(received) == 1
-    assert received[0].confidence == 1.0
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="StartOfTurn")
+        )
+        # Drain one event then close.
+        ev = await _next_event(stt)
+        assert isinstance(ev, SpeechStartedEvent)
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_error_callback_surfaces_as_exception_from_events(fake_deepgram_client):
-    from deepgram import LiveTranscriptionEvents
+async def test_translates_update_to_interim_transcript(
+    fake_v2_connection
+):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
-    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Error]
-    await handler(stt, "ws closed unexpectedly")
-
-    with pytest.raises(RuntimeError, match="deepgram error"):
-        async for _event in stt.events():
-            pass
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="Update", transcript="hi there", confidence=0.8)
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, TranscriptEvent)
+        assert ev.text == "hi there"
+        assert ev.is_final is False
+        assert ev.confidence == pytest.approx(0.8)
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_close_terminates_events_iterator(fake_deepgram_client):
+async def test_translates_eager_end_of_turn(fake_v2_connection):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="EagerEndOfTurn")
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, EarlyTurnEndEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_translates_turn_resumed(fake_v2_connection):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="TurnResumed")
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, TurnResumedEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_translates_end_of_turn_to_final_transcript(
+    fake_v2_connection
+):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(
+                event="EndOfTurn", transcript="hello world", confidence=0.92
+            )
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, TranscriptEvent)
+        assert ev.text == "hello world"
+        assert ev.is_final is True
+        assert ev.confidence == pytest.approx(0.92)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_update_with_empty_transcript_is_dropped(
+    fake_v2_connection
+):
+    """Flux occasionally sends 'Update' with an empty transcript on
+    barge-in or noise — translator drops them so downstream interim
+    handling doesn't see phantom ''."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="Update", transcript="")
+        )
+        # Followed by something we DO expect, so the consumer wakes up.
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="StartOfTurn")
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, SpeechStartedEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_turn_info_event_is_ignored(
+    fake_v2_connection
+):
+    """A future Flux release adding a new event type must not crash
+    a live call. Translator drops unknowns and continues."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="SomeFutureEvent")
+        )
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="StartOfTurn")
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, SpeechStartedEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_events_iterator(fake_v2_connection):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
@@ -258,42 +359,36 @@ async def test_close_terminates_events_iterator(fake_deepgram_client):
     async for event in stt.events():
         received.append(event)
     assert received == []
-    fake_deepgram_client.finish.assert_awaited_once()
+    fake_v2_connection.send_close_stream.assert_awaited()
 
 
 @pytest.mark.asyncio
-async def test_speech_started_callback_emits_event(fake_deepgram_client):
-    """Deepgram's SpeechStarted event becomes a SpeechStartedEvent on
-    the queue.
-
-    The live Deepgram SDK invokes the SpeechStarted callback with just
-    the connection handle — NO second positional argument — unlike the
-    Transcript and Error callbacks which both receive a payload. We
-    invoke the handler the same way here (single positional arg) so a
-    regression that removes the `= None` default on _event is caught
-    by tests instead of by a real call (call CA061e6bf3 on 2026-05-06
-    crashed for exactly this reason)."""
-    from deepgram import LiveTranscriptionEvents
+async def test_recv_exception_surfaces_as_runtime_error(fake_v2_connection):
+    """If the SDK's recv() raises (e.g. WS dropped mid-call), the
+    error should surface from events() so the consumer can react.
+    Errors aren't silently swallowed — that would feel like dead air
+    to whoever's debugging the call."""
     from app.deepgram.stt import DeepgramSTT
-    from app.stt.base import SpeechStartedEvent
 
     stt = DeepgramSTT(call_sid="CAtest")
+    fake_v2_connection.recv = AsyncMock(side_effect=RuntimeError("ws dropped"))
+
     await stt.open()
-    handler = fake_deepgram_client._handlers[
-        LiveTranscriptionEvents.SpeechStarted
-    ]
-    # Mirror the live SDK: single positional arg (the connection handle).
-    await handler(stt)
+    try:
+        with pytest.raises(RuntimeError, match="deepgram error"):
+            async for _ev in stt.events():
+                pass
+    finally:
+        await stt.close()
 
-    received = []
 
-    async def consume():
-        async for event in stt.events():
-            received.append(event)
+# Helpers ----------------------------------------------------------------
 
-    task = asyncio.create_task(consume())
-    await asyncio.sleep(0)
-    await stt.close()
-    await task
 
-    assert received == [SpeechStartedEvent()]
+async def _next_event(stt: Any):
+    """Drain a single event from stt.events() without leaving the
+    iterator open. Tests use this to assert one-event-per-input."""
+    event_iter = stt.events()
+    # asyncio.wait_for guards against the consumer hanging when a test
+    # has misconfigured the recv queue.
+    return await asyncio.wait_for(event_iter.__anext__(), timeout=1.0)

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -363,6 +363,169 @@ async def test_close_terminates_events_iterator(fake_v2_connection):
 
 
 @pytest.mark.asyncio
+async def test_translates_dict_form_messages(fake_v2_connection):
+    """Production path: deepgram-sdk 7.1's ``recv()`` returns plain
+    dicts because ``construct_type`` on a Union doesn't pick a
+    discriminator and falls through to the raw JSON. The translator
+    must route by the dict's ``type`` field directly.
+
+    Without this path the live call sees recv messages, drops every
+    one in ``_translate``, and the silence watchdog fires after 10s
+    despite the caller speaking — that's the bug a 2026-05-06 live
+    call surfaced before this test pinned the dict shape."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        # Connected (lifecycle, no consumer event).
+        fake_v2_connection._recv_queue.put_nowait(
+            {"type": "Connected", "request_id": "abc", "sequence_id": 0}
+        )
+        # StartOfTurn — should produce SpeechStartedEvent.
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "StartOfTurn",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 0.24,
+                "transcript": "",
+                "words": [],
+                "end_of_turn_confidence": 0.05,
+                "sequence_id": 1,
+            }
+        )
+        # Update with text — should produce interim TranscriptEvent.
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "Update",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.0,
+                "transcript": "and a coke",
+                "words": [
+                    {"word": "and", "confidence": 0.9},
+                    {"word": "a", "confidence": 0.85},
+                    {"word": "coke", "confidence": 0.95},
+                ],
+                "end_of_turn_confidence": 0.4,
+                "sequence_id": 2,
+            }
+        )
+        # EndOfTurn — final TranscriptEvent.
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "EndOfTurn",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.5,
+                "transcript": "and a Coke.",
+                "words": [
+                    {"word": "and", "confidence": 0.93},
+                    {"word": "a", "confidence": 0.88},
+                    {"word": "Coke.", "confidence": 0.97},
+                ],
+                "end_of_turn_confidence": 0.92,
+                "sequence_id": 3,
+            }
+        )
+
+        first = await _next_event(stt)
+        assert isinstance(first, SpeechStartedEvent)
+
+        second = await _next_event(stt)
+        assert isinstance(second, TranscriptEvent)
+        assert second.is_final is False
+        assert second.text == "and a coke"
+        assert second.confidence == pytest.approx((0.9 + 0.85 + 0.95) / 3)
+
+        third = await _next_event(stt)
+        assert isinstance(third, TranscriptEvent)
+        assert third.is_final is True
+        assert third.text == "and a Coke."
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_translates_dict_form_speculation_events(fake_v2_connection):
+    """EagerEndOfTurn and TurnResumed must also route via the dict
+    path. The session consumer drops them in this PR, but the
+    provider still has to translate them so the speculation-aware
+    follow-up PR doesn't have to revisit the wire-format question."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "EagerEndOfTurn",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.0,
+                "transcript": "",
+                "words": [],
+                "end_of_turn_confidence": 0.7,
+                "sequence_id": 1,
+            }
+        )
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "TurnResumed",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.2,
+                "transcript": "",
+                "words": [],
+                "end_of_turn_confidence": 0.3,
+                "sequence_id": 2,
+            }
+        )
+
+        first = await _next_event(stt)
+        assert isinstance(first, EarlyTurnEndEvent)
+        second = await _next_event(stt)
+        assert isinstance(second, TurnResumedEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_dict_form_configure_failure_surfaces_error(fake_v2_connection):
+    """A ConfigureFailure dict from Flux should raise out of events()
+    so the call-flow can react (today: end the call cleanly)."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "ConfigureFailure",
+                "request_id": "abc",
+                "sequence_id": 1,
+                "description": "bad model",
+            }
+        )
+        with pytest.raises(RuntimeError, match="deepgram error"):
+            async for _ev in stt.events():
+                pass
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
 async def test_recv_exception_surfaces_as_runtime_error(fake_v2_connection):
     """If the SDK's recv() raises (e.g. WS dropped mid-call), the
     error should surface from events() so the consumer can react.

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -352,3 +352,92 @@ async def test_kill_switch_off_still_processes_final_transcripts(monkeypatch):
     assert barge_in_calls == []  # VAD ignored
     handler.assert_awaited_once()  # but final still flowed through
     assert handler.await_args.args[0] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_early_turn_end_event_is_dropped(monkeypatch):
+    """EarlyTurnEndEvent flows from the Flux provider; this PR does
+    not consume it (speculative drafting is a future PR). The consumer
+    must silently drop it — no barge-in, no Firestore, no LLM dispatch."""
+    from app.stt.base import EarlyTurnEndEvent
+
+    state = _make_state()
+    monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.session._handle_final_transcript", handler
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
+
+    fake = FakeSTT(events=[EarlyTurnEndEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_not_called()
+    bg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_turn_resumed_event_is_dropped(monkeypatch):
+    """TurnResumedEvent is the cancel signal for the speculative
+    draft. Until speculation lands the consumer drops it cleanly."""
+    from app.stt.base import TurnResumedEvent
+
+    state = _make_state()
+    monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.session._handle_final_transcript", handler
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
+
+    fake = FakeSTT(events=[TurnResumedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_not_called()
+    bg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_speculation_events_interleaved_with_finals_pass_through(
+    monkeypatch,
+):
+    """A real Flux call delivers EarlyTurnEnd and TurnResumed in
+    between the SpeechStarted and final TranscriptEvent. The consumer
+    must drop the speculative ones and still process the final."""
+    from app.stt.base import EarlyTurnEndEvent, TurnResumedEvent
+
+    state = _make_state()
+    monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.session._handle_final_transcript", handler
+    )
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
+
+    fake = FakeSTT(
+        events=[
+            SpeechStartedEvent(),
+            TranscriptEvent("hi the", False, 0.8),
+            EarlyTurnEndEvent(),
+            TurnResumedEvent(),
+            TranscriptEvent("hi there", True, 0.9),
+        ]
+    )
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_awaited_once()
+    assert handler.await_args.args[0] == "hi there"

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -120,6 +120,13 @@ async def test_high_confidence_resets_counter(monkeypatch):
 async def test_speech_started_triggers_barge_in_when_llm_task_running(monkeypatch):
     """VAD speech-started while a turn is in flight fires _barge_in_now
     with trigger='vad'."""
+    from app.config import settings
+
+    # Pin the kill-switch ON so this test doesn't depend on local .env
+    # state (a developer with STT_INSTANT_BARGE_IN=false set for a real
+    # call would otherwise see this test fail spuriously).
+    monkeypatch.setattr(settings, "stt_instant_barge_in", True)
+
     state = _make_state()
 
     async def long_turn():
@@ -154,7 +161,12 @@ async def test_speech_started_triggers_barge_in_when_llm_task_running(monkeypatc
 @pytest.mark.asyncio
 async def test_speech_started_no_op_when_no_llm_task(monkeypatch):
     """VAD with no in-flight turn does nothing — there's nothing to
-    barge in on."""
+    barge in on. Pinning kill-switch ON ensures the no-op comes from
+    the no-task branch and not from the kill-switch."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "stt_instant_barge_in", True)
+
     state = _make_state()
     state.llm_task = None
 
@@ -269,6 +281,12 @@ async def test_vad_then_final_transcript_creates_one_barge_in_then_new_turn(
     _handle_final_transcript exactly once for the final. Pins that the
     consumer keeps iterating after a VAD event (would catch a future
     refactor that turned `continue` into `return`)."""
+    from app.config import settings
+
+    # Pin the kill-switch ON so this test doesn't depend on local .env
+    # state.
+    monkeypatch.setattr(settings, "stt_instant_barge_in", True)
+
     state = _make_state()
 
     async def long_turn():


### PR DESCRIPTION
## Summary

- Hard cutover of live STT from Deepgram Nova-2 to **Flux English mono** (`flux-general-en`). Closes #257.
- Per-tenant **keyterm prompting** computed at call-open from each restaurant's menu — fixes anecdotal misrecognitions like `coke→smoke` and `pepper shrimp→pepper soup` that Nova-2 silently ignored on `keyterm`.
- New common-named events `EarlyTurnEndEvent` / `TurnResumedEvent` are emitted by the Flux provider but **dropped by the consumer**. Speculative LLM drafting is a deliberate follow-up PR (needs measurement and UX work).
- `deepgram-sdk` pin: `>=3.0,<4.0` → `>=7.1,<8.0` (v3 doesn't expose `AsyncDeepgramClient` / `listen.v2`).

Spec: [`docs/superpowers/specs/2026-05-06-deepgram-flux-stt-migration-design.md`](https://github.com/tsuki-works/niko/blob/feat/257-deepgram-flux-stt-migration/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-migration-design.md)

## What changed

| File | Change |
|---|---|
| `app/stt/base.py` | Added `EarlyTurnEndEvent`, `TurnResumedEvent`. Widened `STTEvent` union (2→4). |
| `app/restaurants/keyterms.py` | **New.** `compute_keyterms(menu, restaurant_name) -> list[str]`, capped at 450 tokens (50-token margin under Flux's 500 cap). |
| `app/deepgram/stt.py` | **Rewrite.** `AsyncDeepgramClient.listen.v2.connect`. Translates `ListenV2TurnInfo` events into the common-named protocol. Constructor takes `keyterms`. |
| `app/stt/__init__.py` | `get_stt()` widened with optional `keyterms` kwarg, forwarded to provider. |
| `app/telephony/router.py` | Calls `compute_keyterms` after loading the Restaurant; logs the list at call-start; passes to `get_stt()`. |
| `app/telephony/session.py` | Consumer loop drops `EarlyTurnEndEvent` / `TurnResumedEvent`. Defensive `else` branch for unknown event types. |
| `app/config.py` | `stt_model` default → `flux-general-en`. Removed `stt_endpointing_ms`, `stt_utterance_end_ms`. `stt_keyterms` repurposed as debug override. |
| `requirements.txt` | `deepgram-sdk>=7.1,<8.0`. |
| `.env.example` | Updated for new env vars. |

## Translation map (Flux wire → common-named)

| `TurnInfo.event` | Common-named |
|---|---|
| `Update` (non-empty) | `TranscriptEvent(is_final=False)` |
| `StartOfTurn` | `SpeechStartedEvent` |
| `EagerEndOfTurn` | `EarlyTurnEndEvent` (dropped by consumer) |
| `TurnResumed` | `TurnResumedEvent` (dropped by consumer) |
| `EndOfTurn` (non-empty) | `TranscriptEvent(is_final=True)` |

## Twilight menu coverage (sanity)

`compute_keyterms` on the live Twilight menu produces **76 terms / ~323 estimated tokens** — well under the 450-token target. Coverage spans `Pepper Shrimp`, all 8 `Lo-Mein` variants, `Wonton`, `Chow Mein`, `Basha`, brand drinks (`Grace Pop`, `Can Pop`). Skips `French Fries`, `Spring Roll`, `Caesar Salad` (model-cold-recognized).

## Test plan

- [x] Unit: 11 keyterms tests including budget cap, dedup, common-safe-skip, edge cases, real Twilight menu.
- [x] Unit: 5 protocol tests pinning the new event dataclasses.
- [x] Unit: 15 Flux provider tests — every event-type translation, env-override precedence, lifecycle, error path.
- [x] Unit: 2 selector tests for `keyterms` threading.
- [x] Unit: 3 consumer tests for new event drop behavior + interleaved-with-final.
- [x] Full app suite: **436 passed** (`tests/`, excluding 3 pre-existing failures unrelated to this PR — see below).
- [x] Lint: `ruff check` clean on every file this PR modifies.
- [ ] **Manual**: live Twilight call to verify `coke` / `pepper shrimp` recognition, final-transcript latency p50, barge-in responsiveness. Done post-merge.

## Pre-existing failures (NOT introduced by this PR)

Three tests fail on `feat/83-tune-conversational-bot` (the base branch) regardless of this PR:

- `tests/test_recordings_storage.py::test_finalize_recording_mixes_encodes_and_uploads` — bucket-name retrieval issue in feat/83's recording-finalize change.
- `tests/test_recordings_storage.py::test_finalize_recording_swallows_upload_failure` — `session.broken` not flipped due to the early-return added in feat/83's `finalize_recording`.
- `tests/test_llm_integration.py::test_pickup_delivery_flow[delivery_address_uhh_then_real]` — LLM integration test, possibly flaky.

Verified by checking out `master` and `feat/83-tune-conversational-bot` independently with the same venv. Should be addressed separately on `feat/83-tune-conversational-bot`.

## Rollback

`git revert` on the merge commit. There is no env flag to flip — Nova-2 path is removed.

## Out of scope (deliberate, follow-up PRs)

1. Speculative LLM drafting on `EarlyTurnEndEvent` (cancel on `TurnResumedEvent`). Needs UX design for the "bot heard half a word and got cancelled" case + measurement of how often `EagerEndOfTurn` is right.
2. Dashboard keyterm editor + Firestore persistence of computed keyterms. Persistence ships with the editor that needs it.
3. `smart_format=true` experiment (Flux has no such flag — would need to be wired separately if Deepgram exposes it later).
4. Multi-tenant token-budget squeeze (>500-token menus). Twilight at 323 tokens has comfortable headroom.
5. Whisper or other STT provider. Protocol is already vendor-neutral.