### PR TITLE
Sprint 2.1: tune conversational bot — Flux STT + telephony refactor

### DIFF
--- a/.claude/agents/niko-developer.md
+++ b/.claude/agents/niko-developer.md
@@ -31,5 +31,6 @@ You are a niko backend/frontend implementer. Your job is to land working code th
 
 ## Done means
 - Code compiles / type-checks (Python: `python -c "import app.main"`, dashboard: `pnpm --filter dashboard typecheck`).
+- Lint passes locally: `ruff check . && ruff format --check .` (matches CI). Don't claim done if either step fails — fix or surface the failure.
 - New behavior has a test (or you've documented why it can't be tested locally).
 - You've reported what you changed and what's left, in 2-3 sentences.

--- a/.claude/agents/niko-tester.md
+++ b/.claude/agents/niko-tester.md
@@ -30,5 +30,6 @@ You are a niko test engineer. Your job is to make behavior verifiable and to cat
 
 ## Done means
 - Tests run and pass (or fail with a clear, actionable message).
+- Lint passes locally: `ruff check . && ruff format --check .` (matches CI). Don't claim done if either step fails — fix or surface the failure.
 - New tests have descriptive names — `test_<unit>_<condition>_<expected>` style.
 - You've reported pass/fail counts and any flakiness observed.

--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,26 @@
 # Anthropic — Claude Haiku 4.5
 ANTHROPIC_API_KEY=
 
-# Deepgram — streaming STT (Nova-2) and TTS (Aura)
+# Deepgram — streaming STT (Flux English mono) and TTS (Aura)
 DEEPGRAM_API_KEY=
 DEEPGRAM_TTS_MODEL=aura-2-thalia-en
+
+# STT model. Flux English mono is the default (#257). Multi-language
+# support would be flux-general-multi at a small cost premium.
+STT_MODEL=flux-general-en
+
+# Optional debug-override for the per-tenant keyterm list. When set
+# to a non-empty comma-separated list, REPLACES the menu-derived
+# keyterms entirely — used to A/B specific term lists without
+# redeploying. Production should leave this blank.
+STT_KEYTERMS=
+
+# Instant barge-in. When true (default), the bot stops speaking as
+# soon as Flux fires StartOfTurn (~50-200ms after the caller begins
+# speaking). Flip to false if real-call data shows StartOfTurn
+# misfiring on coughs / background noise — the final-transcript
+# barge-in path absorbs the fallback case.
+STT_INSTANT_BARGE_IN=true
 
 # Twilio — Voice webhook + trial number
 TWILIO_ACCOUNT_SID=

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,16 @@ venv/
 .claude/worktrees/
 **/.claude/worktrees/
 
+# IDE / editor configs — local only
+.idea/
+
+# Local dev helpers (per-developer; not team-shared)
+scripts/dev.ps1
+.claude/statusline-command.sh
+
+# Local runtime logs
+uvicorn.log
+
 # Terraform — local state, plan files, provider plugins, lockfile-overrides
 # (.terraform.lock.hcl is intentionally NOT ignored — it pins provider versions
 # for reproducibility and should be committed.)

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ venv/
 # Local dev helpers (per-developer; not team-shared)
 scripts/dev.ps1
 .claude/statusline-command.sh
+docs/07-local-development-setup.md
 
 # Local runtime logs
 uvicorn.log

--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,11 @@ class Settings(BaseSettings):
     # override via DEEPGRAM_TTS_MODEL.
     deepgram_tts_model: str = "aura-2-thalia-en"
 
+    # TTS provider selector. Today only "deepgram" is implemented; the
+    # selector seam exists so a second provider becomes a one-line add
+    # to app/tts/__init__.py.
+    tts_provider: str = "deepgram"
+
     twilio_account_sid: Optional[str] = None
     twilio_auth_token: Optional[str] = None
     twilio_phone_number: Optional[str] = None

--- a/app/config.py
+++ b/app/config.py
@@ -45,6 +45,14 @@ class Settings(BaseSettings):
     # (Nova-3 and later). Parsed lazily in app/deepgram/stt.py.
     stt_keyterms: str = ""
 
+    # Instant barge-in via Deepgram VAD speech-started events. When True
+    # (default), a barge-in fires ~50ms after the caller begins speaking
+    # instead of waiting for the final transcript (~800-1800ms). Flip to
+    # False if VAD turns out to misfire on coughs or background noise on
+    # a real call — the existing final-transcript barge-in path absorbs
+    # the fallback case with no other code changes.
+    stt_instant_barge_in: bool = True
+
     twilio_account_sid: Optional[str] = None
     twilio_auth_token: Optional[str] = None
     twilio_phone_number: Optional[str] = None

--- a/app/config.py
+++ b/app/config.py
@@ -34,23 +34,26 @@ class Settings(BaseSettings):
     # STT provider selector. Today only "deepgram" is implemented.
     stt_provider: str = "deepgram"
 
-    # Deepgram live STT options. Defaults match what was inline in
-    # router.py before the plugin extraction; tuning is done by env var
-    # rather than code change.
-    stt_model: str = "nova-2"
-    stt_endpointing_ms: int = 800
-    stt_utterance_end_ms: int = 1000
-    # Comma-separated keyterms. Only sent to Deepgram when non-empty,
-    # and only respected by models that support keyterm prompting
-    # (Nova-3 and later). Parsed lazily in app/deepgram/stt.py.
+    # Deepgram live STT options. Migrated to Flux English mono in #257.
+    # Flux owns turn detection natively (prosody-aware, ~260ms confirmed
+    # end-of-turn) so the Nova-2 endpointing knobs were removed; if Flux
+    # turn-detection ever needs tuning, expose `eager_eot_threshold` /
+    # `eot_threshold` / `eot_timeout_ms` here, all per the v2 connect API.
+    stt_model: str = "flux-general-en"
+    # Comma-separated debug-override keyterms. When non-empty, REPLACES
+    # the per-tenant heuristic output entirely (used to A/B test what
+    # Flux does with a specific term list). Empty in production —
+    # session.py computes keyterms from each restaurant's menu.
     stt_keyterms: str = ""
 
-    # Instant barge-in via Deepgram VAD speech-started events. When True
-    # (default), a barge-in fires ~50ms after the caller begins speaking
-    # instead of waiting for the final transcript (~800-1800ms). Flip to
-    # False if VAD turns out to misfire on coughs or background noise on
-    # a real call — the existing final-transcript barge-in path absorbs
-    # the fallback case with no other code changes.
+    # Instant barge-in. When True (default), a barge-in fires as soon as
+    # the STT provider signals "user started speaking" (Flux fires
+    # `TurnInfo.event="StartOfTurn"` on the first frame of detected
+    # speech) instead of waiting for the confirmed final transcript.
+    # Flip to False if the start-of-turn signal turns out to misfire
+    # on coughs or background noise on real calls — the
+    # final-transcript path in _handle_final_transcript absorbs the
+    # fallback case with no other code changes.
     stt_instant_barge_in: bool = True
 
     twilio_account_sid: Optional[str] = None

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,20 @@ class Settings(BaseSettings):
     # to app/tts/__init__.py.
     tts_provider: str = "deepgram"
 
+    # STT provider selector. Today only "deepgram" is implemented.
+    stt_provider: str = "deepgram"
+
+    # Deepgram live STT options. Defaults match what was inline in
+    # router.py before the plugin extraction; tuning is done by env var
+    # rather than code change.
+    stt_model: str = "nova-2"
+    stt_endpointing_ms: int = 800
+    stt_utterance_end_ms: int = 1000
+    # Comma-separated keyterms. Only sent to Deepgram when non-empty,
+    # and only respected by models that support keyterm prompting
+    # (Nova-3 and later). Parsed lazily in app/deepgram/stt.py.
+    stt_keyterms: str = ""
+
     twilio_account_sid: Optional[str] = None
     twilio_auth_token: Optional[str] = None
     twilio_phone_number: Optional[str] = None

--- a/app/deepgram/__init__.py
+++ b/app/deepgram/__init__.py
@@ -22,7 +22,6 @@ def _api_key() -> str:
     key = settings.deepgram_api_key
     if not key:
         raise RuntimeError(
-            "DEEPGRAM_API_KEY not set — cannot reach Deepgram. "
-            "Fetch credentials via /shared-creds."
+            "DEEPGRAM_API_KEY not set — cannot reach Deepgram. Fetch credentials via /shared-creds."
         )
     return key

--- a/app/deepgram/__init__.py
+++ b/app/deepgram/__init__.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from app.config import settings
 
-
 _DEEPGRAM_BASE = "https://api.deepgram.com/v1"
 
 

--- a/app/deepgram/__init__.py
+++ b/app/deepgram/__init__.py
@@ -1,0 +1,29 @@
+"""Deepgram vendor package — STT and TTS implementations co-located.
+
+The package exists so per-vendor configuration (API key reader, base URL,
+shared HTTP client) can live in one place and be consumed by both
+``stt.py`` and ``tts.py``. The router never imports from here directly;
+consumers route through ``app/stt`` and ``app/tts``.
+"""
+
+from __future__ import annotations
+
+from app.config import settings
+
+
+_DEEPGRAM_BASE = "https://api.deepgram.com/v1"
+
+
+def _api_key() -> str:
+    """Return the Deepgram API key, raising a clear error when missing.
+
+    Both halves of the Deepgram package call this lazily so importing
+    ``app.deepgram`` never crashes environments where the key isn't set.
+    """
+    key = settings.deepgram_api_key
+    if not key:
+        raise RuntimeError(
+            "DEEPGRAM_API_KEY not set — cannot reach Deepgram. "
+            "Fetch credentials via /shared-creds."
+        )
+    return key

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -16,7 +16,7 @@ from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
 
 from app.config import settings
 from app.deepgram import _api_key
-from app.stt.base import STTEvent, TranscriptEvent
+from app.stt.base import STTEvent, SpeechStartedEvent, TranscriptEvent
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,9 @@ class DeepgramSTT:
         dg = DeepgramClient(_api_key())
         self._conn = dg.listen.asynclive.v("1")
         self._conn.on(LiveTranscriptionEvents.Transcript, self._on_transcript)
+        self._conn.on(
+            LiveTranscriptionEvents.SpeechStarted, self._on_speech_started
+        )
         self._conn.on(LiveTranscriptionEvents.Error, self._on_error)
 
         keyterms = _parse_keyterms(settings.stt_keyterms)
@@ -152,6 +155,15 @@ class DeepgramSTT:
         self._queue.put_nowait(
             TranscriptEvent(text=text, is_final=is_final, confidence=confidence)
         )
+
+    async def _on_speech_started(
+        self, _dg_handle: Any, _event: Any, **_kwargs: Any
+    ) -> None:
+        # Deepgram passes the connection handle as the first arg to bound
+        # handlers in addition to self; we ignore it. The event payload
+        # is also unused — we only need the signal that speech started.
+        logger.info("speech_started call_sid=%s", self._call_sid)
+        self._queue.put_nowait(SpeechStartedEvent())
 
     async def _on_error(self, _dg_handle: Any, error: Any, **_kwargs: Any) -> None:
         # Deepgram passes the connection handle as the first arg to bound

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -153,9 +153,7 @@ class DeepgramSTT:
         keyterms: Optional[Sequence[str]] = None,
     ) -> None:
         self._call_sid = call_sid
-        self._keyterms_arg: Optional[list[str]] = (
-            list(keyterms) if keyterms else None
-        )
+        self._keyterms_arg: Optional[list[str]] = list(keyterms) if keyterms else None
         self._client: Any = None
         self._cm: Any = None
         self._conn: Any = None
@@ -242,9 +240,7 @@ class DeepgramSTT:
                 ListenV2FatalError,
             ),
         ):
-            msg_type = getattr(msg, "type", None) or type(msg).__name__.replace(
-                "ListenV2", ""
-            )
+            msg_type = getattr(msg, "type", None) or type(msg).__name__.replace("ListenV2", "")
 
             def getter(key, default=None, _msg=msg):
                 return getattr(_msg, key, default)
@@ -348,9 +344,7 @@ class DeepgramSTT:
                 msg_type,
                 msg,
             )
-            self._queue.put_nowait(
-                _ErrorBox(RuntimeError(f"deepgram error: {msg}"))
-            )
+            self._queue.put_nowait(_ErrorBox(RuntimeError(f"deepgram error: {msg}")))
             return
 
         logger.debug(
@@ -382,9 +376,7 @@ class DeepgramSTT:
             if item is _CLOSED:
                 return
             if isinstance(item, _ErrorBox):
-                cause = (
-                    item.error if isinstance(item.error, BaseException) else None
-                )
+                cause = item.error if isinstance(item.error, BaseException) else None
                 raise RuntimeError(f"deepgram error: {item.error}") from cause
             yield item
 
@@ -418,8 +410,6 @@ class DeepgramSTT:
             try:
                 await self._cm.__aexit__(None, None, None)
             except Exception:
-                logger.exception(
-                    "deepgram finish failed call_sid=%s", self._call_sid
-                )
+                logger.exception("deepgram finish failed call_sid=%s", self._call_sid)
 
         self._queue.put_nowait(_CLOSED)

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -75,6 +75,7 @@ class _ErrorBox:
 
 def _resolve_keyterms(
     constructor_keyterms: Optional[Sequence[str]],
+    call_sid: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Return the keyterm list to send to Flux, or None.
 
@@ -89,6 +90,17 @@ def _resolve_keyterms(
     env_override = settings.stt_keyterms.strip()
     if env_override:
         items = [t.strip() for t in env_override.split(",") if t.strip()]
+        # The override is process-wide and silently replaces every
+        # tenant's per-call biasing. Log loudly so a misconfigured
+        # deploy is visible in #ci-alerts rather than degrading every
+        # call's keyterms in silence.
+        logger.warning(
+            "stt: STT_KEYTERMS env override active — per-tenant keyterms "
+            "REPLACED for this call (call_sid=%s, n=%d). Unset STT_KEYTERMS "
+            "in non-debug environments.",
+            call_sid,
+            len(items),
+        )
         return items or None
     if constructor_keyterms:
         items = [t for t in constructor_keyterms if t and t.strip()]
@@ -155,7 +167,7 @@ class DeepgramSTT:
         # the SDK with a confusing error message.
         api_key = _api_key()
 
-        keyterms = _resolve_keyterms(self._keyterms_arg)
+        keyterms = _resolve_keyterms(self._keyterms_arg, call_sid=self._call_sid)
 
         self._client = AsyncDeepgramClient(api_key=api_key)
         self._cm = self._client.listen.v2.connect(

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -1,0 +1,160 @@
+"""Deepgram Nova live STT implementation.
+
+Implements the STTProvider contract from app/stt/base.py. Bridges
+Deepgram SDK's callback-based API onto the async-iterator interface
+the router consumer expects, via one internal asyncio.Queue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Optional
+
+from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
+
+from app.config import settings
+from app.deepgram import _api_key
+from app.stt.base import STTEvent, TranscriptEvent
+
+logger = logging.getLogger(__name__)
+
+
+_CLOSED = object()
+
+
+@dataclass(frozen=True)
+class _ErrorBox:
+    # Deepgram's SDK sometimes passes a plain str to the error callback
+    # (e.g., for protocol-level WS closures) and sometimes an Exception;
+    # we accept either and let the consumer's RuntimeError carry it.
+    error: Any
+
+
+def _parse_keyterms(raw: str) -> Optional[list[str]]:
+    """Split STT_KEYTERMS env var into a list, or None when empty."""
+    items = [t.strip() for t in raw.split(",") if t.strip()]
+    return items or None
+
+
+class DeepgramSTT:
+    """Live Deepgram Nova STT provider.
+
+    Lifecycle: ``open()`` opens the live WS and registers SDK callbacks
+    that translate Deepgram events into STTEvents on an internal queue.
+    ``send()`` forwards Twilio media-stream payloads. ``events()`` is an
+    async generator that yields TranscriptEvent and SpeechStartedEvent
+    objects until ``close()`` is called.
+    """
+
+    def __init__(self, *, call_sid: Optional[str] = None) -> None:
+        self._call_sid = call_sid
+        self._conn: Any = None
+        self._queue: asyncio.Queue = asyncio.Queue()
+
+    async def open(self) -> None:
+        dg = DeepgramClient(_api_key())
+        self._conn = dg.listen.asynclive.v("1")
+        self._conn.on(LiveTranscriptionEvents.Transcript, self._on_transcript)
+        self._conn.on(LiveTranscriptionEvents.Error, self._on_error)
+
+        keyterms = _parse_keyterms(settings.stt_keyterms)
+
+        # endpointing + utterance_end_ms together control how aggressively
+        # Deepgram closes a turn. We picked 800/1000 after a 2026-04-26
+        # Twilight test call where endpointing=300 fired ~7 false barge-ins
+        # in 3 minutes — every micro-pause mid-sentence ("i would like to"
+        # <breath> "have") was treated as a turn ending, and the AI kept
+        # saying "take your time" because it thought the caller had spoken.
+        # 800ms is Deepgram's recommended value for conversational flow;
+        # utterance_end_ms=1000 layers a prosody-aware end-of-utterance
+        # signal on top so we wait for "actually finished" instead of just
+        # "stopped making noise".
+        options = LiveOptions(
+            model=settings.stt_model,
+            encoding="mulaw",
+            sample_rate=8000,
+            channels=1,
+            interim_results=True,
+            endpointing=settings.stt_endpointing_ms,
+            utterance_end_ms=settings.stt_utterance_end_ms,
+            vad_events=True,
+            keyterm=keyterms,
+        )
+        started = await self._conn.start(options)
+        if not started:
+            raise RuntimeError(
+                f"Deepgram connection failed to start call_sid={self._call_sid}"
+            )
+
+    async def send(self, audio: bytes) -> None:
+        if self._conn is None:
+            return
+        try:
+            await self._conn.send(audio)
+        except Exception:
+            # Connection-level send failure: log and continue. The next
+            # transcript will be incomplete; the silence watchdog absorbs
+            # the resulting gap.
+            logger.exception(
+                "deepgram send failed call_sid=%s — call continues",
+                self._call_sid,
+            )
+
+    def events(self) -> AsyncIterator[STTEvent]:
+        # Plain def: callers want to "async for" on the result, not "await"
+        # it first. The actual generator lives in _events_impl below.
+        return self._events_impl()
+
+    async def _events_impl(self) -> AsyncIterator[STTEvent]:
+        while True:
+            item = await self._queue.get()
+            if item is _CLOSED:
+                return
+            if isinstance(item, _ErrorBox):
+                # Preserve cause when the SDK passed an actual exception so
+                # production tracebacks chain back to the original failure.
+                # Tests sometimes pass a plain string — guard with isinstance.
+                cause = item.error if isinstance(item.error, BaseException) else None
+                raise RuntimeError(f"deepgram error: {item.error}") from cause
+            yield item
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            try:
+                await self._conn.finish()
+            except Exception:
+                logger.exception(
+                    "deepgram finish failed call_sid=%s", self._call_sid
+                )
+        self._queue.put_nowait(_CLOSED)
+
+    # SDK callbacks ---------------------------------------------------
+    async def _on_transcript(self, _dg_handle: Any, result: Any, **_kwargs: Any) -> None:
+        # Deepgram passes the connection handle as the first arg to bound
+        # handlers in addition to self; we ignore it.
+        alt = result.channel.alternatives[0]
+        text = alt.transcript.strip()
+        if not text:
+            return
+        # Replace None with 1.0 (not 0.0) so callers see worst-case
+        # misheard turns explicitly when Deepgram does provide confidence.
+        raw_confidence = getattr(alt, "confidence", 1.0)
+        confidence = 1.0 if raw_confidence is None else raw_confidence
+
+        is_final = bool(result.is_final)
+        label = "final" if is_final else "interim"
+        logger.info(
+            "transcript [%s] call_sid=%s text=%r", label, self._call_sid, text
+        )
+
+        self._queue.put_nowait(
+            TranscriptEvent(text=text, is_final=is_final, confidence=confidence)
+        )
+
+    async def _on_error(self, _dg_handle: Any, error: Any, **_kwargs: Any) -> None:
+        # Deepgram passes the connection handle as the first arg to bound
+        # handlers in addition to self; we ignore it.
+        logger.error("deepgram error call_sid=%s error=%s", self._call_sid, error)
+        self._queue.put_nowait(_ErrorBox(error))

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -1,8 +1,40 @@
-"""Deepgram Nova live STT implementation.
+"""Deepgram Flux live STT implementation.
 
-Implements the STTProvider contract from app/stt/base.py. Bridges
-Deepgram SDK's callback-based API onto the async-iterator interface
-the router consumer expects, via one internal asyncio.Queue.
+Implements the STTProvider contract from app/stt/base.py. Uses
+``AsyncDeepgramClient.listen.v2.connect`` (Flux v2 API) and translates
+Flux's wire messages into the vendor-neutral common-named events the
+consumer expects.
+
+Translation map (Flux ``TurnInfo.event`` → common-named event):
+
+    | TurnInfo.event   | Common-named             |
+    |------------------|--------------------------|
+    | "Update"         | TranscriptEvent(is_final=False)
+    | "StartOfTurn"    | SpeechStartedEvent
+    | "EagerEndOfTurn" | EarlyTurnEndEvent
+    | "TurnResumed"    | TurnResumedEvent
+    | "EndOfTurn"      | TranscriptEvent(is_final=True)
+
+``EarlyTurnEndEvent`` and ``TurnResumedEvent`` are emitted but the
+session-loop consumer drops them in this PR. They exist on the wire
+so a follow-up speculative-drafting PR can wire them in without
+changing the protocol.
+
+A note on the SDK's wire format: ``deepgram-sdk`` 7.1's
+``recv()`` returns Union-typed messages by passing the JSON to
+``construct_type(Union[...], ...)``, which does NOT pick a Union
+discriminator and falls through to the raw dict. So in practice every
+message arrives as a ``dict`` with a ``type`` field. ``_translate``
+routes on that field for dicts, and keeps an ``isinstance``
+fallback in case a future SDK revision starts returning concrete
+Pydantic models.
+
+Lifecycle: ``open()`` enters the v2 connect context and starts a
+background reader task that drains ``recv()`` into an internal queue.
+``send()`` forwards Twilio mulaw bytes via ``send_media``.
+``events()`` is an async generator yielding STTEvents until
+``close()``. ``close()`` cancels the reader, sends close-stream, and
+exits the context manager.
 """
 
 from __future__ import annotations
@@ -10,13 +42,25 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Optional
+from typing import Any, AsyncIterator, Optional, Sequence
 
-from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
+from deepgram import AsyncDeepgramClient
+from deepgram.listen.v2.types import (
+    ListenV2ConfigureFailure,
+    ListenV2Connected,
+    ListenV2FatalError,
+    ListenV2TurnInfo,
+)
 
 from app.config import settings
 from app.deepgram import _api_key
-from app.stt.base import STTEvent, SpeechStartedEvent, TranscriptEvent
+from app.stt.base import (
+    EarlyTurnEndEvent,
+    SpeechStartedEvent,
+    STTEvent,
+    TranscriptEvent,
+    TurnResumedEvent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,88 +70,298 @@ _CLOSED = object()
 
 @dataclass(frozen=True)
 class _ErrorBox:
-    # Deepgram's SDK sometimes passes a plain str to the error callback
-    # (e.g., for protocol-level WS closures) and sometimes an Exception;
-    # we accept either and let the consumer's RuntimeError carry it.
     error: Any
 
 
-def _parse_keyterms(raw: str) -> Optional[list[str]]:
-    """Split STT_KEYTERMS env var into a list, or None when empty."""
-    items = [t.strip() for t in raw.split(",") if t.strip()]
-    return items or None
+def _resolve_keyterms(
+    constructor_keyterms: Optional[Sequence[str]],
+) -> Optional[list[str]]:
+    """Return the keyterm list to send to Flux, or None.
+
+    Precedence:
+      1. STT_KEYTERMS env var (when non-empty) — debug override that
+         REPLACES the heuristic output entirely. Used to A/B specific
+         lists without redeploying.
+      2. The list passed by the caller (computed per-tenant by
+         app.restaurants.keyterms.compute_keyterms).
+      3. None — Flux runs in pure open-domain mode.
+    """
+    env_override = settings.stt_keyterms.strip()
+    if env_override:
+        items = [t.strip() for t in env_override.split(",") if t.strip()]
+        return items or None
+    if constructor_keyterms:
+        items = [t for t in constructor_keyterms if t and t.strip()]
+        return items or None
+    return None
+
+
+def _confidence_from_words_payload(words: Any) -> float:
+    """Average word-level confidence as a single transcript confidence.
+
+    Accepts either a list of pydantic ``ListenV2TurnInfoWordsItem``
+    instances (attribute access) or a list of plain dicts (key access),
+    which is what Flux's ``recv()`` returns when ``construct_type``
+    falls through to the raw JSON path. Returns 1.0 as the
+    worst-case-visible default when no per-word confidence is
+    available — picking 0.0 would mask genuine low-confidence turns.
+    """
+    if not words:
+        return 1.0
+    try:
+        confs: list[float] = []
+        for w in words:
+            if isinstance(w, dict):
+                c = w.get("confidence")
+            else:
+                c = getattr(w, "confidence", None)
+            if c is None:
+                continue
+            confs.append(float(c))
+        if confs:
+            return sum(confs) / len(confs)
+    except (TypeError, ValueError):
+        pass
+    return 1.0
 
 
 class DeepgramSTT:
-    """Live Deepgram Nova STT provider.
+    """Live Deepgram Flux STT provider.
 
-    Lifecycle: ``open()`` opens the live WS and registers SDK callbacks
-    that translate Deepgram events into STTEvents on an internal queue.
-    ``send()`` forwards Twilio media-stream payloads. ``events()`` is an
-    async generator that yields TranscriptEvent and SpeechStartedEvent
-    objects until ``close()`` is called.
+    Constructor accepts an optional ``keyterms`` list — typically the
+    output of ``app.restaurants.keyterms.compute_keyterms`` for the
+    active tenant. When the ``STT_KEYTERMS`` env var is non-empty it
+    REPLACES this list (debug override).
     """
 
-    def __init__(self, *, call_sid: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        *,
+        call_sid: Optional[str] = None,
+        keyterms: Optional[Sequence[str]] = None,
+    ) -> None:
         self._call_sid = call_sid
+        self._keyterms_arg: Optional[list[str]] = (
+            list(keyterms) if keyterms else None
+        )
+        self._client: Any = None
+        self._cm: Any = None
         self._conn: Any = None
+        self._reader: Optional[asyncio.Task] = None
         self._queue: asyncio.Queue = asyncio.Queue()
 
     async def open(self) -> None:
-        dg = DeepgramClient(_api_key())
-        self._conn = dg.listen.asynclive.v("1")
-        self._conn.on(LiveTranscriptionEvents.Transcript, self._on_transcript)
-        self._conn.on(
-            LiveTranscriptionEvents.SpeechStarted, self._on_speech_started
-        )
-        self._conn.on(LiveTranscriptionEvents.Error, self._on_error)
+        # Eager api-key check so the call fails before we hand off to
+        # the SDK with a confusing error message.
+        api_key = _api_key()
 
-        keyterms = _parse_keyterms(settings.stt_keyterms)
+        keyterms = _resolve_keyterms(self._keyterms_arg)
 
-        # endpointing + utterance_end_ms together control how aggressively
-        # Deepgram closes a turn. We picked 800/1000 after a 2026-04-26
-        # Twilight test call where endpointing=300 fired ~7 false barge-ins
-        # in 3 minutes — every micro-pause mid-sentence ("i would like to"
-        # <breath> "have") was treated as a turn ending, and the AI kept
-        # saying "take your time" because it thought the caller had spoken.
-        # 800ms is Deepgram's recommended value for conversational flow;
-        # utterance_end_ms=1000 layers a prosody-aware end-of-utterance
-        # signal on top so we wait for "actually finished" instead of just
-        # "stopped making noise".
-        options = LiveOptions(
+        self._client = AsyncDeepgramClient(api_key=api_key)
+        self._cm = self._client.listen.v2.connect(
             model=settings.stt_model,
             encoding="mulaw",
             sample_rate=8000,
-            channels=1,
-            interim_results=True,
-            endpointing=settings.stt_endpointing_ms,
-            utterance_end_ms=settings.stt_utterance_end_ms,
-            vad_events=True,
             keyterm=keyterms,
         )
-        started = await self._conn.start(options)
-        if not started:
-            raise RuntimeError(
-                f"Deepgram connection failed to start call_sid={self._call_sid}"
+        try:
+            self._conn = await self._cm.__aenter__()
+        except Exception:
+            # Connect itself failed (network, auth, malformed args).
+            # Re-raise so the caller can decide whether to fall back to
+            # voicemail or end the call cleanly.
+            self._cm = None
+            raise
+
+        self._reader = asyncio.create_task(self._read_loop())
+
+    async def _read_loop(self) -> None:
+        """Drain Flux messages into the internal queue.
+
+        ``recv()`` blocks until the next message; the background task
+        translates each one into a common-named event and enqueues it
+        for the consumer. The task ends when the connection closes
+        (``recv`` raises) or when ``close()`` cancels it. The
+        ``msg_count`` in the cancelled/crashed logs gives the postmortem
+        a quick read on how many wire messages were actually delivered.
+        """
+        msg_count = 0
+        try:
+            while True:
+                msg = await self._conn.recv()
+                msg_count += 1
+                self._translate(msg)
+        except asyncio.CancelledError:
+            logger.info(
+                "deepgram reader cancelled call_sid=%s msg_count=%d",
+                self._call_sid,
+                msg_count,
             )
+            raise
+        except Exception as exc:
+            logger.exception(
+                "deepgram reader crashed call_sid=%s msg_count=%d",
+                self._call_sid,
+                msg_count,
+            )
+            self._queue.put_nowait(_ErrorBox(exc))
+
+    def _translate(self, msg: Any) -> None:
+        """Translate one Flux wire message into a common-named event.
+
+        The SDK's ``recv()`` returns ``dict`` for typed messages because
+        ``construct_type`` on a Union doesn't pick a discriminator and
+        falls through to returning the raw JSON dict. We route on the
+        ``type`` field of the dict and keep the Pydantic-class
+        ``isinstance`` branches as a safety net for any future SDK
+        version that does parse Union members into concrete classes.
+        """
+        # Normalize: extract a ``type`` discriminator from either a
+        # dict or a typed model.
+        if isinstance(msg, dict):
+            msg_type = msg.get("type")
+            getter = msg.get
+        elif isinstance(
+            msg,
+            (
+                ListenV2Connected,
+                ListenV2TurnInfo,
+                ListenV2ConfigureFailure,
+                ListenV2FatalError,
+            ),
+        ):
+            msg_type = getattr(msg, "type", None) or type(msg).__name__.replace(
+                "ListenV2", ""
+            )
+
+            def getter(key, default=None, _msg=msg):
+                return getattr(_msg, key, default)
+        else:
+            logger.debug(
+                "deepgram unknown message type=%s call_sid=%s",
+                type(msg).__name__,
+                self._call_sid,
+            )
+            return
+
+        if msg_type == "Connected":
+            logger.info(
+                "deepgram connected call_sid=%s request_id=%s",
+                self._call_sid,
+                getter("request_id", "?"),
+            )
+            return
+
+        if msg_type == "TurnInfo":
+            event = getter("event", "")
+            text = (getter("transcript", "") or "").strip()
+
+            if event == "StartOfTurn":
+                logger.info(
+                    "speech_started call_sid=%s turn=%s",
+                    self._call_sid,
+                    getter("turn_index", "?"),
+                )
+                self._queue.put_nowait(SpeechStartedEvent())
+                return
+
+            if event == "Update":
+                # Interim transcript. Skip empty payloads — Flux
+                # streams an "Update" event every ~250ms with a
+                # rolling end_of_turn_confidence even when there's
+                # no speech yet, and an empty transcript downstream
+                # confuses logging and the low-confidence counter.
+                if not text:
+                    return
+                confidence = _confidence_from_words_payload(getter("words", []))
+                logger.info(
+                    "transcript [interim] call_sid=%s text=%r",
+                    self._call_sid,
+                    text,
+                )
+                self._queue.put_nowait(
+                    TranscriptEvent(text=text, is_final=False, confidence=confidence)
+                )
+                return
+
+            if event == "EagerEndOfTurn":
+                logger.info(
+                    "eager_eot call_sid=%s turn=%s",
+                    self._call_sid,
+                    getter("turn_index", "?"),
+                )
+                self._queue.put_nowait(EarlyTurnEndEvent())
+                return
+
+            if event == "TurnResumed":
+                logger.info(
+                    "turn_resumed call_sid=%s turn=%s",
+                    self._call_sid,
+                    getter("turn_index", "?"),
+                )
+                self._queue.put_nowait(TurnResumedEvent())
+                return
+
+            if event == "EndOfTurn":
+                if not text:
+                    # Confirmed turn-end with no transcript — caller
+                    # said nothing recognizable. Drop; the consumer
+                    # has nothing to act on.
+                    return
+                confidence = _confidence_from_words_payload(getter("words", []))
+                logger.info(
+                    "transcript [final] call_sid=%s text=%r",
+                    self._call_sid,
+                    text,
+                )
+                self._queue.put_nowait(
+                    TranscriptEvent(text=text, is_final=True, confidence=confidence)
+                )
+                return
+
+            # Unknown event — log and drop. New Flux versions may add
+            # event types we haven't taught the translator about; we'd
+            # rather no-op than crash the call.
+            logger.debug(
+                "deepgram unknown turn_info event=%r call_sid=%s",
+                event,
+                self._call_sid,
+            )
+            return
+
+        if msg_type in ("ConfigureFailure", "FatalError"):
+            logger.error(
+                "deepgram error call_sid=%s msg_type=%s msg=%s",
+                self._call_sid,
+                msg_type,
+                msg,
+            )
+            self._queue.put_nowait(
+                _ErrorBox(RuntimeError(f"deepgram error: {msg}"))
+            )
+            return
+
+        logger.debug(
+            "deepgram unknown message type=%r call_sid=%s",
+            msg_type,
+            self._call_sid,
+        )
 
     async def send(self, audio: bytes) -> None:
         if self._conn is None:
             return
         try:
-            await self._conn.send(audio)
+            await self._conn.send_media(audio)
         except Exception:
-            # Connection-level send failure: log and continue. The next
-            # transcript will be incomplete; the silence watchdog absorbs
-            # the resulting gap.
+            # Connection-level send failure: log and continue. The
+            # next transcript will be incomplete; the silence
+            # watchdog absorbs the resulting gap.
             logger.exception(
                 "deepgram send failed call_sid=%s — call continues",
                 self._call_sid,
             )
 
     def events(self) -> AsyncIterator[STTEvent]:
-        # Plain def: callers want to "async for" on the result, not "await"
-        # it first. The actual generator lives in _events_impl below.
         return self._events_impl()
 
     async def _events_impl(self) -> AsyncIterator[STTEvent]:
@@ -116,61 +370,44 @@ class DeepgramSTT:
             if item is _CLOSED:
                 return
             if isinstance(item, _ErrorBox):
-                # Preserve cause when the SDK passed an actual exception so
-                # production tracebacks chain back to the original failure.
-                # Tests sometimes pass a plain string — guard with isinstance.
-                cause = item.error if isinstance(item.error, BaseException) else None
+                cause = (
+                    item.error if isinstance(item.error, BaseException) else None
+                )
                 raise RuntimeError(f"deepgram error: {item.error}") from cause
             yield item
 
     async def close(self) -> None:
+        # Stop the reader first so it doesn't see the close-stream
+        # turn-around as a crash and enqueue a spurious _ErrorBox.
+        if self._reader and not self._reader.done():
+            self._reader.cancel()
+            try:
+                await self._reader
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception(
+                    "deepgram reader cleanup failed call_sid=%s",
+                    self._call_sid,
+                )
+
         if self._conn is not None:
             try:
-                await self._conn.finish()
+                await self._conn.send_close_stream()
+            except Exception:
+                # Socket already gone — exit the context manager
+                # anyway so resources are released.
+                logger.debug(
+                    "deepgram send_close_stream failed (likely already closed) call_sid=%s",
+                    self._call_sid,
+                )
+
+        if self._cm is not None:
+            try:
+                await self._cm.__aexit__(None, None, None)
             except Exception:
                 logger.exception(
                     "deepgram finish failed call_sid=%s", self._call_sid
                 )
+
         self._queue.put_nowait(_CLOSED)
-
-    # SDK callbacks ---------------------------------------------------
-    async def _on_transcript(self, _dg_handle: Any, result: Any, **_kwargs: Any) -> None:
-        # Deepgram passes the connection handle as the first arg to bound
-        # handlers in addition to self; we ignore it.
-        alt = result.channel.alternatives[0]
-        text = alt.transcript.strip()
-        if not text:
-            return
-        # Replace None with 1.0 (not 0.0) so callers see worst-case
-        # misheard turns explicitly when Deepgram does provide confidence.
-        raw_confidence = getattr(alt, "confidence", 1.0)
-        confidence = 1.0 if raw_confidence is None else raw_confidence
-
-        is_final = bool(result.is_final)
-        label = "final" if is_final else "interim"
-        logger.info(
-            "transcript [%s] call_sid=%s text=%r", label, self._call_sid, text
-        )
-
-        self._queue.put_nowait(
-            TranscriptEvent(text=text, is_final=is_final, confidence=confidence)
-        )
-
-    async def _on_speech_started(
-        self, _dg_handle: Any, _event: Any = None, **_kwargs: Any
-    ) -> None:
-        # Deepgram's SDK calls _on_transcript and _on_error with
-        # (handle, payload), but SpeechStarted is invoked with just
-        # (handle) — no second positional arg. The `_event=None` default
-        # tolerates both shapes. Removing the default crashes the live
-        # SDK at runtime even though the unit test passes (the test was
-        # explicitly supplying a second arg, hiding the real SDK calling
-        # convention).
-        logger.info("speech_started call_sid=%s", self._call_sid)
-        self._queue.put_nowait(SpeechStartedEvent())
-
-    async def _on_error(self, _dg_handle: Any, error: Any, **_kwargs: Any) -> None:
-        # Deepgram passes the connection handle as the first arg to bound
-        # handlers in addition to self; we ignore it.
-        logger.error("deepgram error call_sid=%s error=%s", self._call_sid, error)
-        self._queue.put_nowait(_ErrorBox(error))

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -157,11 +157,15 @@ class DeepgramSTT:
         )
 
     async def _on_speech_started(
-        self, _dg_handle: Any, _event: Any, **_kwargs: Any
+        self, _dg_handle: Any, _event: Any = None, **_kwargs: Any
     ) -> None:
-        # Deepgram passes the connection handle as the first arg to bound
-        # handlers in addition to self; we ignore it. The event payload
-        # is also unused — we only need the signal that speech started.
+        # Deepgram's SDK calls _on_transcript and _on_error with
+        # (handle, payload), but SpeechStarted is invoked with just
+        # (handle) — no second positional arg. The `_event=None` default
+        # tolerates both shapes. Removing the default crashes the live
+        # SDK at runtime even though the unit test passes (the test was
+        # explicitly supplying a second arg, hiding the real SDK calling
+        # convention).
         logger.info("speech_started call_sid=%s", self._call_sid)
         self._queue.put_nowait(SpeechStartedEvent())
 

--- a/app/deepgram/tts.py
+++ b/app/deepgram/tts.py
@@ -1,7 +1,7 @@
-"""Deepgram Aura TTS client for the niko voice agent.
+"""Deepgram Aura TTS implementation.
 
-Streams LLM reply text through Deepgram Aura and pipes mulaw 8 kHz audio
-back to the caller via the active Twilio Media Streams WebSocket.
+Streams Aura audio through Twilio Media Streams. Implements the SpeakFunc
+contract from app/tts/base.py.
 
 Why Deepgram Aura (over ElevenLabs):
   - Server-to-server design — no abuse detector that blocks Cloud Run egress.
@@ -13,17 +13,17 @@ from __future__ import annotations
 
 import base64
 import logging
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 import httpx
 from fastapi import WebSocket
 from starlette.websockets import WebSocketDisconnect
 
 from app.config import settings
+from app.deepgram import _DEEPGRAM_BASE, _api_key
 
 logger = logging.getLogger(__name__)
 
-_DEEPGRAM_BASE = "https://api.deepgram.com/v1"
 
 # Process-wide reusable client (#151). Constructing an httpx.AsyncClient
 # costs a TLS handshake on every speak() call; reusing one across the
@@ -43,22 +43,13 @@ def _get_client() -> httpx.AsyncClient:
     return _default_client
 
 
-def _api_key() -> str:
-    key = settings.deepgram_api_key
-    if not key:
-        raise RuntimeError(
-            "DEEPGRAM_API_KEY not set — cannot call TTS. Fetch credentials via /shared-creds."
-        )
-    return key
-
-
 async def speak(
     text: str,
     websocket: WebSocket,
     stream_sid: str,
     *,
     client: Optional[httpx.AsyncClient] = None,
-    recording_session: Optional[Any] = None,
+    on_chunk: Optional[Callable[[bytes], None]] = None,
     on_first_byte: Optional[Callable[[], None]] = None,
 ) -> None:
     """Stream Deepgram Aura TTS audio back into the Twilio call.
@@ -67,25 +58,6 @@ async def speak(
     bytes that Twilio's Media Streams accepts directly. Each binary chunk
     is base64-encoded and sent as a Twilio ``media`` WebSocket event
     immediately, keeping latency low.
-
-    Args:
-        text:              LLM reply text to synthesize.
-        websocket:         Active Twilio Media Streams WebSocket.
-        stream_sid:        Twilio streamSid from the ``start`` event.
-        client:            Optional injected httpx.AsyncClient (for unit tests).
-        recording_session: Optional ``RecordingUploadSession`` from
-                           ``app.storage.recordings``. When set, each TTS
-                           chunk is also fed into the recording's
-                           outbound side via ``append_chunks(session, b"",
-                           chunk)``. ``<Connect><Stream>`` only sends us
-                           inbound audio from Twilio, so the only way
-                           to get the agent's voice into the recording is
-                           to capture the bytes we generate ourselves.
-        on_first_byte:     Optional zero-arg sync callable fired exactly once
-                           when the first non-empty chunk arrives from
-                           Deepgram. Used by the router to measure actual
-                           TTS network latency (#152). Exceptions are
-                           swallowed so a buggy callback never breaks a call.
     """
     if not text.strip():
         return
@@ -143,13 +115,8 @@ async def speak(
             except WebSocketDisconnect:
                 logger.info("tts: websocket disconnected mid-stream stream_sid=%s", stream_sid)
                 return
-            if recording_session is not None:
+            if on_chunk is not None:
                 try:
-                    from app.storage import recordings as _recordings
-
-                    _recordings.append_chunks(recording_session, b"", chunk)
+                    on_chunk(chunk)
                 except Exception:
-                    logger.exception(
-                        "tts: failed to feed chunk into recording session stream_sid=%s",
-                        stream_sid,
-                    )
+                    logger.exception("tts: on_chunk callback raised stream_sid=%s", stream_sid)

--- a/app/restaurants/keyterms.py
+++ b/app/restaurants/keyterms.py
@@ -1,0 +1,124 @@
+"""Per-tenant keyterm computation for Deepgram Flux STT.
+
+Flux exposes a ``keyterm`` parameter on its v2 connect API that biases
+recognition toward menu-specific vocabulary. Without it, every call is
+open-domain English and items like "Coke" or "Pepper Shrimp" lose to
+acoustically-similar everyday phrases ("smoke", "pepper soup").
+
+Deepgram caps the keyterm payload at 500 tokens across all terms per
+request. Token here means a sub-word vocabulary unit; we approximate
+it with ``ceil(word_count * 1.3)`` because the tokenizer is not
+public. The 50-token safety margin under the 500 cap absorbs the
+heuristic's slop.
+
+This module is intentionally a pure function over a menu dict. No
+Firestore reads, no settings reads, no logging — the caller owns
+all of that. Keeps the heuristic deterministic and trivially testable.
+"""
+
+from __future__ import annotations
+
+from math import ceil
+from typing import Any
+
+# Items the model recognizes reliably without keyterm bias. Lowercase
+# substrings; if a menu item's name contains one of these, we skip it
+# to save token budget for items that actually need biasing. The list
+# is intentionally short — when in doubt, include the term and let
+# Flux's tokenizer absorb a few wasted tokens.
+_COMMON_SAFE_TERMS = frozenset(
+    {
+        "french fries",
+        "chicken wings",
+        "caesar salad",
+        "garlic bread",
+        "ice cream",
+        "spring roll",
+        "shrimp roll",
+        "vegetable spring roll",
+        "fried rice",
+    }
+)
+
+# Conservative token estimate. Deepgram's tokenizer isn't public; a
+# 1.3x word multiplier slightly overestimates so the safety margin
+# accommodates terms with sub-word splits like "Bánh Mì".
+_TOKENS_PER_WORD = 1.3
+
+# Target budget. Flux's hard cap is 500 tokens; the 50-token margin
+# protects against heuristic underestimation.
+_TOKEN_BUDGET = 450
+
+
+def _estimate_tokens(term: str) -> int:
+    """Rough sub-word token count. Always returns at least 1."""
+    words = term.split()
+    if not words:
+        return 0
+    return max(1, ceil(len(words) * _TOKENS_PER_WORD))
+
+
+def _is_common_safe_term(name: str) -> bool:
+    """True iff the name contains a substring the model recognizes
+    reliably without bias. Substring match avoids forcing the safe
+    list to enumerate every variant ('Spicy French Fries' is also
+    safe because it contains 'french fries')."""
+    name_lower = name.lower()
+    return any(safe in name_lower for safe in _COMMON_SAFE_TERMS)
+
+
+def compute_keyterms(menu: dict[str, Any], restaurant_name: str) -> list[str]:
+    """Build a Flux keyterm list for one restaurant.
+
+    Returns ``restaurant_name`` first (always — the caller may say it
+    when greeting), then menu item names in menu order, skipping items
+    in the common-safe set and items that duplicate something already
+    included (case-insensitive). Stops at the first item whose addition
+    would push the running token estimate over the budget — remaining
+    items get no bias on this call.
+
+    Pathological input where ``restaurant_name`` alone exceeds budget:
+    return only ``[restaurant_name]`` — the caller is responsible for
+    deciding whether that's acceptable. Returning an empty list would
+    mean *no* bias at all, which is worse.
+    """
+    name_tokens = _estimate_tokens(restaurant_name)
+    if name_tokens >= _TOKEN_BUDGET:
+        # Name alone exceeds the budget. Return as-is and let the
+        # caller log/triage; producing an empty list would silently
+        # drop biasing for the caller-spoken restaurant name.
+        return [restaurant_name]
+
+    terms: list[str] = [restaurant_name]
+    used_tokens = name_tokens
+    seen: set[str] = {restaurant_name.lower()}
+
+    for category_key, items in menu.items():
+        if isinstance(category_key, str) and category_key.startswith("_"):
+            # Reserved keys like _category_order. Skip — they aren't
+            # category lists and would crash isinstance(items, list).
+            continue
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            name = (item.get("name") or "").strip()
+            if not name:
+                continue
+            name_lower = name.lower()
+            if name_lower in seen:
+                continue
+            if _is_common_safe_term(name):
+                continue
+            cost = _estimate_tokens(name)
+            if used_tokens + cost > _TOKEN_BUDGET:
+                # We've hit the budget — stop emitting. Any items we
+                # haven't reached yet simply don't get biased on this
+                # call. The caller can decide whether to log this.
+                return terms
+            terms.append(name)
+            used_tokens += cost
+            seen.add(name_lower)
+
+    return terms

--- a/app/storage/recordings.py
+++ b/app/storage/recordings.py
@@ -231,6 +231,9 @@ def finalize_recording(
     if not session.inbound_pcm and not session.outbound_pcm:
         return ("", 0)
 
+    if not settings.recordings_bucket:
+        return ("", 0)
+
     try:
         mixed = _mix_pcm_streams(bytes(session.inbound_pcm), bytes(session.outbound_pcm))
         if not mixed:

--- a/app/stt/__init__.py
+++ b/app/stt/__init__.py
@@ -1,9 +1,7 @@
 """Public entry point for the STT abstraction layer.
 
 Re-exports the contract so callers do ``from app.stt import
-TranscriptEvent`` instead of reaching into ``app.stt.base``. The
-``get_stt()`` selector is added in a later task once a concrete
-implementation exists.
+TranscriptEvent`` instead of reaching into ``app.stt.base``.
 """
 
 from app.stt.base import (
@@ -18,4 +16,22 @@ __all__ = [
     "STTProvider",
     "SpeechStartedEvent",
     "TranscriptEvent",
+    "get_stt",
 ]
+
+
+def get_stt(*, call_sid: str | None = None) -> tuple["STTProvider", str]:
+    """Return the configured STT provider plus its name.
+
+    The name is returned alongside the provider so the caller (the router
+    consumer) can include ``provider`` metadata in events when desired,
+    without the plugin needing to know its own name.
+    """
+    from app.config import settings
+
+    name = settings.stt_provider
+    if name == "deepgram":
+        from app.deepgram.stt import DeepgramSTT
+
+        return DeepgramSTT(call_sid=call_sid), name
+    raise ValueError(f"Unknown STT provider: {name}")

--- a/app/stt/__init__.py
+++ b/app/stt/__init__.py
@@ -5,27 +5,41 @@ TranscriptEvent`` instead of reaching into ``app.stt.base``.
 """
 
 from app.stt.base import (
+    EarlyTurnEndEvent,
+    SpeechStartedEvent,
     STTEvent,
     STTProvider,
-    SpeechStartedEvent,
     TranscriptEvent,
+    TurnResumedEvent,
 )
 
 __all__ = [
+    "EarlyTurnEndEvent",
     "STTEvent",
     "STTProvider",
     "SpeechStartedEvent",
     "TranscriptEvent",
+    "TurnResumedEvent",
     "get_stt",
 ]
 
 
-def get_stt(*, call_sid: str | None = None) -> tuple["STTProvider", str]:
+def get_stt(
+    *,
+    call_sid: str | None = None,
+    keyterms: "list[str] | None" = None,
+) -> tuple["STTProvider", str]:
     """Return the configured STT provider plus its name.
 
-    The name is returned alongside the provider so the caller (the router
-    consumer) can include ``provider`` metadata in events when desired,
-    without the plugin needing to know its own name.
+    ``keyterms`` (when provided) is forwarded to providers that support
+    biased recognition; the Deepgram Flux provider uses it to pre-bias
+    against the active tenant's menu vocabulary. Providers that don't
+    support keyterms ignore the argument — callers can always pass it
+    safely.
+
+    The provider name is returned alongside the provider so the caller
+    (the router consumer) can include ``provider`` metadata in events
+    when desired, without the plugin needing to know its own name.
     """
     from app.config import settings
 
@@ -33,5 +47,5 @@ def get_stt(*, call_sid: str | None = None) -> tuple["STTProvider", str]:
     if name == "deepgram":
         from app.deepgram.stt import DeepgramSTT
 
-        return DeepgramSTT(call_sid=call_sid), name
+        return DeepgramSTT(call_sid=call_sid, keyterms=keyterms), name
     raise ValueError(f"Unknown STT provider: {name}")

--- a/app/stt/__init__.py
+++ b/app/stt/__init__.py
@@ -1,0 +1,21 @@
+"""Public entry point for the STT abstraction layer.
+
+Re-exports the contract so callers do ``from app.stt import
+TranscriptEvent`` instead of reaching into ``app.stt.base``. The
+``get_stt()`` selector is added in a later task once a concrete
+implementation exists.
+"""
+
+from app.stt.base import (
+    STTEvent,
+    STTProvider,
+    SpeechStartedEvent,
+    TranscriptEvent,
+)
+
+__all__ = [
+    "STTEvent",
+    "STTProvider",
+    "SpeechStartedEvent",
+    "TranscriptEvent",
+]

--- a/app/stt/base.py
+++ b/app/stt/base.py
@@ -32,7 +32,30 @@ class TranscriptEvent:
     confidence: float
 
 
-STTEvent = Union[TranscriptEvent, SpeechStartedEvent]
+@dataclass(frozen=True)
+class EarlyTurnEndEvent:
+    """The provider speculates the caller's turn is ending. A consumer
+    that wants minimal-latency replies may use this to start drafting
+    speculatively; a ``TurnResumedEvent`` will follow if the caller
+    keeps talking. Providers without prosody-aware turn detection (e.g.
+    Whisper) never emit this event — consumers must treat it as
+    advisory and tolerate its absence."""
+
+
+@dataclass(frozen=True)
+class TurnResumedEvent:
+    """The caller resumed speaking after an ``EarlyTurnEndEvent``. A
+    consumer that started speculative work in response to the eager
+    end should cancel it. Providers that do not emit
+    ``EarlyTurnEndEvent`` will likewise never emit this event."""
+
+
+STTEvent = Union[
+    TranscriptEvent,
+    SpeechStartedEvent,
+    EarlyTurnEndEvent,
+    TurnResumedEvent,
+]
 
 
 class STTProvider(Protocol):

--- a/app/stt/base.py
+++ b/app/stt/base.py
@@ -1,0 +1,59 @@
+"""STT provider contract.
+
+The router talks to STT through this interface; concrete providers
+(today: Deepgram) live under app/<vendor>/stt.py. Future providers
+implement the same Protocol and become a one-line addition to the
+selector in app/stt/__init__.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import AsyncIterator, Protocol, Union
+
+
+@dataclass(frozen=True)
+class SpeechStartedEvent:
+    """VAD detected the caller began speaking. Fires before any transcript
+    is available — used for instant barge-in (~50ms vs ~800ms waiting on
+    a final transcript)."""
+
+    at: float = 0.0  # optional Deepgram timestamp; 0 if SDK omits it
+
+
+@dataclass(frozen=True)
+class TranscriptEvent:
+    """One recognition result from the STT provider. Interim results
+    (``is_final=False``) are rewritten by subsequent events; only finals
+    should drive behavior."""
+
+    text: str
+    is_final: bool
+    confidence: float
+
+
+STTEvent = Union[TranscriptEvent, SpeechStartedEvent]
+
+
+class STTProvider(Protocol):
+    """Live streaming STT contract.
+
+    Lifecycle: ``open()`` → many ``send(audio)`` + ``async for`` over
+    ``events()`` → ``close()``. Errors mid-stream raise out of
+    ``events()``; the consumer decides whether to recover or end the call.
+    """
+
+    async def open(self) -> None:
+        """Open the live STT connection. Raises on failure."""
+
+    async def send(self, audio: bytes) -> None:
+        """Forward one chunk of caller audio (mulaw 8 kHz from Twilio).
+        Connection-level errors are caught internally and logged; the call
+        does not die on transient send failures."""
+
+    def events(self) -> AsyncIterator[STTEvent]:
+        """Yield STTEvents until close() is called. Raises on connection
+        error — the consumer is responsible for catching and recovering."""
+
+    async def close(self) -> None:
+        """Tear down the connection and signal events() to terminate."""

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -256,6 +256,35 @@ async def clear_twilio_audio(websocket: WebSocket, stream_sid: str | None) -> No
         logger.exception("clear: failed to send Twilio clear event stream_sid=%s", stream_sid)
 
 
+async def _barge_in_now(
+    state: "_CallState",
+    websocket: WebSocket,
+    *,
+    trigger: str,
+) -> None:
+    """Stop the bot mid-utterance.
+
+    Three mechanical steps:
+      1. Cancel the in-flight LLM/TTS task → halt audio generation.
+      2. Cancel the silence watchdog → caller is speaking; "are you still
+         there?" would be wrong.
+      3. Send Twilio 'clear' → flush already-buffered audio playback (#74).
+
+    The barge_in Firestore event is NOT emitted here. It's emitted by
+    _run_llm_tts_turn's existing CancelledError handler when the task we
+    just cancelled actually receives the cancellation. Trigger
+    information flows via state.barge_in_trigger, which is set ONLY when
+    there is actually a task to cancel — preventing stale triggers from
+    leaking into the next turn's barge-in event, and preventing phantom
+    barge_in events on cleanup-path cancellations (WS shutdown).
+    """
+    if state.llm_task and not state.llm_task.done():
+        state.barge_in_trigger = trigger
+        state.llm_task.cancel()
+    _cancel_silence_task(state)
+    await clear_twilio_audio(websocket, state.stream_sid)
+
+
 @dataclass
 class _CallState:
     call_sid: str | None = None
@@ -289,6 +318,10 @@ class _CallState:
     # turn's user words aren't lost (#170). Cleared by ``_run_llm_tts_turn``
     # the moment ``event.final`` writes ``state.history``.
     in_flight_transcript: str = ""
+    # Set by _barge_in_now() before cancelling state.llm_task; read and
+    # cleared by _run_llm_tts_turn's CancelledError handler when emitting
+    # the barge_in Firestore event. None at all other times.
+    barge_in_trigger: str | None = None
 
 
 async def _open_deepgram_connection(
@@ -588,8 +621,28 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                             )
 
     except asyncio.CancelledError:
-        logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)
-        _bg_call_event(state.call_sid, _state_rid(state), kind="barge_in")
+        trigger = state.barge_in_trigger
+        state.barge_in_trigger = None
+        if trigger is not None:
+            # User-driven barge-in: trigger was set by _barge_in_now
+            # before cancelling the task. Emit the timeline event.
+            logger.info(
+                "llm_turn cancelled (barge-in trigger=%s) call_sid=%s",
+                trigger,
+                state.call_sid,
+            )
+            _bg_call_event(
+                state.call_sid,
+                _state_rid(state),
+                kind="barge_in",
+                detail={"trigger": trigger},
+            )
+        else:
+            # Cleanup-path cancellation: WS handler's finally block
+            # cancels the task during call teardown. No barge_in event.
+            logger.info(
+                "llm_turn cancelled (cleanup) call_sid=%s", state.call_sid
+            )
         raise
     except Exception as exc:
         logger.exception("llm_turn errored call_sid=%s", state.call_sid)
@@ -607,26 +660,32 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
 
 async def _handle_final_transcript(text: str, state: _CallState, websocket: WebSocket) -> None:
     interrupted = bool(state.llm_task and not state.llm_task.done())
-    if interrupted:
-        state.llm_task.cancel()
     # Carry forward — if any prior turn (cancelled or errored) left a
     # transcript on state without persisting it to history, prepend it
     # so Haiku sees the full caller intent in this turn (#170). The
-    # field is cleared by `_run_llm_tts_turn` only on `event.final`,
+    # field is cleared by ``_run_llm_tts_turn`` only on ``event.final``,
     # so a non-empty value here always means "user words from a prior
     # turn that never made it into history."
     if state.in_flight_transcript.strip():
         text = f"{state.in_flight_transcript} {text}".strip()
     silence_was_active = bool(state.silence_task and not state.silence_task.done())
-    _cancel_silence_task(state)
     # Caller spoke — abort any pending auto-hangup (#78). Even if they
     # spoke during the grace window after a confirmation, we want to
     # keep the call alive and process this transcript.
     _abort_pending_hangup(state)
-    if interrupted or silence_was_active:
-        # Drop Twilio's pending audio buffer so the caller actually hears
-        # us pause instead of getting talked over (#74).
+
+    if interrupted:
+        # True barge-in: a turn is running and we're interrupting it.
+        # The barge_in Firestore event fires from _run_llm_tts_turn's
+        # CancelledError handler.
+        await _barge_in_now(state, websocket, trigger="final_transcript")
+    elif silence_was_active:
+        # Caller resumed after a silence prompt — flush any leftover
+        # prompt audio still buffered, but this isn't a barge-in (no
+        # task to cancel, no event to emit).
+        _cancel_silence_task(state)
         await clear_twilio_audio(websocket, state.stream_sid)
+
     state.in_flight_transcript = text
     state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
     state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -1,20 +1,13 @@
-"""Twilio telephony endpoints.
+"""Twilio telephony FastAPI surface.
 
-POST /voice        — TwiML webhook: answers the inbound call, opens a
-                     Twilio Media Stream so the STT→LLM→TTS pipeline can
-                     take over.  The AI greeting is delivered via the
-                     configured TTS provider on the 'start' event rather
-                     than a static TwiML <Say>.
-
-WS   /media-stream — Receives the Twilio Media Stream over WebSocket and
-                     runs the full call loop:
-                       STT transcript → stream_reply() → speak()
-                     Supports barge-in (VAD speech-started fires the
-                     fast path; final-transcript arrival fires the
-                     fallback path) and a 10-second silence watchdog.
-
-Vendor-specific STT/TTS implementations live under app/<vendor>/; this
-router only knows about the abstractions in app/stt and app/tts.
+Five HTTP webhook endpoints (`/voice`, `/voice/stream-ended`,
+`/voice/transfer-result`, `/voice/voicemail-recorded`,
+`/voice/voicemail-transcription`) and one WebSocket
+(`/media-stream`) that runs Twilio's Media Stream loop. Endpoint
+bodies parse Twilio's webhook form and delegate: TwiML construction
+to app/twilio/twiml.py, REST credentials to app/twilio/__init__.py,
+call orchestration (state, barge-in, hangup, LLM turn) to
+app/telephony/session.py.
 """
 
 from __future__ import annotations
@@ -23,24 +16,35 @@ import asyncio
 import base64
 import json
 import logging
-import time
-from dataclasses import dataclass, field
-from typing import Any, Callable
 
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
-from app.config import settings
-from app.llm.client import stream_reply
+
+import app.twilio as app_twilio
 from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
-from app.orders.models import Order, OrderStatus
-from app.restaurants.models import Restaurant
+from app.orders.models import Order
 from app.restaurants.open_check import is_open_now
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
-from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
-from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
-import app.twilio as app_twilio
+from app.stt import get_stt
+from app.config import settings
+from app.telephony.session import (
+    GREETING_TRANSCRIPT,
+    END_OF_CALL_MARK,
+    _CallState,
+    _abort_pending_hangup,
+    _arm_silence_watchdog,
+    _bg_call_event,
+    _cancel_silence_task,
+    _consume_transcripts,
+    _hang_up_after_grace,
+    _make_recording_chunk_handler,
+    _resolve_restaurant_for_voice,
+    _run_llm_tts_turn,
+    _state_rid,
+)
 from app.telephony.voicemail_twiml import voicemail_response
+from app.tts import speak
 from app.twilio.twiml import (
     closed_hangup_twiml,
     empty_twiml,
@@ -48,632 +52,17 @@ from app.twilio.twiml import (
     unconfigured_hangup_twiml,
     voice_twiml,
 )
-from app.tts import speak
-from app.twilio.media_stream import send_clear, send_mark
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-SILENCE_TIMEOUT_SECONDS = 10.0
-SILENCE_PROMPT = "Are you still there?"
-GREETING_TRANSCRIPT = "[call started — greet the caller]"
-
-# Auto-hangup after order confirmation (#78). Twilio echoes back this
-# named mark when its audio buffer drains, signalling the caller has
-# heard the goodbye; we then hold for the grace window in case they
-# squeeze in a late question before terminating the call.
-END_OF_CALL_MARK = "end_of_call"
-HANGUP_GRACE_SECONDS = 5.0
-# Fallback if Twilio never echoes the end_of_call mark back to us
-# (WebSocket dropped, mark lost in transit). After this many seconds
-# we trigger the grace window anyway so the call still terminates
-# instead of hanging open. Picked > typical mark round-trip (1-3s).
-MARK_ECHO_TIMEOUT_SECONDS = 8.0
-
-# Chunking thresholds for TTS handoff (#151). Sentence terminators
-# always flush; soft breaks (commas, semicolons, colons, em dashes)
-# only flush once the buffered chunk is ≥ _MIN_CHUNK_CHARS so that
-# fragments like "Got it," don't become their own Aura round-trip.
-# 20 chars ≈ "One Chicken Fried Rice coming up," length when the
-# 4/26 Twilight call's longest "over budget" turn would have hit.
-_HARD_BREAKS = (".", "?", "!")
-_SOFT_BREAKS = (",", ";", ":", "—")
-_MIN_CHUNK_CHARS = 20
-
-
-def _should_flush_chunk(delta: str, buffered_chars: int) -> bool:
-    """True if the current text-delta should close a TTS chunk.
-
-    ``delta`` is the latest streamed text fragment from Anthropic;
-    ``buffered_chars`` is the total length of all deltas accumulated
-    since the last flush (i.e. the chunk we'd ship if we flushed now).
-    """
-    if delta.endswith(_HARD_BREAKS):
-        return True
-    if delta.endswith(_SOFT_BREAKS) and buffered_chars >= _MIN_CHUNK_CHARS:
-        return True
-    return False
-
-
-# Phrases the model uses when wrapping up. Used as a fallback signal
-# for auto-hangup when Haiku says a goodbye but forgets to mark the
-# order status as confirmed via update_order (#79). Matched
-# case-insensitive against the full assembled reply.
-_GOODBYE_PATTERNS = (
-    "your order is in",
-    "have it ready",
-    "see you soon",
-    "see you in a",
-    "thanks for calling",
-    "thanks for ordering",
-    "have a great day",
-    "have a good day",
-    "enjoy your",
-)
-
-
-def _looks_like_goodbye(reply: str) -> bool:
-    """True if ``reply`` reads as a terminal wrap-up rather than another
-    follow-up question. Combined with ``Order.is_ready_to_confirm`` this
-    is the fallback trigger for auto-hangup."""
-    if not reply:
-        return False
-    stripped = reply.strip()
-    if stripped.endswith("?"):
-        return False
-    lower = stripped.lower()
-    return any(pat in lower for pat in _GOODBYE_PATTERNS)
-
-
-def _bg_call_event(call_sid: str | None, restaurant_id: str | None, **kwargs) -> None:
-    """Fire-and-forget Firestore write so the audio loop never blocks on it.
-
-    The storage module catches its own exceptions, so failures here just
-    drop the event from the live dashboard — the call continues normally.
-    Both ``call_sid`` and ``restaurant_id`` must be set; if either is
-    missing (early-lifecycle event before ``start`` resolved the tenant),
-    we silently skip rather than guess at the path.
-    """
-    if not call_sid or not restaurant_id:
-        return
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        return
-    loop.create_task(
-        asyncio.to_thread(call_sessions.record_event, call_sid, restaurant_id, **kwargs)
-    )
-
-
-async def _hang_up_after_grace(state: _CallState) -> None:
-    """Wait HANGUP_GRACE_SECONDS, then close the WebSocket to end the
-    call.
-
-    Closing our /media-stream WebSocket ends Twilio's <Connect>; with no
-    further TwiML the inbound call hangs up. This avoids the Twilio REST
-    Calls.update endpoint, which returns 404 on calls in <Connect> state
-    (same root cause as the recording 404). The grace window lets a
-    caller squeeze in a late follow-up like *"how long does that
-    take?"* — a final transcript clears ``state.pending_hangup`` and
-    we abort.
-
-    ``state.should_hangup`` is also set as a fallback signal in case
-    the WS close doesn't immediately unblock ``receive_text()`` (rare,
-    but harmless to set both).
-    """
-    try:
-        await asyncio.sleep(HANGUP_GRACE_SECONDS)
-    except asyncio.CancelledError:
-        return
-    if not state.pending_hangup or not state.call_sid:
-        return
-    state.should_hangup.set()
-    if state.websocket is not None:
-        try:
-            await state.websocket.close(code=1000)
-            logger.info(
-                "call ended by server (WS-close path) call_sid=%s",
-                state.call_sid,
-            )
-        except Exception:
-            logger.exception("auto-hangup: WS close failed call_sid=%s", state.call_sid)
-
-
-async def _hang_up_after_mark_timeout(state: _CallState) -> None:
-    """Fallback for when Twilio never echoes the end_of_call mark.
-
-    The primary path is: send mark → Twilio echoes when audio drains →
-    start grace timer. If the echo never arrives, this timer fires
-    after ``MARK_ECHO_TIMEOUT_SECONDS`` and starts the grace window
-    anyway, so the call still ends instead of hanging open.
-
-    Cancelled by the echo handler when the echo arrives, or by
-    ``_abort_pending_hangup`` when the caller speaks.
-    """
-    try:
-        await asyncio.sleep(MARK_ECHO_TIMEOUT_SECONDS)
-    except asyncio.CancelledError:
-        return
-    if not state.pending_hangup or not state.call_sid:
-        return
-    logger.warning(
-        "auto-hangup: mark echo timed out after %.1fs, falling back to grace window call_sid=%s",
-        MARK_ECHO_TIMEOUT_SECONDS,
-        state.call_sid,
-    )
-    if state.hangup_task and not state.hangup_task.done():
-        state.hangup_task.cancel()
-    state.hangup_task = None
-    await _hang_up_after_grace(state)
-
-
-def _abort_pending_hangup(state: _CallState) -> None:
-    """Cancel a pending auto-hangup because the caller spoke during
-    the grace window. Safe to call when no hangup is pending."""
-    state.pending_hangup = False
-    if state.hangup_task and not state.hangup_task.done():
-        state.hangup_task.cancel()
-    state.hangup_task = None
-    if state.mark_timeout_task and not state.mark_timeout_task.done():
-        state.mark_timeout_task.cancel()
-    state.mark_timeout_task = None
-
-
-async def _barge_in_now(
-    state: "_CallState",
-    websocket: WebSocket,
-    *,
-    trigger: str,
-) -> None:
-    """Stop the bot mid-utterance.
-
-    Three mechanical steps:
-      1. Cancel the in-flight LLM/TTS task → halt audio generation.
-      2. Cancel the silence watchdog → caller is speaking; "are you still
-         there?" would be wrong.
-      3. Send Twilio 'clear' → flush already-buffered audio playback (#74).
-
-    The barge_in Firestore event is NOT emitted here. It's emitted by
-    _run_llm_tts_turn's existing CancelledError handler when the task we
-    just cancelled actually receives the cancellation. Trigger
-    information flows via state.barge_in_trigger, which is set ONLY when
-    there is actually a task to cancel — preventing stale triggers from
-    leaking into the next turn's barge-in event, and preventing phantom
-    barge_in events on cleanup-path cancellations (WS shutdown).
-    """
-    if state.llm_task and not state.llm_task.done():
-        state.barge_in_trigger = trigger
-        state.llm_task.cancel()
-    _cancel_silence_task(state)
-    await send_clear(websocket, state.stream_sid)
-
-
-@dataclass
-class _CallState:
-    call_sid: str | None = None
-    stream_sid: str | None = None
-    order: Order | None = None
-    history: list[dict] = field(default_factory=list)
-    restaurant: Restaurant | None = None  # tenant for this call (#79)
-    system_prompt: str = ""  # built from restaurant on start
-    llm_task: asyncio.Task | None = None  # current LLM→TTS turn
-    silence_task: asyncio.Task | None = None  # silence watchdog
-    hangup_task: asyncio.Task | None = None  # pending auto-hangup (#78)
-    mark_timeout_task: asyncio.Task | None = None  # mark-echo fallback (#114)
-    pending_hangup: bool = False  # set when goodbye mark sent (#78)
-    recording_session: "RecordingUploadSession | None" = None
-    should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
-    # WS reference so _hang_up_after_grace can close the connection
-    # server-side. Closing the WS ends Twilio's <Connect>; with no
-    # further TwiML the call hangs up. Avoids the Twilio REST
-    # Calls.update endpoint which 404s on <Connect>-state calls.
-    websocket: "WebSocket | None" = None
-    # Transfer trigger accumulators (#7 Sprint 2.4 Track 2). Set by
-    # transcript / LLM-error handlers; read in the finally block to
-    # decide whether to write a transfer flag to the call session.
-    consecutive_low_confidence_turns: int = 0
-    last_caller_transcript: str = ""
-    llm_error_occurred: bool = False
-    # Carry-forward of the most recent transcript fed to an LLM turn
-    # that has not yet been persisted to ``history``. When a new final
-    # transcript arrives mid-turn, ``_handle_final_transcript`` cancels
-    # the in-flight task and prepends this string so the cancelled
-    # turn's user words aren't lost (#170). Cleared by ``_run_llm_tts_turn``
-    # the moment ``event.final`` writes ``state.history``.
-    in_flight_transcript: str = ""
-    # Set by _barge_in_now() before cancelling state.llm_task; read and
-    # cleared by _run_llm_tts_turn's CancelledError handler when emitting
-    # the barge_in Firestore event. None at all other times.
-    barge_in_trigger: str | None = None
-    # STT plugin lifecycle. Set on "start"; consumer task drains
-    # stt.events() and is cancelled in the WS handler's finally block.
-    stt: "STTProvider | None" = None
-    stt_provider: str | None = None
-    transcript_task: asyncio.Task | None = None
-
-
-def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:
-    """Return a chunk handler that appends outbound TTS audio to the
-    recording session, or None when no session is active.
-
-    Returning None means ``speak()`` won't fire ``on_chunk`` at all,
-    which is the desired behaviour when ``RECORDINGS_BUCKET`` is unset
-    and ``state.recording_session`` therefore stays None.
-    """
-    if state.recording_session is None:
-        return None
-    rs = state.recording_session
-
-    def _handle(chunk: bytes) -> None:
-        try:
-            recordings.append_chunks(rs, b"", chunk)
-        except Exception:
-            logger.exception(
-                "tts: recording append failed call_sid=%s", state.call_sid
-            )
-
-    return _handle
-
-
-def _state_rid(state: _CallState) -> str | None:
-    """Restaurant id from state, or None if start hasn't resolved a tenant
-    yet (early-lifecycle defense)."""
-    return state.restaurant.id if state.restaurant else None
-
-
-async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
-    try:
-        await asyncio.sleep(SILENCE_TIMEOUT_SECONDS)
-        logger.info("silence timeout call_sid=%s", state.call_sid)
-        _bg_call_event(state.call_sid, _state_rid(state), kind="silence_timeout")
-        if state.stream_sid:
-            await speak(
-                SILENCE_PROMPT,
-                websocket,
-                state.stream_sid,
-                on_chunk=_make_recording_chunk_handler(state),
-            )
-    except asyncio.CancelledError:
-        pass
-
-
-def _cancel_silence_task(state: _CallState) -> None:
-    if state.silence_task and not state.silence_task.done():
-        state.silence_task.cancel()
-    state.silence_task = None
-
-
-def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
-    if state.llm_task and state.llm_task.cancelled():
-        return  # barge-in — caller spoke again, no watchdog needed
-    _cancel_silence_task(state)
-    state.silence_task = asyncio.get_event_loop().create_task(_silence_watchdog(state, websocket))
-
-
-async def _consume_transcripts(
-    stt: STTProvider,
-    state: _CallState,
-    websocket: WebSocket,
-) -> None:
-    """Background task consuming events from the STT plugin.
-
-    All state mutation, Firestore emission, and dispatch into
-    _handle_final_transcript happens here — the plugin is pure and
-    knows nothing about call state. SpeechStartedEvent triggers an
-    instant barge-in via _barge_in_now (gated on STT_INSTANT_BARGE_IN).
-    """
-    try:
-        async for event in stt.events():
-            if isinstance(event, SpeechStartedEvent):
-                # Instant barge-in: fire ~50ms after the caller starts
-                # speaking instead of waiting for the final transcript
-                # (~800-1800ms). The final-transcript path in
-                # _handle_final_transcript still runs as a fallback for
-                # short utterances or missed VAD signals.
-                if not settings.stt_instant_barge_in:
-                    continue
-                if state.llm_task and not state.llm_task.done():
-                    await _barge_in_now(state, websocket, trigger="vad")
-                continue
-
-            # event is a TranscriptEvent
-            if not event.is_final:
-                continue   # interim: captured in plugin logs only
-
-            state.last_caller_transcript = event.text
-            if event.confidence < 0.5:
-                state.consecutive_low_confidence_turns += 1
-            else:
-                state.consecutive_low_confidence_turns = 0
-
-            _bg_call_event(
-                state.call_sid,
-                _state_rid(state),
-                kind="transcript_final",
-                text=event.text,
-                detail={"text": event.text, "confidence": event.confidence},
-            )
-            await _handle_final_transcript(event.text, state, websocket)
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:
-        logger.exception(
-            "transcript consumer crashed call_sid=%s", state.call_sid
-        )
-        # Mark the call as errored so the transfer-trigger logic in
-        # finally has a signal to act on, and surface the failure to the
-        # dashboard so it doesn't look like dead air to whoever's watching.
-        state.llm_error_occurred = True
-        _bg_call_event(
-            state.call_sid,
-            _state_rid(state),
-            kind="error",
-            text=f"transcript consumer crashed: {exc}"[:500],
-            detail={"exception": type(exc).__name__},
-        )
-
-
-async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSocket) -> None:
-    turn_start = time.monotonic()
-    logger.info("llm_turn start call_sid=%s transcript=%r", state.call_sid, transcript)
-    _bg_call_event(
-        state.call_sid,
-        _state_rid(state),
-        kind="llm_turn_start",
-        text=transcript,
-        detail={"transcript": transcript},
-    )
-    text_buffer: list[str] = []
-    first_speak = True
-    full_reply_parts: list[str] = []
-    # #146 — instrumentation. ``stream_reply`` yields one timing snapshot
-    # the moment the first text content block opens; we stash it and
-    # fold the breakdown into the first_audio Firestore event so the
-    # dashboard can show ttft/tool_prefix/cache without anyone needing
-    # GCP log access.
-    timing_snapshot: dict[str, Any] | None = None
-    first_text_at: float | None = None
-
-    def _record_first_audio() -> None:
-        latency = time.monotonic() - turn_start
-        logger.info(
-            "llm_turn first_audio latency=%.3fs call_sid=%s",
-            latency,
-            state.call_sid,
-        )
-        detail: dict[str, Any] = {"latency_seconds": round(latency, 3)}
-        if first_text_at is not None:
-            detail["first_text_seconds"] = round(first_text_at - turn_start, 3)
-        if timing_snapshot is not None:
-            detail.update(timing_snapshot)
-        _bg_call_event(
-            state.call_sid,
-            _state_rid(state),
-            kind="first_audio",
-            detail=detail,
-        )
-
-    def _record_first_tts_byte() -> None:
-        # #152 — captures the actual moment the first audio byte arrives
-        # from Deepgram Aura, closing the gap that first_audio misses
-        # (first_audio fires before await speak(), hiding TTS network time).
-        latency = time.monotonic() - turn_start
-        logger.info(
-            "llm_turn first_tts_byte latency=%.3fs call_sid=%s",
-            latency,
-            state.call_sid,
-        )
-        _bg_call_event(
-            state.call_sid,
-            _state_rid(state),
-            kind="first_tts_byte",
-            detail={"latency_seconds": round(latency, 3)},
-        )
-
-    try:
-        async for event in stream_reply(
-            transcript=transcript,
-            history=state.history,
-            order=state.order,
-            system_prompt=state.system_prompt,
-        ):
-            if asyncio.current_task().cancelled():
-                return
-
-            if event.timing is not None:
-                timing_snapshot = event.timing
-                continue
-
-            if event.text_delta is not None:
-                if first_text_at is None:
-                    first_text_at = time.monotonic()
-                text_buffer.append(event.text_delta)
-                full_reply_parts.append(event.text_delta)
-                buffered_chars = sum(len(p) for p in text_buffer)
-                if _should_flush_chunk(event.text_delta, buffered_chars):
-                    chunk = "".join(text_buffer).strip()
-                    text_buffer.clear()
-                    if chunk and state.stream_sid:
-                        if first_speak:
-                            _record_first_audio()
-                            first_speak = False
-                            on_first_byte = _record_first_tts_byte
-                        else:
-                            on_first_byte = None
-                        await speak(
-                            chunk,
-                            websocket,
-                            state.stream_sid,
-                            on_chunk=_make_recording_chunk_handler(state),
-                            on_first_byte=on_first_byte,
-                        )
-
-            elif event.final is not None:
-                remainder = "".join(text_buffer).strip()
-                text_buffer.clear()
-                if remainder and state.stream_sid:
-                    if first_speak:
-                        _record_first_audio()
-                        first_speak = False
-                        on_first_byte = _record_first_tts_byte
-                    else:
-                        on_first_byte = None
-                    await speak(
-                        remainder,
-                        websocket,
-                        state.stream_sid,
-                        on_chunk=_make_recording_chunk_handler(state),
-                        on_first_byte=on_first_byte,
-                    )
-                state.history = event.final.history
-                state.order = event.final.order
-                # Transcript is now durably in history — no need to carry
-                # it forward if a future turn is cancelled (#170).
-                state.in_flight_transcript = ""
-                full_reply = "".join(full_reply_parts).strip()
-                if full_reply:
-                    logger.info(
-                        "agent_reply call_sid=%s text=%r",
-                        state.call_sid,
-                        full_reply,
-                    )
-                    _bg_call_event(
-                        state.call_sid,
-                        _state_rid(state),
-                        kind="agent_reply",
-                        text=full_reply,
-                        detail={"text": full_reply},
-                    )
-                # Decide whether this turn is the wrap-up. Two signals:
-                #  1. Haiku set status=confirmed via update_order (the
-                #     primary path the prompt asks for).
-                #  2. Fallback (#79) — Haiku emitted a goodbye-shaped
-                #     reply ("your order is in", "see you soon", etc.)
-                #     AND the order has the data to actually confirm.
-                #     The model sometimes says the right closing line
-                #     without remembering to flip status.
-                if state.order is not None and state.stream_sid:
-                    explicitly_confirmed = state.order.status == OrderStatus.CONFIRMED
-                    fallback_confirmed = (
-                        state.order.is_ready_to_confirm()
-                        and state.order.status != OrderStatus.CANCELLED
-                        and _looks_like_goodbye(full_reply)
-                    )
-                    if explicitly_confirmed or fallback_confirmed:
-                        if fallback_confirmed and not explicitly_confirmed:
-                            logger.info(
-                                "auto-hangup: heuristic wrap-up detected "
-                                "(LLM didn't set status=confirmed) call_sid=%s",
-                                state.call_sid,
-                            )
-                            # Mirror the explicit-confirmation path locally
-                            # so the finally-block persist sees it too.
-                            state.order = state.order.model_copy(
-                                update={"status": OrderStatus.CONFIRMED}
-                            )
-                        sent = await send_mark(websocket, state.stream_sid, name=END_OF_CALL_MARK)
-                        if sent:
-                            state.pending_hangup = True
-                            if state.mark_timeout_task and not state.mark_timeout_task.done():
-                                state.mark_timeout_task.cancel()
-                            state.mark_timeout_task = asyncio.create_task(
-                                _hang_up_after_mark_timeout(state)
-                            )
-
-    except asyncio.CancelledError:
-        trigger = state.barge_in_trigger
-        state.barge_in_trigger = None
-        if trigger is not None:
-            # User-driven barge-in: trigger was set by _barge_in_now
-            # before cancelling the task. Emit the timeline event.
-            logger.info(
-                "llm_turn cancelled (barge-in trigger=%s) call_sid=%s",
-                trigger,
-                state.call_sid,
-            )
-            _bg_call_event(
-                state.call_sid,
-                _state_rid(state),
-                kind="barge_in",
-                detail={"trigger": trigger},
-            )
-        else:
-            # Cleanup-path cancellation: WS handler's finally block
-            # cancels the task during call teardown. No barge_in event.
-            logger.info(
-                "llm_turn cancelled (cleanup) call_sid=%s", state.call_sid
-            )
-        raise
-    except Exception as exc:
-        logger.exception("llm_turn errored call_sid=%s", state.call_sid)
-        # #7: signal the trigger detector at end-of-stream
-        state.llm_error_occurred = True
-        _bg_call_event(
-            state.call_sid,
-            _state_rid(state),
-            kind="error",
-            text=str(exc)[:500],
-            detail={"exception": type(exc).__name__},
-        )
-        raise
-
-
-async def _handle_final_transcript(text: str, state: _CallState, websocket: WebSocket) -> None:
-    interrupted = bool(state.llm_task and not state.llm_task.done())
-    # Carry forward — if any prior turn (cancelled or errored) left a
-    # transcript on state without persisting it to history, prepend it
-    # so Haiku sees the full caller intent in this turn (#170). The
-    # field is cleared by ``_run_llm_tts_turn`` only on ``event.final``,
-    # so a non-empty value here always means "user words from a prior
-    # turn that never made it into history."
-    if state.in_flight_transcript.strip():
-        text = f"{state.in_flight_transcript} {text}".strip()
-    silence_was_active = bool(state.silence_task and not state.silence_task.done())
-    # Caller spoke — abort any pending auto-hangup (#78). Even if they
-    # spoke during the grace window after a confirmation, we want to
-    # keep the call alive and process this transcript.
-    _abort_pending_hangup(state)
-
-    if interrupted:
-        # True barge-in: a turn is running and we're interrupting it.
-        # The barge_in Firestore event fires from _run_llm_tts_turn's
-        # CancelledError handler.
-        await _barge_in_now(state, websocket, trigger="final_transcript")
-    elif silence_was_active:
-        # Caller resumed after a silence prompt — flush any leftover
-        # prompt audio still buffered, but this isn't a barge-in (no
-        # task to cancel, no event to emit).
-        _cancel_silence_task(state)
-        await send_clear(websocket, state.stream_sid)
-
-    state.in_flight_transcript = text
-    state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
-    state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
-
-
-def _resolve_restaurant_for_voice(
-    to_e164: str,
-) -> Restaurant | None:
-    """Find the tenant for an inbound Twilio call (PR B of #79).
-
-    Looks up by the ``To`` field — Twilio's name for the dialed number,
-    which equals the per-restaurant ``twilio_phone`` we provisioned. If
-    Firestore returns nothing AND the dialed number matches the
-    demo's hardcoded ``twilio_phone``, falls back to building the demo
-    restaurant from ``app.menu.MENU``. The fallback is removed in PR F
-    once the seed is canonical.
-    """
-    restaurant = restaurants_storage.get_restaurant_by_twilio_phone(to_e164)
-    if restaurant is not None:
-        return restaurant
-    demo = restaurants_storage.demo_restaurant_from_menu()
-    if to_e164 == demo.twilio_phone:
-        logger.warning(
-            "voice: demo Twilio number %s not in Firestore — falling back to MENU",
-            to_e164,
-        )
-        return demo
-    return None
+_TRANSFER_STATUS_MAP = {
+    "completed": "answered",
+    "no-answer": "no_answer",
+    "busy": "busy",
+    "failed": "failed",
+    "canceled": "failed",
+}
 
 
 @router.post("/voice")
@@ -731,15 +120,6 @@ async def voice(request: Request) -> Response:
         content=str(voice_twiml(restaurant, host)),
         media_type="application/xml",
     )
-
-
-_TRANSFER_STATUS_MAP = {
-    "completed": "answered",
-    "no-answer": "no_answer",
-    "busy": "busy",
-    "failed": "failed",
-    "canceled": "failed",
-}
 
 
 @router.post("/voice/stream-ended")

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -39,6 +39,7 @@ from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
 from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
+import app.twilio as app_twilio
 from app.telephony.voicemail_twiml import voicemail_response
 from app.twilio.twiml import (
     closed_hangup_twiml,
@@ -891,7 +892,7 @@ async def voicemail_recorded(
             media_type="application/xml",
         )
 
-    if not settings.twilio_account_sid or not settings.twilio_auth_token:
+    if app_twilio.twilio_basic_auth() is None:
         logger.error(
             "voicemail upload: twilio creds missing call_sid=%s",
             call_sid,
@@ -902,11 +903,10 @@ async def voicemail_recorded(
         )
 
     try:
-        gs_url = recordings.upload_voicemail_from_twilio(
+        gs_url = app_twilio.upload_voicemail(
             call_sid=call_sid,
             restaurant_id=rid,
             twilio_recording_url=recording_url,
-            auth=(settings.twilio_account_sid, settings.twilio_auth_token),
         )
     except Exception:
         logger.exception(

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -396,13 +396,22 @@ async def _consume_transcripts(
 
     All state mutation, Firestore emission, and dispatch into
     _handle_final_transcript happens here — the plugin is pure and
-    knows nothing about call state. SpeechStartedEvent is silently
-    ignored in this commit; α-7 wires VAD-triggered barge-in.
+    knows nothing about call state. SpeechStartedEvent triggers an
+    instant barge-in via _barge_in_now (gated on STT_INSTANT_BARGE_IN).
     """
     try:
         async for event in stt.events():
             if isinstance(event, SpeechStartedEvent):
-                continue  # α-7 will handle this
+                # Instant barge-in: fire ~50ms after the caller starts
+                # speaking instead of waiting for the final transcript
+                # (~800-1800ms). The final-transcript path in
+                # _handle_final_transcript still runs as a fallback for
+                # short utterances or missed VAD signals.
+                if not settings.stt_instant_barge_in:
+                    continue
+                if state.llm_task and not state.llm_task.done():
+                    await _barge_in_now(state, websocket, trigger="vad")
+                continue
 
             # event is a TranscriptEvent
             if not event.is_final:

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -38,7 +38,7 @@ from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
 from app.telephony.voicemail_twiml import voicemail_response
-from app.tts.client import speak
+from app.tts import speak
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -362,6 +362,29 @@ async def _open_deepgram_connection(
     return conn
 
 
+def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:
+    """Return a chunk handler that appends outbound TTS audio to the
+    recording session, or None when no session is active.
+
+    Returning None means ``speak()`` won't fire ``on_chunk`` at all,
+    which is the desired behaviour when ``RECORDINGS_BUCKET`` is unset
+    and ``state.recording_session`` therefore stays None.
+    """
+    if state.recording_session is None:
+        return None
+    rs = state.recording_session
+
+    def _handle(chunk: bytes) -> None:
+        try:
+            recordings.append_chunks(rs, b"", chunk)
+        except Exception:
+            logger.exception(
+                "tts: recording append failed call_sid=%s", state.call_sid
+            )
+
+    return _handle
+
+
 def _state_rid(state: _CallState) -> str | None:
     """Restaurant id from state, or None if start hasn't resolved a tenant
     yet (early-lifecycle defense)."""
@@ -378,7 +401,7 @@ async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
                 SILENCE_PROMPT,
                 websocket,
                 state.stream_sid,
-                recording_session=state.recording_session,
+                on_chunk=_make_recording_chunk_handler(state),
             )
     except asyncio.CancelledError:
         pass
@@ -488,7 +511,7 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                             chunk,
                             websocket,
                             state.stream_sid,
-                            recording_session=state.recording_session,
+                            on_chunk=_make_recording_chunk_handler(state),
                             on_first_byte=on_first_byte,
                         )
 
@@ -506,7 +529,7 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                         remainder,
                         websocket,
                         state.stream_sid,
-                        recording_session=state.recording_session,
+                        on_chunk=_make_recording_chunk_handler(state),
                         on_first_byte=on_first_byte,
                     )
                 state.history = event.final.history
@@ -1028,7 +1051,7 @@ async def media_stream(websocket: WebSocket) -> None:
                         f"Test build {settings.commit_sha[:7]}.",
                         websocket,
                         state.stream_sid,
-                        recording_session=state.recording_session,
+                        on_chunk=_make_recording_chunk_handler(state),
                     )
                 state.llm_task = asyncio.create_task(
                     _run_llm_tts_turn(GREETING_TRANSCRIPT, state, websocket)

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -418,9 +418,7 @@ async def media_stream(websocket: WebSocket) -> None:
                     init_stream_sid = state.stream_sid or ""
 
                     async def _init_then_start_event() -> None:
-                        await asyncio.to_thread(
-                            call_sessions.init_call_session, init_sid, init_rid
-                        )
+                        await asyncio.to_thread(call_sessions.init_call_session, init_sid, init_rid)
                         await asyncio.to_thread(
                             call_sessions.record_event,
                             init_sid,
@@ -429,17 +427,13 @@ async def media_stream(websocket: WebSocket) -> None:
                             detail={"stream_sid": init_stream_sid},
                         )
 
-                    state.session_init_task = asyncio.create_task(
-                        _init_then_start_event()
-                    )
+                    state.session_init_task = asyncio.create_task(_init_then_start_event())
                 # Compute per-tenant keyterms from the loaded menu and
                 # log them once so the call audit has a record of what
                 # was biased. Empty list when the menu is unusably thin
                 # — the heuristic always includes the restaurant name
                 # at minimum, so the list is never literally empty.
-                keyterms = compute_keyterms(
-                    state.restaurant.menu, state.restaurant.name
-                )
+                keyterms = compute_keyterms(state.restaurant.menu, state.restaurant.name)
                 logger.info(
                     "keyterms call_sid=%s rid=%s n=%d preview=%r",
                     state.call_sid,
@@ -447,15 +441,11 @@ async def media_stream(websocket: WebSocket) -> None:
                     len(keyterms),
                     keyterms[:5],
                 )
-                state.stt, state.stt_provider = get_stt(
-                    call_sid=state.call_sid, keyterms=keyterms
-                )
+                state.stt, state.stt_provider = get_stt(call_sid=state.call_sid, keyterms=keyterms)
                 try:
                     await state.stt.open()
                 except Exception:
-                    logger.exception(
-                        "stt: failed to open call_sid=%s", state.call_sid
-                    )
+                    logger.exception("stt: failed to open call_sid=%s", state.call_sid)
                     _bg_call_event(
                         state.call_sid,
                         state.restaurant.id,
@@ -576,9 +566,7 @@ async def media_stream(websocket: WebSocket) -> None:
             try:
                 await state.stt.close()
             except Exception:
-                logger.exception(
-                    "stt: close failed call_sid=%s", state.call_sid
-                )
+                logger.exception("stt: close failed call_sid=%s", state.call_sid)
         if state.llm_task and not state.llm_task.done():
             state.llm_task.cancel()
             try:

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -407,18 +407,30 @@ async def media_stream(websocket: WebSocket) -> None:
                     state.restaurant.id,
                 )
                 if state.call_sid:
-                    asyncio.get_running_loop().create_task(
-                        asyncio.to_thread(
-                            call_sessions.init_call_session,
-                            state.call_sid,
-                            state.restaurant.id,
+                    # init_call_session creates the parent doc; record_event
+                    # (kind="start") then update()s it. Chain them in a single
+                    # task so the start event never races init and 404s.
+                    # Tracked on state.session_init_task so the WS finally
+                    # block can await it — otherwise a fast hangup tears the
+                    # loop down before the chained record_event lands.
+                    init_sid = state.call_sid
+                    init_rid = state.restaurant.id
+                    init_stream_sid = state.stream_sid or ""
+
+                    async def _init_then_start_event() -> None:
+                        await asyncio.to_thread(
+                            call_sessions.init_call_session, init_sid, init_rid
                         )
-                    )
-                    _bg_call_event(
-                        state.call_sid,
-                        state.restaurant.id,
-                        kind="start",
-                        detail={"stream_sid": state.stream_sid or ""},
+                        await asyncio.to_thread(
+                            call_sessions.record_event,
+                            init_sid,
+                            init_rid,
+                            kind="start",
+                            detail={"stream_sid": init_stream_sid},
+                        )
+
+                    state.session_init_task = asyncio.create_task(
+                        _init_then_start_event()
                     )
                 # Compute per-tenant keyterms from the loaded menu and
                 # log them once so the call audit has a record of what

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -543,6 +543,18 @@ async def media_stream(websocket: WebSocket) -> None:
 
     except WebSocketDisconnect:
         logger.info("media-stream disconnected call_sid=%s", state.call_sid)
+    except RuntimeError:
+        # Server-initiated close (auto-hangup #78) flips Starlette's
+        # application_state to DISCONNECTED before the next receive_text()
+        # iteration; that guard then raises RuntimeError instead of the
+        # WebSocketDisconnect we'd otherwise catch. Gate on should_hangup
+        # so any other RuntimeError still surfaces as a real bug.
+        if not state.should_hangup.is_set():
+            raise
+        logger.info(
+            "media-stream disconnected (server-initiated close) call_sid=%s",
+            state.call_sid,
+        )
     finally:
         _cancel_silence_task(state)
         # Auto-hangup: stop any pending grace-window timer; the call is

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -2,15 +2,19 @@
 
 POST /voice        — TwiML webhook: answers the inbound call, opens a
                      Twilio Media Stream so the STT→LLM→TTS pipeline can
-                     take over.  The AI greeting is delivered via Deepgram
-                     Aura on the 'start' event rather than a static TwiML
-                     <Say>.
+                     take over.  The AI greeting is delivered via the
+                     configured TTS provider on the 'start' event rather
+                     than a static TwiML <Say>.
 
 WS   /media-stream — Receives the Twilio Media Stream over WebSocket and
                      runs the full call loop:
-                       Deepgram transcript → stream_reply() → speak()
-                     Supports barge-in (new transcript cancels in-flight TTS)
-                     and a 10-second silence watchdog.
+                       STT transcript → stream_reply() → speak()
+                     Supports barge-in (VAD speech-started fires the
+                     fast path; final-transcript arrival fires the
+                     fallback path) and a 10-second silence watchdog.
+
+Vendor-specific STT/TTS implementations live under app/<vendor>/; this
+router only knows about the abstractions in app/stt and app/tts.
 """
 
 from __future__ import annotations
@@ -1021,12 +1025,12 @@ async def voicemail_transcription(
 
 @router.websocket("/media-stream")
 async def media_stream(websocket: WebSocket) -> None:
-    """Full call loop: Twilio Media Stream → Deepgram STT → LLM → Deepgram Aura TTS.
+    """Full call loop: Twilio Media Stream → STT → LLM → TTS.
 
     Twilio event types:
       connected  — protocol handshake
-      start      — stream open; initialises Order, opens Deepgram, fires AI greeting
-      media      — base64 mulaw 8 kHz audio forwarded to Deepgram
+      start      — stream open; initialises Order, opens STT, fires AI greeting
+      media      — base64 mulaw 8 kHz audio forwarded to the STT provider
       stop       — call ended; persists completed orders to Firestore
     """
     await websocket.accept()
@@ -1202,6 +1206,10 @@ async def media_stream(websocket: WebSocket) -> None:
         # a fresh task from a buffered transcript that we'd never await.
         if state.transcript_task and not state.transcript_task.done():
             state.transcript_task.cancel()
+            try:
+                await state.transcript_task
+            except (asyncio.CancelledError, Exception):
+                pass
         if state.stt is not None:
             try:
                 await state.stt.close()

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -28,8 +28,6 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
-from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
-
 from app.config import settings
 from app.llm.client import stream_reply
 from app.llm.prompts import build_system_prompt
@@ -42,6 +40,13 @@ from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
 from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
 from app.telephony.voicemail_twiml import voicemail_response
+from app.twilio.twiml import (
+    closed_hangup_twiml,
+    empty_twiml,
+    transfer_twiml,
+    unconfigured_hangup_twiml,
+    voice_twiml,
+)
 from app.tts import speak
 from app.twilio.media_stream import send_clear, send_mark
 
@@ -645,9 +650,6 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
     state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
 
 
-_UNCONFIGURED_TWIML_MESSAGE = "Sorry, this number is not currently configured. Goodbye."
-
-
 def _resolve_restaurant_for_voice(
     to_e164: str,
 ) -> Restaurant | None:
@@ -694,23 +696,20 @@ async def voice(request: Request) -> Response:
     call_sid = (form.get("CallSid") or "").strip()
     restaurant = _resolve_restaurant_for_voice(to_e164)
 
-    twiml = VoiceResponse()
     if restaurant is None:
         logger.warning("voice: no restaurant for To=%s — rejecting call", to_e164 or "(missing)")
-        twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
-        twiml.hangup()
-        return Response(content=str(twiml), media_type="application/xml")
+        return Response(
+            content=str(unconfigured_hangup_twiml()),
+            media_type="application/xml",
+        )
 
-    if restaurant is not None and not is_open_now(restaurant):
+    if not is_open_now(restaurant):
         # After-hours: skip the AI flow, drop straight to voicemail.
         if not call_sid:
             # Defensive: Twilio always posts CallSid. Without it, we
             # can't key the recording or call_session — bail.
-            twiml = VoiceResponse()
-            twiml.say("Sorry, we're closed. Please call back during business hours.")
-            twiml.hangup()
             return Response(
-                content=str(twiml),
+                content=str(closed_hangup_twiml()),
                 media_type="application/xml",
             )
         try:
@@ -727,17 +726,10 @@ async def voice(request: Request) -> Response:
         )
 
     host = request.headers.get("host", "localhost:8000")
-    connect = Connect(action="/voice/stream-ended", method="POST")
-    # NOTE: <Connect><Stream> only supports the default ``inbound_track``;
-    # passing ``track="both_tracks"`` makes Twilio reject the TwiML and
-    # the call drops the moment the caller dismisses the trial-account
-    # interstitial. To capture the agent's voice in the recording, the
-    # /media-stream WS handler intercepts the TTS bytes we send out via
-    # ``speak()`` and feeds them directly into the recording session.
-    stream = connect.stream(url=f"wss://{host}/media-stream")
-    stream.parameter(name="restaurant_id", value=restaurant.id)
-    twiml.append(connect)
-    return Response(content=str(twiml), media_type="application/xml")
+    return Response(
+        content=str(voice_twiml(restaurant, host)),
+        media_type="application/xml",
+    )
 
 
 _TRANSFER_STATUS_MAP = {
@@ -765,7 +757,7 @@ async def stream_ended(request: Request) -> Response:
 
     if not call_sid:
         # Twilio always sends CallSid; missing → defensive hangup.
-        return Response(content=str(VoiceResponse()), media_type="application/xml")
+        return Response(content=str(empty_twiml()), media_type="application/xml")
 
     # Resolve the tenant by reading the call_session doc. Uses the legacy
     # flat path because this action callback only receives CallSid — the
@@ -779,7 +771,7 @@ async def stream_ended(request: Request) -> Response:
 
     if rid is None:
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -789,7 +781,7 @@ async def stream_ended(request: Request) -> Response:
 
     if not transfer_requested:
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -813,15 +805,10 @@ async def stream_ended(request: Request) -> Response:
             media_type="application/xml",
         )
 
-    twiml = VoiceResponse()
-    dial = Dial(
-        action=f"/voice/transfer-result?call_sid={call_sid}&rid={rid}",
-        method="POST",
-        timeout=20,
+    return Response(
+        content=str(transfer_twiml(restaurant.fallback_phone, call_sid, rid)),
+        media_type="application/xml",
     )
-    dial.number(restaurant.fallback_phone)
-    twiml.append(dial)
-    return Response(content=str(twiml), media_type="application/xml")
 
 
 @router.post("/voice/transfer-result")
@@ -852,7 +839,7 @@ async def transfer_result(
 
     if internal_status == "answered":
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -883,7 +870,7 @@ async def voicemail_recorded(
 
     if not recording_url or not recording_sid:
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -900,7 +887,7 @@ async def voicemail_recorded(
             recording_sid,
         )
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -910,7 +897,7 @@ async def voicemail_recorded(
             call_sid,
         )
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -928,7 +915,7 @@ async def voicemail_recorded(
             recording_sid,
         )
         return Response(
-            content=str(VoiceResponse()),
+            content=str(empty_twiml()),
             media_type="application/xml",
         )
 
@@ -947,7 +934,7 @@ async def voicemail_recorded(
             call_sid,
         )
 
-    return Response(content=str(VoiceResponse()), media_type="application/xml")
+    return Response(content=str(empty_twiml()), media_type="application/xml")
 
 
 @router.post("/voice/voicemail-transcription")

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -43,6 +43,7 @@ from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing
 from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
 from app.telephony.voicemail_twiml import voicemail_response
 from app.tts import speak
+from app.twilio.media_stream import send_clear, send_mark
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -138,32 +139,6 @@ def _bg_call_event(call_sid: str | None, restaurant_id: str | None, **kwargs) ->
     )
 
 
-async def send_end_of_call_mark(websocket: WebSocket, stream_sid: str | None) -> bool:
-    """Append a named ``mark`` event to Twilio's outgoing media stream.
-
-    Twilio echoes the same mark back over the WebSocket once its audio
-    buffer drains past it — i.e. once the caller has heard everything
-    we sent. We use that as the precise trigger for auto-hangup (#78).
-    Returns True if the send succeeded.
-    """
-    if not stream_sid:
-        return False
-    try:
-        await websocket.send_json(
-            {
-                "event": "mark",
-                "streamSid": stream_sid,
-                "mark": {"name": END_OF_CALL_MARK},
-            }
-        )
-        return True
-    except WebSocketDisconnect:
-        return False
-    except Exception:
-        logger.exception("mark: failed to send end_of_call mark stream_sid=%s", stream_sid)
-        return False
-
-
 async def _hang_up_after_grace(state: _CallState) -> None:
     """Wait HANGUP_GRACE_SECONDS, then close the WebSocket to end the
     call.
@@ -238,28 +213,6 @@ def _abort_pending_hangup(state: _CallState) -> None:
     state.mark_timeout_task = None
 
 
-async def clear_twilio_audio(websocket: WebSocket, stream_sid: str | None) -> None:
-    """Tell Twilio to flush its audio buffer and stop playback.
-
-    Cancelling the LLM task only stops *generation* of new audio — bytes
-    already in Twilio's buffer keep playing for another 1–3 seconds, which
-    is exactly what callers experience as "the bot doesn't pause when I
-    interrupt." Twilio's Media Streams API has a dedicated ``clear`` event
-    that drops the buffer in ~80ms; we fire it whenever we cancel an
-    in-flight reply (#74).
-    """
-    if not stream_sid:
-        return
-    try:
-        await websocket.send_json({"event": "clear", "streamSid": stream_sid})
-    except WebSocketDisconnect:
-        # Caller already hung up — nothing to clear.
-        return
-    except Exception:
-        # Don't let a transient send failure break the call loop.
-        logger.exception("clear: failed to send Twilio clear event stream_sid=%s", stream_sid)
-
-
 async def _barge_in_now(
     state: "_CallState",
     websocket: WebSocket,
@@ -286,7 +239,7 @@ async def _barge_in_now(
         state.barge_in_trigger = trigger
         state.llm_task.cancel()
     _cancel_silence_task(state)
-    await clear_twilio_audio(websocket, state.stream_sid)
+    await send_clear(websocket, state.stream_sid)
 
 
 @dataclass
@@ -612,7 +565,7 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                             state.order = state.order.model_copy(
                                 update={"status": OrderStatus.CONFIRMED}
                             )
-                        sent = await send_end_of_call_mark(websocket, state.stream_sid)
+                        sent = await send_mark(websocket, state.stream_sid, name=END_OF_CALL_MARK)
                         if sent:
                             state.pending_hangup = True
                             if state.mark_timeout_task and not state.mark_timeout_task.done():
@@ -685,7 +638,7 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
         # prompt audio still buffered, but this isn't a barge-in (no
         # task to cancel, no event to emit).
         _cancel_silence_task(state)
-        await clear_twilio_audio(websocket, state.stream_sid)
+        await send_clear(websocket, state.stream_sid)
 
     state.in_flight_transcript = text
     state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -19,7 +19,7 @@ import logging
 
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
 
-import app.twilio as app_twilio
+from app.config import settings
 from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
 from app.orders.models import Order
@@ -27,7 +27,6 @@ from app.restaurants.open_check import is_open_now
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.stt import get_stt
-from app.config import settings
 from app.telephony.session import (
     GREETING_TRANSCRIPT,
     END_OF_CALL_MARK,
@@ -45,6 +44,7 @@ from app.telephony.session import (
 )
 from app.telephony.voicemail_twiml import voicemail_response
 from app.tts import speak
+import app.twilio as app_twilio
 from app.twilio.twiml import (
     closed_hangup_twiml,
     empty_twiml,

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -516,6 +516,11 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                 state.in_flight_transcript = ""
                 full_reply = "".join(full_reply_parts).strip()
                 if full_reply:
+                    logger.info(
+                        "agent_reply call_sid=%s text=%r",
+                        state.call_sid,
+                        full_reply,
+                    )
                     _bg_call_event(
                         state.call_sid,
                         _state_rid(state),

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -19,21 +19,23 @@ import logging
 
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
 
+import app.twilio as app_twilio
 from app.config import settings
 from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
 from app.orders.models import Order
+from app.restaurants.keyterms import compute_keyterms
 from app.restaurants.open_check import is_open_now
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.stt import get_stt
 from app.telephony.session import (
-    GREETING_TRANSCRIPT,
     END_OF_CALL_MARK,
-    _CallState,
+    GREETING_TRANSCRIPT,
     _abort_pending_hangup,
     _arm_silence_watchdog,
     _bg_call_event,
+    _CallState,
     _cancel_silence_task,
     _consume_transcripts,
     _hang_up_after_grace,
@@ -44,7 +46,6 @@ from app.telephony.session import (
 )
 from app.telephony.voicemail_twiml import voicemail_response
 from app.tts import speak
-import app.twilio as app_twilio
 from app.twilio.twiml import (
     closed_hangup_twiml,
     empty_twiml,
@@ -419,7 +420,24 @@ async def media_stream(websocket: WebSocket) -> None:
                         kind="start",
                         detail={"stream_sid": state.stream_sid or ""},
                     )
-                state.stt, state.stt_provider = get_stt(call_sid=state.call_sid)
+                # Compute per-tenant keyterms from the loaded menu and
+                # log them once so the call audit has a record of what
+                # was biased. Empty list when the menu is unusably thin
+                # — the heuristic always includes the restaurant name
+                # at minimum, so the list is never literally empty.
+                keyterms = compute_keyterms(
+                    state.restaurant.menu, state.restaurant.name
+                )
+                logger.info(
+                    "keyterms call_sid=%s rid=%s n=%d preview=%r",
+                    state.call_sid,
+                    state.restaurant.id,
+                    len(keyterms),
+                    keyterms[:5],
+                )
+                state.stt, state.stt_provider = get_stt(
+                    call_sid=state.call_sid, keyterms=keyterms
+                )
                 try:
                     await state.stt.open()
                 except Exception:

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -23,7 +23,6 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
 from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
 from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
 
@@ -37,6 +36,7 @@ from app.restaurants.open_check import is_open_now
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
+from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
 from app.telephony.voicemail_twiml import voicemail_response
 from app.tts import speak
 
@@ -322,77 +322,11 @@ class _CallState:
     # cleared by _run_llm_tts_turn's CancelledError handler when emitting
     # the barge_in Firestore event. None at all other times.
     barge_in_trigger: str | None = None
-
-
-async def _open_deepgram_connection(
-    call_sid: str | None,
-    restaurant_id: str | None,
-    on_final: Callable,
-    state: "_CallState | None" = None,
-):
-    assert settings.deepgram_api_key, "DEEPGRAM_API_KEY is not set"
-
-    dg = DeepgramClient(settings.deepgram_api_key)
-    conn = dg.listen.asynclive.v("1")
-
-    async def on_transcript(self, result, **kwargs):
-        alt = result.channel.alternatives[0]
-        text = alt.transcript.strip()
-        if not text:
-            return
-        label = "final" if result.is_final else "interim"
-        logger.info("transcript [%s] call_sid=%s text=%r", label, call_sid, text)
-        if result.is_final:
-            # Track confidence for transfer-trigger detection (#7).
-            # Explicit None check — `or 1.0` would replace 0.0 (falsy)
-            # with 1.0, masking a legitimate worst-case misheard signal.
-            raw_confidence = getattr(alt, "confidence", 1.0)
-            confidence = 1.0 if raw_confidence is None else raw_confidence
-            if state is not None:
-                state.last_caller_transcript = text
-                if confidence < 0.5:
-                    state.consecutive_low_confidence_turns += 1
-                else:
-                    state.consecutive_low_confidence_turns = 0
-            _bg_call_event(
-                call_sid,
-                restaurant_id,
-                kind="transcript_final",
-                text=text,
-                detail={"text": text, "confidence": confidence},
-            )
-            asyncio.get_event_loop().create_task(on_final(text))
-
-    async def on_error(self, error, **kwargs):
-        logger.error("deepgram error call_sid=%s error=%s", call_sid, error)
-
-    conn.on(LiveTranscriptionEvents.Transcript, on_transcript)
-    conn.on(LiveTranscriptionEvents.Error, on_error)
-
-    # endpointing + utterance_end_ms together control how aggressively
-    # Deepgram closes a turn. We picked 800/1000 after a 2026-04-26
-    # Twilight test call where endpointing=300 fired ~7 false barge-ins
-    # in 3 minutes — every micro-pause mid-sentence ("i would like to"
-    # <breath> "have") was treated as a turn ending, and the AI kept
-    # saying "take your time" because it thought the caller had spoken.
-    # 800ms is Deepgram's recommended value for conversational flow;
-    # utterance_end_ms=1000 layers a prosody-aware end-of-utterance
-    # signal on top so we wait for "actually finished" instead of just
-    # "stopped making noise".
-    options = LiveOptions(
-        model="nova-2",
-        encoding="mulaw",
-        sample_rate=8000,
-        channels=1,
-        interim_results=True,
-        endpointing=800,
-        utterance_end_ms=1000,
-        vad_events=True,
-    )
-    started = await conn.start(options)
-    if not started:
-        raise RuntimeError(f"Deepgram connection failed to start call_sid={call_sid}")
-    return conn
+    # STT plugin lifecycle. Set on "start"; consumer task drains
+    # stt.events() and is cancelled in the WS handler's finally block.
+    stt: "STTProvider | None" = None
+    stt_provider: str | None = None
+    transcript_task: asyncio.Task | None = None
 
 
 def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:
@@ -451,6 +385,60 @@ def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
         return  # barge-in — caller spoke again, no watchdog needed
     _cancel_silence_task(state)
     state.silence_task = asyncio.get_event_loop().create_task(_silence_watchdog(state, websocket))
+
+
+async def _consume_transcripts(
+    stt: STTProvider,
+    state: _CallState,
+    websocket: WebSocket,
+) -> None:
+    """Background task consuming events from the STT plugin.
+
+    All state mutation, Firestore emission, and dispatch into
+    _handle_final_transcript happens here — the plugin is pure and
+    knows nothing about call state. SpeechStartedEvent is silently
+    ignored in this commit; α-7 wires VAD-triggered barge-in.
+    """
+    try:
+        async for event in stt.events():
+            if isinstance(event, SpeechStartedEvent):
+                continue  # α-7 will handle this
+
+            # event is a TranscriptEvent
+            if not event.is_final:
+                continue   # interim: captured in plugin logs only
+
+            state.last_caller_transcript = event.text
+            if event.confidence < 0.5:
+                state.consecutive_low_confidence_turns += 1
+            else:
+                state.consecutive_low_confidence_turns = 0
+
+            _bg_call_event(
+                state.call_sid,
+                _state_rid(state),
+                kind="transcript_final",
+                text=event.text,
+                detail={"text": event.text, "confidence": event.confidence},
+            )
+            await _handle_final_transcript(event.text, state, websocket)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "transcript consumer crashed call_sid=%s", state.call_sid
+        )
+        # Mark the call as errored so the transfer-trigger logic in
+        # finally has a signal to act on, and surface the failure to the
+        # dashboard so it doesn't look like dead air to whoever's watching.
+        state.llm_error_occurred = True
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="error",
+            text=f"transcript consumer crashed: {exc}"[:500],
+            detail={"exception": type(exc).__name__},
+        )
 
 
 async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSocket) -> None:
@@ -1034,10 +1022,6 @@ async def media_stream(websocket: WebSocket) -> None:
     """
     await websocket.accept()
     state = _CallState(websocket=websocket)
-    dg_conn = None
-
-    async def on_final(text: str) -> None:
-        await _handle_final_transcript(text, state, websocket)
 
     try:
         while True:
@@ -1102,8 +1086,40 @@ async def media_stream(websocket: WebSocket) -> None:
                         kind="start",
                         detail={"stream_sid": state.stream_sid or ""},
                     )
-                dg_conn = await _open_deepgram_connection(
-                    state.call_sid, state.restaurant.id, on_final, state=state
+                state.stt, state.stt_provider = get_stt(call_sid=state.call_sid)
+                try:
+                    await state.stt.open()
+                except Exception:
+                    logger.exception(
+                        "stt: failed to open call_sid=%s", state.call_sid
+                    )
+                    _bg_call_event(
+                        state.call_sid,
+                        state.restaurant.id,
+                        kind="error",
+                        text="STT failed to open",
+                        detail={"provider": state.stt_provider},
+                    )
+                    # Speak a brief audible fallback before bailing — without
+                    # this the caller hears dead air until Twilio's idle
+                    # timeout closes the WS. TTS uses a different vendor path,
+                    # so a Deepgram-STT outage doesn't block this audio.
+                    if state.stream_sid:
+                        try:
+                            await speak(
+                                "Sorry, our service is briefly unavailable. Please call back in a moment.",
+                                websocket,
+                                state.stream_sid,
+                                on_chunk=_make_recording_chunk_handler(state),
+                            )
+                        except Exception:
+                            logger.exception(
+                                "stt: fallback speak failed call_sid=%s",
+                                state.call_sid,
+                            )
+                    return
+                state.transcript_task = asyncio.create_task(
+                    _consume_transcripts(state.stt, state, websocket)
                 )
                 if settings.testing_mode and settings.commit_sha and state.stream_sid:
                     await speak(
@@ -1123,8 +1139,8 @@ async def media_stream(websocket: WebSocket) -> None:
                 if track == "inbound":
                     inbound_chunk = payload
                     outbound_chunk = b""
-                    if dg_conn is not None:
-                        await dg_conn.send(payload)
+                    if state.stt is not None:
+                        await state.stt.send(payload)
                 elif track == "outbound":
                     inbound_chunk = b""
                     outbound_chunk = payload
@@ -1169,6 +1185,21 @@ async def media_stream(websocket: WebSocket) -> None:
         # Auto-hangup: stop any pending grace-window timer; the call is
         # already ending so we don't need to fire the REST close (#78).
         _abort_pending_hangup(state)
+        # Quiesce the transcript consumer FIRST so it can't spawn a new
+        # state.llm_task from a late final transcript while we're cleaning
+        # up the in-flight one. Closing the STT connection here also
+        # short-circuits any pending Deepgram callbacks. Order matters:
+        # if we cancelled state.llm_task first, the consumer could create
+        # a fresh task from a buffered transcript that we'd never await.
+        if state.transcript_task and not state.transcript_task.done():
+            state.transcript_task.cancel()
+        if state.stt is not None:
+            try:
+                await state.stt.close()
+            except Exception:
+                logger.exception(
+                    "stt: close failed call_sid=%s", state.call_sid
+                )
         if state.llm_task and not state.llm_task.done():
             state.llm_task.cancel()
             try:
@@ -1243,5 +1274,3 @@ async def media_stream(websocket: WebSocket) -> None:
                     "recording: finalize/mark failed call_sid=%s",
                     state.call_sid,
                 )
-        if dg_conn is not None:
-            await dg_conn.finish()

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -196,9 +196,7 @@ def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None
         try:
             recordings.append_chunks(rs, b"", chunk)
         except Exception:
-            logger.exception(
-                "tts: recording append failed call_sid=%s", state.call_sid
-            )
+            logger.exception("tts: recording append failed call_sid=%s", state.call_sid)
 
     return _handle
 
@@ -395,9 +393,7 @@ async def _consume_transcripts(
                         "confidence": event.confidence,
                     },
                 )
-                await _handle_final_transcript(
-                    event.text, state, websocket
-                )
+                await _handle_final_transcript(event.text, state, websocket)
                 continue
 
             # Unknown event type — providers may extend the event union
@@ -411,9 +407,7 @@ async def _consume_transcripts(
     except asyncio.CancelledError:
         raise
     except Exception as exc:
-        logger.exception(
-            "transcript consumer crashed call_sid=%s", state.call_sid
-        )
+        logger.exception("transcript consumer crashed call_sid=%s", state.call_sid)
         # Mark the call as errored so the transfer-trigger logic in
         # finally has a signal to act on, and surface the failure to the
         # dashboard so it doesn't look like dead air to whoever's watching.
@@ -614,9 +608,7 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
         else:
             # Cleanup-path cancellation: WS handler's finally block
             # cancels the task during call teardown. No barge_in event.
-            logger.info(
-                "llm_turn cancelled (cleanup) call_sid=%s", state.call_sid
-            )
+            logger.info("llm_turn cancelled (cleanup) call_sid=%s", state.call_sid)
         raise
     except Exception as exc:
         logger.exception("llm_turn errored call_sid=%s", state.call_sid)

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -28,7 +28,13 @@ from app.restaurants.models import Restaurant
 from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
-from app.stt import STTProvider, SpeechStartedEvent
+from app.stt import (
+    EarlyTurnEndEvent,
+    SpeechStartedEvent,
+    STTProvider,
+    TranscriptEvent,
+    TurnResumedEvent,
+)
 from app.tts import speak
 from app.twilio.media_stream import send_clear, send_mark
 
@@ -345,35 +351,58 @@ async def _consume_transcripts(
     try:
         async for event in stt.events():
             if isinstance(event, SpeechStartedEvent):
-                # Instant barge-in: fire ~50ms after the caller starts
-                # speaking instead of waiting for the final transcript
-                # (~800-1800ms). The final-transcript path in
-                # _handle_final_transcript still runs as a fallback for
-                # short utterances or missed VAD signals.
+                # Instant barge-in: fire as soon as the STT provider
+                # reports the caller began speaking (Flux:
+                # TurnInfo.event="StartOfTurn") instead of waiting for
+                # the confirmed final transcript. The final-transcript
+                # path in _handle_final_transcript still runs as a
+                # fallback for short utterances or missed VAD signals.
                 if not settings.stt_instant_barge_in:
                     continue
                 if state.llm_task and not state.llm_task.done():
                     await _barge_in_now(state, websocket, trigger="vad")
                 continue
 
-            # event is a TranscriptEvent
-            if not event.is_final:
-                continue   # interim: captured in plugin logs only
+            if isinstance(event, (EarlyTurnEndEvent, TurnResumedEvent)):
+                # Speculative end-of-turn signals from Flux. The
+                # speculative-drafting work that consumes them lives
+                # in a separate follow-up PR; for now we drop them
+                # to keep behavior identical to today.
+                continue
 
-            state.last_caller_transcript = event.text
-            if event.confidence < 0.5:
-                state.consecutive_low_confidence_turns += 1
-            else:
-                state.consecutive_low_confidence_turns = 0
+            if isinstance(event, TranscriptEvent):
+                if not event.is_final:
+                    continue  # interim: captured in plugin logs only
 
-            _bg_call_event(
+                state.last_caller_transcript = event.text
+                if event.confidence < 0.5:
+                    state.consecutive_low_confidence_turns += 1
+                else:
+                    state.consecutive_low_confidence_turns = 0
+
+                _bg_call_event(
+                    state.call_sid,
+                    _state_rid(state),
+                    kind="transcript_final",
+                    text=event.text,
+                    detail={
+                        "text": event.text,
+                        "confidence": event.confidence,
+                    },
+                )
+                await _handle_final_transcript(
+                    event.text, state, websocket
+                )
+                continue
+
+            # Unknown event type — providers may extend the event union
+            # in the future. Log once and keep going rather than crash
+            # the call.
+            logger.debug(
+                "stt: unknown event type=%s call_sid=%s",
+                type(event).__name__,
                 state.call_sid,
-                _state_rid(state),
-                kind="transcript_final",
-                text=event.text,
-                detail={"text": event.text, "confidence": event.confidence},
             )
-            await _handle_final_transcript(event.text, state, websocket)
     except asyncio.CancelledError:
         raise
     except Exception as exc:

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -230,7 +230,7 @@ def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
     if state.llm_task and state.llm_task.cancelled():
         return  # barge-in — caller spoke again, no watchdog needed
     _cancel_silence_task(state)
-    state.silence_task = asyncio.get_event_loop().create_task(_silence_watchdog(state, websocket))
+    state.silence_task = asyncio.create_task(_silence_watchdog(state, websocket))
 
 
 async def _hang_up_after_grace(state: _CallState) -> None:

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -1,0 +1,656 @@
+"""Call orchestration — vendor-neutral.
+
+Owns _CallState and every helper that runs during the lifetime of an
+active call: barge-in, hangup, silence, the LLM/TTS turn loop, and the
+STT transcript consumer. The module knows about the abstract STT/TTS
+provider interfaces in app/stt and app/tts but nothing about Twilio
+specifics — those live in app/twilio/.
+
+The FastAPI endpoints + WS event-loop dispatch live in
+app/telephony/router.py. router.py imports from this module; this
+module does not import from router.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from fastapi import WebSocket
+
+from app.config import settings
+from app.llm.client import stream_reply
+from app.orders.models import Order, OrderStatus
+from app.restaurants.models import Restaurant
+from app.storage import call_sessions, recordings
+from app.storage import restaurants as restaurants_storage
+from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
+from app.stt import STTProvider, SpeechStartedEvent
+from app.tts import speak
+from app.twilio.media_stream import send_clear, send_mark
+
+logger = logging.getLogger(__name__)
+
+SILENCE_TIMEOUT_SECONDS = 10.0
+SILENCE_PROMPT = "Are you still there?"
+GREETING_TRANSCRIPT = "[call started — greet the caller]"
+
+# Auto-hangup after order confirmation (#78). Twilio echoes back this
+# named mark when its audio buffer drains, signalling the caller has
+# heard the goodbye; we then hold for the grace window in case they
+# squeeze in a late question before terminating the call.
+END_OF_CALL_MARK = "end_of_call"
+HANGUP_GRACE_SECONDS = 5.0
+# Fallback if Twilio never echoes the end_of_call mark back to us
+# (WebSocket dropped, mark lost in transit). After this many seconds
+# we trigger the grace window anyway so the call still terminates
+# instead of hanging open. Picked > typical mark round-trip (1-3s).
+MARK_ECHO_TIMEOUT_SECONDS = 8.0
+
+# Chunking thresholds for TTS handoff (#151). Sentence terminators
+# always flush; soft breaks (commas, semicolons, colons, em dashes)
+# only flush once the buffered chunk is ≥ _MIN_CHUNK_CHARS so that
+# fragments like "Got it," don't become their own Aura round-trip.
+# 20 chars ≈ "One Chicken Fried Rice coming up," length when the
+# 4/26 Twilight call's longest "over budget" turn would have hit.
+_HARD_BREAKS = (".", "?", "!")
+_SOFT_BREAKS = (",", ";", ":", "—")
+_MIN_CHUNK_CHARS = 20
+
+
+def _should_flush_chunk(delta: str, buffered_chars: int) -> bool:
+    """True if the current text-delta should close a TTS chunk.
+
+    ``delta`` is the latest streamed text fragment from Anthropic;
+    ``buffered_chars`` is the total length of all deltas accumulated
+    since the last flush (i.e. the chunk we'd ship if we flushed now).
+    """
+    if delta.endswith(_HARD_BREAKS):
+        return True
+    if delta.endswith(_SOFT_BREAKS) and buffered_chars >= _MIN_CHUNK_CHARS:
+        return True
+    return False
+
+
+# Phrases the model uses when wrapping up. Used as a fallback signal
+# for auto-hangup when Haiku says a goodbye but forgets to mark the
+# order status as confirmed via update_order (#79). Matched
+# case-insensitive against the full assembled reply.
+_GOODBYE_PATTERNS = (
+    "your order is in",
+    "have it ready",
+    "see you soon",
+    "see you in a",
+    "thanks for calling",
+    "thanks for ordering",
+    "have a great day",
+    "have a good day",
+    "enjoy your",
+)
+
+
+def _looks_like_goodbye(reply: str) -> bool:
+    """True if ``reply`` reads as a terminal wrap-up rather than another
+    follow-up question. Combined with ``Order.is_ready_to_confirm`` this
+    is the fallback trigger for auto-hangup."""
+    if not reply:
+        return False
+    stripped = reply.strip()
+    if stripped.endswith("?"):
+        return False
+    lower = stripped.lower()
+    return any(pat in lower for pat in _GOODBYE_PATTERNS)
+
+
+def _bg_call_event(call_sid: str | None, restaurant_id: str | None, **kwargs) -> None:
+    """Fire-and-forget Firestore write so the audio loop never blocks on it.
+
+    The storage module catches its own exceptions, so failures here just
+    drop the event from the live dashboard — the call continues normally.
+    Both ``call_sid`` and ``restaurant_id`` must be set; if either is
+    missing (early-lifecycle event before ``start`` resolved the tenant),
+    we silently skip rather than guess at the path.
+    """
+    if not call_sid or not restaurant_id:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    loop.create_task(
+        asyncio.to_thread(call_sessions.record_event, call_sid, restaurant_id, **kwargs)
+    )
+
+
+@dataclass
+class _CallState:
+    call_sid: str | None = None
+    stream_sid: str | None = None
+    order: Order | None = None
+    history: list[dict] = field(default_factory=list)
+    restaurant: Restaurant | None = None  # tenant for this call (#79)
+    system_prompt: str = ""  # built from restaurant on start
+    llm_task: asyncio.Task | None = None  # current LLM→TTS turn
+    silence_task: asyncio.Task | None = None  # silence watchdog
+    hangup_task: asyncio.Task | None = None  # pending auto-hangup (#78)
+    mark_timeout_task: asyncio.Task | None = None  # mark-echo fallback (#114)
+    pending_hangup: bool = False  # set when goodbye mark sent (#78)
+    recording_session: "RecordingUploadSession | None" = None
+    should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
+    # WS reference so _hang_up_after_grace can close the connection
+    # server-side. Closing the WS ends Twilio's <Connect>; with no
+    # further TwiML the call hangs up. Avoids the Twilio REST
+    # Calls.update endpoint which 404s on <Connect>-state calls.
+    websocket: "WebSocket | None" = None
+    # Transfer trigger accumulators (#7 Sprint 2.4 Track 2). Set by
+    # transcript / LLM-error handlers; read in the finally block to
+    # decide whether to write a transfer flag to the call session.
+    consecutive_low_confidence_turns: int = 0
+    last_caller_transcript: str = ""
+    llm_error_occurred: bool = False
+    # Carry-forward of the most recent transcript fed to an LLM turn
+    # that has not yet been persisted to ``history``. When a new final
+    # transcript arrives mid-turn, ``_handle_final_transcript`` cancels
+    # the in-flight task and prepends this string so the cancelled
+    # turn's user words aren't lost (#170). Cleared by ``_run_llm_tts_turn``
+    # the moment ``event.final`` writes ``state.history``.
+    in_flight_transcript: str = ""
+    # Set by _barge_in_now() before cancelling state.llm_task; read and
+    # cleared by _run_llm_tts_turn's CancelledError handler when emitting
+    # the barge_in Firestore event. None at all other times.
+    barge_in_trigger: str | None = None
+    # STT plugin lifecycle. Set on "start"; consumer task drains
+    # stt.events() and is cancelled in the WS handler's finally block.
+    stt: "STTProvider | None" = None
+    stt_provider: str | None = None
+    transcript_task: asyncio.Task | None = None
+
+
+def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:
+    """Return a chunk handler that appends outbound TTS audio to the
+    recording session, or None when no session is active.
+
+    Returning None means ``speak()`` won't fire ``on_chunk`` at all,
+    which is the desired behaviour when ``RECORDINGS_BUCKET`` is unset
+    and ``state.recording_session`` therefore stays None.
+    """
+    if state.recording_session is None:
+        return None
+    rs = state.recording_session
+
+    def _handle(chunk: bytes) -> None:
+        try:
+            recordings.append_chunks(rs, b"", chunk)
+        except Exception:
+            logger.exception(
+                "tts: recording append failed call_sid=%s", state.call_sid
+            )
+
+    return _handle
+
+
+def _state_rid(state: _CallState) -> str | None:
+    """Restaurant id from state, or None if start hasn't resolved a tenant
+    yet (early-lifecycle defense)."""
+    return state.restaurant.id if state.restaurant else None
+
+
+async def _silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
+    try:
+        await asyncio.sleep(SILENCE_TIMEOUT_SECONDS)
+        logger.info("silence timeout call_sid=%s", state.call_sid)
+        _bg_call_event(state.call_sid, _state_rid(state), kind="silence_timeout")
+        if state.stream_sid:
+            await speak(
+                SILENCE_PROMPT,
+                websocket,
+                state.stream_sid,
+                on_chunk=_make_recording_chunk_handler(state),
+            )
+    except asyncio.CancelledError:
+        pass
+
+
+def _cancel_silence_task(state: _CallState) -> None:
+    if state.silence_task and not state.silence_task.done():
+        state.silence_task.cancel()
+    state.silence_task = None
+
+
+def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
+    if state.llm_task and state.llm_task.cancelled():
+        return  # barge-in — caller spoke again, no watchdog needed
+    _cancel_silence_task(state)
+    state.silence_task = asyncio.get_event_loop().create_task(_silence_watchdog(state, websocket))
+
+
+async def _hang_up_after_grace(state: _CallState) -> None:
+    """Wait HANGUP_GRACE_SECONDS, then close the WebSocket to end the
+    call.
+
+    Closing our /media-stream WebSocket ends Twilio's <Connect>; with no
+    further TwiML the inbound call hangs up. This avoids the Twilio REST
+    Calls.update endpoint, which returns 404 on calls in <Connect> state
+    (same root cause as the recording 404). The grace window lets a
+    caller squeeze in a late follow-up like *"how long does that
+    take?"* — a final transcript clears ``state.pending_hangup`` and
+    we abort.
+
+    ``state.should_hangup`` is also set as a fallback signal in case
+    the WS close doesn't immediately unblock ``receive_text()`` (rare,
+    but harmless to set both).
+    """
+    try:
+        await asyncio.sleep(HANGUP_GRACE_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.pending_hangup or not state.call_sid:
+        return
+    state.should_hangup.set()
+    if state.websocket is not None:
+        try:
+            await state.websocket.close(code=1000)
+            logger.info(
+                "call ended by server (WS-close path) call_sid=%s",
+                state.call_sid,
+            )
+        except Exception:
+            logger.exception("auto-hangup: WS close failed call_sid=%s", state.call_sid)
+
+
+async def _hang_up_after_mark_timeout(state: _CallState) -> None:
+    """Fallback for when Twilio never echoes the end_of_call mark.
+
+    The primary path is: send mark → Twilio echoes when audio drains →
+    start grace timer. If the echo never arrives, this timer fires
+    after ``MARK_ECHO_TIMEOUT_SECONDS`` and starts the grace window
+    anyway, so the call still ends instead of hanging open.
+
+    Cancelled by the echo handler when the echo arrives, or by
+    ``_abort_pending_hangup`` when the caller speaks.
+    """
+    try:
+        await asyncio.sleep(MARK_ECHO_TIMEOUT_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.pending_hangup or not state.call_sid:
+        return
+    logger.warning(
+        "auto-hangup: mark echo timed out after %.1fs, falling back to grace window call_sid=%s",
+        MARK_ECHO_TIMEOUT_SECONDS,
+        state.call_sid,
+    )
+    if state.hangup_task and not state.hangup_task.done():
+        state.hangup_task.cancel()
+    state.hangup_task = None
+    await _hang_up_after_grace(state)
+
+
+def _abort_pending_hangup(state: _CallState) -> None:
+    """Cancel a pending auto-hangup because the caller spoke during
+    the grace window. Safe to call when no hangup is pending."""
+    state.pending_hangup = False
+    if state.hangup_task and not state.hangup_task.done():
+        state.hangup_task.cancel()
+    state.hangup_task = None
+    if state.mark_timeout_task and not state.mark_timeout_task.done():
+        state.mark_timeout_task.cancel()
+    state.mark_timeout_task = None
+
+
+async def _barge_in_now(
+    state: "_CallState",
+    websocket: WebSocket,
+    *,
+    trigger: str,
+) -> None:
+    """Stop the bot mid-utterance.
+
+    Three mechanical steps:
+      1. Cancel the in-flight LLM/TTS task → halt audio generation.
+      2. Cancel the silence watchdog → caller is speaking; "are you still
+         there?" would be wrong.
+      3. Send Twilio 'clear' → flush already-buffered audio playback (#74).
+
+    The barge_in Firestore event is NOT emitted here. It's emitted by
+    _run_llm_tts_turn's existing CancelledError handler when the task we
+    just cancelled actually receives the cancellation. Trigger
+    information flows via state.barge_in_trigger, which is set ONLY when
+    there is actually a task to cancel — preventing stale triggers from
+    leaking into the next turn's barge-in event, and preventing phantom
+    barge_in events on cleanup-path cancellations (WS shutdown).
+    """
+    if state.llm_task and not state.llm_task.done():
+        state.barge_in_trigger = trigger
+        state.llm_task.cancel()
+    _cancel_silence_task(state)
+    await send_clear(websocket, state.stream_sid)
+
+
+async def _consume_transcripts(
+    stt: STTProvider,
+    state: _CallState,
+    websocket: WebSocket,
+) -> None:
+    """Background task consuming events from the STT plugin.
+
+    All state mutation, Firestore emission, and dispatch into
+    _handle_final_transcript happens here — the plugin is pure and
+    knows nothing about call state. SpeechStartedEvent triggers an
+    instant barge-in via _barge_in_now (gated on STT_INSTANT_BARGE_IN).
+    """
+    try:
+        async for event in stt.events():
+            if isinstance(event, SpeechStartedEvent):
+                # Instant barge-in: fire ~50ms after the caller starts
+                # speaking instead of waiting for the final transcript
+                # (~800-1800ms). The final-transcript path in
+                # _handle_final_transcript still runs as a fallback for
+                # short utterances or missed VAD signals.
+                if not settings.stt_instant_barge_in:
+                    continue
+                if state.llm_task and not state.llm_task.done():
+                    await _barge_in_now(state, websocket, trigger="vad")
+                continue
+
+            # event is a TranscriptEvent
+            if not event.is_final:
+                continue   # interim: captured in plugin logs only
+
+            state.last_caller_transcript = event.text
+            if event.confidence < 0.5:
+                state.consecutive_low_confidence_turns += 1
+            else:
+                state.consecutive_low_confidence_turns = 0
+
+            _bg_call_event(
+                state.call_sid,
+                _state_rid(state),
+                kind="transcript_final",
+                text=event.text,
+                detail={"text": event.text, "confidence": event.confidence},
+            )
+            await _handle_final_transcript(event.text, state, websocket)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "transcript consumer crashed call_sid=%s", state.call_sid
+        )
+        # Mark the call as errored so the transfer-trigger logic in
+        # finally has a signal to act on, and surface the failure to the
+        # dashboard so it doesn't look like dead air to whoever's watching.
+        state.llm_error_occurred = True
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="error",
+            text=f"transcript consumer crashed: {exc}"[:500],
+            detail={"exception": type(exc).__name__},
+        )
+
+
+async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSocket) -> None:
+    turn_start = time.monotonic()
+    logger.info("llm_turn start call_sid=%s transcript=%r", state.call_sid, transcript)
+    _bg_call_event(
+        state.call_sid,
+        _state_rid(state),
+        kind="llm_turn_start",
+        text=transcript,
+        detail={"transcript": transcript},
+    )
+    text_buffer: list[str] = []
+    first_speak = True
+    full_reply_parts: list[str] = []
+    # #146 — instrumentation. ``stream_reply`` yields one timing snapshot
+    # the moment the first text content block opens; we stash it and
+    # fold the breakdown into the first_audio Firestore event so the
+    # dashboard can show ttft/tool_prefix/cache without anyone needing
+    # GCP log access.
+    timing_snapshot: dict[str, Any] | None = None
+    first_text_at: float | None = None
+
+    def _record_first_audio() -> None:
+        latency = time.monotonic() - turn_start
+        logger.info(
+            "llm_turn first_audio latency=%.3fs call_sid=%s",
+            latency,
+            state.call_sid,
+        )
+        detail: dict[str, Any] = {"latency_seconds": round(latency, 3)}
+        if first_text_at is not None:
+            detail["first_text_seconds"] = round(first_text_at - turn_start, 3)
+        if timing_snapshot is not None:
+            detail.update(timing_snapshot)
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="first_audio",
+            detail=detail,
+        )
+
+    def _record_first_tts_byte() -> None:
+        # #152 — captures the actual moment the first audio byte arrives
+        # from Deepgram Aura, closing the gap that first_audio misses
+        # (first_audio fires before await speak(), hiding TTS network time).
+        latency = time.monotonic() - turn_start
+        logger.info(
+            "llm_turn first_tts_byte latency=%.3fs call_sid=%s",
+            latency,
+            state.call_sid,
+        )
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="first_tts_byte",
+            detail={"latency_seconds": round(latency, 3)},
+        )
+
+    try:
+        async for event in stream_reply(
+            transcript=transcript,
+            history=state.history,
+            order=state.order,
+            system_prompt=state.system_prompt,
+        ):
+            if asyncio.current_task().cancelled():
+                return
+
+            if event.timing is not None:
+                timing_snapshot = event.timing
+                continue
+
+            if event.text_delta is not None:
+                if first_text_at is None:
+                    first_text_at = time.monotonic()
+                text_buffer.append(event.text_delta)
+                full_reply_parts.append(event.text_delta)
+                buffered_chars = sum(len(p) for p in text_buffer)
+                if _should_flush_chunk(event.text_delta, buffered_chars):
+                    chunk = "".join(text_buffer).strip()
+                    text_buffer.clear()
+                    if chunk and state.stream_sid:
+                        if first_speak:
+                            _record_first_audio()
+                            first_speak = False
+                            on_first_byte = _record_first_tts_byte
+                        else:
+                            on_first_byte = None
+                        await speak(
+                            chunk,
+                            websocket,
+                            state.stream_sid,
+                            on_chunk=_make_recording_chunk_handler(state),
+                            on_first_byte=on_first_byte,
+                        )
+
+            elif event.final is not None:
+                remainder = "".join(text_buffer).strip()
+                text_buffer.clear()
+                if remainder and state.stream_sid:
+                    if first_speak:
+                        _record_first_audio()
+                        first_speak = False
+                        on_first_byte = _record_first_tts_byte
+                    else:
+                        on_first_byte = None
+                    await speak(
+                        remainder,
+                        websocket,
+                        state.stream_sid,
+                        on_chunk=_make_recording_chunk_handler(state),
+                        on_first_byte=on_first_byte,
+                    )
+                state.history = event.final.history
+                state.order = event.final.order
+                # Transcript is now durably in history — no need to carry
+                # it forward if a future turn is cancelled (#170).
+                state.in_flight_transcript = ""
+                full_reply = "".join(full_reply_parts).strip()
+                if full_reply:
+                    logger.info(
+                        "agent_reply call_sid=%s text=%r",
+                        state.call_sid,
+                        full_reply,
+                    )
+                    _bg_call_event(
+                        state.call_sid,
+                        _state_rid(state),
+                        kind="agent_reply",
+                        text=full_reply,
+                        detail={"text": full_reply},
+                    )
+                # Decide whether this turn is the wrap-up. Two signals:
+                #  1. Haiku set status=confirmed via update_order (the
+                #     primary path the prompt asks for).
+                #  2. Fallback (#79) — Haiku emitted a goodbye-shaped
+                #     reply ("your order is in", "see you soon", etc.)
+                #     AND the order has the data to actually confirm.
+                #     The model sometimes says the right closing line
+                #     without remembering to flip status.
+                if state.order is not None and state.stream_sid:
+                    explicitly_confirmed = state.order.status == OrderStatus.CONFIRMED
+                    fallback_confirmed = (
+                        state.order.is_ready_to_confirm()
+                        and state.order.status != OrderStatus.CANCELLED
+                        and _looks_like_goodbye(full_reply)
+                    )
+                    if explicitly_confirmed or fallback_confirmed:
+                        if fallback_confirmed and not explicitly_confirmed:
+                            logger.info(
+                                "auto-hangup: heuristic wrap-up detected "
+                                "(LLM didn't set status=confirmed) call_sid=%s",
+                                state.call_sid,
+                            )
+                            # Mirror the explicit-confirmation path locally
+                            # so the finally-block persist sees it too.
+                            state.order = state.order.model_copy(
+                                update={"status": OrderStatus.CONFIRMED}
+                            )
+                        sent = await send_mark(websocket, state.stream_sid, name=END_OF_CALL_MARK)
+                        if sent:
+                            state.pending_hangup = True
+                            if state.mark_timeout_task and not state.mark_timeout_task.done():
+                                state.mark_timeout_task.cancel()
+                            state.mark_timeout_task = asyncio.create_task(
+                                _hang_up_after_mark_timeout(state)
+                            )
+
+    except asyncio.CancelledError:
+        trigger = state.barge_in_trigger
+        state.barge_in_trigger = None
+        if trigger is not None:
+            # User-driven barge-in: trigger was set by _barge_in_now
+            # before cancelling the task. Emit the timeline event.
+            logger.info(
+                "llm_turn cancelled (barge-in trigger=%s) call_sid=%s",
+                trigger,
+                state.call_sid,
+            )
+            _bg_call_event(
+                state.call_sid,
+                _state_rid(state),
+                kind="barge_in",
+                detail={"trigger": trigger},
+            )
+        else:
+            # Cleanup-path cancellation: WS handler's finally block
+            # cancels the task during call teardown. No barge_in event.
+            logger.info(
+                "llm_turn cancelled (cleanup) call_sid=%s", state.call_sid
+            )
+        raise
+    except Exception as exc:
+        logger.exception("llm_turn errored call_sid=%s", state.call_sid)
+        # #7: signal the trigger detector at end-of-stream
+        state.llm_error_occurred = True
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="error",
+            text=str(exc)[:500],
+            detail={"exception": type(exc).__name__},
+        )
+        raise
+
+
+async def _handle_final_transcript(text: str, state: _CallState, websocket: WebSocket) -> None:
+    interrupted = bool(state.llm_task and not state.llm_task.done())
+    # Carry forward — if any prior turn (cancelled or errored) left a
+    # transcript on state without persisting it to history, prepend it
+    # so Haiku sees the full caller intent in this turn (#170). The
+    # field is cleared by ``_run_llm_tts_turn`` only on ``event.final``,
+    # so a non-empty value here always means "user words from a prior
+    # turn that never made it into history."
+    if state.in_flight_transcript.strip():
+        text = f"{state.in_flight_transcript} {text}".strip()
+    silence_was_active = bool(state.silence_task and not state.silence_task.done())
+    # Caller spoke — abort any pending auto-hangup (#78). Even if they
+    # spoke during the grace window after a confirmation, we want to
+    # keep the call alive and process this transcript.
+    _abort_pending_hangup(state)
+
+    if interrupted:
+        # True barge-in: a turn is running and we're interrupting it.
+        # The barge_in Firestore event fires from _run_llm_tts_turn's
+        # CancelledError handler.
+        await _barge_in_now(state, websocket, trigger="final_transcript")
+    elif silence_was_active:
+        # Caller resumed after a silence prompt — flush any leftover
+        # prompt audio still buffered, but this isn't a barge-in (no
+        # task to cancel, no event to emit).
+        _cancel_silence_task(state)
+        await send_clear(websocket, state.stream_sid)
+
+    state.in_flight_transcript = text
+    state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
+    state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
+
+
+def _resolve_restaurant_for_voice(
+    to_e164: str,
+) -> Restaurant | None:
+    """Find the tenant for an inbound Twilio call (PR B of #79).
+
+    Looks up by the ``To`` field — Twilio's name for the dialed number,
+    which equals the per-restaurant ``twilio_phone`` we provisioned. If
+    Firestore returns nothing AND the dialed number matches the
+    demo's hardcoded ``twilio_phone``, falls back to building the demo
+    restaurant from ``app.menu.MENU``. The fallback is removed in PR F
+    once the seed is canonical.
+    """
+    restaurant = restaurants_storage.get_restaurant_by_twilio_phone(to_e164)
+    if restaurant is not None:
+        return restaurant
+    demo = restaurants_storage.demo_restaurant_from_menu()
+    if to_e164 == demo.twilio_phone:
+        logger.warning(
+            "voice: demo Twilio number %s not in Firestore — falling back to MENU",
+            to_e164,
+        )
+        return demo
+    return None

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -173,6 +173,11 @@ class _CallState:
     stt: "STTProvider | None" = None
     stt_provider: str | None = None
     transcript_task: asyncio.Task | None = None
+    # Chained init_call_session + record_event(kind="start"). Held on
+    # state so a strong reference exists for the task's lifetime;
+    # serialising the two writes ensures the start event never races
+    # init's parent-doc set() and 404s on Firestore.
+    session_init_task: asyncio.Task | None = None
 
 
 def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:

--- a/app/tts/__init__.py
+++ b/app/tts/__init__.py
@@ -1,0 +1,45 @@
+"""Public entry point for the TTS abstraction layer.
+
+Dispatches to the configured provider. Today only Deepgram is wired in;
+adding ElevenLabs or another HTTP-streaming TTS is a one-clause addition
+to ``speak()`` plus a new ``app/<vendor>/tts.py`` matching the SpeakFunc
+contract from ``app/tts/base.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import httpx
+from fastapi import WebSocket
+
+from app.config import settings
+from app.tts.base import SpeakFunc
+
+__all__ = ["SpeakFunc", "speak"]
+
+
+async def speak(
+    text: str,
+    websocket: WebSocket,
+    stream_sid: str,
+    *,
+    client: Optional[httpx.AsyncClient] = None,
+    on_chunk: Optional[Callable[[bytes], None]] = None,
+    on_first_byte: Optional[Callable[[], None]] = None,
+) -> None:
+    """Synthesize ``text`` through the configured TTS provider and stream
+    audio into the Twilio call via ``websocket``."""
+    provider = settings.tts_provider
+    if provider == "deepgram":
+        from app.deepgram.tts import speak as _speak
+
+        return await _speak(
+            text,
+            websocket,
+            stream_sid,
+            client=client,
+            on_chunk=on_chunk,
+            on_first_byte=on_first_byte,
+        )
+    raise ValueError(f"Unknown TTS provider: {provider}")

--- a/app/tts/base.py
+++ b/app/tts/base.py
@@ -1,0 +1,43 @@
+"""TTS provider contract.
+
+TTS is per-utterance and stateless across calls (an HTTP request that
+streams audio bytes back). The contract is therefore a callable signature
+rather than a class — same shape works for Deepgram Aura, ElevenLabs,
+OpenAI TTS, and similar HTTP-streaming providers.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Protocol
+
+import httpx
+from fastapi import WebSocket
+
+
+class SpeakFunc(Protocol):
+    """Signature any TTS provider implementation must match.
+
+    Args:
+        text: LLM reply text to synthesize.
+        websocket: Active Twilio Media Streams WebSocket.
+        stream_sid: Twilio streamSid from the ``start`` event.
+        client: Optional injected httpx.AsyncClient for tests.
+        on_chunk: Optional zero-arg sync callable fired with each raw
+            audio chunk (mulaw bytes) as it streams in. Used by callers
+            that want a copy of the outbound audio (e.g., for recording).
+            Exceptions are swallowed by the implementation.
+        on_first_byte: Optional zero-arg sync callable fired exactly once
+            when the first non-empty chunk arrives. Used to measure TTS
+            network latency. Exceptions are swallowed.
+    """
+
+    async def __call__(
+        self,
+        text: str,
+        websocket: WebSocket,
+        stream_sid: str,
+        *,
+        client: Optional[httpx.AsyncClient] = None,
+        on_chunk: Optional[Callable[[bytes], None]] = None,
+        on_first_byte: Optional[Callable[[], None]] = None,
+    ) -> None: ...

--- a/app/twilio/__init__.py
+++ b/app/twilio/__init__.py
@@ -12,12 +12,8 @@ envelope, TwiML XML, or Twilio's REST API lives under this package.
 
 from __future__ import annotations
 
-import logging
-
 from app.config import settings
 from app.storage import recordings as _recordings
-
-logger = logging.getLogger(__name__)
 
 
 def twilio_basic_auth() -> tuple[str, str] | None:

--- a/app/twilio/__init__.py
+++ b/app/twilio/__init__.py
@@ -1,0 +1,13 @@
+"""Twilio vendor module.
+
+Holds Twilio-specific I/O — TwiML response builders, Media Stream
+WebSocket protocol primitives, and REST helpers — kept separate from
+the vendor-neutral call orchestration in app/telephony/. Mirrors the
+app/deepgram/ pattern.
+
+Consumers that need vendor-agnostic call logic should import from
+app/telephony/, not from here. Anything that touches a Twilio JSON
+envelope, TwiML XML, or Twilio's REST API lives under this package.
+"""
+
+from __future__ import annotations

--- a/app/twilio/__init__.py
+++ b/app/twilio/__init__.py
@@ -11,3 +11,51 @@ envelope, TwiML XML, or Twilio's REST API lives under this package.
 """
 
 from __future__ import annotations
+
+import logging
+
+from app.config import settings
+from app.storage import recordings as _recordings
+
+logger = logging.getLogger(__name__)
+
+
+def twilio_basic_auth() -> tuple[str, str] | None:
+    """Return Twilio REST basic-auth tuple, or None when unconfigured.
+
+    Centralised so the voicemail-recorded callback doesn't have to
+    reach into ``settings.twilio_account_sid`` /
+    ``settings.twilio_auth_token`` directly. Returns None (rather than
+    raising) so the caller can log + degrade gracefully — voicemail
+    upload is best-effort, missing creds shouldn't crash the request.
+    """
+    sid = settings.twilio_account_sid
+    token = settings.twilio_auth_token
+    if not sid or not token:
+        return None
+    return (sid, token)
+
+
+def upload_voicemail(
+    *,
+    call_sid: str,
+    restaurant_id: str,
+    twilio_recording_url: str,
+) -> str:
+    """Download the voicemail recording from Twilio's REST API and
+    upload to GCS. Wraps app.storage.recordings.upload_voicemail_from_twilio
+    with the Twilio creds resolved from settings.
+
+    Raises RuntimeError if Twilio creds are missing — the caller is
+    expected to check ``twilio_basic_auth()`` first if it wants to
+    short-circuit gracefully (the voicemail-recorded handler does).
+    """
+    auth = twilio_basic_auth()
+    if auth is None:
+        raise RuntimeError("Twilio credentials missing")
+    return _recordings.upload_voicemail_from_twilio(
+        call_sid=call_sid,
+        restaurant_id=restaurant_id,
+        twilio_recording_url=twilio_recording_url,
+        auth=auth,
+    )

--- a/app/twilio/media_stream.py
+++ b/app/twilio/media_stream.py
@@ -1,0 +1,68 @@
+"""Twilio Media Stream WS protocol primitives — outgoing frames only.
+
+Incoming frame parsing (start/media/mark/stop) stays inline in the
+WS event-loop in app/telephony/router.py until a second telephony
+provider forces a real shape difference.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+
+async def send_clear(websocket: WebSocket, stream_sid: str | None) -> None:
+    """Tell Twilio to flush its audio buffer and stop playback (#74).
+
+    Cancelling the LLM/TTS task only stops generation — bytes already in
+    Twilio's buffer keep playing for 1-3 seconds. Twilio's clear event
+    drops the buffer in ~80ms. Used by barge-in and post-silence cleanup.
+    """
+    if not stream_sid:
+        return
+    try:
+        await websocket.send_json({"event": "clear", "streamSid": stream_sid})
+    except WebSocketDisconnect:
+        return
+    except Exception:
+        logger.exception(
+            "clear: failed to send Twilio clear event stream_sid=%s",
+            stream_sid,
+        )
+
+
+async def send_mark(
+    websocket: WebSocket,
+    stream_sid: str | None,
+    name: str,
+) -> bool:
+    """Append a named mark to Twilio's outgoing media stream (#78).
+
+    Twilio echoes the mark back over the WebSocket once its audio buffer
+    drains past it — i.e. once the caller has heard everything we sent.
+    The auto-hangup path uses this as the precise trigger to begin its
+    grace window. Returns True if the send succeeded.
+    """
+    if not stream_sid:
+        return False
+    try:
+        await websocket.send_json(
+            {
+                "event": "mark",
+                "streamSid": stream_sid,
+                "mark": {"name": name},
+            }
+        )
+        return True
+    except WebSocketDisconnect:
+        return False
+    except Exception:
+        logger.exception(
+            "mark: failed to send mark name=%s stream_sid=%s",
+            name,
+            stream_sid,
+        )
+        return False

--- a/app/twilio/twiml.py
+++ b/app/twilio/twiml.py
@@ -18,12 +18,8 @@ from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
 
 from app.restaurants.models import Restaurant
 
-_UNCONFIGURED_TWIML_MESSAGE = (
-    "Sorry, this number is not currently configured. Goodbye."
-)
-_CLOSED_TWIML_MESSAGE = (
-    "Sorry, we're closed. Please call back during business hours."
-)
+_UNCONFIGURED_TWIML_MESSAGE = "Sorry, this number is not currently configured. Goodbye."
+_CLOSED_TWIML_MESSAGE = "Sorry, we're closed. Please call back during business hours."
 
 
 def empty_twiml() -> VoiceResponse:

--- a/app/twilio/twiml.py
+++ b/app/twilio/twiml.py
@@ -1,0 +1,88 @@
+"""TwiML response builders for the Twilio voice webhook surface.
+
+Pure functions returning Twilio VoiceResponse objects. The FastAPI
+handlers in app/telephony/router.py call these and wrap the result
+in a fastapi.Response with media_type='application/xml'.
+
+Kept separate so that:
+- TwiML XML construction lives in one place (mirrors app/deepgram/);
+- builders are easy to snapshot-test without spinning up FastAPI;
+- the orchestration layer in app/telephony/ never imports from
+  twilio.twiml directly.
+"""
+
+from __future__ import annotations
+
+from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
+
+from app.restaurants.models import Restaurant
+
+
+_UNCONFIGURED_TWIML_MESSAGE = (
+    "Sorry, this number is not currently configured. Goodbye."
+)
+_CLOSED_TWIML_MESSAGE = (
+    "Sorry, we're closed. Please call back during business hours."
+)
+
+
+def empty_twiml() -> VoiceResponse:
+    """Empty <Response/>. Used for hangup-on-success paths and as a
+    safe default when a Twilio callback can't be acted on."""
+    return VoiceResponse()
+
+
+def unconfigured_hangup_twiml() -> VoiceResponse:
+    """Inbound call to a number that isn't mapped to any tenant."""
+    twiml = VoiceResponse()
+    twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
+    twiml.hangup()
+    return twiml
+
+
+def closed_hangup_twiml() -> VoiceResponse:
+    """Defensive after-hours hangup for the rare case the voicemail
+    flow can't run (e.g. CallSid missing on the inbound webhook)."""
+    twiml = VoiceResponse()
+    twiml.say(_CLOSED_TWIML_MESSAGE)
+    twiml.hangup()
+    return twiml
+
+
+def voice_twiml(restaurant: Restaurant, ws_host: str) -> VoiceResponse:
+    """Open a bidirectional Media Stream back to /media-stream and
+    forward the resolved restaurant id via <Parameter> so the WS
+    handler doesn't need to re-query Firestore."""
+    twiml = VoiceResponse()
+    connect = Connect(action="/voice/stream-ended", method="POST")
+    # NOTE: <Connect><Stream> only supports the default ``inbound_track``;
+    # passing ``track="both_tracks"`` makes Twilio reject the TwiML and
+    # the call drops the moment the caller dismisses the trial-account
+    # interstitial. To capture the agent's voice in the recording, the
+    # /media-stream WS handler intercepts the TTS bytes we send out via
+    # ``speak()`` and feeds them directly into the recording session.
+    stream = connect.stream(url=f"wss://{ws_host}/media-stream")
+    stream.parameter(name="restaurant_id", value=restaurant.id)
+    twiml.append(connect)
+    return twiml
+
+
+def transfer_twiml(
+    fallback_phone: str,
+    call_sid: str,
+    rid: str,
+    *,
+    timeout: int = 20,
+) -> VoiceResponse:
+    """Dial the tenant's fallback number, with action callback to
+    /voice/transfer-result so we can record the outcome and cascade
+    to voicemail on no-answer/busy/failed."""
+    twiml = VoiceResponse()
+    dial = Dial(
+        action=f"/voice/transfer-result?call_sid={call_sid}&rid={rid}",
+        method="POST",
+        timeout=timeout,
+    )
+    dial.number(fallback_phone)
+    twiml.append(dial)
+    return twiml

--- a/app/twilio/twiml.py
+++ b/app/twilio/twiml.py
@@ -18,7 +18,6 @@ from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
 
 from app.restaurants.models import Restaurant
 
-
 _UNCONFIGURED_TWIML_MESSAGE = (
     "Sorry, this number is not currently configured. Goodbye."
 )

--- a/app/twilio/twiml.py
+++ b/app/twilio/twiml.py
@@ -7,8 +7,9 @@ in a fastapi.Response with media_type='application/xml'.
 Kept separate so that:
 - TwiML XML construction lives in one place (mirrors app/deepgram/);
 - builders are easy to snapshot-test without spinning up FastAPI;
-- the orchestration layer in app/telephony/ never imports from
-  twilio.twiml directly.
+- the orchestration layer in app/telephony/ avoids importing from
+  twilio.twiml directly (one exception: voicemail_twiml.py builds
+  Twilio Record TwiML inline; folding it in here is a follow-up).
 """
 
 from __future__ import annotations

--- a/docs/superpowers/plans/2026-05-06-stt-tts-plugin-extraction.md
+++ b/docs/superpowers/plans/2026-05-06-stt-tts-plugin-extraction.md
@@ -1,0 +1,2421 @@
+# STT/TTS Plugin Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract Deepgram STT and TTS out of `app/telephony/router.py` into a focused plugin layer (`app/stt/`, `app/tts/`, `app/deepgram/`) with a thin selector seam for future provider swaps, and add instant barge-in via VAD speech-started events.
+
+**Architecture:** Two abstraction layers — `app/stt/` (live streaming STT contract) and `app/tts/` (per-utterance TTS contract). Vendor implementations live under `app/deepgram/`. Selectors in `app/stt/__init__.py` and `app/tts/__init__.py` pick a provider by env var. STT exposes an async-iterator events interface (TranscriptEvent + SpeechStartedEvent); the router's `_consume_transcripts` background task consumes events and is solely responsible for state mutation, Firestore emission, and barge-in dispatch.
+
+**Tech Stack:** Python 3.11+, FastAPI, pytest, asyncio, Deepgram SDK v3.11, httpx, pydantic-settings. Existing patterns: print-style logging with call_sid, `_bg_call_event` for Firestore writes via `app.storage.call_sessions.record_event`.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-stt-tts-plugin-extraction-design.md`
+
+**Issue:** [#250](https://github.com/tsuki-works/niko/issues/250) (refactor) and [#83](https://github.com/tsuki-works/niko/issues/83) (parent tuning).
+
+**Branch:** `feat/83-tune-conversational-bot`. All α tasks land here as atomic commits. One PR at the end references both issues.
+
+---
+
+## File Structure
+
+### Files created
+
+| Path | Responsibility |
+|---|---|
+| `app/stt/__init__.py` | Exports `get_stt()`, `STTProvider`, `TranscriptEvent`, `SpeechStartedEvent` |
+| `app/stt/base.py` | `STTProvider` Protocol; `TranscriptEvent`, `SpeechStartedEvent` dataclasses; `STTEvent` union |
+| `app/tts/base.py` | `SpeakFunc` Protocol describing the TTS callable signature |
+| `app/deepgram/__init__.py` | Shared: `_api_key()` reader, `_DEEPGRAM_BASE` constant |
+| `app/deepgram/stt.py` | `DeepgramSTT` class implementing `STTProvider` |
+| `app/deepgram/tts.py` | `speak()` implementation lifted from today's `app/tts/client.py`, with `recording_session` swapped for `on_chunk` |
+| `tests/fakes/__init__.py` | Marker for the fakes package |
+| `tests/fakes/stt.py` | `FakeSTT` test fixture |
+| `tests/test_fake_stt.py` | Unit tests of the fake itself |
+| `tests/test_stt_deepgram.py` | Unit tests of `DeepgramSTT` |
+| `tests/test_transcript_consumer.py` | Unit tests of `_consume_transcripts` |
+| `tests/test_barge_in_helper.py` | Unit tests of `_barge_in_now` |
+| `tests/test_provider_selector.py` | Unit tests of `get_stt()` and TTS selector |
+| `tests/test_deepgram_tts.py` | Renamed from `tests/test_tts_client.py` |
+
+### Files modified
+
+| Path | Change |
+|---|---|
+| `app/tts/__init__.py` | Add `speak()` selector dispatching by `settings.tts_provider` |
+| `app/config.py` | Add `stt_provider`, `tts_provider`, `stt_model`, `stt_endpointing_ms`, `stt_utterance_end_ms`, `stt_keyterms`, `stt_instant_barge_in` settings |
+| `app/telephony/router.py` | Remove `_open_deepgram_connection` and inline Deepgram code; add `_consume_transcripts`, `_barge_in_now`, `_make_recording_chunk_handler`; new fields on `_CallState`; update `media_stream` WS handler; update `_handle_final_transcript` |
+| `tests/test_telephony.py` | Migrate `mock_pipeline` fixture to inject `FakeSTT`; collapse five ad-hoc patch blocks into the fixture |
+
+### Files deleted
+
+| Path | Reason |
+|---|---|
+| `app/tts/client.py` | Body relocated to `app/deepgram/tts.py`; no shim |
+| `tests/test_tts_client.py` | Renamed to `tests/test_deepgram_tts.py` |
+
+---
+
+## Task 1: STTProvider Protocol and event dataclasses (α-1)
+
+**Goal:** Pure type definitions — the contracts that everything else implements. No behavior, no tests.
+
+**Files:**
+- Create: `app/stt/__init__.py`
+- Create: `app/stt/base.py`
+- Create: `app/tts/base.py`
+
+- [ ] **Step 1: Create `app/stt/base.py`**
+
+```python
+"""STT provider contract.
+
+The router talks to STT through this interface; concrete providers
+(today: Deepgram) live under app/<vendor>/stt.py. Future providers
+implement the same Protocol and become a one-line addition to the
+selector in app/stt/__init__.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import AsyncIterator, Protocol, Union
+
+
+@dataclass(frozen=True)
+class SpeechStartedEvent:
+    """VAD detected the caller began speaking. Fires before any transcript
+    is available — used for instant barge-in (~50ms vs ~800ms waiting on
+    a final transcript)."""
+
+    at: float = 0.0  # optional Deepgram timestamp; 0 if SDK omits it
+
+
+@dataclass(frozen=True)
+class TranscriptEvent:
+    """One recognition result from the STT provider. Interim results
+    (``is_final=False``) are rewritten by subsequent events; only finals
+    should drive behavior."""
+
+    text: str
+    is_final: bool
+    confidence: float
+
+
+STTEvent = Union[TranscriptEvent, SpeechStartedEvent]
+
+
+class STTProvider(Protocol):
+    """Live streaming STT contract.
+
+    Lifecycle: ``open()`` → many ``send(audio)`` + ``async for`` over
+    ``events()`` → ``close()``. Errors mid-stream raise out of
+    ``events()``; the consumer decides whether to recover or end the call.
+    """
+
+    async def open(self) -> None:
+        """Open the live STT connection. Raises on failure."""
+
+    async def send(self, audio: bytes) -> None:
+        """Forward one chunk of caller audio (mulaw 8 kHz from Twilio).
+        Connection-level errors are caught internally and logged; the call
+        does not die on transient send failures."""
+
+    def events(self) -> AsyncIterator[STTEvent]:
+        """Yield STTEvents until close() is called. Raises on connection
+        error — the consumer is responsible for catching and recovering."""
+
+    async def close(self) -> None:
+        """Tear down the connection and signal events() to terminate."""
+```
+
+- [ ] **Step 2: Create `app/stt/__init__.py`**
+
+```python
+"""Public entry point for the STT abstraction layer.
+
+Re-exports the contract so callers do ``from app.stt import
+TranscriptEvent`` instead of reaching into ``app.stt.base``. The
+``get_stt()`` selector is added in a later task once a concrete
+implementation exists.
+"""
+
+from app.stt.base import (
+    STTEvent,
+    STTProvider,
+    SpeechStartedEvent,
+    TranscriptEvent,
+)
+
+__all__ = [
+    "STTEvent",
+    "STTProvider",
+    "SpeechStartedEvent",
+    "TranscriptEvent",
+]
+```
+
+- [ ] **Step 3: Create `app/tts/base.py`**
+
+```python
+"""TTS provider contract.
+
+TTS is per-utterance and stateless across calls (an HTTP request that
+streams audio bytes back). The contract is therefore a callable signature
+rather than a class — same shape works for Deepgram Aura, ElevenLabs,
+OpenAI TTS, and similar HTTP-streaming providers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Protocol
+
+import httpx
+from fastapi import WebSocket
+
+
+class SpeakFunc(Protocol):
+    """Signature any TTS provider implementation must match.
+
+    Args:
+        text: LLM reply text to synthesize.
+        websocket: Active Twilio Media Streams WebSocket.
+        stream_sid: Twilio streamSid from the ``start`` event.
+        client: Optional injected httpx.AsyncClient for tests.
+        on_chunk: Optional zero-arg sync callable fired with each raw
+            audio chunk (mulaw bytes) as it streams in. Used by callers
+            that want a copy of the outbound audio (e.g., for recording).
+            Exceptions are swallowed by the implementation.
+        on_first_byte: Optional zero-arg sync callable fired exactly once
+            when the first non-empty chunk arrives. Used to measure TTS
+            network latency. Exceptions are swallowed.
+    """
+
+    async def __call__(
+        self,
+        text: str,
+        websocket: WebSocket,
+        stream_sid: str,
+        *,
+        client: Optional[httpx.AsyncClient] = None,
+        on_chunk: Optional[Callable[[bytes], None]] = None,
+        on_first_byte: Optional[Callable[[], None]] = None,
+    ) -> None: ...
+```
+
+- [ ] **Step 4: Verify nothing breaks — run the existing test suite**
+
+Run: `python -m pytest tests/ -x --tb=short -q`
+Expected: all existing tests pass (we've only added new modules; nothing imports them yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/stt/__init__.py app/stt/base.py app/tts/base.py
+git commit -m "feat(stt): add STTProvider protocol and event dataclasses
+
+Pure type definitions — contracts for the upcoming plugin layer.
+STTProvider is implemented by app/deepgram/stt.py in a later commit;
+SpeakFunc is matched by app/deepgram/tts.py. No behavior, no consumers
+yet.
+
+Refs #250."
+```
+
+---
+
+## Task 2: FakeSTT test fixture (α-2)
+
+**Goal:** A test double that implements `STTProvider` so consumer tests can script call flows without touching the Deepgram SDK or network.
+
+**Files:**
+- Create: `tests/fakes/__init__.py`
+- Create: `tests/fakes/stt.py`
+- Create: `tests/test_fake_stt.py`
+
+- [ ] **Step 1: Create `tests/fakes/__init__.py` (empty file)**
+
+```python
+```
+
+- [ ] **Step 2: Create `tests/fakes/stt.py`**
+
+```python
+"""FakeSTT — test double for app.stt.base.STTProvider.
+
+Tests script events and assert on calls. The fake is intentionally
+minimal: just enough plumbing to support the scenarios the real plugin
+needs to handle (open, send, multi-event streams, close, error).
+
+Usage:
+
+    fake = FakeSTT(events=[TranscriptEvent("hi", True, 0.95)])
+    await fake.open()
+    async for event in fake.events():
+        ...
+
+    fake.feed(SpeechStartedEvent())             # inject mid-test
+    fake.feed_error(RuntimeError("dropped"))    # surface error in events()
+    await fake.close()
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import AsyncIterator
+
+from app.stt.base import STTEvent
+
+
+_CLOSED = object()
+
+
+@dataclass
+class _ErrorBox:
+    exc: BaseException
+
+
+class FakeSTT:
+    """Implements STTProvider; lets tests feed scripted events."""
+
+    def __init__(self, *, events=None) -> None:
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.opened = False
+        self.closed = False
+        self.sent: list[bytes] = []
+        for ev in events or []:
+            self._queue.put_nowait(ev)
+
+    async def open(self) -> None:
+        self.opened = True
+
+    async def send(self, audio: bytes) -> None:
+        self.sent.append(audio)
+
+    async def events(self) -> AsyncIterator[STTEvent]:
+        while True:
+            item = await self._queue.get()
+            if item is _CLOSED:
+                return
+            if isinstance(item, _ErrorBox):
+                raise item.exc
+            yield item
+
+    async def close(self) -> None:
+        self.closed = True
+        self._queue.put_nowait(_CLOSED)
+
+    # Test-side helpers ----------------------------------------------------
+    def feed(self, event: STTEvent) -> None:
+        """Inject one event into the live stream."""
+        self._queue.put_nowait(event)
+
+    def feed_error(self, exc: BaseException) -> None:
+        """Cause the next ``events()`` pull to raise ``exc``."""
+        self._queue.put_nowait(_ErrorBox(exc))
+```
+
+- [ ] **Step 3: Write `tests/test_fake_stt.py`**
+
+```python
+"""Tests for tests/fakes/stt.py — the FakeSTT test double itself.
+
+We test the fake because every other test in this push relies on it
+behaving exactly like a real STTProvider should. A bug in the fake
+would be a bug in dozens of consumer tests at once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.stt.base import SpeechStartedEvent, TranscriptEvent
+from tests.fakes.stt import FakeSTT
+
+
+@pytest.mark.asyncio
+async def test_open_marks_opened() -> None:
+    fake = FakeSTT()
+    await fake.open()
+    assert fake.opened is True
+
+
+@pytest.mark.asyncio
+async def test_send_records_audio_chunks_in_order() -> None:
+    fake = FakeSTT()
+    await fake.send(b"chunk1")
+    await fake.send(b"chunk2")
+    assert fake.sent == [b"chunk1", b"chunk2"]
+
+
+@pytest.mark.asyncio
+async def test_events_yields_seeded_events_in_order() -> None:
+    seeded = [
+        TranscriptEvent("hi", False, 0.7),
+        TranscriptEvent("hello", True, 0.95),
+    ]
+    fake = FakeSTT(events=seeded)
+    await fake.open()
+
+    received = []
+    async def consume():
+        async for event in fake.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)  # let consumer drain seeded items
+    await fake.close()
+    await task
+
+    assert received == seeded
+
+
+@pytest.mark.asyncio
+async def test_feed_injects_event_into_live_stream() -> None:
+    fake = FakeSTT()
+    await fake.open()
+
+    received = []
+    async def consume():
+        async for event in fake.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    fake.feed(SpeechStartedEvent())
+    fake.feed(TranscriptEvent("ok", True, 0.9))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert isinstance(received[0], SpeechStartedEvent)
+    assert isinstance(received[1], TranscriptEvent)
+    assert received[1].text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_feed_error_raises_from_events() -> None:
+    fake = FakeSTT()
+    await fake.open()
+    fake.feed_error(RuntimeError("dropped"))
+
+    with pytest.raises(RuntimeError, match="dropped"):
+        async for _event in fake.events():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_events_iterator() -> None:
+    fake = FakeSTT()
+    await fake.open()
+    await fake.close()
+
+    received = []
+    async for event in fake.events():
+        received.append(event)
+
+    assert received == []
+    assert fake.closed is True
+```
+
+- [ ] **Step 4: Run the new tests, expect FAIL (FakeSTT not yet importable)**
+
+Run: `python -m pytest tests/test_fake_stt.py -v`
+Expected: ImportError or ModuleNotFoundError on `tests.fakes.stt`. (Verify by message.)
+
+If they pass without the fake existing, you have the wrong test file or stale `__pycache__`. Run `python -m pytest --cache-clear tests/test_fake_stt.py`.
+
+- [ ] **Step 5: Re-run after `tests/fakes/stt.py` exists from Step 2**
+
+Run: `python -m pytest tests/test_fake_stt.py -v`
+Expected: 6 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fakes/__init__.py tests/fakes/stt.py tests/test_fake_stt.py
+git commit -m "test(stt): add FakeSTT fixture for offline testing
+
+Test double for STTProvider that lets tests script transcript events,
+inject speech-started events, and surface connection errors — all
+without touching the Deepgram SDK or network. Used by the consumer,
+barge-in, and provider-selector tests in following commits.
+
+Refs #250."
+```
+
+---
+
+## Task 3: Move Deepgram TTS into vendor package (α-3)
+
+**Goal:** Lift `app/tts/client.py` body into `app/deepgram/tts.py`, replace `recording_session` parameter with `on_chunk` callback, add the TTS selector at `app/tts/__init__.py`, update the five call sites in `router.py`, rename and update tests.
+
+**Files:**
+- Create: `app/deepgram/__init__.py`
+- Create: `app/deepgram/tts.py`
+- Modify: `app/tts/__init__.py`
+- Modify: `app/config.py`
+- Modify: `app/telephony/router.py`
+- Delete: `app/tts/client.py`
+- Rename: `tests/test_tts_client.py` → `tests/test_deepgram_tts.py`
+- Modify: renamed test file (imports + recording_session → on_chunk)
+- Create: `tests/test_provider_selector.py`
+
+- [ ] **Step 1: Add `tts_provider` setting to `app/config.py`**
+
+Edit `app/config.py`. Add inside `Settings` class, immediately after `deepgram_tts_model`:
+
+```python
+    # TTS provider selector. Today only "deepgram" is implemented; the
+    # selector seam exists so a second provider becomes a one-line add
+    # to app/tts/__init__.py.
+    tts_provider: str = "deepgram"
+```
+
+- [ ] **Step 2: Create `app/deepgram/__init__.py`**
+
+```python
+"""Deepgram vendor package — STT and TTS implementations co-located.
+
+The package exists so per-vendor configuration (API key reader, base URL,
+shared HTTP client) can live in one place and be consumed by both
+``stt.py`` and ``tts.py``. The router never imports from here directly;
+consumers route through ``app/stt`` and ``app/tts``.
+"""
+
+from __future__ import annotations
+
+from app.config import settings
+
+
+_DEEPGRAM_BASE = "https://api.deepgram.com/v1"
+
+
+def _api_key() -> str:
+    """Return the Deepgram API key, raising a clear error when missing.
+
+    Both halves of the Deepgram package call this lazily so importing
+    ``app.deepgram`` never crashes environments where the key isn't set.
+    """
+    key = settings.deepgram_api_key
+    if not key:
+        raise RuntimeError(
+            "DEEPGRAM_API_KEY not set — cannot reach Deepgram. "
+            "Fetch credentials via /shared-creds."
+        )
+    return key
+```
+
+- [ ] **Step 3: Create `app/deepgram/tts.py` — body lifted from `app/tts/client.py`, with `recording_session` swapped for `on_chunk`**
+
+```python
+"""Deepgram Aura TTS implementation.
+
+Streams Aura audio through Twilio Media Streams. Implements the SpeakFunc
+contract from app/tts/base.py.
+
+Why Deepgram Aura (over ElevenLabs):
+  - Server-to-server design — no abuse detector that blocks Cloud Run egress.
+  - Native ``mulaw`` 8 kHz output — drop-in for Twilio Media Streams.
+  - Reuses the Deepgram API key already in use for STT.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Callable, Optional
+
+import httpx
+from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+from app.config import settings
+from app.deepgram import _DEEPGRAM_BASE, _api_key
+
+logger = logging.getLogger(__name__)
+
+
+# Process-wide reusable client (#151). Constructing an httpx.AsyncClient
+# costs a TLS handshake on every speak() call; reusing one across the
+# whole process keeps the connection pool warm so subsequent sentence
+# chunks skip the handshake. Lazy-initialised so importing this module
+# never spins up sockets at startup. Tests reset this between cases via
+# a fixture; the real process never needs to.
+_default_client: Optional[httpx.AsyncClient] = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _default_client
+    if _default_client is None:
+        _default_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=5.0, read=10.0, write=5.0, pool=5.0)
+        )
+    return _default_client
+
+
+async def speak(
+    text: str,
+    websocket: WebSocket,
+    stream_sid: str,
+    *,
+    client: Optional[httpx.AsyncClient] = None,
+    on_chunk: Optional[Callable[[bytes], None]] = None,
+    on_first_byte: Optional[Callable[[], None]] = None,
+) -> None:
+    """Stream Deepgram Aura TTS audio back into the Twilio call.
+
+    Requests ``encoding=mulaw`` at 8 kHz with no container — raw mulaw
+    bytes that Twilio's Media Streams accepts directly. Each binary chunk
+    is base64-encoded and sent as a Twilio ``media`` WebSocket event
+    immediately, keeping latency low.
+    """
+    if not text.strip():
+        return
+
+    key = _api_key()
+    model = settings.deepgram_tts_model
+    url = f"{_DEEPGRAM_BASE}/speak"
+    params = {
+        "model": model,
+        "encoding": "mulaw",
+        "sample_rate": "8000",
+        "container": "none",
+    }
+
+    headers = {
+        "Authorization": f"Token {key}",
+        "Content-Type": "application/json",
+    }
+    body = {"text": text}
+
+    _client = client if client is not None else _get_client()
+    first_byte_fired = False
+
+    async with _client.stream("POST", url, headers=headers, params=params, json=body) as response:
+        if response.status_code != 200:
+            error_body = await response.aread()
+            logger.error(
+                "tts: Deepgram returned %d stream_sid=%s body=%s",
+                response.status_code,
+                stream_sid,
+                error_body.decode(errors="replace")[:200],
+            )
+            raise RuntimeError(
+                f"Deepgram returned {response.status_code}: {error_body.decode(errors='replace')}"
+            )
+
+        async for chunk in response.aiter_bytes():
+            if not chunk:
+                continue
+            if not first_byte_fired and on_first_byte is not None:
+                first_byte_fired = True
+                try:
+                    on_first_byte()
+                except Exception:
+                    logger.exception("tts: on_first_byte callback raised stream_sid=%s", stream_sid)
+            payload = base64.b64encode(chunk).decode()
+            try:
+                await websocket.send_json(
+                    {
+                        "event": "media",
+                        "streamSid": stream_sid,
+                        "media": {"payload": payload},
+                    }
+                )
+            except WebSocketDisconnect:
+                logger.info("tts: websocket disconnected mid-stream stream_sid=%s", stream_sid)
+                return
+            if on_chunk is not None:
+                try:
+                    on_chunk(chunk)
+                except Exception:
+                    logger.exception("tts: on_chunk callback raised stream_sid=%s", stream_sid)
+```
+
+Note the differences from the original `app/tts/client.py`:
+- `_DEEPGRAM_BASE` and `_api_key()` are imported from `app.deepgram` (shared with the future `app/deepgram/stt.py`).
+- The `recording_session` parameter and its `app.storage.recordings` import are replaced by the more general `on_chunk` callback.
+- Module docstring updated to "implementation" framing.
+
+- [ ] **Step 4: Replace `app/tts/__init__.py` with the selector**
+
+Overwrite `app/tts/__init__.py` (currently empty) with:
+
+```python
+"""Public entry point for the TTS abstraction layer.
+
+Dispatches to the configured provider. Today only Deepgram is wired in;
+adding ElevenLabs or another HTTP-streaming TTS is a one-clause addition
+to ``speak()`` plus a new ``app/<vendor>/tts.py`` matching the SpeakFunc
+contract from ``app/tts/base.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import httpx
+from fastapi import WebSocket
+
+from app.config import settings
+from app.tts.base import SpeakFunc
+
+__all__ = ["SpeakFunc", "speak"]
+
+
+async def speak(
+    text: str,
+    websocket: WebSocket,
+    stream_sid: str,
+    *,
+    client: Optional[httpx.AsyncClient] = None,
+    on_chunk: Optional[Callable[[bytes], None]] = None,
+    on_first_byte: Optional[Callable[[], None]] = None,
+) -> None:
+    """Synthesize ``text`` through the configured TTS provider and stream
+    audio into the Twilio call via ``websocket``."""
+    provider = settings.tts_provider
+    if provider == "deepgram":
+        from app.deepgram.tts import speak as _speak
+
+        return await _speak(
+            text,
+            websocket,
+            stream_sid,
+            client=client,
+            on_chunk=on_chunk,
+            on_first_byte=on_first_byte,
+        )
+    raise ValueError(f"Unknown TTS provider: {provider}")
+```
+
+- [ ] **Step 5: Delete `app/tts/client.py`**
+
+```bash
+git rm app/tts/client.py
+```
+
+- [ ] **Step 6: Update import in `app/telephony/router.py:41`**
+
+Edit `app/telephony/router.py`. Find:
+
+```python
+from app.tts.client import speak
+```
+
+Replace with:
+
+```python
+from app.tts import speak
+```
+
+- [ ] **Step 7: Add `_make_recording_chunk_handler` helper to `app/telephony/router.py`**
+
+Find the `_state_rid` function (around line 365). Insert the new helper immediately before it:
+
+```python
+def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:
+    """Return a chunk handler that appends outbound TTS audio to the
+    recording session, or None when no session is active.
+
+    Returning None means ``speak()`` won't fire ``on_chunk`` at all,
+    which is the desired behaviour when ``RECORDINGS_BUCKET`` is unset
+    and ``state.recording_session`` therefore stays None.
+    """
+    if state.recording_session is None:
+        return None
+    rs = state.recording_session
+
+    def _handle(chunk: bytes) -> None:
+        try:
+            recordings.append_chunks(rs, b"", chunk)
+        except Exception:
+            logger.exception(
+                "tts: recording append failed call_sid=%s", state.call_sid
+            )
+
+    return _handle
+```
+
+- [ ] **Step 8: Update the five `speak(...)` call sites in `app/telephony/router.py`**
+
+Each call site currently passes `recording_session=state.recording_session`. Replace with `on_chunk=_make_recording_chunk_handler(state)`.
+
+Find each occurrence in `router.py` (lines ~377, ~487, ~505, ~1027 from the Step 6 grep) and convert. Example diff at line ~377:
+
+```python
+# Before
+await speak(
+    SILENCE_PROMPT,
+    websocket,
+    state.stream_sid,
+    recording_session=state.recording_session,
+)
+
+# After
+await speak(
+    SILENCE_PROMPT,
+    websocket,
+    state.stream_sid,
+    on_chunk=_make_recording_chunk_handler(state),
+)
+```
+
+Repeat for all five call sites. Use `git diff app/telephony/router.py` to verify exactly five `recording_session=` removals and five `on_chunk=` additions.
+
+- [ ] **Step 9: Rename `tests/test_tts_client.py` to `tests/test_deepgram_tts.py`**
+
+```bash
+git mv tests/test_tts_client.py tests/test_deepgram_tts.py
+```
+
+- [ ] **Step 10: Update imports and parameters inside `tests/test_deepgram_tts.py`**
+
+Find every `from app.tts.client import` and replace with `from app.deepgram.tts import`. Find every `recording_session=` keyword argument in test calls to `speak(...)` and replace with `on_chunk=`. The corresponding test setup of mock recording sessions becomes a small inline `on_chunk` callback that records bytes into a list.
+
+Example pattern: a test that previously did
+
+```python
+session = make_fake_recording_session()
+await speak(text, ws, "MZ1", recording_session=session)
+assert session.outbound_chunks == [b"hello"]
+```
+
+becomes
+
+```python
+captured: list[bytes] = []
+await speak(text, ws, "MZ1", on_chunk=captured.append)
+assert captured == [b"hello"]
+```
+
+Apply this pattern test-by-test. Don't change test names — keep the renames purely mechanical.
+
+- [ ] **Step 11: Add a new test for `on_chunk` callback shape**
+
+Append to `tests/test_deepgram_tts.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_on_chunk_receives_each_audio_chunk(monkeypatch):
+    """Every non-empty body chunk Deepgram returns is forwarded to on_chunk."""
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    chunks_seen: list[bytes] = []
+    fake_chunks = [b"\x01\x02", b"\x03\x04", b"\x05"]
+
+    async def fake_aiter_bytes():
+        for c in fake_chunks:
+            yield c
+
+    response = AsyncMock()
+    response.status_code = 200
+    response.aiter_bytes = fake_aiter_bytes
+
+    stream_cm = AsyncMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=response)
+    stream_cm.__aexit__ = AsyncMock(return_value=None)
+
+    fake_client = AsyncMock()
+    fake_client.stream = MagicMock(return_value=stream_cm)
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await speak("hello", ws, "MZ123", client=fake_client, on_chunk=chunks_seen.append)
+
+    assert chunks_seen == fake_chunks
+
+
+@pytest.mark.asyncio
+async def test_on_chunk_exceptions_are_swallowed(monkeypatch, caplog):
+    """A buggy on_chunk callback never breaks a call."""
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    async def fake_aiter_bytes():
+        yield b"\x01"
+
+    response = AsyncMock()
+    response.status_code = 200
+    response.aiter_bytes = fake_aiter_bytes
+
+    stream_cm = AsyncMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=response)
+    stream_cm.__aexit__ = AsyncMock(return_value=None)
+
+    fake_client = AsyncMock()
+    fake_client.stream = MagicMock(return_value=stream_cm)
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    def bad(_chunk: bytes) -> None:
+        raise RuntimeError("boom")
+
+    # No exception escapes; the assertion is that this returns normally.
+    await speak("hi", ws, "MZ123", client=fake_client, on_chunk=bad)
+```
+
+Add the imports at the top of the file if not already present:
+
+```python
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config import settings
+from app.deepgram.tts import speak
+```
+
+- [ ] **Step 12: Create `tests/test_provider_selector.py` (TTS portion only — STT portion added in Task 6)**
+
+```python
+"""Tests for app/tts and app/stt selector functions.
+
+Confirms the configured provider is dispatched to and unknown providers
+raise. STT-side selector tests are added when get_stt() lands.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config import settings
+
+
+@pytest.mark.asyncio
+async def test_speak_dispatches_to_deepgram_when_provider_is_deepgram(monkeypatch):
+    monkeypatch.setattr(settings, "tts_provider", "deepgram")
+    fake_speak = AsyncMock()
+    monkeypatch.setattr("app.deepgram.tts.speak", fake_speak)
+
+    from app.tts import speak
+
+    ws = MagicMock()
+    await speak("hi", ws, "MZ1")
+    fake_speak.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_speak_raises_for_unknown_tts_provider(monkeypatch):
+    monkeypatch.setattr(settings, "tts_provider", "elevenlabs-not-implemented")
+    from app.tts import speak
+
+    ws = MagicMock()
+    with pytest.raises(ValueError, match="Unknown TTS provider"):
+        await speak("hi", ws, "MZ1")
+```
+
+- [ ] **Step 13: Run the full test suite**
+
+Run: `python -m pytest tests/ -x --tb=short -q`
+Expected: all tests pass. The renamed `test_deepgram_tts.py` runs in its new location; `test_telephony.py` still patches `_open_deepgram_connection` (we haven't removed it yet) but its `speak` patch path stays valid since `router.py` imports `speak` into its own namespace via `from app.tts import speak`.
+
+If any `test_telephony.py` test fails because `monkeypatch.setattr("app.telephony.router.speak", fake_speak)` no longer hits the right object: confirm `from app.tts import speak` is at the top of `router.py` (Step 6). The patch path is namespace-relative, so it follows the binding in `router.py`'s module namespace.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add app/config.py app/deepgram/__init__.py app/deepgram/tts.py app/tts/__init__.py app/telephony/router.py tests/test_deepgram_tts.py tests/test_provider_selector.py
+git rm app/tts/client.py
+git commit -m "refactor(tts): move Deepgram TTS to app/deepgram/tts.py
+
+- Lift app/tts/client.py body into app/deepgram/tts.py
+- Replace recording_session= parameter with general-purpose on_chunk
+  callback; TTS no longer imports app.storage.recordings
+- Add app/tts/__init__.py selector that dispatches by TTS_PROVIDER
+- Add _make_recording_chunk_handler helper in router; pass on_chunk at
+  the five call sites
+- Rename tests/test_tts_client.py to tests/test_deepgram_tts.py and
+  update imports + recording_session->on_chunk
+- Add TTS-provider selector tests
+
+Behaviour unchanged. Recording stays disabled on this branch
+(RECORDINGS_BUCKET unset; state.recording_session is None;
+_make_recording_chunk_handler returns None; on_chunk never fires).
+
+Refs #250."
+```
+
+---
+
+## Task 4: Implement DeepgramSTT plugin (α-4)
+
+**Goal:** Concrete `STTProvider` for Deepgram. Bridges the SDK's callback API to the async-iterator contract via an internal queue. Not yet wired into `router.py`.
+
+**Files:**
+- Create: `app/deepgram/stt.py`
+- Modify: `app/config.py`
+- Create: `tests/test_stt_deepgram.py`
+
+- [ ] **Step 1: Add STT settings to `app/config.py`**
+
+Edit `app/config.py`. Add inside `Settings`, after `tts_provider`:
+
+```python
+    # STT provider selector. Today only "deepgram" is implemented.
+    stt_provider: str = "deepgram"
+
+    # Deepgram live STT options. Defaults match what was inline in
+    # router.py before the plugin extraction; tuning is done by env var
+    # rather than code change.
+    stt_model: str = "nova-2"
+    stt_endpointing_ms: int = 800
+    stt_utterance_end_ms: int = 1000
+    # Comma-separated keyterms. Only sent to Deepgram when non-empty,
+    # and only respected by models that support keyterm prompting
+    # (Nova-3 and later). Parsed lazily in app/deepgram/stt.py.
+    stt_keyterms: str = ""
+```
+
+- [ ] **Step 2: Create `app/deepgram/stt.py`**
+
+```python
+"""Deepgram Nova live STT implementation.
+
+Implements the STTProvider contract from app/stt/base.py. Bridges
+Deepgram SDK's callback-based API onto the async-iterator interface
+the router consumer expects, via one internal asyncio.Queue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Optional
+
+from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
+
+from app.config import settings
+from app.deepgram import _api_key
+from app.stt.base import STTEvent, SpeechStartedEvent, TranscriptEvent
+
+logger = logging.getLogger(__name__)
+
+
+_CLOSED = object()
+
+
+@dataclass
+class _ErrorBox:
+    error: BaseException
+
+
+def _parse_keyterms(raw: str) -> Optional[list[str]]:
+    """Split STT_KEYTERMS env var into a list, or None when empty."""
+    items = [t.strip() for t in raw.split(",") if t.strip()]
+    return items or None
+
+
+class DeepgramSTT:
+    """Live Deepgram Nova STT provider.
+
+    Lifecycle: ``open()`` opens the live WS and registers SDK callbacks
+    that translate Deepgram events into STTEvents on an internal queue.
+    ``send()`` forwards Twilio media-stream payloads. ``events()`` is an
+    async generator that yields TranscriptEvent and SpeechStartedEvent
+    objects until ``close()`` is called.
+    """
+
+    def __init__(self, *, call_sid: Optional[str] = None) -> None:
+        self._call_sid = call_sid
+        self._conn: Any = None
+        self._queue: asyncio.Queue = asyncio.Queue()
+
+    async def open(self) -> None:
+        dg = DeepgramClient(_api_key())
+        self._conn = dg.listen.asynclive.v("1")
+        self._conn.on(LiveTranscriptionEvents.Transcript, self._on_transcript)
+        self._conn.on(LiveTranscriptionEvents.Error, self._on_error)
+
+        keyterms = _parse_keyterms(settings.stt_keyterms)
+
+        # endpointing + utterance_end_ms together control how aggressively
+        # Deepgram closes a turn. We picked 800/1000 after a 2026-04-26
+        # Twilight test call where endpointing=300 fired ~7 false barge-ins
+        # in 3 minutes — every micro-pause mid-sentence ("i would like to"
+        # <breath> "have") was treated as a turn ending, and the AI kept
+        # saying "take your time" because it thought the caller had spoken.
+        # 800ms is Deepgram's recommended value for conversational flow;
+        # utterance_end_ms=1000 layers a prosody-aware end-of-utterance
+        # signal on top so we wait for "actually finished" instead of just
+        # "stopped making noise".
+        options = LiveOptions(
+            model=settings.stt_model,
+            encoding="mulaw",
+            sample_rate=8000,
+            channels=1,
+            interim_results=True,
+            endpointing=settings.stt_endpointing_ms,
+            utterance_end_ms=settings.stt_utterance_end_ms,
+            vad_events=True,
+            keyterms=keyterms,
+        )
+        started = await self._conn.start(options)
+        if not started:
+            raise RuntimeError(
+                f"Deepgram connection failed to start call_sid={self._call_sid}"
+            )
+
+    async def send(self, audio: bytes) -> None:
+        if self._conn is None:
+            return
+        try:
+            await self._conn.send(audio)
+        except Exception:
+            # Connection-level send failure: log and continue. The next
+            # transcript will be incomplete; the silence watchdog absorbs
+            # the resulting gap.
+            logger.exception(
+                "deepgram send failed call_sid=%s — call continues",
+                self._call_sid,
+            )
+
+    async def events(self) -> AsyncIterator[STTEvent]:
+        while True:
+            item = await self._queue.get()
+            if item is _CLOSED:
+                return
+            if isinstance(item, _ErrorBox):
+                raise RuntimeError(f"deepgram error: {item.error}")
+            yield item
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            try:
+                await self._conn.finish()
+            except Exception:
+                logger.exception(
+                    "deepgram finish failed call_sid=%s", self._call_sid
+                )
+        self._queue.put_nowait(_CLOSED)
+
+    # SDK callbacks ---------------------------------------------------
+    async def _on_transcript(self, _self, result: Any, **_kwargs: Any) -> None:
+        alt = result.channel.alternatives[0]
+        text = alt.transcript.strip()
+        if not text:
+            return
+        # Explicit None check — `or 1.0` would replace 0.0 (falsy) with
+        # 1.0, masking a legitimate worst-case misheard signal.
+        raw_confidence = getattr(alt, "confidence", 1.0)
+        confidence = 1.0 if raw_confidence is None else raw_confidence
+
+        is_final = bool(result.is_final)
+        label = "final" if is_final else "interim"
+        logger.info(
+            "transcript [%s] call_sid=%s text=%r", label, self._call_sid, text
+        )
+
+        self._queue.put_nowait(
+            TranscriptEvent(text=text, is_final=is_final, confidence=confidence)
+        )
+
+    async def _on_error(self, _self, error: Any, **_kwargs: Any) -> None:
+        logger.error("deepgram error call_sid=%s error=%s", self._call_sid, error)
+        self._queue.put_nowait(_ErrorBox(error))
+```
+
+Note: the `SpeechStarted` callback is **not** registered here yet. That happens in Task 7.
+
+- [ ] **Step 3: Write `tests/test_stt_deepgram.py`**
+
+```python
+"""Tests for app/deepgram/stt.py — DeepgramSTT plugin.
+
+The Deepgram SDK is the only thing mocked; everything else exercises
+real plugin code (queue plumbing, callback wiring, options building).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.stt.base import TranscriptEvent
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch):
+    """Every test needs the api key set so _api_key() doesn't raise."""
+    from app.config import settings
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+
+@pytest.fixture
+def fake_deepgram_client(monkeypatch):
+    """Replace DeepgramClient inside app.deepgram.stt with a fake."""
+    fake_conn = AsyncMock()
+    fake_conn.send = AsyncMock()
+    fake_conn.finish = AsyncMock()
+    fake_conn.start = AsyncMock(return_value=True)
+    fake_conn._handlers = {}
+
+    def fake_on(event, handler):
+        fake_conn._handlers[event] = handler
+
+    fake_conn.on = MagicMock(side_effect=fake_on)
+
+    fake_listen = MagicMock()
+    fake_listen.asynclive.v = MagicMock(return_value=fake_conn)
+    fake_client = MagicMock()
+    fake_client.listen = fake_listen
+
+    monkeypatch.setattr(
+        "app.deepgram.stt.DeepgramClient",
+        MagicMock(return_value=fake_client),
+    )
+    return fake_conn
+
+
+@pytest.mark.asyncio
+async def test_open_starts_connection_with_configured_options(
+    fake_deepgram_client, monkeypatch,
+):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "stt_model", "nova-3")
+    monkeypatch.setattr(settings, "stt_endpointing_ms", 600)
+    monkeypatch.setattr(settings, "stt_utterance_end_ms", 1200)
+    monkeypatch.setattr(settings, "stt_keyterms", "tikka,naan")
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+
+    fake_deepgram_client.start.assert_awaited_once()
+    options = fake_deepgram_client.start.await_args.args[0]
+    assert options.model == "nova-3"
+    assert options.endpointing == 600
+    assert options.utterance_end_ms == 1200
+    assert options.keyterms == ["tikka", "naan"]
+    assert options.encoding == "mulaw"
+    assert options.sample_rate == 8000
+
+
+@pytest.mark.asyncio
+async def test_keyterms_empty_string_yields_none(fake_deepgram_client, monkeypatch):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "stt_keyterms", "")
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+
+    options = fake_deepgram_client.start.await_args.args[0]
+    assert options.keyterms is None
+
+
+@pytest.mark.asyncio
+async def test_open_raises_when_start_returns_false(fake_deepgram_client):
+    from app.deepgram.stt import DeepgramSTT
+
+    fake_deepgram_client.start = AsyncMock(return_value=False)
+    stt = DeepgramSTT(call_sid="CAtest")
+    with pytest.raises(RuntimeError, match="failed to start"):
+        await stt.open()
+
+
+@pytest.mark.asyncio
+async def test_open_raises_when_api_key_missing(monkeypatch, fake_deepgram_client):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "deepgram_api_key", None)
+    stt = DeepgramSTT(call_sid="CAtest")
+    with pytest.raises(RuntimeError, match="DEEPGRAM_API_KEY not set"):
+        await stt.open()
+
+
+@pytest.mark.asyncio
+async def test_send_forwards_audio_to_sdk(fake_deepgram_client):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    await stt.send(b"\x01\x02\x03")
+
+    fake_deepgram_client.send.assert_awaited_once_with(b"\x01\x02\x03")
+
+
+@pytest.mark.asyncio
+async def test_send_swallows_sdk_exceptions(fake_deepgram_client, caplog):
+    from app.deepgram.stt import DeepgramSTT
+
+    fake_deepgram_client.send = AsyncMock(side_effect=RuntimeError("dropped"))
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    # No exception escapes — log line proves we caught it.
+    await stt.send(b"x")
+
+
+@pytest.mark.asyncio
+async def test_transcript_callback_emits_events_in_order(fake_deepgram_client):
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
+
+    def make_result(text: str, is_final: bool, confidence: float):
+        alt = SimpleNamespace(transcript=text, confidence=confidence)
+        channel = SimpleNamespace(alternatives=[alt])
+        return SimpleNamespace(channel=channel, is_final=is_final)
+
+    await handler(stt, make_result("hi", False, 0.7))
+    await handler(stt, make_result("hello", True, 0.95))
+
+    received = []
+    async def consume():
+        async for event in stt.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    await stt.close()
+    await task
+
+    assert received == [
+        TranscriptEvent("hi", False, 0.7),
+        TranscriptEvent("hello", True, 0.95),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcript_callback_skips_empty_text(fake_deepgram_client):
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
+
+    alt = SimpleNamespace(transcript="   ", confidence=0.9)
+    result = SimpleNamespace(
+        channel=SimpleNamespace(alternatives=[alt]),
+        is_final=True,
+    )
+    await handler(stt, result)
+
+    received = []
+    async def consume():
+        async for event in stt.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    await stt.close()
+    await task
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_transcript_callback_normalizes_none_confidence(fake_deepgram_client):
+    """Deepgram occasionally returns confidence=None; we replace with 1.0
+    rather than 0.0 (which would mask worst-case misheard turns)."""
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
+
+    alt = SimpleNamespace(transcript="ok", confidence=None)
+    result = SimpleNamespace(
+        channel=SimpleNamespace(alternatives=[alt]),
+        is_final=True,
+    )
+    await handler(stt, result)
+
+    received = []
+    async def consume():
+        async for event in stt.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    await stt.close()
+    await task
+
+    assert len(received) == 1
+    assert received[0].confidence == 1.0
+
+
+@pytest.mark.asyncio
+async def test_error_callback_surfaces_as_exception_from_events(fake_deepgram_client):
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Error]
+    await handler(stt, "ws closed unexpectedly")
+
+    with pytest.raises(RuntimeError, match="deepgram error"):
+        async for _event in stt.events():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_events_iterator(fake_deepgram_client):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    await stt.close()
+
+    received = []
+    async for event in stt.events():
+        received.append(event)
+    assert received == []
+    fake_deepgram_client.finish.assert_awaited_once()
+```
+
+- [ ] **Step 4: Run the new tests, expect all pass**
+
+Run: `python -m pytest tests/test_stt_deepgram.py -v`
+Expected: 11 passed.
+
+If a test fails on `options.keyterms` because the installed `deepgram` SDK version's `LiveOptions` doesn't accept `keyterms=`: the SDK is too old. Run `pip install --upgrade deepgram-sdk` and re-run. Spec assumes deepgram-sdk v3.11+ which supports the field.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/config.py app/deepgram/stt.py tests/test_stt_deepgram.py
+git commit -m "feat(stt): implement DeepgramSTT plugin
+
+DeepgramSTT translates the SDK's callback API into the async-iterator
+contract the router consumer expects (TranscriptEvent + future
+SpeechStartedEvent). Bridges via one internal asyncio.Queue. Open/send/
+events/close lifecycle. Error callback surfaces as exception out of
+events(); send() catches and logs SDK errors so transient issues don't
+kill the call.
+
+Adds STT_PROVIDER, STT_MODEL, STT_ENDPOINTING_MS, STT_UTTERANCE_END_MS,
+STT_KEYTERMS to settings — defaults match the values inline in
+router.py today, so behaviour is unchanged.
+
+Not yet wired into router.py.
+
+Refs #250."
+```
+
+---
+
+## Task 5: Extract `_barge_in_now` helper (α-5)
+
+**Goal:** Pull the cancel + flush + cancel-watchdog block out of `_handle_final_transcript` into a reusable helper, so the new VAD trigger (Task 7) can fire the same pipeline. Add `barge_in_trigger` field to `_CallState`. Update `_run_llm_tts_turn`'s `CancelledError` handler to read and clear it. Behavior is preserved exactly: a `barge_in` Firestore event still fires only on actual task cancellation.
+
+**Files:**
+- Modify: `app/telephony/router.py`
+- Create: `tests/test_barge_in_helper.py`
+
+- [ ] **Step 1: Add `barge_in_trigger` field to `_CallState` in `app/telephony/router.py`**
+
+Find the `_CallState` dataclass (around line 250). Add the new field after `in_flight_transcript`:
+
+```python
+    # Set by _barge_in_now() before cancelling state.llm_task; read and
+    # cleared by _run_llm_tts_turn's CancelledError handler when emitting
+    # the barge_in Firestore event. None at all other times.
+    barge_in_trigger: str | None = None
+```
+
+- [ ] **Step 2: Add `_barge_in_now` helper to `app/telephony/router.py`**
+
+Find the `clear_twilio_audio` function (around line 237). Insert `_barge_in_now` immediately after it:
+
+```python
+async def _barge_in_now(
+    state: "_CallState",
+    websocket: WebSocket,
+    *,
+    trigger: str,
+) -> None:
+    """Stop the bot mid-utterance.
+
+    Three mechanical steps:
+      1. Cancel the in-flight LLM/TTS task → halt audio generation.
+      2. Cancel the silence watchdog → caller is speaking; "are you still
+         there?" would be wrong.
+      3. Send Twilio 'clear' → flush already-buffered audio playback (#74).
+
+    The barge_in Firestore event is NOT emitted here. It's emitted by
+    _run_llm_tts_turn's existing CancelledError handler when the task we
+    just cancelled actually receives the cancellation. Trigger
+    information flows via state.barge_in_trigger, read and cleared
+    inside that handler. This preserves today's invariant that barge_in
+    events correspond to genuine task cancellations.
+    """
+    state.barge_in_trigger = trigger
+    if state.llm_task and not state.llm_task.done():
+        state.llm_task.cancel()
+    _cancel_silence_task(state)
+    await clear_twilio_audio(websocket, state.stream_sid)
+```
+
+- [ ] **Step 3: Update `_run_llm_tts_turn` `CancelledError` handler in `app/telephony/router.py`**
+
+Find the existing handler (around line 567):
+
+```python
+    except asyncio.CancelledError:
+        logger.info("llm_turn cancelled (barge-in) call_sid=%s", state.call_sid)
+        _bg_call_event(state.call_sid, _state_rid(state), kind="barge_in")
+        raise
+```
+
+Replace with:
+
+```python
+    except asyncio.CancelledError:
+        trigger = state.barge_in_trigger or "unknown"
+        state.barge_in_trigger = None
+        logger.info(
+            "llm_turn cancelled (barge-in trigger=%s) call_sid=%s",
+            trigger,
+            state.call_sid,
+        )
+        _bg_call_event(
+            state.call_sid,
+            _state_rid(state),
+            kind="barge_in",
+            detail={"trigger": trigger},
+        )
+        raise
+```
+
+- [ ] **Step 4: Update `_handle_final_transcript` in `app/telephony/router.py`**
+
+Find the function (around line 585). Replace its body:
+
+```python
+async def _handle_final_transcript(text: str, state: _CallState, websocket: WebSocket) -> None:
+    interrupted = bool(state.llm_task and not state.llm_task.done())
+    # Carry forward — if any prior turn (cancelled or errored) left a
+    # transcript on state without persisting it to history, prepend it
+    # so Haiku sees the full caller intent in this turn (#170). The
+    # field is cleared by ``_run_llm_tts_turn`` only on ``event.final``,
+    # so a non-empty value here always means "user words from a prior
+    # turn that never made it into history."
+    if state.in_flight_transcript.strip():
+        text = f"{state.in_flight_transcript} {text}".strip()
+    silence_was_active = bool(state.silence_task and not state.silence_task.done())
+    # Caller spoke — abort any pending auto-hangup (#78). Even if they
+    # spoke during the grace window after a confirmation, we want to
+    # keep the call alive and process this transcript.
+    _abort_pending_hangup(state)
+
+    if interrupted:
+        # True barge-in: a turn is running and we're interrupting it.
+        # The barge_in Firestore event fires from _run_llm_tts_turn's
+        # CancelledError handler.
+        await _barge_in_now(state, websocket, trigger="final_transcript")
+    elif silence_was_active:
+        # Caller resumed after a silence prompt — flush any leftover
+        # prompt audio still buffered, but this isn't a barge-in (no
+        # task to cancel, no event to emit).
+        _cancel_silence_task(state)
+        await clear_twilio_audio(websocket, state.stream_sid)
+
+    state.in_flight_transcript = text
+    state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
+    state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
+```
+
+- [ ] **Step 5: Write `tests/test_barge_in_helper.py`**
+
+```python
+"""Tests for _barge_in_now() — the helper that stops the bot mid-utterance.
+
+The helper itself does not emit a Firestore event; the event is emitted
+by _run_llm_tts_turn's CancelledError handler when the cancellation we
+trigger here actually propagates. These tests verify the mechanical
+steps (task cancel, watchdog cancel, Twilio clear, trigger field set).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.telephony.router import _CallState, _barge_in_now
+
+
+@pytest.mark.asyncio
+async def test_cancels_running_llm_task():
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    async def long_task():
+        await asyncio.sleep(60)
+    state.llm_task = asyncio.create_task(long_task())
+
+    ws = AsyncMock()
+    await _barge_in_now(state, ws, trigger="vad")
+    await asyncio.sleep(0)  # let cancellation propagate
+
+    assert state.llm_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_no_op_when_no_llm_task():
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    state.llm_task = None
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    # Should not raise.
+    await _barge_in_now(state, ws, trigger="vad")
+    ws.send_json.assert_awaited_once_with({"event": "clear", "streamSid": "MZ1"})
+
+
+@pytest.mark.asyncio
+async def test_cancels_silence_task():
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    async def long_silence():
+        await asyncio.sleep(60)
+    state.silence_task = asyncio.create_task(long_silence())
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    await _barge_in_now(state, ws, trigger="vad")
+    await asyncio.sleep(0)
+    assert state.silence_task is None
+
+
+@pytest.mark.asyncio
+async def test_sends_twilio_clear_event():
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZabc"
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await _barge_in_now(state, ws, trigger="vad")
+    ws.send_json.assert_awaited_once_with(
+        {"event": "clear", "streamSid": "MZabc"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_sets_barge_in_trigger_on_state():
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await _barge_in_now(state, ws, trigger="final_transcript")
+    assert state.barge_in_trigger == "final_transcript"
+
+
+@pytest.mark.asyncio
+async def test_swallows_websocket_disconnect_during_clear():
+    """If the caller already hung up, sending clear raises but we must
+    not let that exception escape into the call loop."""
+    from starlette.websockets import WebSocketDisconnect
+
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    ws = AsyncMock()
+    ws.send_json = AsyncMock(side_effect=WebSocketDisconnect())
+    # No exception escapes is the assertion.
+    await _barge_in_now(state, ws, trigger="vad")
+```
+
+- [ ] **Step 6: Run the new tests + the existing barge-in tests**
+
+Run: `python -m pytest tests/test_barge_in_helper.py tests/test_telephony.py -v --tb=short -q`
+Expected: 6 new tests pass; existing telephony tests still pass (the helper change is behaviour-preserving for the final-transcript path).
+
+If `test_telephony.py::test_*` fails because barge_in event detail now includes `{"trigger": "..."}`: update the assertion to either ignore detail or assert the trigger value matches.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/telephony/router.py tests/test_barge_in_helper.py
+git commit -m "refactor(telephony): extract _barge_in_now helper
+
+Pull the cancel-task / cancel-watchdog / Twilio-clear pipeline out of
+_handle_final_transcript into a reusable helper. Trigger flows through
+state.barge_in_trigger to _run_llm_tts_turn's existing CancelledError
+handler, which emits the barge_in Firestore event with the trigger in
+detail. Behaviour preserved: events fire only on actual task
+cancellations.
+
+Sets up Task 7 (VAD speech-started -> instant barge-in) to use the
+same helper.
+
+Refs #250."
+```
+
+---
+
+## Task 6: Wire DeepgramSTT into router (α-6)
+
+**Goal:** Replace the inline Deepgram code in the `media_stream` WS handler with `get_stt()` + a `_consume_transcripts` background task. State mutation, Firestore emission, and dispatch into `_handle_final_transcript` move from the SDK callback into the consumer. Migrate the test fixture.
+
+**Files:**
+- Modify: `app/stt/__init__.py`
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_telephony.py`
+- Modify: `tests/test_provider_selector.py`
+- Create: `tests/test_transcript_consumer.py`
+
+- [ ] **Step 1: Add `get_stt()` to `app/stt/__init__.py`**
+
+Append to `app/stt/__init__.py`:
+
+```python
+def get_stt(*, call_sid: str | None = None) -> tuple["STTProvider", str]:
+    """Return the configured STT provider plus its name.
+
+    The name is returned alongside the provider so the caller (the router
+    consumer) can include ``provider`` metadata in events when desired,
+    without the plugin needing to know its own name.
+    """
+    from app.config import settings
+
+    name = settings.stt_provider
+    if name == "deepgram":
+        from app.deepgram.stt import DeepgramSTT
+
+        return DeepgramSTT(call_sid=call_sid), name
+    raise ValueError(f"Unknown STT provider: {name}")
+
+
+__all__ = [
+    "STTEvent",
+    "STTProvider",
+    "SpeechStartedEvent",
+    "TranscriptEvent",
+    "get_stt",
+]
+```
+
+- [ ] **Step 2: Add new fields to `_CallState` in `app/telephony/router.py`**
+
+After the `barge_in_trigger` field added in Task 5, add:
+
+```python
+    # STT plugin lifecycle. Set on "start"; consumer task drains
+    # stt.events() and is cancelled in the WS handler's finally block.
+    stt: "STTProvider | None" = None
+    stt_provider: str | None = None
+    transcript_task: asyncio.Task | None = None
+```
+
+You'll also need to import `STTProvider` at the top of `router.py`. Add to existing imports:
+
+```python
+from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent, get_stt
+```
+
+- [ ] **Step 3: Add `_consume_transcripts` to `app/telephony/router.py`**
+
+Insert immediately after `_arm_silence_watchdog` (around line 397):
+
+```python
+async def _consume_transcripts(
+    stt: STTProvider,
+    state: _CallState,
+    websocket: WebSocket,
+) -> None:
+    """Background task consuming events from the STT plugin.
+
+    All state mutation, Firestore emission, and dispatch into
+    _handle_final_transcript happens here — the plugin is pure and
+    knows nothing about call state.
+    """
+    try:
+        async for event in stt.events():
+            if isinstance(event, SpeechStartedEvent):
+                # VAD branch handled in Task 7. Today: ignore.
+                continue
+
+            # event is a TranscriptEvent
+            if not event.is_final:
+                continue   # interim: captured in plugin logs only
+
+            state.last_caller_transcript = event.text
+            if event.confidence < 0.5:
+                state.consecutive_low_confidence_turns += 1
+            else:
+                state.consecutive_low_confidence_turns = 0
+
+            _bg_call_event(
+                state.call_sid,
+                _state_rid(state),
+                kind="transcript_final",
+                text=event.text,
+                detail={"text": event.text, "confidence": event.confidence},
+            )
+            await _handle_final_transcript(event.text, state, websocket)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception(
+            "transcript consumer crashed call_sid=%s", state.call_sid
+        )
+```
+
+- [ ] **Step 4: Replace inline Deepgram code in `media_stream` WS handler**
+
+In `media_stream` (around line 943), find the `dg_conn = None` line near the top of the handler. Remove it.
+
+Find the `start` event branch (around line 1023) where `_open_deepgram_connection(...)` is called. Replace:
+
+```python
+                dg_conn = await _open_deepgram_connection(
+                    state.call_sid, state.restaurant.id, on_final, state=state
+                )
+```
+
+with:
+
+```python
+                state.stt, state.stt_provider = get_stt(call_sid=state.call_sid)
+                try:
+                    await state.stt.open()
+                except Exception:
+                    logger.exception(
+                        "stt: failed to open call_sid=%s", state.call_sid
+                    )
+                    _bg_call_event(
+                        state.call_sid,
+                        state.restaurant.id,
+                        kind="error",
+                        text="STT failed to open",
+                        detail={"provider": state.stt_provider},
+                    )
+                    return
+                state.transcript_task = asyncio.create_task(
+                    _consume_transcripts(state.stt, state, websocket)
+                )
+```
+
+Also remove the now-unused `on_final` inner function (around line 957) and any reference to `dg_conn`.
+
+In the `media` event branch (around line 1044), find:
+
+```python
+                    if dg_conn is not None:
+                        await dg_conn.send(payload)
+```
+
+Replace with:
+
+```python
+                    if state.stt is not None:
+                        await state.stt.send(payload)
+```
+
+In the WS handler's `finally` block (around line 1164), find:
+
+```python
+        if dg_conn is not None:
+            await dg_conn.finish()
+```
+
+Replace with:
+
+```python
+        if state.transcript_task and not state.transcript_task.done():
+            state.transcript_task.cancel()
+        if state.stt is not None:
+            await state.stt.close()
+```
+
+- [ ] **Step 5: Remove `_open_deepgram_connection` and Deepgram SDK imports from `router.py`**
+
+Delete the entire `_open_deepgram_connection` function (lines 294–362 in the pre-refactor file).
+
+Delete the line at the top of the file:
+
+```python
+from deepgram import DeepgramClient, LiveOptions, LiveTranscriptionEvents
+```
+
+Run `python -m pyflakes app/telephony/router.py` to confirm no remaining references. If pyflakes isn't installed: `python -c "import ast; ast.parse(open('app/telephony/router.py').read())"` at minimum confirms the file still parses.
+
+- [ ] **Step 6: Migrate `mock_pipeline` fixture in `tests/test_telephony.py`**
+
+Find the `mock_pipeline` fixture (around line 77). Replace its body:
+
+```python
+@pytest.fixture()
+def mock_pipeline(monkeypatch):
+    """Patch all four network-bound callables for offline testing."""
+    from tests.fakes.stt import FakeSTT
+
+    fake_stt = FakeSTT()
+
+    def fake_get_stt(**kwargs):
+        return fake_stt, "deepgram"
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    from app.storage import call_sessions
+
+    monkeypatch.setattr("app.telephony.router.get_stt", fake_get_stt)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
+    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
+    return fake_stt
+```
+
+- [ ] **Step 7: Collapse the five ad-hoc `fake_open_dg` patch blocks in `tests/test_telephony.py`**
+
+Search for `monkeypatch.setattr("app.telephony.router._open_deepgram_connection"` in the test file. Each match is inside a test function that builds its own AsyncMock and patches piece-by-piece. Convert each test to use the `mock_pipeline` fixture:
+
+```python
+# Before
+def test_some_flow(monkeypatch):
+    fake_dg = AsyncMock()
+    fake_dg.send = AsyncMock()
+    fake_dg.finish = AsyncMock()
+    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
+        return fake_dg
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    ...
+    # uses fake_dg.send
+
+# After
+def test_some_flow(mock_pipeline):
+    # mock_pipeline is the FakeSTT — use mock_pipeline.sent for assertions
+    ...
+```
+
+For tests that previously asserted on `fake_dg.send.call_args_list`, switch to `mock_pipeline.sent` (which is a list of bytes payloads in the order they arrived). For tests that previously asserted `fake_dg.finish.assert_awaited_once()`, switch to `mock_pipeline.closed is True`.
+
+- [ ] **Step 8: Add STT-side tests to `tests/test_provider_selector.py`**
+
+Append to the file:
+
+```python
+def test_get_stt_returns_deepgram_by_default(monkeypatch):
+    monkeypatch.setattr(settings, "stt_provider", "deepgram")
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    from app.deepgram.stt import DeepgramSTT
+    from app.stt import get_stt
+
+    provider, name = get_stt(call_sid="CAtest")
+    assert isinstance(provider, DeepgramSTT)
+    assert name == "deepgram"
+
+
+def test_get_stt_raises_for_unknown_provider(monkeypatch):
+    monkeypatch.setattr(settings, "stt_provider", "whisper-not-implemented")
+    from app.stt import get_stt
+
+    with pytest.raises(ValueError, match="Unknown STT provider"):
+        get_stt(call_sid="CAtest")
+```
+
+- [ ] **Step 9: Write `tests/test_transcript_consumer.py`**
+
+```python
+"""Tests for _consume_transcripts in app/telephony/router.py.
+
+The consumer is the router's bridge between the STT plugin and call
+state. We feed scripted events into a FakeSTT and assert state changes,
+Firestore emissions, and dispatch into _handle_final_transcript.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.stt.base import SpeechStartedEvent, TranscriptEvent
+from app.telephony.router import _CallState, _consume_transcripts
+from tests.fakes.stt import FakeSTT
+
+
+def _make_state() -> _CallState:
+    state = _CallState(websocket=AsyncMock())
+    state.call_sid = "CAtest"
+    state.stream_sid = "MZ1"
+    return state
+
+
+@pytest.mark.asyncio
+async def test_interim_transcripts_ignored(monkeypatch):
+    """Interims arrive on the queue but cause no state mutation, no
+    Firestore call, no _handle_final_transcript dispatch."""
+    state = _make_state()
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", handler
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+
+    fake = FakeSTT(events=[TranscriptEvent("partial", False, 0.7)])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_not_called()
+    bg.assert_not_called()
+    assert state.last_caller_transcript == ""
+
+
+@pytest.mark.asyncio
+async def test_final_transcript_mutates_state_and_dispatches(monkeypatch):
+    state = _make_state()
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", handler
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+
+    ws = AsyncMock()
+    fake = FakeSTT(events=[TranscriptEvent("two pizzas", True, 0.9)])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, ws))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert state.last_caller_transcript == "two pizzas"
+    handler.assert_awaited_once_with("two pizzas", state, ws)
+    bg.assert_called_once()
+    args, kwargs = bg.call_args
+    assert kwargs["kind"] == "transcript_final"
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_increments_counter(monkeypatch):
+    state = _make_state()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", AsyncMock()
+    )
+    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+
+    fake = FakeSTT(events=[
+        TranscriptEvent("muffled", True, 0.3),
+        TranscriptEvent("still muffled", True, 0.4),
+    ])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert state.consecutive_low_confidence_turns == 2
+
+
+@pytest.mark.asyncio
+async def test_high_confidence_resets_counter(monkeypatch):
+    state = _make_state()
+    state.consecutive_low_confidence_turns = 3
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", AsyncMock()
+    )
+    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+
+    fake = FakeSTT(events=[TranscriptEvent("clear", True, 0.95)])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert state.consecutive_low_confidence_turns == 0
+
+
+@pytest.mark.asyncio
+async def test_speech_started_currently_ignored(monkeypatch):
+    """Until Task 7 wires VAD-triggered barge-in, SpeechStartedEvents
+    are silently dropped by the consumer."""
+    state = _make_state()
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", handler
+    )
+
+    fake = FakeSTT(events=[SpeechStartedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
+    state = _make_state()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", AsyncMock()
+    )
+
+    fake = FakeSTT()
+    await fake.open()
+    fake.feed_error(RuntimeError("dropped"))
+
+    # Consumer catches the exception and exits cleanly.
+    await _consume_transcripts(fake, state, AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_consumer_propagates_cancellation(monkeypatch):
+    state = _make_state()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", AsyncMock()
+    )
+
+    fake = FakeSTT()
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+```
+
+- [ ] **Step 10: Run the full suite**
+
+Run: `python -m pytest tests/ -x --tb=short -q`
+Expected: every test passes — the new consumer tests, the migrated telephony tests, the deepgram tests, the selector tests, the fake-stt tests, and every pre-existing test.
+
+If `tests/test_telephony.py` fails on a previously-passing test: the most likely cause is an ad-hoc patch block that wasn't migrated. Search for `_open_deepgram_connection` in the test file — it should appear zero times after this task.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add app/stt/__init__.py app/telephony/router.py tests/test_telephony.py tests/test_transcript_consumer.py tests/test_provider_selector.py
+git commit -m "feat(telephony): replace inline Deepgram with STTProvider
+
+Wire get_stt() and _consume_transcripts into the media-stream WS
+handler. State mutation, Firestore emission, and dispatch into
+_handle_final_transcript move from the SDK callback closure into the
+consumer task. _open_deepgram_connection and the 'from deepgram import'
+line are removed from router.py.
+
+Migrates tests/test_telephony.py mock_pipeline fixture to inject
+FakeSTT; collapses five ad-hoc patch blocks into the fixture.
+
+Behaviour preserved. Instant barge-in via VAD speech-started lands in
+the next commit.
+
+Refs #250."
+```
+
+---
+
+## Task 7: Instant barge-in via VAD speech-started (α-7)
+
+**Goal:** Subscribe to Deepgram's `SpeechStarted` event in the plugin; consumer fires `_barge_in_now(trigger="vad")` when one arrives during an in-flight turn. Add `STT_INSTANT_BARGE_IN` kill-switch.
+
+**Files:**
+- Modify: `app/config.py`
+- Modify: `app/deepgram/stt.py`
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_stt_deepgram.py`
+- Modify: `tests/test_transcript_consumer.py`
+
+- [ ] **Step 1: Add `stt_instant_barge_in` setting to `app/config.py`**
+
+After `stt_keyterms`, add:
+
+```python
+    # Instant barge-in via Deepgram VAD speech-started events. When True
+    # (default), a barge-in fires ~50ms after the caller begins speaking
+    # instead of waiting for the final transcript (~800-1800ms). Flip to
+    # False if VAD turns out to misfire on coughs or background noise on
+    # a real call — the call falls back to the existing final-transcript
+    # barge-in path with no other changes.
+    stt_instant_barge_in: bool = True
+```
+
+- [ ] **Step 2: Subscribe to SpeechStarted in `app/deepgram/stt.py`**
+
+Inside `DeepgramSTT.open()`, after the existing `self._conn.on(LiveTranscriptionEvents.Error, ...)` line, add:
+
+```python
+        self._conn.on(
+            LiveTranscriptionEvents.SpeechStarted, self._on_speech_started
+        )
+```
+
+Add the new callback method on the class:
+
+```python
+    async def _on_speech_started(
+        self, _self, _event: Any = None, **_kwargs: Any
+    ) -> None:
+        logger.info("speech_started call_sid=%s", self._call_sid)
+        self._queue.put_nowait(SpeechStartedEvent())
+```
+
+Update the import at the top of `app/deepgram/stt.py` so `SpeechStartedEvent` is available:
+
+```python
+from app.stt.base import STTEvent, SpeechStartedEvent, TranscriptEvent
+```
+
+- [ ] **Step 3: Update `_consume_transcripts` in `app/telephony/router.py`**
+
+Find the existing speech-started branch (currently `# VAD branch handled in Task 7. Today: ignore.`):
+
+```python
+            if isinstance(event, SpeechStartedEvent):
+                # VAD branch handled in Task 7. Today: ignore.
+                continue
+```
+
+Replace with:
+
+```python
+            if isinstance(event, SpeechStartedEvent):
+                if not settings.stt_instant_barge_in:
+                    continue
+                if state.llm_task and not state.llm_task.done():
+                    await _barge_in_now(state, websocket, trigger="vad")
+                continue
+```
+
+`settings` is already imported at the top of `router.py`.
+
+- [ ] **Step 4: Add VAD-event test to `tests/test_stt_deepgram.py`**
+
+Append:
+
+```python
+@pytest.mark.asyncio
+async def test_speech_started_callback_emits_event(fake_deepgram_client):
+    """Deepgram's SpeechStarted event becomes a SpeechStartedEvent on
+    the queue."""
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+    from app.stt.base import SpeechStartedEvent
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.SpeechStarted]
+    await handler(stt, None)
+
+    received = []
+    async def consume():
+        async for event in stt.events():
+            received.append(event)
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    await stt.close()
+    await task
+
+    assert len(received) == 1
+    assert isinstance(received[0], SpeechStartedEvent)
+```
+
+- [ ] **Step 5: Add VAD-trigger tests to `tests/test_transcript_consumer.py`**
+
+Append:
+
+```python
+@pytest.mark.asyncio
+async def test_speech_started_triggers_barge_in_when_llm_task_running(monkeypatch):
+    state = _make_state()
+
+    async def long_turn():
+        await asyncio.sleep(60)
+    state.llm_task = asyncio.create_task(long_turn())
+
+    barge_in_calls = []
+    async def fake_barge(state_, ws_, *, trigger):
+        barge_in_calls.append(trigger)
+    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+
+    fake = FakeSTT(events=[SpeechStartedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert barge_in_calls == ["vad"]
+
+
+@pytest.mark.asyncio
+async def test_speech_started_no_op_when_no_llm_task(monkeypatch):
+    state = _make_state()
+    state.llm_task = None
+
+    barge_in_calls = []
+    async def fake_barge(state_, ws_, *, trigger):
+        barge_in_calls.append(trigger)
+    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+
+    fake = FakeSTT(events=[SpeechStartedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert barge_in_calls == []
+
+
+@pytest.mark.asyncio
+async def test_speech_started_disabled_by_setting(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "stt_instant_barge_in", False)
+    state = _make_state()
+
+    async def long_turn():
+        await asyncio.sleep(60)
+    state.llm_task = asyncio.create_task(long_turn())
+
+    barge_in_calls = []
+    async def fake_barge(state_, ws_, *, trigger):
+        barge_in_calls.append(trigger)
+    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+
+    fake = FakeSTT(events=[SpeechStartedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert barge_in_calls == []
+```
+
+- [ ] **Step 6: Update the placeholder consumer test from Task 6**
+
+In `tests/test_transcript_consumer.py`, replace `test_speech_started_currently_ignored` (the placeholder from Task 6) with the actual VAD branch tests above. Delete the placeholder test.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `python -m pytest tests/ -x --tb=short -q`
+Expected: every test passes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git commit -am "feat(telephony): instant barge-in via VAD speech-started
+
+Subscribe to Deepgram's SpeechStarted event in DeepgramSTT; consumer
+fires _barge_in_now(trigger='vad') when one arrives during an
+in-flight LLM/TTS turn. Cuts barge-in latency from ~800-1800ms (waiting
+for a final transcript) to ~50ms (VAD signal).
+
+Adds STT_INSTANT_BARGE_IN env-var kill-switch (default True). Set to
+False if VAD turns out to misfire on coughs or background noise during
+a real call — the existing final-transcript barge-in path is unchanged
+and absorbs the fallback case.
+
+Refs #250."
+```
+
+---
+
+## Phase α complete
+
+After Task 7, the structural extraction is finished. Bot behavior matches today **except** instant barge-in is on by default. The first real test call should sound like today's bot but pause faster when interrupted.
+
+### Verification before declaring α done
+
+- [ ] **Run the full test suite once more.**
+
+Run: `python -m pytest tests/ --tb=short -q`
+Expected: 100% pass.
+
+- [ ] **Run pre-commit hooks (ruff format, ruff check).**
+
+Run: `pre-commit run --all-files`
+Expected: pass with no auto-formatting changes left in the working tree (commit any auto-formatting that does happen).
+
+- [ ] **Confirm `_open_deepgram_connection` and `from deepgram import` no longer appear in `router.py`.**
+
+Run: `grep -n "_open_deepgram_connection\|from deepgram" app/telephony/router.py`
+Expected: no matches.
+
+- [ ] **Confirm `app/tts/client.py` is gone.**
+
+Run: `ls app/tts/`
+Expected: `__init__.py base.py` and nothing else.
+
+- [ ] **First test call.** Place a real test call to the niko-pizza-kitchen Twilio number. Verify:
+  - Bot greets normally.
+  - Caller is transcribed correctly (check Cloud Logging for `transcript [final]` lines).
+  - Order can be placed end-to-end.
+  - Barge-in by speaking over the bot mid-sentence — bot should stop within ~500ms (instant barge-in is on).
+  - Recording stays disabled (no GCS uploads, no errors).
+
+If the first test call sounds wrong: revert via `STT_INSTANT_BARGE_IN=False` env var (no code change) and verify the call now matches today's behavior.
+
+---
+
+## Phase β — tuning iterations
+
+β commits are open-ended and judged by test calls. Each is one or two of:
+
+- env var flip → test call → keep / revert / retune
+- prompt edit in `app/llm/prompts.py` → test call → keep / revert
+- small router tweak (silence prompt copy, hangup grace seconds, etc.) → test call → keep / revert
+
+What this push enables:
+
+| Knob | Try | Expected effect |
+|---|---|---|
+| `STT_MODEL=nova-3` | Retry the reverted #199 model bump | Better recognition on menu-item names |
+| `STT_KEYTERMS=tikka,naan,paneer,...` | Send menu vocabulary | Fewer mishears (Nova-3 only) |
+| `STT_ENDPOINTING_MS=600` | Tighten | Bot interrupts caller mid-thought (likely too low) |
+| `STT_ENDPOINTING_MS=1000` | Loosen | Long pauses before bot replies (likely too high) |
+| `STT_INSTANT_BARGE_IN=False` | Disable VAD | If barge-in misfires on coughs |
+| `DEEPGRAM_TTS_MODEL=...` | Try a different Aura voice | TTS naturalness |
+
+β commits use the same atomic-commit discipline. Anything bigger than a config flip lands as its own α-style commit with tests.
+
+---
+
+## Final merge to master
+
+When call quality is where you want it:
+
+- [ ] **Tests green:** `python -m pytest tests/`
+- [ ] **Hooks green:** `pre-commit run --all-files`
+- [ ] **Three consecutive clean test calls** demonstrating the conversational quality goal of #83.
+- [ ] **Master rebase clean:** `git fetch origin master && git rebase origin/master` with no conflicts deferred.
+- [ ] **Open PR** referencing both #83 and #250. Structure the description with α (extraction list) separately from β (behavior changes).
+
+---
+
+## Self-review checklist (run before handing off to executor)
+
+This was checked while writing the plan; documenting for transparency:
+
+- **Spec coverage:** Module layout (Tasks 1, 3, 4), STT contract (Task 1), TTS contract (Task 1, Task 3 implementation), consumer + barge-in (Task 5, Task 6, Task 7), config (Tasks 3, 4, 7), error handling (covered in DeepgramSTT, consumer, and WS handler updates), observability (no new event kinds; `barge_in` detail extension in Task 5), testing strategy (FakeSTT in Task 2, dedicated test files per task), migration sequence (Tasks 1–7).
+- **Type consistency:** `STTProvider`, `TranscriptEvent`, `SpeechStartedEvent`, `STTEvent`, `SpeakFunc`, `_CallState` field names verified consistent across tasks. `get_stt(call_sid=...)` returns `(STTProvider, str)` everywhere it's called. `_barge_in_now(state, websocket, *, trigger)` signature matches in helper, in `_handle_final_transcript`, and in the consumer.
+- **Placeholders:** None. Every step has actual code, exact commands, expected output, or named files.

--- a/docs/superpowers/plans/2026-05-06-telephony-router-modularization.md
+++ b/docs/superpowers/plans/2026-05-06-telephony-router-modularization.md
@@ -1,0 +1,893 @@
+# Telephony Router Modularization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `app/telephony/router.py` (1293 lines) into focused modules — vendor-specific Twilio I/O in `app/twilio/`, vendor-neutral orchestration in `app/telephony/session.py`, FastAPI shells + WS event-loop in a slimmed `app/telephony/router.py`. Mirrors the existing `app/deepgram/` pattern.
+
+**Architecture:** Geographic split, no new abstractions, no behavior changes. Mechanical move of code; existing test suite verifies behavior preservation.
+
+**Tech Stack:** Python 3.13, FastAPI, asyncio, Twilio TwiML SDK (`twilio.twiml.voice_response`).
+
+**Spec:** `docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md` (PR #252).
+
+**Branch:** `refactor/251-telephony-router-split` (already created off `feat/83-tune-conversational-bot`).
+
+**Note on TDD:** This is a behavior-preserving refactor — no new tests needed. The discipline is "tests pass at every commit boundary." Each task runs the focused telephony test subset and only commits if green.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+git branch --show-current
+```
+
+Expected: `refactor/251-telephony-router-split`.
+
+- [ ] **Step 2: Verify baseline tests pass**
+
+```bash
+pytest tests/test_telephony.py tests/test_voice.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py -q
+```
+
+Expected: all pass. If any fail, stop — the baseline is broken and the refactor would mask it.
+
+---
+
+## Task 1: Extract Twilio WS protocol primitives
+
+Goal: pull `clear_twilio_audio` and `send_end_of_call_mark` out of `router.py` into `app/twilio/media_stream.py`. They're the only two outgoing Twilio-shaped JSON literals the orchestration layer emits.
+
+**Files:**
+- Create: `app/twilio/__init__.py`
+- Create: `app/twilio/media_stream.py`
+- Modify: `app/telephony/router.py`
+
+- [ ] **Step 1: Create the package marker**
+
+`app/twilio/__init__.py`:
+
+```python
+"""Twilio vendor module.
+
+Holds Twilio-specific I/O — TwiML response builders, Media Stream
+WebSocket protocol primitives, and REST helpers — kept separate from
+the vendor-neutral call orchestration in app/telephony/. Mirrors the
+app/deepgram/ pattern.
+
+Consumers that need vendor-agnostic call logic should import from
+app/telephony/, not from here. Anything that touches a Twilio JSON
+envelope, TwiML XML, or Twilio's REST API lives under this package.
+"""
+
+from __future__ import annotations
+```
+
+- [ ] **Step 2: Create `media_stream.py`**
+
+`app/twilio/media_stream.py`:
+
+```python
+"""Twilio Media Stream WS protocol primitives — outgoing frames only.
+
+Incoming frame parsing (start/media/mark/stop) stays inline in the
+WS event-loop in app/telephony/router.py until a second telephony
+provider forces a real shape difference.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+logger = logging.getLogger(__name__)
+
+
+async def send_clear(websocket: WebSocket, stream_sid: str | None) -> None:
+    """Tell Twilio to flush its audio buffer and stop playback (#74).
+
+    Cancelling the LLM/TTS task only stops generation — bytes already in
+    Twilio's buffer keep playing for 1-3 seconds. Twilio's clear event
+    drops the buffer in ~80ms. Used by barge-in and post-silence cleanup.
+    """
+    if not stream_sid:
+        return
+    try:
+        await websocket.send_json({"event": "clear", "streamSid": stream_sid})
+    except WebSocketDisconnect:
+        return
+    except Exception:
+        logger.exception(
+            "clear: failed to send Twilio clear event stream_sid=%s",
+            stream_sid,
+        )
+
+
+async def send_mark(
+    websocket: WebSocket,
+    stream_sid: str | None,
+    name: str,
+) -> bool:
+    """Append a named mark to Twilio's outgoing media stream (#78).
+
+    Twilio echoes the mark back over the WebSocket once its audio buffer
+    drains past it — i.e. once the caller has heard everything we sent.
+    The auto-hangup path uses this as the precise trigger to begin its
+    grace window. Returns True if the send succeeded.
+    """
+    if not stream_sid:
+        return False
+    try:
+        await websocket.send_json(
+            {
+                "event": "mark",
+                "streamSid": stream_sid,
+                "mark": {"name": name},
+            }
+        )
+        return True
+    except WebSocketDisconnect:
+        return False
+    except Exception:
+        logger.exception(
+            "mark: failed to send mark name=%s stream_sid=%s",
+            name,
+            stream_sid,
+        )
+        return False
+```
+
+- [ ] **Step 3: Wire `router.py` to the new primitives**
+
+In `app/telephony/router.py`:
+
+1. Add the import near the top with the other `app.*` imports:
+
+```python
+from app.twilio.media_stream import send_clear, send_mark
+```
+
+2. **Delete** the existing `clear_twilio_audio` function definition (currently around lines 241-260).
+
+3. **Delete** the existing `send_end_of_call_mark` function definition (currently around lines 141-164).
+
+4. Replace the call sites:
+
+In `_barge_in_now` (currently around line 289), change:
+
+```python
+await clear_twilio_audio(websocket, state.stream_sid)
+```
+
+to:
+
+```python
+await send_clear(websocket, state.stream_sid)
+```
+
+In `_handle_final_transcript` (currently around line 688), change:
+
+```python
+await clear_twilio_audio(websocket, state.stream_sid)
+```
+
+to:
+
+```python
+await send_clear(websocket, state.stream_sid)
+```
+
+In `_run_llm_tts_turn` (currently around line 615), change:
+
+```python
+sent = await send_end_of_call_mark(websocket, state.stream_sid)
+```
+
+to:
+
+```python
+sent = await send_mark(websocket, state.stream_sid, name=END_OF_CALL_MARK)
+```
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+pytest tests/test_telephony.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py -q
+```
+
+Expected: all pass. `test_barge_in_helper.py` asserts on the JSON payload `{"event": "clear", ...}` so it verifies the new `send_clear` produces the same bytes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/twilio/__init__.py app/twilio/media_stream.py app/telephony/router.py
+git commit -m "refactor(telephony): extract Twilio WS protocol primitives to app/twilio/ (#251)
+
+Pulls clear_twilio_audio and send_end_of_call_mark out of router.py
+into app/twilio/media_stream.py as send_clear and send_mark. These
+are the only outgoing Twilio-shaped JSON frames the orchestration
+emits; isolating them clears the path for the rest of the split.
+
+No behavior change — the new functions reproduce the existing
+WebSocketDisconnect handling and exception logging."
+```
+
+---
+
+## Task 2: Extract TwiML response builders
+
+Goal: pull all `VoiceResponse(...)` construction out of the FastAPI handlers in `router.py` into `app/twilio/twiml.py`. Handlers shrink to "parse form → call builder → return Response".
+
+**Files:**
+- Create: `app/twilio/twiml.py`
+- Modify: `app/telephony/router.py`
+
+- [ ] **Step 1: Create `twiml.py`**
+
+`app/twilio/twiml.py`:
+
+```python
+"""TwiML response builders for the Twilio voice webhook surface.
+
+Pure functions returning Twilio VoiceResponse objects. The FastAPI
+handlers in app/telephony/router.py call these and wrap the result
+in a fastapi.Response with media_type='application/xml'.
+
+Kept separate so that:
+- TwiML XML construction lives in one place (mirrors app/deepgram/);
+- builders are easy to snapshot-test without spinning up FastAPI;
+- the orchestration layer in app/telephony/ never imports from
+  twilio.twiml directly.
+"""
+
+from __future__ import annotations
+
+from twilio.twiml.voice_response import Connect, Dial, VoiceResponse
+
+from app.restaurants.models import Restaurant
+
+
+_UNCONFIGURED_TWIML_MESSAGE = (
+    "Sorry, this number is not currently configured. Goodbye."
+)
+_CLOSED_TWIML_MESSAGE = (
+    "Sorry, we're closed. Please call back during business hours."
+)
+
+
+def empty_twiml() -> VoiceResponse:
+    """Empty <Response/>. Used for hangup-on-success paths and as a
+    safe default when a Twilio callback can't be acted on."""
+    return VoiceResponse()
+
+
+def unconfigured_hangup_twiml() -> VoiceResponse:
+    """Inbound call to a number that isn't mapped to any tenant."""
+    twiml = VoiceResponse()
+    twiml.say(_UNCONFIGURED_TWIML_MESSAGE)
+    twiml.hangup()
+    return twiml
+
+
+def closed_hangup_twiml() -> VoiceResponse:
+    """Defensive after-hours hangup for the rare case the voicemail
+    flow can't run (e.g. CallSid missing on the inbound webhook)."""
+    twiml = VoiceResponse()
+    twiml.say(_CLOSED_TWIML_MESSAGE)
+    twiml.hangup()
+    return twiml
+
+
+def voice_twiml(restaurant: Restaurant, ws_host: str) -> VoiceResponse:
+    """Open a bidirectional Media Stream back to /media-stream and
+    forward the resolved restaurant id via <Parameter> so the WS
+    handler doesn't need to re-query Firestore."""
+    twiml = VoiceResponse()
+    connect = Connect(action="/voice/stream-ended", method="POST")
+    # NOTE: <Connect><Stream> only supports the default ``inbound_track``;
+    # passing ``track="both_tracks"`` makes Twilio reject the TwiML and
+    # the call drops the moment the caller dismisses the trial-account
+    # interstitial. To capture the agent's voice in the recording, the
+    # /media-stream WS handler intercepts the TTS bytes we send out via
+    # ``speak()`` and feeds them directly into the recording session.
+    stream = connect.stream(url=f"wss://{ws_host}/media-stream")
+    stream.parameter(name="restaurant_id", value=restaurant.id)
+    twiml.append(connect)
+    return twiml
+
+
+def transfer_twiml(
+    fallback_phone: str,
+    call_sid: str,
+    rid: str,
+    *,
+    timeout: int = 20,
+) -> VoiceResponse:
+    """Dial the tenant's fallback number, with action callback to
+    /voice/transfer-result so we can record the outcome and cascade
+    to voicemail on no-answer/busy/failed."""
+    twiml = VoiceResponse()
+    dial = Dial(
+        action=f"/voice/transfer-result?call_sid={call_sid}&rid={rid}",
+        method="POST",
+        timeout=timeout,
+    )
+    dial.number(fallback_phone)
+    twiml.append(dial)
+    return twiml
+```
+
+- [ ] **Step 2: Wire `router.py` handlers to the builders**
+
+In `app/telephony/router.py`:
+
+1. Add the import:
+
+```python
+from app.twilio.twiml import (
+    closed_hangup_twiml,
+    empty_twiml,
+    transfer_twiml,
+    unconfigured_hangup_twiml,
+    voice_twiml,
+)
+```
+
+2. Remove the `_UNCONFIGURED_TWIML_MESSAGE` constant (now lives in `twiml.py`).
+
+3. Remove `from twilio.twiml.voice_response import Connect, Dial, VoiceResponse` from the top of the file — no longer needed in router.
+
+4. Rewrite the `voice` handler body. Replace the section starting `twiml = VoiceResponse()` and ending at `return Response(content=str(twiml), ...)` with:
+
+```python
+    if restaurant is None:
+        logger.warning("voice: no restaurant for To=%s — rejecting call", to_e164 or "(missing)")
+        return Response(
+            content=str(unconfigured_hangup_twiml()),
+            media_type="application/xml",
+        )
+
+    if not is_open_now(restaurant):
+        # After-hours: skip the AI flow, drop straight to voicemail.
+        if not call_sid:
+            # Defensive: Twilio always posts CallSid. Without it, we
+            # can't key the recording or call_session — bail.
+            return Response(
+                content=str(closed_hangup_twiml()),
+                media_type="application/xml",
+            )
+        try:
+            call_sessions.init_call_session(call_sid, restaurant.id)
+        except Exception:
+            logger.exception(
+                "voice: init_call_session failed call_sid=%s rid=%s",
+                call_sid,
+                restaurant.id,
+            )
+        return Response(
+            content=str(voicemail_response(call_sid, restaurant.id)),
+            media_type="application/xml",
+        )
+
+    host = request.headers.get("host", "localhost:8000")
+    return Response(
+        content=str(voice_twiml(restaurant, host)),
+        media_type="application/xml",
+    )
+```
+
+5. In `stream_ended`, replace the three `Response(content=str(VoiceResponse()), ...)` returns with:
+
+```python
+return Response(content=str(empty_twiml()), media_type="application/xml")
+```
+
+And replace the `<Dial>` construction (currently `twiml = VoiceResponse(); dial = Dial(...); ... twiml.append(dial); return Response(content=str(twiml), ...)`) with:
+
+```python
+return Response(
+    content=str(transfer_twiml(restaurant.fallback_phone, call_sid, rid)),
+    media_type="application/xml",
+)
+```
+
+6. In `transfer_result`, replace `Response(content=str(VoiceResponse()), ...)` with `Response(content=str(empty_twiml()), ...)` (two occurrences).
+
+7. In `voicemail_recorded`, replace all five `Response(content=str(VoiceResponse()), ...)` returns with `Response(content=str(empty_twiml()), ...)`.
+
+- [ ] **Step 3: Run focused tests**
+
+```bash
+pytest tests/test_telephony.py tests/test_voice.py -q
+```
+
+Expected: all pass. `test_voice.py` exercises the public `/voice` surface; `test_telephony.py` covers the WS handler.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/twilio/twiml.py app/telephony/router.py
+git commit -m "refactor(telephony): extract TwiML builders to app/twilio/twiml.py (#251)
+
+Pure functions for the five TwiML responses the voice webhook
+surface returns. Handlers in router.py shrink to form-parsing +
+builder call + Response wrap. No behavior change."
+```
+
+---
+
+## Task 3: Extract Twilio REST recording download
+
+Goal: move the inline Twilio REST recording fetch out of `voicemail_recorded` into `app/twilio/__init__.py`. Currently the handler imports `recordings.upload_voicemail_from_twilio`, which already lives in `app/storage/recordings.py` and takes Twilio creds — so the actual change is small. The Twilio-specific *credentials check* and the `(account_sid, auth_token)` tuple construction move out of router.
+
+**Files:**
+- Modify: `app/twilio/__init__.py`
+- Modify: `app/telephony/router.py`
+
+- [ ] **Step 1: Add a credentialed-fetch helper to `app/twilio/__init__.py`**
+
+Append to `app/twilio/__init__.py`:
+
+```python
+import logging
+
+from app.config import settings
+from app.storage import recordings as _recordings
+
+logger = logging.getLogger(__name__)
+
+
+def twilio_basic_auth() -> tuple[str, str] | None:
+    """Return Twilio REST basic-auth tuple, or None when unconfigured.
+
+    Centralised so the voicemail-recorded callback doesn't have to
+    reach into ``settings.twilio_account_sid`` / ``twilio_auth_token``
+    directly. Returns None (rather than raising) so the caller can
+    log + degrade gracefully — voicemail upload is best-effort.
+    """
+    sid = settings.twilio_account_sid
+    token = settings.twilio_auth_token
+    if not sid or not token:
+        return None
+    return (sid, token)
+
+
+def upload_voicemail(
+    *,
+    call_sid: str,
+    restaurant_id: str,
+    twilio_recording_url: str,
+) -> str:
+    """Download the voicemail recording from Twilio's REST and upload
+    to GCS. Wraps app.storage.recordings.upload_voicemail_from_twilio
+    with the Twilio creds resolved from settings.
+
+    Raises RuntimeError if Twilio creds are missing — the caller is
+    expected to check ``twilio_basic_auth()`` first if it wants to
+    short-circuit gracefully.
+    """
+    auth = twilio_basic_auth()
+    if auth is None:
+        raise RuntimeError("Twilio credentials missing")
+    return _recordings.upload_voicemail_from_twilio(
+        call_sid=call_sid,
+        restaurant_id=restaurant_id,
+        twilio_recording_url=twilio_recording_url,
+        auth=auth,
+    )
+```
+
+- [ ] **Step 2: Wire `voicemail_recorded` to the helper**
+
+In `app/telephony/router.py`, replace the block in `voicemail_recorded` that reads:
+
+```python
+if not settings.twilio_account_sid or not settings.twilio_auth_token:
+    logger.error(
+        "voicemail upload: twilio creds missing call_sid=%s",
+        call_sid,
+    )
+    return Response(
+        content=str(empty_twiml()),
+        media_type="application/xml",
+    )
+
+try:
+    gs_url = recordings.upload_voicemail_from_twilio(
+        call_sid=call_sid,
+        restaurant_id=rid,
+        twilio_recording_url=recording_url,
+        auth=(settings.twilio_account_sid, settings.twilio_auth_token),
+    )
+except Exception:
+    ...
+```
+
+with:
+
+```python
+if app_twilio.twilio_basic_auth() is None:
+    logger.error(
+        "voicemail upload: twilio creds missing call_sid=%s",
+        call_sid,
+    )
+    return Response(
+        content=str(empty_twiml()),
+        media_type="application/xml",
+    )
+
+try:
+    gs_url = app_twilio.upload_voicemail(
+        call_sid=call_sid,
+        restaurant_id=rid,
+        twilio_recording_url=recording_url,
+    )
+except Exception:
+    logger.exception(
+        "voicemail upload failed call_sid=%s sid=%s",
+        call_sid,
+        recording_sid,
+    )
+    return Response(
+        content=str(empty_twiml()),
+        media_type="application/xml",
+    )
+```
+
+Add the import at the top of `router.py`:
+
+```python
+import app.twilio as app_twilio
+```
+
+(Aliased to `app_twilio` to make it clear at the call site that this is *our* package, not the third-party `twilio` SDK.)
+
+- [ ] **Step 3: Run focused tests**
+
+```bash
+pytest tests/test_telephony.py tests/test_voice.py -q
+```
+
+Expected: all pass. (Voicemail upload is mocked in `test_telephony.py`'s pipeline fixture; the wiring change is covered by the existing test.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/twilio/__init__.py app/telephony/router.py
+git commit -m "refactor(telephony): centralise Twilio REST creds + voicemail upload (#251)
+
+Adds twilio_basic_auth() and upload_voicemail() helpers in
+app/twilio/__init__.py so the voicemail-recorded webhook handler
+doesn't have to dereference settings.twilio_account_sid /
+twilio_auth_token directly. Behaviour preserved."
+```
+
+---
+
+## Task 4: Move `_CallState` and orchestration helpers to `session.py`
+
+Goal: this is the big one — move the bulk of `router.py` (everything except FastAPI shells and the WS event-loop dispatch) into `app/telephony/session.py`. Public test-imported names (`_CallState`, `_barge_in_now`, `_consume_transcripts`, `_should_flush_chunk`, `_MIN_CHUNK_CHARS`) become public from the new location. Test imports update.
+
+**Files:**
+- Create: `app/telephony/session.py`
+- Modify: `app/telephony/router.py`
+- Modify: `tests/test_barge_in_helper.py`
+- Modify: `tests/test_transcript_consumer.py`
+- Modify: `tests/test_telephony.py`
+
+- [ ] **Step 1: Create `session.py` with the moved code**
+
+Create `app/telephony/session.py` containing, in order, copied verbatim from `router.py`:
+
+1. The module docstring (rewritten — see below).
+2. All imports `router.py` needs for these helpers — minus FastAPI's `APIRouter, Request, Response` and minus `Connect, Dial, VoiceResponse`. Keep `WebSocket, WebSocketDisconnect`.
+3. The constants block:
+   - `SILENCE_TIMEOUT_SECONDS`, `SILENCE_PROMPT`, `GREETING_TRANSCRIPT`
+   - `END_OF_CALL_MARK`, `HANGUP_GRACE_SECONDS`, `MARK_ECHO_TIMEOUT_SECONDS`
+   - `_HARD_BREAKS`, `_SOFT_BREAKS`, `_MIN_CHUNK_CHARS`
+   - `_GOODBYE_PATTERNS`
+4. The pure helpers:
+   - `_should_flush_chunk`
+   - `_looks_like_goodbye`
+5. The Firestore helper:
+   - `_bg_call_event`
+6. **`_CallState` dataclass.** Move verbatim. Keep all field comments.
+7. The recording-handler factory: `_make_recording_chunk_handler`.
+8. `_state_rid`.
+9. Silence watchdog trio: `_silence_watchdog`, `_cancel_silence_task`, `_arm_silence_watchdog`.
+10. Auto-hangup trio: `_hang_up_after_grace`, `_hang_up_after_mark_timeout`, `_abort_pending_hangup`.
+11. Barge-in: `_barge_in_now`.
+12. Transcript consumer: `_consume_transcripts`.
+13. LLM turn: `_run_llm_tts_turn`, `_handle_final_transcript`.
+14. Tenant resolver: `_resolve_restaurant_for_voice` (still needed by `voice` handler in router.py).
+
+The new file's docstring:
+
+```python
+"""Call orchestration — vendor-neutral.
+
+Owns _CallState and every helper that runs during the lifetime of an
+active call: barge-in, hangup, silence, the LLM/TTS turn loop, and the
+STT transcript consumer. The module knows about the abstract STT/TTS
+provider interfaces in app/stt and app/tts but nothing about Twilio
+specifics — those live in app/twilio/.
+
+The FastAPI endpoints + WS event-loop dispatch live in
+app/telephony/router.py. router.py imports from this module; this
+module does not import from router.py.
+"""
+```
+
+Imports the new file needs (build this list by reading the moved code):
+
+```python
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from fastapi import WebSocket, WebSocketDisconnect
+
+from app.config import settings
+from app.llm.client import stream_reply
+from app.llm.prompts import build_system_prompt  # used by ws handler — see note
+from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm  # used by ws handler — see note
+from app.orders.models import Order, OrderStatus
+from app.restaurants.models import Restaurant
+from app.restaurants.open_check import is_open_now  # used by voice handler — see note
+from app.storage import call_sessions, recordings, restaurants as restaurants_storage
+from app.storage.recordings import RecordingUploadSession  # noqa: F401  (typing only)
+from app.stt import STTProvider, SpeechStartedEvent, TranscriptEvent
+from app.twilio.media_stream import send_clear, send_mark
+```
+
+Notes on imports — some symbols (`build_system_prompt`, `OrderNotReadyError`, `persist_on_confirm`, `is_open_now`) are referenced from the WS handler in `router.py` not directly from helpers being moved. Re-check after the move: import only what `session.py` actually uses. Static analysis: a final `pyflakes app/telephony/session.py` must show zero unused imports.
+
+Replace the inline call sites in `_barge_in_now` and `_run_llm_tts_turn` to use `send_clear` / `send_mark` (already done in Tasks 1, but verify these moved code blocks still reference the new names).
+
+- [ ] **Step 2: Slim `router.py` to shells + WS event-loop**
+
+Rewrite `app/telephony/router.py` to contain only:
+
+1. Module docstring (rewritten — focused on the FastAPI surface).
+2. Imports needed for the HTTP handlers and the WS dispatch.
+3. The `router = APIRouter()` declaration.
+4. `_TRANSFER_STATUS_MAP` (used by `transfer_result`).
+5. The five HTTP handlers: `voice`, `stream_ended`, `transfer_result`, `voicemail_recorded`, `voicemail_transcription`.
+6. The `media_stream` WebSocket handler.
+
+Imports for the new `router.py`:
+
+```python
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+
+from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
+
+import app.twilio as app_twilio
+from app.config import settings
+from app.llm.prompts import build_system_prompt
+from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
+from app.orders.models import Order
+from app.restaurants.open_check import is_open_now
+from app.storage import call_sessions, recordings
+from app.storage import restaurants as restaurants_storage
+from app.stt import get_stt
+from app.telephony.session import (
+    GREETING_TRANSCRIPT,
+    END_OF_CALL_MARK,
+    _CallState,
+    _abort_pending_hangup,
+    _arm_silence_watchdog,
+    _bg_call_event,
+    _cancel_silence_task,
+    _consume_transcripts,
+    _hang_up_after_grace,
+    _make_recording_chunk_handler,
+    _resolve_restaurant_for_voice,
+    _run_llm_tts_turn,
+    _state_rid,
+)
+from app.telephony.voicemail_twiml import voicemail_response
+from app.tts import speak
+from app.twilio.twiml import (
+    closed_hangup_twiml,
+    empty_twiml,
+    transfer_twiml,
+    unconfigured_hangup_twiml,
+    voice_twiml,
+)
+```
+
+Re-check after the rewrite: `pyflakes app/telephony/router.py` shows zero unused imports.
+
+The HTTP handlers and WS event-loop body are *unchanged* from the post-Task-3 state — only the imports + the helper definitions move out.
+
+- [ ] **Step 3: Update test imports**
+
+`tests/test_telephony.py` — change:
+
+```python
+from app.telephony.router import _MIN_CHUNK_CHARS, _should_flush_chunk
+```
+
+to:
+
+```python
+from app.telephony.session import _MIN_CHUNK_CHARS, _should_flush_chunk
+```
+
+`tests/test_barge_in_helper.py` — change:
+
+```python
+from app.telephony.router import _CallState, _barge_in_now
+```
+
+to:
+
+```python
+from app.telephony.session import _CallState, _barge_in_now
+```
+
+`tests/test_transcript_consumer.py` — change:
+
+```python
+from app.telephony.router import _CallState, _consume_transcripts
+```
+
+to:
+
+```python
+from app.telephony.session import _CallState, _consume_transcripts
+```
+
+- [ ] **Step 4: Run focused tests**
+
+```bash
+pytest tests/test_telephony.py tests/test_voice.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Verify line-count targets**
+
+```bash
+wc -l app/telephony/router.py app/telephony/session.py
+```
+
+Expected:
+- `app/telephony/router.py` — between 200 and 350 lines (FastAPI shells + WS event-loop only).
+- `app/telephony/session.py` — between 700 and 900 lines.
+
+If either is wildly off, something didn't move (or got duplicated). Eyeball the diff before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/telephony/session.py app/telephony/router.py tests/test_telephony.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py
+git commit -m "refactor(telephony): move _CallState + orchestration helpers to session.py (#251)
+
+Slims router.py to FastAPI shells + WS event-loop dispatch
+(~250 lines). All call orchestration — barge-in, hangup, silence,
+LLM turn, transcript consumer — now lives in session.py
+(~800 lines). Test imports updated to the new module path.
+
+No behavior change. Tests pass."
+```
+
+---
+
+## Task 5: Final verification
+
+Goal: run the full test suite, confirm the public surface is unchanged, and update PR #252 to reflect that the implementation has landed.
+
+- [ ] **Step 1: Run the full pytest suite**
+
+```bash
+pytest -q
+```
+
+Expected: all pass. If the telephony-focused subset passed in Task 4 but the full suite fails, the failure is somewhere else (unrelated regression) — investigate before proceeding.
+
+- [ ] **Step 2: Static check — no unused imports**
+
+```bash
+python -m pyflakes app/telephony/router.py app/telephony/session.py app/twilio/__init__.py app/twilio/media_stream.py app/twilio/twiml.py
+```
+
+Expected: no output (no unused imports, no undefined names).
+
+- [ ] **Step 3: Public-surface diff check**
+
+```bash
+git diff feat/83-tune-conversational-bot..HEAD -- app/main.py
+```
+
+Expected: no diff. The FastAPI app mount is unchanged.
+
+```bash
+git diff feat/83-tune-conversational-bot..HEAD -- app/telephony/router.py | grep -E "^\+@router\.(post|websocket)"
+```
+
+Expected: no output (no new endpoints — same five POSTs and one WebSocket as before, with unchanged paths).
+
+- [ ] **Step 4: Push and update PR**
+
+```bash
+git push origin refactor/251-telephony-router-split
+```
+
+Then update PR #252's title and body via `gh pr edit 252`. New title: `refactor(telephony): split router.py + carve app/twilio/ (#251)`. Body should describe the implementation, not just the spec.
+
+```bash
+gh pr edit 252 --repo tsuki-works/niko --title "refactor(telephony): split router.py + carve app/twilio/ (#251)" --body "$(cat <<'EOF'
+## Summary
+
+Splits app/telephony/router.py (1293 lines) along the Twilio-vs-orchestration boundary, mirroring the existing app/deepgram/ pattern.
+
+- app/telephony/router.py — FastAPI shells + WS event-loop only (~250 lines)
+- app/telephony/session.py — _CallState + orchestration helpers (~800 lines)
+- app/twilio/twiml.py — TwiML response builders
+- app/twilio/media_stream.py — send_clear, send_mark WS protocol primitives
+- app/twilio/__init__.py — Twilio REST credential helpers + voicemail upload wrapper
+
+## Non-goals (deliberate)
+
+- No TelephonyProvider ABC — single vendor today.
+- No CallSession class — possible follow-up.
+- No public-API changes; no behavior changes.
+
+Spec: docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md
+
+Closes #251.
+
+## Test plan
+
+- [x] pytest tests/test_telephony.py tests/test_voice.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py — all green
+- [x] pyflakes on the touched files — no unused imports
+- [x] git diff on app/main.py — no public-surface change
+- [ ] Manual smoke via dev call flow (greeting plays, barge-in works, silence prompt fires, order confirmation triggers auto-hangup)
+EOF
+)"
+```
+
+- [ ] **Step 5: Manual smoke (deferred to reviewer)**
+
+Manual smoke is left for the reviewer / merger to perform on the dev environment per the spec's validation step 4. Note this in the PR test plan so it isn't forgotten.
+
+---
+
+## Self-review checklist
+
+Run through this list after the plan is written. Fix issues inline.
+
+1. **Spec coverage** — every file role and mapping row in the spec corresponds to a task step:
+   - `app/twilio/media_stream.py` (`send_clear`, `send_mark`) → Task 1.
+   - `app/twilio/twiml.py` (5 builders) → Task 2.
+   - `app/twilio/__init__.py` (REST helpers) → Task 3.
+   - `app/telephony/session.py` (everything from the spec's mapping table marked `session.py`) → Task 4.
+   - `app/telephony/router.py` slimming → Task 4 step 2.
+   - Test import updates → Task 4 step 3.
+
+2. **Placeholder scan** — no "TBD", "implement later", "similar to", "add appropriate handling". All code shown verbatim. ✓
+
+3. **Type/name consistency:**
+   - `send_clear(websocket, stream_sid)` — used in Tasks 1, 4. ✓
+   - `send_mark(websocket, stream_sid, name)` — used in Tasks 1, 4. ✓
+   - `_CallState` — referenced in Task 4 in import lists matching the dataclass move. ✓
+   - `app_twilio` import alias — Tasks 3 and 4 both use the same alias. ✓
+   - `END_OF_CALL_MARK` constant — moves to `session.py` in Task 4 and is re-imported by `router.py`. ✓
+
+4. **Order check** — Tasks 1-3 are independent of Task 4 and can land in any order, but the plan runs them first because they reduce the size of the Task 4 diff.
+
+5. **Atomicity** — each task ends with passing tests + a commit. No half-states.

--- a/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-investigation.md
+++ b/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-investigation.md
@@ -1,0 +1,222 @@
+# Deepgram Flux STT — Investigation Summary
+
+**Date:** 2026-05-06
+**Author:** Sandeep (with Claude, research-only session — no code changes)
+**Status:** Direction agreed; not yet implemented. Hand off to next agent for spec → plan → implementation.
+
+---
+
+## Context
+
+Real-world STT errors on recent calls (no logs retained, anecdotal from Sandeep):
+- "**coke**" misheard as "**smoke**"
+- "**pepper shrimp**" misheard as "**pepper soup**"
+
+These are textbook acoustic-confusability cases on phone audio (mulaw 8 kHz band-limits to ~3.4 kHz, sibilants degrade). The root cause is that our STT has no language-model prior for "this is a restaurant ordering call for *this menu*" — it picks the more common everyday English phrase over the menu term.
+
+We did a research/thinking session to evaluate what Deepgram offers to fix this and improve the voice-agent stack overall. Scope was deliberately Deepgram-only (sticking with our incumbent vendor).
+
+## Current state (what `niko` ships today)
+
+`app/deepgram/stt.py` + `app/config.py:40-46`:
+
+| Setting | Value |
+|---|---|
+| Model | `nova-2` |
+| Endpoint | `wss://api.deepgram.com/v1/listen` (`dg.listen.asynclive.v("1")`) |
+| Encoding | mulaw, 8 kHz mono (Twilio media-stream native) |
+| `interim_results` | true |
+| `endpointing_ms` | 800 (silence-based turn end) |
+| `utterance_end_ms` | 1000 (prosody-aware end-of-utterance) |
+| `vad_events` | true → drives `SpeechStartedEvent` for instant barge-in |
+| `keyterm` | env-driven, **empty by default** |
+
+Turn-taking and barge-in live in `app/telephony/router.py` as a hand-rolled state machine layered on top of those Deepgram parameters and events.
+
+### Critical bug-in-spirit
+
+**Nova-2 silently ignores the `keyterm` parameter.** Keyterm prompting is Nova-3+ only (config.py:45 even comments this). The plumbing is wired but the model selection means it's a no-op. So today we have *no* mechanism to bias recognition toward menu vocabulary — every call is open-domain English.
+
+## What's on the table from Deepgram
+
+| Feature | What it does | Verdict for niko |
+|---|---|---|
+| **Nova-3 mono** | Newer model, supports keyterm prompting | Solves menu accuracy; doesn't change turn-taking latency |
+| **Nova-3 multi** | 45+ languages, code-switching | Nice-to-have; defer unless tenant needs it |
+| **Flux mono (`flux-general-en`)** | Nova-3-quality STT + native turn detection (~260 ms) + native barge-in | **Chosen path** |
+| **Flux multi (`flux-general-multi`)** | Flux + ~10 languages | Defer — not enough language coverage to justify cost premium today |
+| **`numerals=true`** | "two" → "2" in transcripts | Cheap orthogonal win, applicable on any model |
+| **`smart_format=true`** | Auto-format prices, phone numbers, addresses | Tradeoff vs LLM word-form parsing; A/B later |
+| **Word-level timestamps** | Per-word start/end | Could enable mid-word TTS interrupt; nice-to-have |
+| **Pre-recorded Listen API** | Post-call summarization, sentiment, topic detection | Future dashboard feature; not on critical path |
+| **Diarization** | Speaker separation | Overkill for 1:1 phone calls |
+| **Redaction** | PII/PCI redaction | Only if/when we take card numbers by phone |
+| **Voice Agent API** | Full STT+LLM+TTS bundle | **Reject** — conflicts with our menu-validation LLM and order state machine |
+| **Self-hosted Deepgram** | On-prem deployment | Not relevant at our scale |
+
+## Decision
+
+**Migrate STT from Nova-2 live to Deepgram Flux English mono (`flux-general-en`) with per-tenant keyterm prompting sourced from each restaurant's menu JSON.**
+
+### Why Flux over Nova-3 + keyterms
+
+1. **Flux mono and Nova-3 mono are priced the same.** No premium for Flux's bundled features at the mono tier.
+2. **Native turn detection** at ~260 ms vs our 800–1800 ms hand-rolled approach — meaningful per-turn latency win.
+3. **Native barge-in handling** via `EagerEndOfTurn` / `TurnResumed` events — replaces the custom `vad_events` + `SpeechStartedEvent` plumbing in `router.py`.
+4. **`EagerEndOfTurn`** lets us start drafting the LLM reply *before* the turn fully ends, with `TurnResumed` to cancel the draft if the caller resumes speaking.
+5. **Same recognition quality** as Nova-3 (Flux uses Nova-3 accuracy level), so menu accuracy via keyterms is preserved.
+
+### Why not stay on Nova-2
+
+- Keyterms silently ignored → no fix for `coke→smoke` / `pepper shrimp→pepper soup`.
+- Nova-2 is not on Deepgram's current published pricing page — likely on a deprecation track.
+- We're paying maintenance cost on a model with no forward roadmap.
+
+### Why not Voice Agent API
+
+We have non-trivial menu validation, order-state, and Firestore logic between transcript and LLM. Delegating all of that to a bundled agent would force our prompts and tool-use into Deepgram's orchestration shape — not a tradeoff we want.
+
+## Critical constraint: keyterm token cap
+
+> **"Maximum 500 tokens across all keyterms per request. Exceeding returns: `Keyterm limit exceeded.`"**
+
+Token ≠ word. A "token" is a vocabulary unit (word or sub-word piece). Working heuristic:
+- "Coke" ≈ 1 token
+- "Pepper Shrimp" ≈ 2 tokens
+- "Stir Fry Mixed Vegetables with Tofu" ≈ 6–7 tokens
+- Proper nouns ("Bánh Mì", "Basha") may be more if Deepgram's tokenizer doesn't know them
+
+### Fit check against existing menus
+
+| Menu | Items | Est. tokens | Fits 500-cap? |
+|---|---|---|---|
+| Niko's Pizza demo (`app/menu.py`) | 12 | ~40 | ✅ trivial |
+| Twilight (`restaurants/twilight-family-restaurant.json`) | ~80 | ~370 | ✅ tight but ok |
+| Hypothetical 250-item menu | 250+ | ~1200+ | ❌ needs prioritization |
+
+### Prioritization strategy when cap is hit
+
+When a menu exceeds 500 tokens, rank what to keep:
+
+1. **Acoustically confusable items** (English-collision potential): Pepper Shrimp, Coke, Wonton, Lo-Mein, Chow Mein.
+2. **Proper-noun dishes the model has likely never seen**: Basha, Bánh Mì, Horchata, Tikka Masala.
+3. **Restaurant name** (caller may say it).
+4. **Brand drink names** (Coke, Sprite, etc.).
+5. **Common modifiers**: "extra spicy", "no", "side of", "half", "whole".
+6. **Skip** items the model gets right cold (French Fries, Chicken Wings, Caesar Salad).
+7. **Skip duplicates** — if "Pepper Shrimp" is in, "Pepper Shrimp Fried Rice" probably isn't needed (bigram already biased).
+
+This is a pure function: `(menu_dict, restaurant_name) → list[str]` capped at 500 tokens. Natural home: `app/restaurants/keyterms.py`.
+
+## Pricing summary
+
+Two AI-summary sources during this session disagreed on absolute numbers but agreed on relative ordering. **Verify in a browser before commitment.**
+
+| Tier | Source A ($/min PAYG) | Source B ($/min PAYG) |
+|---|---|---|
+| Nova-2 streaming | not on page | $0.0058 |
+| Nova-3 mono streaming | $0.0048 | $0.0077 |
+| Nova-3 multi streaming | $0.0058 | $0.0092 |
+| **Flux mono streaming** | **$0.0065** | **$0.0077** |
+| Flux multi streaming | $0.0078 | — |
+
+Either way:
+- Flux mono ≈ Nova-3 mono (same tier or near it).
+- Flux is pennies/call premium over Nova-2 even in the more expensive estimate.
+- Free $200 credit (no expiration) easily covers an A/B test before committing.
+- Aura-2 TTS at $0.030/1k chars often costs more per call than STT — TTS, not STT, dominates the per-call Deepgram bill.
+
+## Implementation surface (sketch — for the next agent to refine)
+
+### SDK shape
+
+Today (`app/deepgram/stt.py:57-58`):
+```python
+dg = DeepgramClient(_api_key())
+self._conn = dg.listen.asynclive.v("1")
+self._conn.on(LiveTranscriptionEvents.Transcript, self._on_transcript)
+# ... start(options), send(audio), finish()
+```
+
+Flux:
+```python
+from deepgram import AsyncDeepgramClient
+from deepgram.core.events import EventType
+from deepgram.listen.v2.types import ListenV2TurnInfo
+
+client = AsyncDeepgramClient()  # picks up DEEPGRAM_API_KEY from env
+
+async with client.listen.v2.connect(
+    model="flux-general-en",
+    encoding="mulaw",
+    sample_rate=8000,
+    keyterm=[...],  # per-tenant, ≤500 tokens
+) as connection:
+    connection.on(EventType.MESSAGE, on_message)
+    # events: Connected, TurnInfo, EagerEndOfTurn, TurnResumed, Close
+```
+
+Package: `deepgram-sdk` (already in `requirements.txt`). **Verify minimum version exposes `AsyncDeepgramClient` and `listen.v2`** — current code uses the older `DeepgramClient` façade.
+
+### Files that change
+
+| File | Change |
+|---|---|
+| `app/deepgram/stt.py` | Rewrite for Flux (`AsyncDeepgramClient.listen.v2.connect`, new event vocabulary) |
+| `app/stt/base.py` | Extend `STTProvider` protocol — add `EndOfTurnEvent`, `EagerEndOfTurnEvent`, `TurnResumedEvent` |
+| `app/telephony/router.py` | Delegate turn detection + barge-in to Flux events; remove or deprecate the hand-rolled state machine layered on `endpointing_ms` / `utterance_end_ms` / `SpeechStartedEvent` |
+| `app/config.py` | Add `stt_provider="deepgram-flux"` option (or similar). Deprecate or remove `stt_endpointing_ms` / `stt_utterance_end_ms` once Flux owns turn detection |
+| `app/restaurants/keyterms.py` | **New.** Pure function `(menu_dict, restaurant_name) → list[str]` capped at 500 tokens, with confusability-based prioritization |
+| `app/restaurants/menu_writes.py` | Optionally compute and cache keyterm list at menu-write time (vs. recomputing per-call) |
+| `tests/test_stt_deepgram.py` | New tests for Flux event handling; keep backward-compat tests for Nova-2 path during rollout if we keep it env-flagged |
+| `tests/` (new) | Test for `app/restaurants/keyterms.py` — token-budget ranking, edge cases |
+| `requirements.txt` | Possibly bump `deepgram-sdk` minimum version |
+| `.env.example` | Document `STT_PROVIDER=deepgram-flux` and any new env vars |
+
+### Rollout plan (suggested)
+
+1. Land the Flux provider behind an env flag (`STT_PROVIDER=deepgram-flux` vs current `deepgram`).
+2. Run both side-by-side on a small fraction of calls; compare:
+   - Menu-term recognition accuracy (the original `coke→smoke` motivation)
+   - End-of-turn latency
+   - Barge-in correctness (false barge-ins, missed barge-ins)
+   - Call duration / TTFT
+3. If green, flip default and remove the Nova-2 path.
+
+## Open questions for the next agent
+
+1. **Live pricing verification** — pull Deepgram's pricing page directly in a browser; resolve the discrepancy between session sources.
+2. **Deepgram tokenizer for keyterm budget** — is there a public way to count tokens, or do we use a conservative heuristic (~1.3 × word count)? `tiktoken` is closer than word-counting but still not exact.
+3. **Flux keyterm cap behavior** — does Flux truncate, error, or silently drop terms when we exceed 500 tokens? (Sandeep's note says it errors; verify.)
+4. **`flux-general-multi` language list** — explicit list of the ~10 languages, mapped against our pilot tenant demand.
+5. **`EagerEndOfTurn` semantics** — exactly when does Flux fire it, and how often does it cancel via `TurnResumed`? (i.e., what fraction of LLM drafts are wasted?) Worth measuring on real calls.
+6. **`deepgram-sdk` min version** — does our current pinned version expose `AsyncDeepgramClient` and `listen.v2`? Check via `pip show deepgram` and the SDK changelog.
+7. **Numerals + smart_format** — should we also turn these on as part of the migration, or hold them as separate experiments?
+8. **Where keyterm computation lives** — at menu-write time (cached on the restaurant doc) or at call-open time (computed in router)? Cache is simpler at runtime; recomputation is simpler at code-change time. Lean: cache at menu-write, recompute on menu update.
+
+## What to keep doing in `router.py` (Flux does NOT do)
+
+- LLM orchestration (Anthropic Claude calls, prompt assembly).
+- Order state machine (item parsing, validation against menu, totals).
+- Firestore writes (call session, order lifecycle, recordings).
+- Twilio integration (TwiML, recording status callbacks, transfer triggers).
+- TTS (Deepgram Aura-2 today — separate product, no Flux change).
+- The fallback case where Flux's turn detection misfires — keep a watchdog timer as defense-in-depth.
+
+## What's settled vs. what's open
+
+**Settled:**
+- Direction is Flux English mono.
+- Per-tenant keyterms from menu JSON.
+- 500-token cap is the design constraint.
+- Voice Agent API is rejected.
+- Nova-2 is the past, not the present.
+
+**Open / needs next-session attention:**
+- All eight items in "Open questions" above.
+- Spec → plan → implementation sequence (this doc is the spec input, not a plan).
+- Whether to bundle `numerals=true` into the same migration or split it.
+
+---
+
+*Hand-off note for the next agent: This is a research summary, not an implementation plan. Use it as input to write a proper spec (and then plan) under `docs/superpowers/specs/` and `docs/superpowers/plans/` following the niko convention. The eight open questions above should be answered before plan-writing starts.*

--- a/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-migration-design.md
+++ b/docs/superpowers/specs/2026-05-06-deepgram-flux-stt-migration-design.md
@@ -1,0 +1,269 @@
+# Deepgram Flux STT Migration — Design
+
+**Date:** 2026-05-06
+**Author:** Sandeep (with Claude)
+**Status:** Spec — ready for plan-writing
+**Companion doc:** [`2026-05-06-deepgram-flux-stt-investigation.md`](./2026-05-06-deepgram-flux-stt-investigation.md) (research summary)
+
+---
+
+## Summary
+
+Migrate live STT from Deepgram Nova-2 to Deepgram Flux English mono (`flux-general-en`) with per-tenant keyterm prompting computed from each restaurant's menu. Hard cutover — no Nova-2 fallback path is preserved.
+
+> **SDK probe correction (2026-05-06, post-spec):** Flux v2's `connect()` does **not** accept `numerals` or `smart_format` — those are Nova-only. Whatever digit/word formatting Flux produces natively is what we ship. The original "migration + numerals" decision is moot at the API level. `smart_format` was already out of scope.
+
+Flux's prosody-aware turn detection replaces Nova-2's silence-based endpointing, dropping confirmed-final transcript latency from 800–1800ms to ~260ms. Keyterm prompting (silently no-op'd on Nova-2) becomes the mechanism that fixes anecdotal misrecognitions like "coke→smoke" and "pepper shrimp→pepper soup."
+
+The existing `STTProvider` protocol in `app/stt/base.py` is widened with two new vendor-neutral event types (`EarlyTurnEndEvent`, `TurnResumedEvent`) so Flux's speculation signals are exposed through the seam — but **this PR's consumer drops them.** Speculative LLM drafting on `EarlyTurnEndEvent` is a separate follow-up PR (see "Out of scope").
+
+## Goals
+
+1. Eliminate the menu-vocabulary recognition gap on Twilight calls.
+2. Replace Nova-2 (no published forward roadmap) with a current-tier Deepgram model.
+3. Reduce confirmed-final transcript latency.
+4. Ship a vendor-neutral protocol shape that scales to a future Whisper or other provider.
+
+## Non-goals
+
+- Speculative LLM drafting on `EarlyTurnEndEvent` / cancellation on `TurnResumedEvent`. Events are exposed; consumer ignores them.
+- Dashboard-driven keyterm editing.
+- Persisting computed keyterms to Firestore.
+- `smart_format=true` rollout.
+- Word-level timestamps, diarization, redaction, pre-recorded Listen API.
+- Voice Agent API (rejected in the investigation — conflicts with our menu validation + order state machine).
+- Multi-tenant token-budget squeeze (no live tenant exceeds 500 tokens; revisit when one does).
+
+## Settled design decisions
+
+Each links back to a question debated during brainstorming.
+
+| # | Decision | Why |
+|---|---|---|
+| D1 | **Hard cutover.** Replace `app/deepgram/stt.py` outright; delete Nova-2 model selection. Revert path is `git revert`. | Nova-2 is a dead end; one live tenant; 4-person team — dual-provider maintenance cost outweighs A/B safety. |
+| D2 | ~~Migration + `numerals=true`~~. **Superseded by SDK probe:** Flux v2 has no `numerals` flag. Ship Flux's native formatting as-is. `smart_format` similarly out of scope. | Flux's connect signature exposes only `keyterm`, `language_hint`, and EOT thresholds — no Nova-style formatting flags. |
+| D3 | **In-memory keyterm computation at call-open.** Pure function `compute_keyterms(menu, restaurant_name) -> list[str]`; result is logged then handed to Flux's `connect(keyterm=[...])`. No Firestore field, no menu schema change. | Persistence is only valuable when something else reads it; nothing does today. The dashboard PR that introduces an editor is the right place to introduce the schema. |
+| D4 | **Auto-detect heuristic in code, no per-item menu tags.** Restaurant name is auto-included. | Heuristic deploys instantly across all tenants; menu schema stays untouched; Twilight needs no backfill. The investigation doc's prioritization rules drive the heuristic. |
+| D5 | **Common-named events at the protocol layer, vendor translation inside the provider.** `app/stt/base.py` grows from 2 to 4 event types. Flux provider emits all four; Whisper (future) emits two. | Keeps the protocol vendor-neutral; Flux jargon (`EagerEndOfTurn`) does not appear at the seam. |
+| D6 | **Consumer ignores `EarlyTurnEndEvent` / `TurnResumedEvent` in this PR.** Events are emitted by the Flux module and silently swallowed by the session loop. | Speculative drafting needs measurement (how often `EagerEndOfTurn` is right vs `TurnResumed`-cancelled) and a careful UX design (handling half-spoken bot replies that get cancelled). Ship the migration first; speculate second. |
+
+## Architecture
+
+### Event flow
+
+`session.py:344-376`'s consumer loop sees the same two events it sees today (`SpeechStartedEvent`, `TranscriptEvent`) and adds one defensive branch:
+
+```python
+async for event in stt.events():
+    if isinstance(event, SpeechStartedEvent):
+        if state.llm_task and not state.llm_task.done():
+            await _barge_in_now(state, websocket, trigger="vad")
+        continue
+
+    if isinstance(event, TranscriptEvent):
+        if not event.is_final:
+            continue
+        # final transcript → LLM+TTS pipeline
+        await _handle_final_transcript(event.text, state, websocket)
+        continue
+
+    # EarlyTurnEndEvent, TurnResumedEvent — fired by Flux,
+    # consumed in a future speculative-drafting PR
+    continue
+```
+
+### Per-call lifecycle
+
+| Phase | Action | Source |
+|---|---|---|
+| WS `start` | Load `Restaurant`; build prompt; **compute keyterms**; open Flux connection. | `session.py` (existing call-start path; new call to `compute_keyterms`) |
+| Per audio frame | Forward mulaw bytes. | `state.stt.send(audio)` |
+| Per Flux event | Translate to common-named event; enqueue. | `app/deepgram/stt.py` (rewrite) |
+| Per common-named event | Branch and react (or drop). | `session.py` consumer (one new defensive `continue`) |
+| WS `stop` | `state.stt.close()` (Flux connection torn down). | `session.py` (existing) |
+
+### Translation map (Flux wire → common-named event)
+
+| Flux event | Translated to | Notes |
+|---|---|---|
+| `Connected` | (none — lifecycle) | Provider state only. |
+| `TurnInfo(end_of_turn=False)` | `TranscriptEvent(is_final=False)` | Interim, logged only by consumer. |
+| `TurnInfo(end_of_turn=True)` | `TranscriptEvent(is_final=True)` | The committed turn-end. THIS is what triggers `_handle_final_transcript`. |
+| `TurnInfo(event="StartOfTurn")` | `SpeechStartedEvent` | Fast barge-in path. (Resolved post-probe: Flux signals turn start via `TurnInfo.event="StartOfTurn"`.) |
+| `EagerEndOfTurn` | `EarlyTurnEndEvent` | Emitted; consumer drops. |
+| `TurnResumed` | `TurnResumedEvent` | Emitted; consumer drops. |
+| `Close` | (none — lifecycle) | Provider state only. |
+
+### Files that change
+
+| File | Change |
+|---|---|
+| `app/deepgram/stt.py` | **Rewrite.** Switch from `DeepgramClient.listen.asynclive.v("1")` (callback-based v1) to `AsyncDeepgramClient.listen.v2.connect(...)` (async-context-manager v2). Translate Flux events into the common-named protocol. Drop the silence-based-endpointing knobs (Flux owns turn detection). Keep the internal queue + async iterator façade so the consumer interface is unchanged. |
+| `app/stt/base.py` | Add `EarlyTurnEndEvent` and `TurnResumedEvent` dataclasses. Widen `STTEvent` union from 2 to 4 members. Update the docstring on `STTProvider`. |
+| `app/restaurants/keyterms.py` | **NEW.** Pure function `compute_keyterms(menu: dict, restaurant_name: str) -> list[str]`. Heuristic ranks confusables, proper-noun dishes, brand drinks, and common modifiers; restaurant name always included. Capped well under 500 tokens (target ≤450 tokens — 50-token safety margin). See "Keyterm computation" below. |
+| `app/telephony/session.py` | Two changes: (1) call `compute_keyterms` and pass the result into Flux; (2) add the trailing `continue` in the event loop to defensively drop `EarlyTurnEndEvent` / `TurnResumedEvent`. |
+| `app/config.py` | Set `stt_model` default to `flux-general-en`. **Remove** `stt_endpointing_ms` and `stt_utterance_end_ms` (Flux owns turn detection — these have no analog). Keep `stt_keyterms` as a debug override: when non-empty, **replaces** the heuristic output entirely. (Augment-mode is YAGNI; revisit if a tenant-level use case appears.) ~~Add `stt_numerals: bool = True`.~~ Per probe correction, no numerals setting. |
+| `requirements.txt` | Bump `deepgram-sdk` minimum version to whatever first exposes `AsyncDeepgramClient` and `listen.v2`. **Verification needed in plan** — current pin is `>=3.0,<4.0` and the local install is 3.11.0; Flux v2 surface likely requires v4. |
+| `tests/test_stt_deepgram.py` | Update fixtures and translation tests for the Flux SDK shape. Add tests for emission of `EarlyTurnEndEvent` and `TurnResumedEvent`. |
+| `tests/test_keyterms.py` | **NEW.** Token-budget cap, restaurant-name inclusion, prioritization edge cases. |
+| `tests/test_telephony_router.py` (or session-tests) | Add a defensive case that asserts `EarlyTurnEndEvent` / `TurnResumedEvent` events flow through the consumer loop without behavioral effect. |
+| `.env.example` | Document new defaults: `STT_MODEL=flux-general-en`. Remove `STT_ENDPOINTING_MS`, `STT_UTTERANCE_END_MS`. Add `STT_NUMERALS=true`. |
+
+### Files explicitly NOT touched
+
+- `app/stt/__init__.py` — selector seam already accommodates one provider; no second provider added.
+- `app/telephony/router.py` — orchestration, barge-in, LLM/TTS turn loop are unchanged.
+- `app/restaurants/menu_writes.py`, `app/restaurants/models.py` — no menu schema or storage change.
+- `app/llm/prompts.py` — no prompt change. Numeral form ("two" vs "2") is invisible to Claude.
+- `restaurants/*.json` — no per-tenant data migration.
+- `app/tts/*` — Aura-2 unchanged.
+
+## Keyterm computation
+
+### Contract
+
+```python
+# app/restaurants/keyterms.py
+def compute_keyterms(
+    menu: dict,
+    restaurant_name: str,
+) -> list[str]:
+    """Return a prioritized list of terms to bias Flux recognition toward,
+    capped under the 500-token Deepgram limit (target ≤450 tokens for a
+    50-token safety margin).
+
+    Always includes restaurant_name first. Then ranks menu items by:
+      1. Acoustically confusable items (Coke, Pepper Shrimp, Wonton, Lo Mein, ...)
+      2. Proper-noun dishes the model is unlikely to know (Basha, Bánh Mì, ...)
+      3. Brand drink names
+      4. Common modifiers ("extra spicy", "no", "side of", "half", "whole")
+    Skips items the model gets right cold (French Fries, Chicken Wings, ...).
+    Skips redundant n-grams (if "Pepper Shrimp" is included, "Pepper Shrimp
+    Fried Rice" is not).
+    """
+```
+
+### Token-budget heuristic
+
+We do not have access to Deepgram's tokenizer. Approximate token count as `ceil(word_count * 1.3)` — slightly conservative vs typical sub-word tokenizers. The plan should validate the heuristic against a few menus and decide whether to swap to `tiktoken`'s `cl100k_base` (closer but still inexact) or stick with the simpler estimate.
+
+The function returns at the first term whose inclusion would push the running total over the safety budget. If `restaurant_name` alone exceeds budget — pathological — return only `[restaurant_name]` and log a warning.
+
+### Logging
+
+At call-start, log one line listing the keyterms passed to Flux (restaurant_id, term count, total estimated tokens, first 5 terms). This is the only audit surface until persistence ships.
+
+### Failure mode
+
+If Flux returns `Keyterm limit exceeded` on `connect`, the connection attempt fails. Rather than dropping the call, the provider retries `connect` once *without* the `keyterm` parameter, logs the budget miss with the offending term count for post-hoc fix-up, and proceeds in transcript-only mode. The conservative 50-token safety margin should make this path nearly unreachable; if we see it in production it means the heuristic underestimates tokens and needs tuning.
+
+## Behavior parity walkthrough
+
+Time-ordered for a representative call. Times are illustrative.
+
+### Phase A — connection setup
+
+| t | Event | Action |
+|---|---|---|
+| 0 | Twilio WS `start` | Router loads Restaurant + builds prompt. |
+| +5ms | (in-process) | `compute_keyterms(menu, name)` → list, logged. |
+| +10ms | Flux `Connected` | Flux WS open with `numerals=true, keyterm=[...]`. |
+| +50ms | (greeting TTS) | Bot speaks. |
+
+### Phase B — caller's first turn ("Hi, can I get a pepper shrimp?")
+
+| t | Flux | Common-named | Consumer |
+|---|---|---|---|
+| 0 | first-speech signal | `SpeechStartedEvent` | Bot not mid-response → no barge-in. |
+| 200ms | `TurnInfo(is_final=False)` | `TranscriptEvent(is_final=False)` | Interim — drop. |
+| 600ms | `TurnInfo(is_final=False)` | `TranscriptEvent(is_final=False)` | Interim — drop. |
+| 1100ms | `EagerEndOfTurn` | `EarlyTurnEndEvent` | **This PR: drop.** |
+| 1360ms | `TurnInfo(end_of_turn=true, text="...pepper shrimp?")` | `TranscriptEvent(is_final=True)` | **Trigger `_handle_final_transcript`** → LLM+TTS. |
+
+Confirmed-final latency end-of-speech to LLM trigger: ~260ms (vs 800–1800ms today).
+
+### Phase C — caller barges in mid-bot ("Yeah, and one... uhh... coke please.")
+
+| t | Flux | Common-named | Consumer |
+|---|---|---|---|
+| 0 | first-speech signal | `SpeechStartedEvent` | Bot IS mid-response → `_barge_in_now(trigger="vad")`. |
+| 250ms | `TurnInfo(is_final=False)` | `TranscriptEvent(is_final=False)` | Interim — drop. |
+| 600ms | `EagerEndOfTurn` (caller hesitated) | `EarlyTurnEndEvent` | **Drop.** |
+| 850ms | `TurnResumed` (caller continued) | `TurnResumedEvent` | **Drop.** |
+| 1400ms | `TurnInfo(is_final=False)` | `TranscriptEvent(is_final=False)` | Interim — drop. |
+| 1900ms | `TurnInfo(end_of_turn=true)` | `TranscriptEvent(is_final=True)` | Trigger `_handle_final_transcript`. |
+
+Net: barge-in path identical to today. Speculation-relevant events flow through but are silently dropped.
+
+### Acceptance signals
+
+A successful migration shows, on real Twilight calls:
+- Final-transcript latency (caller-stop → `_handle_final_transcript`) drops below 500ms p50.
+- Mishearings of menu items in Twilight's keyterm list are anecdotally absent or rare.
+- Barge-in continues to fire promptly mid-bot-response (within the same envelope as today).
+- No new error classes in call logs (`Keyterm limit exceeded`, malformed Flux events, SDK version errors).
+
+## Testing
+
+Unit:
+- `app/restaurants/keyterms.py`: token-budget cap, restaurant-name always-first invariant, edge cases (empty menu, all-confusables menu, single-item menu, name longer than budget).
+- `app/deepgram/stt.py`: each Flux event type translates to the expected common-named event; `EarlyTurnEndEvent` and `TurnResumedEvent` are emitted; lifecycle events are silently consumed.
+- `app/stt/base.py`: dataclasses immutable, `STTEvent` union members.
+
+Integration / end-to-end:
+- `app/telephony/session.py` consumer loop drops `EarlyTurnEndEvent` and `TurnResumedEvent` without side effects; barge-in path on `SpeechStartedEvent` unchanged; `_handle_final_transcript` trigger on `TranscriptEvent(is_final=True)` unchanged.
+- A simulated call delivering all four event types in time order produces the same observable behavior the consumer produces today.
+
+## Rollout
+
+Single PR. Hard cutover. Land on `master`, deploy to the running service, watch the next Twilight call.
+
+Monitoring during the first day of live calls:
+- Final-transcript latency.
+- `Keyterm limit exceeded` errors in logs.
+- Recognition accuracy on Twilight's known confusables (`coke`, `pepper shrimp`, `lo mein`, `wonton`, `basha`).
+- Barge-in latency / false barge-ins / missed barge-ins.
+
+If quality regresses, `git revert` is the rollback. There is no env flag to flip.
+
+## Open items / risks
+
+These need to be resolved during plan-writing or implementation, not before.
+
+| # | Item | Resolution path |
+|---|---|---|
+| O1 | ~~Which Flux event maps to `SpeechStartedEvent`.~~ **Resolved by probe: `TurnInfo.event="StartOfTurn"` fires when a turn begins.** Latency vs Nova-2 VAD's ~50ms still needs measurement on real calls. | Resolved at the API surface; latency comparison is post-merge measurement. |
+| O2 | ~~`deepgram-sdk` minimum version.~~ **Resolved by probe: bump to `>=7.1,<8.0`.** v3 didn't expose `AsyncDeepgramClient`. | Resolved. |
+| O3 | **`Keyterm limit exceeded` error vs silent truncation.** Spec assumes Flux errors. Should be confirmed empirically; if Flux truncates instead, the safety margin is less critical. | Implementation-time. Either way, the conservative budget covers both. |
+| O4 | **Token-counting heuristic accuracy.** `word_count * 1.3` is approximate. | Plan to gate against a small empirical check on Twilight's menu (estimated tokens vs Flux's reported behavior). |
+| O5 | **Pricing verification.** Investigation flagged conflicting per-minute estimates from two summarizer sources; should be confirmed at Deepgram's pricing page before merge so we know the actual per-call delta. | Out-of-band; not a blocker for the plan. |
+
+## Out of scope (follow-up work)
+
+These are explicitly downstream PRs and should not be merged into this migration:
+
+1. **Speculative LLM drafting** on `EarlyTurnEndEvent`, with cancellation on `TurnResumedEvent`. Requires its own UX spec for the "bot heard half a word and got cancelled" failure mode.
+2. **Dashboard keyterm editor.** When the dashboard ships, this PR introduces both the Firestore schema for keyterms and the UI to edit them. Migration of existing tenants follows.
+3. **`smart_format=true` experiment.** Run as a flagged A/B once a measurement harness exists.
+4. **Multi-tenant token-budget squeeze.** When a real tenant onboards with a >500-token-equivalent menu, layer tighter prioritization or per-item tagging on top.
+5. **Whisper (or other) STT provider.** When the time comes, the `app/stt/base.py` protocol is already vendor-neutral; the new provider implements `STTProvider` and only emits `SpeechStartedEvent` + `TranscriptEvent`.
+
+## What's settled vs. what's open
+
+**Settled (this spec is decisive):**
+- Hard cutover to `flux-general-en`.
+- `numerals=true`; `smart_format=false`.
+- Common-named protocol with 4 event types; consumer uses 2.
+- Auto-detect heuristic, in-memory at call-open, no persistence.
+- No speculative drafting in this PR.
+
+**Open (resolved during plan/implementation):**
+- O1 — which Flux event seeds `SpeechStartedEvent`.
+- O2 — `deepgram-sdk` version bump.
+- O3 — Flux behavior on keyterm budget exceed.
+- O4 — token-counting heuristic precision.
+- O5 — pricing verification (out-of-band).
+
+---
+
+*Hand-off note: this is the spec. Plan-writing should produce step-by-step implementation tasks under `docs/superpowers/plans/2026-05-XX-deepgram-flux-stt-migration-plan.md` following the niko convention. Open items O1–O4 should be resolved as the first plan tasks; O5 is out-of-band and does not block.*

--- a/docs/superpowers/specs/2026-05-06-stt-tts-plugin-extraction-design.md
+++ b/docs/superpowers/specs/2026-05-06-stt-tts-plugin-extraction-design.md
@@ -1,0 +1,419 @@
+# STT/TTS plugin extraction — design
+
+**Branch:** `feat/83-tune-conversational-bot`
+**Related issues:** #83 (tune conversational bot); a new refactor-tracking issue to be opened once this spec lands.
+**Status:** Approved design; ready for implementation plan.
+
+## Context
+
+`app/telephony/router.py` is 1,165 lines. A 70-line block of inline Deepgram STT (`_open_deepgram_connection` and its callbacks at lines 294–362) is welded into the WS handler, with the transcript callback closing over `_CallState` and emitting Firestore events directly. TTS lives in `app/tts/client.py` — already isolated, but with an `app.storage.recordings` import leaking into the synthesis path.
+
+The user is about to do substantial conversational-quality tuning under #83 (Nova-3 retry, keyterm prompting, endpointing tweaks, possibly more). Each tuning change in the current shape is a router-shaped diff. The goal of this work is to make those tuning changes config-shaped instead.
+
+## Goals
+
+- Extract Deepgram STT out of `router.py` into a focused plugin module.
+- Co-locate Deepgram TTS with STT under one vendor package.
+- Introduce thin abstraction layers (`app/stt`, `app/tts`) so a second provider is additive, not a refactor.
+- Preserve every existing behavior. Add one user-facing improvement: instant barge-in via VAD speech-started.
+- Make conversational tuning a config-flip exercise (`STT_MODEL`, `STT_KEYTERMS`, `STT_ENDPOINTING_MS`, etc.).
+
+## Non-goals
+
+- **Multi-provider implementation.** Deepgram only, today. Selector seam exists; second impl arrives when there's a concrete need.
+- **Per-restaurant overrides.** Global env vars. Firestore stays untouched in this push.
+- **Auto-reconnect on STT WS drop.** Out of scope; logged + handled via existing silence watchdog as today.
+- **TTS retry on 5xx.** Unchanged from today's behavior.
+- **Recording integration changes.** Recording is disabled on this branch (no `RECORDINGS_BUCKET`); the architectural seam (`on_chunk` callback) is in place but not exercised.
+
+## Module layout
+
+```
+app/
+  stt/
+    __init__.py        # get_stt() selector; re-exports STTProvider, TranscriptEvent, SpeechStartedEvent
+    base.py            # Protocol + event dataclasses
+  tts/
+    __init__.py        # speak() selector; re-exports SpeakFunc
+    base.py            # SpeakFunc Protocol
+  deepgram/
+    __init__.py        # shared: _api_key(), _DEEPGRAM_BASE
+    stt.py             # class DeepgramSTT(STTProvider)
+    tts.py             # speak() — body lifted from today's app/tts/client.py
+```
+
+**Deletions:** `app/tts/client.py` (body moved to `app/deepgram/tts.py`).
+
+**Future vendor:** `app/elevenlabs/tts.py`, `app/whisper/stt.py`, etc. — each lives at `app/<vendor>/<capability>.py`, with a one-clause add to the relevant selector in `app/stt/__init__.py` or `app/tts/__init__.py`.
+
+## STT contract
+
+### Event types — `app/stt/base.py`
+
+```python
+@dataclass(frozen=True)
+class SpeechStartedEvent:
+    """VAD detected the caller began speaking. Fires before any transcript
+    is available — used for instant barge-in (~50ms vs ~800ms waiting on
+    a final transcript)."""
+    at: float = 0.0   # optional Deepgram timestamp; 0 if SDK omits it
+
+@dataclass(frozen=True)
+class TranscriptEvent:
+    text: str
+    is_final: bool
+    confidence: float
+
+STTEvent = TranscriptEvent | SpeechStartedEvent
+```
+
+### Provider Protocol
+
+```python
+class STTProvider(Protocol):
+    async def open(self) -> None:
+        """Open the live STT connection. Raises on failure."""
+
+    async def send(self, audio: bytes) -> None:
+        """Forward one chunk of caller audio (mulaw 8 kHz from Twilio).
+        Connection-level errors are caught internally and logged; the call
+        does not die on transient send failures."""
+
+    def events(self) -> AsyncIterator[STTEvent]:
+        """Yield STTEvents until close() is called. Raises on connection
+        error — the consumer is responsible for catching and recovering."""
+
+    async def close(self) -> None:
+        """Tear down the connection and signal events() to terminate."""
+```
+
+### `DeepgramSTT` implementation notes
+
+- Bridges the SDK's callback world to the iterator world via one internal `asyncio.Queue` (unbounded — final transcripts arrive at human-conversation pace; even interim volume of 5–10/sec is trivial memory).
+- Subscribes to three Deepgram events: `Transcript` (interim + final), `SpeechStarted`, `Error`.
+- Existing log line preserved: `logger.info("transcript [%s] call_sid=%s text=%r", label, call_sid, text)`. This is the **only** place interim transcripts are surfaced — they're intentionally not emitted to Firestore (see Observability).
+- `_on_error` pushes a private `_ErrorBox` sentinel onto the queue; `events()` raises when it dequeues one.
+- `close()` pushes a private `_Closed` sentinel; `events()` returns when it dequeues one.
+
+### Configuration
+
+Seven new settings on `app/config.py`, plus two existing. All global (no per-restaurant overrides today):
+
+| Setting | Default | Notes |
+|---|---|---|
+| `STT_PROVIDER` | `"deepgram"` | Selector key |
+| `TTS_PROVIDER` | `"deepgram"` | Selector key |
+| `STT_MODEL` | `"nova-2"` | Clean path to retry Nova-3 |
+| `STT_ENDPOINTING_MS` | `800` | Today's tuned value |
+| `STT_UTTERANCE_END_MS` | `1000` | Today's tuned value |
+| `STT_KEYTERMS` | `[]` | Comma-separated; only sent when non-empty; requires Nova-3 |
+| `STT_INSTANT_BARGE_IN` | `True` | Kill-switch for VAD-driven barge-in |
+| `DEEPGRAM_TTS_MODEL` | (existing) | Aura voice |
+| `DEEPGRAM_API_KEY` | (existing) | Required |
+
+## TTS contract
+
+`SpeakFunc` Protocol in `app/tts/base.py` describes the callable signature. Both `app/tts/__init__.py` (selector) and `app/deepgram/tts.py` (impl) match it.
+
+```python
+class SpeakFunc(Protocol):
+    async def __call__(
+        self,
+        text: str,
+        websocket: WebSocket,
+        stream_sid: str,
+        *,
+        client: Optional[httpx.AsyncClient] = None,
+        on_chunk: Optional[Callable[[bytes], None]] = None,
+        on_first_byte: Optional[Callable[[], None]] = None,
+    ) -> None: ...
+```
+
+### Why a free function, not a class
+
+TTS today is stateless per call — `speak()` opens an HTTP request, streams audio, returns. The only "state" is a process-wide `httpx.AsyncClient` for connection pooling, which is already a module-level lazy singleton. Future HTTP-based TTS providers (ElevenLabs, OpenAI TTS, Cartesia) fit the same shape. Wrapping a stateless function in a class for "consistency" with the stateful STT provider would be ceremony with no payoff. Class-based TTS arrives only when a provider with genuine cross-call state arrives.
+
+### Recording-session decoupling
+
+The current `recording_session` parameter is replaced by an `on_chunk: Callable[[bytes], None] | None` callback. TTS no longer imports `app.storage.recordings`. The router builds the closure that appends to the recording session via a small helper:
+
+```python
+def _make_recording_chunk_handler(state: _CallState) -> Callable[[bytes], None] | None:
+    if state.recording_session is None:
+        return None
+    rs = state.recording_session
+    def _handle(chunk: bytes) -> None:
+        try:
+            recordings.append_chunks(rs, b"", chunk)
+        except Exception:
+            logger.exception("tts: recording append failed call_sid=%s", state.call_sid)
+    return _handle
+```
+
+When `RECORDINGS_BUCKET` is unset (current branch state), `state.recording_session` is `None`, the helper returns `None`, `on_chunk` isn't fired, no audio is appended anywhere. Enabling recording later is a config flip, no code changes needed.
+
+## Router consumer + unified barge-in
+
+### `_consume_transcripts` — the new event consumer
+
+A background task per call. Replaces the inline `on_transcript` callback closure. State mutation, Firestore emission, and dispatch into `_handle_final_transcript` all live here, in plain top-to-bottom code.
+
+```python
+async def _consume_transcripts(
+    stt: STTProvider,
+    state: _CallState,
+    websocket: WebSocket,
+) -> None:
+    try:
+        async for event in stt.events():
+            if isinstance(event, SpeechStartedEvent):
+                if not settings.stt_instant_barge_in:
+                    continue
+                if state.llm_task and not state.llm_task.done():
+                    await _barge_in_now(state, websocket, trigger="vad")
+                continue
+
+            # event is a TranscriptEvent
+            if not event.is_final:
+                continue   # interims captured in plugin logs only
+
+            state.last_caller_transcript = event.text
+            if event.confidence < 0.5:
+                state.consecutive_low_confidence_turns += 1
+            else:
+                state.consecutive_low_confidence_turns = 0
+
+            _bg_call_event(
+                state.call_sid, _state_rid(state),
+                kind="transcript_final",
+                text=event.text,
+                detail={"text": event.text, "confidence": event.confidence},
+            )
+            await _handle_final_transcript(event.text, state, websocket)
+
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.exception("transcript consumer crashed call_sid=%s", state.call_sid)
+```
+
+### `_barge_in_now` helper — one entry point for both triggers
+
+Today's barge-in pipeline is fully built (cancel + flush + watchdog + carry-forward + Firestore event), but only triggered by final-transcript arrival (~800–1800ms after the caller starts speaking). The helper extracts the common steps so the new VAD trigger can fire the same pipeline ~50ms after speech starts.
+
+```python
+async def _barge_in_now(
+    state: _CallState,
+    websocket: WebSocket,
+    *,
+    trigger: str,
+) -> None:
+    """Stop the bot mid-utterance.
+
+    Three mechanical steps:
+      1. Cancel the in-flight LLM/TTS task → halt audio generation.
+      2. Cancel the silence watchdog → caller is speaking; 'are you still
+         there?' would be wrong.
+      3. Send Twilio 'clear' → flush already-buffered audio playback (#74).
+
+    Note: the `barge_in` Firestore event is NOT emitted here. It's emitted
+    by `_run_llm_tts_turn`'s existing CancelledError handler, which fires
+    when the task we just cancelled actually receives the cancellation.
+    Trigger information flows via `state.barge_in_trigger`, read and
+    cleared inside that handler. This preserves today's invariant that
+    `barge_in` events correspond to genuine task cancellations.
+    """
+    state.barge_in_trigger = trigger
+    if state.llm_task and not state.llm_task.done():
+        state.llm_task.cancel()
+    _cancel_silence_task(state)
+    await clear_twilio_audio(websocket, state.stream_sid)
+```
+
+`_CallState` gains a `barge_in_trigger: str | None = None` field. `_run_llm_tts_turn`'s `CancelledError` handler is updated to read and clear it:
+
+```python
+# inside _run_llm_tts_turn
+except asyncio.CancelledError:
+    trigger = state.barge_in_trigger or "unknown"
+    state.barge_in_trigger = None
+    logger.info("llm_turn cancelled (barge-in trigger=%s) call_sid=%s",
+                trigger, state.call_sid)
+    _bg_call_event(state.call_sid, _state_rid(state),
+                   kind="barge_in",
+                   detail={"trigger": trigger})
+    raise
+```
+
+### How the two barge-in paths coexist
+
+- **Fast path:** VAD speech-started → consumer calls `_barge_in_now(trigger="vad")`. ~50ms latency.
+- **Fallback path:** final transcript arrives mid-turn → `_handle_final_transcript` calls `_barge_in_now(trigger="final_transcript")` (refactored to use the helper). Catches short utterances and missed-VAD cases.
+
+Both paths produce a single `barge_in` Firestore event (emitted by `_run_llm_tts_turn`'s `CancelledError` handler when the cancellation propagates) with `trigger` in `detail`. The previously-considered `barge_in_speech` kind is dropped — one kind, two trigger values.
+
+### `_handle_final_transcript` after the refactor
+
+The carry-forward (`#170`) and new-task creation stay. The cancel/flush block splits into two branches: a true barge-in (when there's a running turn to interrupt) routes through `_barge_in_now`; a silence-resume (where no turn is running, just the watchdog) cancels the watchdog and flushes Twilio directly without setting the barge-in trigger or emitting a barge_in event.
+
+```python
+async def _handle_final_transcript(text, state, websocket):
+    interrupted = bool(state.llm_task and not state.llm_task.done())
+    if state.in_flight_transcript.strip():
+        text = f"{state.in_flight_transcript} {text}".strip()
+    silence_was_active = bool(state.silence_task and not state.silence_task.done())
+    _abort_pending_hangup(state)
+
+    if interrupted:
+        await _barge_in_now(state, websocket, trigger="final_transcript")
+    elif silence_was_active:
+        # Caller resumed after a silence prompt — flush any leftover prompt
+        # audio still buffered, but this isn't a barge-in.
+        _cancel_silence_task(state)
+        await clear_twilio_audio(websocket, state.stream_sid)
+
+    state.in_flight_transcript = text
+    state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
+    state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
+```
+
+This matches today's emission semantics exactly: a `barge_in` event fires for and only for an actually-cancelled in-flight turn. Silence-resume produces no `barge_in` event, same as today.
+
+### WS handler integration
+
+Three touch points in `media_stream`:
+
+```python
+# on "start"
+state.stt, state.stt_provider = get_stt(call_sid=state.call_sid)
+await state.stt.open()
+state.transcript_task = asyncio.create_task(
+    _consume_transcripts(state.stt, state, websocket)
+)
+
+# on "media", inbound track
+await state.stt.send(payload)
+
+# in finally
+if state.transcript_task and not state.transcript_task.done():
+    state.transcript_task.cancel()
+if state.stt is not None:
+    await state.stt.close()
+```
+
+`_CallState` gains: `stt: STTProvider | None`, `stt_provider: str | None`, `transcript_task: asyncio.Task | None`. The `dg_conn` local variable disappears.
+
+## Error handling
+
+| Scenario | Behavior |
+|---|---|
+| STT can't open | `DeepgramSTT.open()` raises; WS handler emits `error` Firestore event, logs, closes call. |
+| STT WS drops mid-call | Plugin pushes `_ErrorBox` → `events()` raises → consumer logs + exits. Silence watchdog fires after 10s. |
+| `stt.send()` fails | Caught inside the plugin, logged, no-op. Call continues; transcript stream may dry up briefly. |
+| TTS 5xx / connection refused | Unchanged — `_run_llm_tts_turn`'s exception handler catches, logs, emits `error` event. |
+| Consumer task crashes | Bare `except Exception` logs + exits. Silence watchdog handles UX. |
+| Provider misconfigured | `get_stt()` raises `ValueError` at `start` event; surfaces as `error` Firestore event. |
+
+## Observability
+
+- **No new Firestore event kinds.** Existing kinds (`start`, `stop`, `transcript_final`, `barge_in`, `silence_timeout`, `first_audio`, `agent_reply`, `error`, etc.) cover all observable states. `barge_in` gains a `trigger` field in `detail` for future dashboard filtering.
+- **Interim transcripts in logs only.** Plugin emits `logger.info("transcript [interim] call_sid=%s text=%r")`. Queryable in Cloud Logging by `call_sid` for debugging mishears. No Firestore writes.
+- **Existing log lines preserved** at the same call_sid format.
+- **No `provider` field on events.** Speculative until a second provider exists.
+
+## Testing strategy
+
+### `FakeSTT` test fixture — `tests/fakes/stt.py`
+
+The core testing primitive. Implements `STTProvider`, exposes a `feed(event)` method to inject events mid-test, plus `feed_error(exc)` to surface errors. Tests script call flows without touching the Deepgram SDK or network.
+
+### Existing tests that change
+
+- `tests/test_telephony.py`: `mock_pipeline` fixture migrates from patching `_open_deepgram_connection` to injecting `FakeSTT`. Five ad-hoc patch blocks in test functions collapse into the fixture.
+- `tests/test_tts_client.py` → renamed to `tests/test_deepgram_tts.py`. Logic unchanged; import paths updated; one new test for the `on_chunk` callback shape.
+- `test_clear_twilio_audio_*` tests stay green (helper unchanged).
+
+### Net-new test files
+
+- `tests/test_fake_stt.py` — ~5 tests of the fake itself.
+- `tests/test_stt_deepgram.py` — ~9 tests of `DeepgramSTT` against a faked Deepgram SDK.
+- `tests/test_transcript_consumer.py` — ~9 tests of `_consume_transcripts` against `FakeSTT`.
+- `tests/test_barge_in_helper.py` — ~6 tests of `_barge_in_now`.
+- `tests/test_provider_selector.py` — ~4 tests of `get_stt()` / `speak()` selectors.
+
+### Not tested
+
+- Live Deepgram WS — covered by test calls, not pytest.
+- Twilio Media Stream protocol — already mocked in existing tests.
+- Test-call call quality — human-in-the-loop, not automatable.
+
+## Migration plan
+
+### Phase α — extraction (7 atomic commits, each green)
+
+1. **α-1** `feat(stt): add STTProvider protocol and event dataclasses` — `app/stt/base.py`, `app/tts/base.py`. Pure type definitions.
+2. **α-2** `test(stt): add FakeSTT fixture for offline testing` — `tests/fakes/stt.py` + tests of the fake.
+3. **α-3** `refactor(tts): move Deepgram TTS to app/deepgram/tts.py` — TTS body relocates; `app/tts/client.py` deleted; `recording_session` → `on_chunk`; 5 call sites switched.
+4. **α-4** `feat(stt): implement DeepgramSTT plugin` — `app/deepgram/{__init__.py,stt.py}`. Not wired into router yet.
+5. **α-5** `refactor(telephony): extract _barge_in_now helper` — helper introduced; `_handle_final_transcript` updated to call it (behavior identical).
+6. **α-6** `feat(telephony): replace inline Deepgram with STTProvider` — wire `get_stt()` + `_consume_transcripts`; remove `_open_deepgram_connection`; migrate `mock_pipeline` fixture.
+7. **α-7** `feat(telephony): instant barge-in via VAD speech-started` — subscribe `SpeechStarted`; consumer calls `_barge_in_now(trigger="vad")`; add `STT_INSTANT_BARGE_IN` kill-switch.
+
+After α-7: structural extraction complete. Bot behavior identical to today **except** instant barge-in is on. First test call should sound the same but pause faster on interruption. If VAD misfires on real audio, `STT_INSTANT_BARGE_IN=False` reverts.
+
+### Phase β — tuning (open-ended, judged by test calls)
+
+Cheap iterations now that everything is config-driven:
+
+| Knob | What changes |
+|---|---|
+| `STT_MODEL=nova-3` | Retry the reverted #199 model bump |
+| `STT_KEYTERMS=...` | Send menu vocabulary (Nova-3) |
+| `STT_ENDPOINTING_MS=600` (or 1000) | Trade responsiveness vs. mid-sentence false-finals |
+| `STT_INSTANT_BARGE_IN=False` | Disable VAD trigger if twitchy |
+| `DEEPGRAM_TTS_MODEL=...` | Try a different Aura voice |
+
+Anything bigger than a config flip lands as its own α-style commit on the same branch.
+
+### Rebase cadence
+
+Rebase onto `master` weekly, more often if Dependabot churn or someone touches `app/telephony/router.py` / `app/storage/recordings.py` on master. Standard `git fetch && git rebase origin/master` once α-1 commits exist.
+
+### Test-call discipline
+
+- After α-3 (TTS moved): test call.
+- After α-6 (STT moved): test call. Confirm transcripts flow, final-transcript barge-in works.
+- After α-7 (instant barge-in): test call. Deliberately interrupt mid-bot-sentence; confirm bot stops in <500ms.
+- After every β iteration: test call.
+
+Recording stays off the whole branch.
+
+### Merge criteria
+
+1. All pytest tests green.
+2. Pre-commit hooks pass.
+3. Three consecutive clean test calls demonstrating the conversational quality goal of #83.
+4. Master rebase clean.
+5. Spec doc and PR description reference both #83 and the new refactor issue.
+
+One fat PR at the end. PR description structures α (extraction list) separately from β (behavior changes).
+
+## Risks
+
+- **VAD false positives.** Background noise, coughs, or echo could trip speech-started and audibly cut the bot off mid-word. Mitigation: `STT_INSTANT_BARGE_IN=False` env var. If persistent, follow-up work adds "require interim transcript within N ms after speech-started before committing."
+- **Long-lived branch drift.** Without weekly rebases, the eventual merge becomes a 100-commit reconciliation. Today's 28-behind rebase was painless; an 8-week-behind rebase with deps + CI rule churn won't be.
+- **Recording over-representation when re-enabled** (pre-existing limitation): outbound TTS chunks get appended to the recording at send-time, but `clear_twilio_audio` may flush some before they play. Recording slightly over-represents the bot's actual playback. Acceptable today; documented for when recording comes back online.
+
+## Deferred work
+
+- Per-restaurant STT/TTS overrides (Firestore-backed).
+- Auto-reconnect on STT WS drop.
+- TTS retry on 5xx.
+- Structured logging migration.
+- Speculative LLM warm-up on stable interim transcripts.
+- VAD-false-positive guard ("require interim within N ms").
+- Live-call-watching dashboard view (would resurface interim Firestore emission).
+
+## Open questions
+
+None at design-approval time.

--- a/docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md
+++ b/docs/superpowers/specs/2026-05-06-telephony-router-modularization-design.md
@@ -1,0 +1,150 @@
+# Telephony router modularization
+
+**Issue:** [tsuki-works/niko#251](https://github.com/tsuki-works/niko/issues/251)
+**Branch:** `refactor/251-telephony-router-split`
+**Base:** `feat/83-tune-conversational-bot` — this refactor depends on the STTProvider extraction and instant-barge-in work landing first. The 1293-line `router.py` analysed below is the post-feat/83 file. PR target should be feat/83 (or master once feat/83 merges).
+**Type:** Structural refactor — no behavior change.
+
+## Problem
+
+`app/telephony/router.py` is 1293 lines and mixes ~10 concerns in one file:
+
+- TwiML HTTP endpoints (`/voice`, `/voice/stream-ended`, `/voice/transfer-result`, `/voice/voicemail-recorded`, `/voice/voicemail-transcription`)
+- The `/media-stream` WebSocket event loop (start/media/mark/stop dispatch)
+- `_CallState` dataclass
+- LLM-turn streaming + chunking (`_run_llm_tts_turn`, `_should_flush_chunk`, hard/soft break thresholds)
+- STT consumer (`_consume_transcripts`)
+- Auto-hangup machinery (mark-echo, grace window, timeout fallback)
+- Barge-in (`_barge_in_now`)
+- Silence watchdog
+- Twilio-specific WS protocol primitives (`clear_twilio_audio`, `send_end_of_call_mark`)
+- Goodbye-detection heuristic + Firestore-event helper
+
+Recent telephony work (#170, #151, #114, #78, #74, instant barge-in via VAD) is being delivered into a single increasingly-tangled file. Reading or editing any one concern requires scrolling through the others.
+
+## Goal
+
+Split the file along its real boundary — vendor-specific Twilio I/O vs vendor-neutral call orchestration — without introducing new abstractions and without changing behavior.
+
+## Non-goals
+
+- **No `TelephonyProvider` ABC.** Single-vendor today; designing an abstraction against one concrete is a guess. The interface emerges when a second provider arrives.
+- **No `CallSession` class refactor.** Possible follow-up; out of scope here. `_CallState` stays a dataclass; the orchestration helpers stay as module-level functions taking `(state, websocket, ...)`.
+- **No public-API changes.** FastAPI endpoint paths, params, and response shapes unchanged.
+- **No behavior changes.** Existing tests pass without modification beyond import-path updates.
+- **No decorative fragmentation.** Two-line helper modules (`turn.py`, `events.py`) explicitly rejected during brainstorming. Pure helpers live next to the code that uses them.
+
+## Proposed structure
+
+```
+app/telephony/
+  router.py            # FastAPI endpoints + WS event-loop only
+  session.py           # _CallState + all orchestration helpers
+  voicemail_twiml.py   # existing — unchanged
+  transfer_triggers.py # existing — unchanged
+
+app/twilio/
+  __init__.py          # exports + Twilio REST recording fetch
+  twiml.py             # TwiML response builders
+  media_stream.py      # send_clear, send_mark — outgoing WS protocol primitives
+```
+
+### File roles
+
+**`app/telephony/router.py`** (~250 lines)
+FastAPI endpoint shells. Each HTTP handler parses the form, calls a TwiML builder from `app/twilio/twiml.py`, returns `Response`. The `/media-stream` WS handler runs the start/media/mark/stop dispatch loop and the cleanup `finally`, delegating per-event work to functions in `session.py`. No call orchestration logic here, no TwiML XML construction here.
+
+**`app/telephony/session.py`** (~800 lines)
+The bulk of today's `router.py` minus the FastAPI shells and Twilio I/O:
+
+- `_CallState` dataclass
+- Chunking constants + `_should_flush_chunk`
+- Goodbye constants + `_looks_like_goodbye`
+- `_bg_call_event` + `_state_rid`
+- `_make_recording_chunk_handler`
+- Silence watchdog: `_silence_watchdog`, `_cancel_silence_task`, `_arm_silence_watchdog`
+- Auto-hangup: `_hang_up_after_grace`, `_hang_up_after_mark_timeout`, `_abort_pending_hangup`
+- Barge-in: `_barge_in_now`
+- Transcript consumer: `_consume_transcripts`
+- LLM turn: `_run_llm_tts_turn`, `_handle_final_transcript`
+- `_resolve_restaurant_for_voice`
+
+Helpers continue to take `(state, websocket, ...)`. They call into `app/twilio/media_stream.py` (`send_clear`, `send_mark`) instead of writing JSON envelopes inline.
+
+**`app/twilio/__init__.py`** (~40 lines)
+Re-exports the public Twilio surface (`twiml`, `media_stream`). Holds `download_recording(url, account_sid, auth_token)` for `/voice/voicemail-recorded` — small enough that a dedicated `recordings.py` would be ceremony.
+
+**`app/twilio/twiml.py`** (~120 lines)
+Pure functions returning `VoiceResponse` (or its `str`-encoding):
+
+- `voice_twiml(restaurant, ws_host)` — `<Connect><Stream>` with `restaurant_id` parameter
+- `unconfigured_hangup_twiml()` — "this number is not configured"
+- `closed_hangup_twiml()` — "we're closed; call back during business hours"
+- `transfer_twiml(fallback_phone, call_sid, rid)` — `<Dial>` with action callback
+- `empty_twiml()` — empty `VoiceResponse()` for hangup paths
+
+No side effects, easy to snapshot-test. `router.py` imports from here.
+
+**`app/twilio/media_stream.py`** (~80 lines)
+The two outgoing Twilio Media Stream WS frames that today live as inline `websocket.send_json` calls in `router.py`:
+
+- `send_clear(websocket, stream_sid)` — flush Twilio's audio buffer (#74)
+- `send_mark(websocket, stream_sid, name)` — append a named mark for buffer-drain detection (#78)
+
+Both are tiny but capture the only outgoing Twilio-shaped JSON literals. `session.py`'s `_barge_in_now` and `_run_llm_tts_turn` import from here. Incoming events (`start`, `media`, `mark`, `stop`) stay parsed inline in `router.py`'s WS handler — typed wrappers are speculative until a second provider forces a real shape difference.
+
+## Mapping (where each thing moves)
+
+| Current (`router.py`) | Destination |
+|---|---|
+| `SILENCE_TIMEOUT_SECONDS`, `SILENCE_PROMPT`, `GREETING_TRANSCRIPT` | `session.py` |
+| `END_OF_CALL_MARK`, `HANGUP_GRACE_SECONDS`, `MARK_ECHO_TIMEOUT_SECONDS` | `session.py` |
+| `_HARD_BREAKS`, `_SOFT_BREAKS`, `_MIN_CHUNK_CHARS`, `_should_flush_chunk` | `session.py` |
+| `_GOODBYE_PATTERNS`, `_looks_like_goodbye` | `session.py` |
+| `_bg_call_event`, `_state_rid` | `session.py` |
+| `_CallState` | `session.py` |
+| `_make_recording_chunk_handler` | `session.py` |
+| `_silence_watchdog`, `_cancel_silence_task`, `_arm_silence_watchdog` | `session.py` |
+| `_hang_up_after_grace`, `_hang_up_after_mark_timeout`, `_abort_pending_hangup` | `session.py` |
+| `_barge_in_now` | `session.py` |
+| `_consume_transcripts` | `session.py` |
+| `_run_llm_tts_turn`, `_handle_final_transcript` | `session.py` |
+| `_resolve_restaurant_for_voice` | `session.py` |
+| `clear_twilio_audio` (rewritten) | `app/twilio/media_stream.py` as `send_clear` |
+| `send_end_of_call_mark` (rewritten) | `app/twilio/media_stream.py` as `send_mark` |
+| TwiML construction in `voice` / `stream_ended` / `transfer_result` / voicemail handlers | `app/twilio/twiml.py` |
+| Twilio REST recording download in `voicemail_recorded` | `app/twilio/__init__.py` (`download_recording`) |
+| `@router.post("/voice")` and the four other HTTP endpoints | `router.py` (shells only) |
+| `@router.websocket("/media-stream")` event-loop body | `router.py` (still the dispatch shell, calls into `session.py`) |
+| `_TRANSFER_STATUS_MAP`, `_UNCONFIGURED_TWIML_MESSAGE` | Move with the consumer (status map → `router.py`; message → `app/twilio/twiml.py`) |
+
+## Test impact
+
+Current tests that import internals (verified on `feat/83-tune-conversational-bot`):
+
+- `tests/test_telephony.py`: `from app.telephony.router import _MIN_CHUNK_CHARS, _should_flush_chunk`
+- `tests/test_barge_in_helper.py`: `from app.telephony.router import _CallState, _barge_in_now`
+- `tests/test_transcript_consumer.py`: `from app.telephony.router import _CallState, _consume_transcripts`
+
+All three update from `app.telephony.router` to `app.telephony.session`. No test logic changes.
+
+`tests/test_voice.py` exercises `/voice` via TestClient — public surface unchanged, no edits expected.
+
+## Risk + validation
+
+**Risk:** low–medium. Mechanical move; strong existing coverage (`tests/test_telephony.py` 1892 lines, plus targeted barge-in / transcript-consumer / voice tests). Recent active tuning (instant-barge-in via VAD just landed) means the diff lands near hot code — care needed to avoid an accidental rebase conflict on whoever's iterating next.
+
+**Validation:**
+
+1. Full pytest suite passes with import paths updated.
+2. `pytest tests/test_telephony.py tests/test_barge_in_helper.py tests/test_transcript_consumer.py tests/test_voice.py -v` — telephony-focused subset green.
+3. Diff review: every moved function moved verbatim (no logic edits hidden in the move).
+4. Manual smoke via the dev call flow (one inbound test call, listen for: greeting plays, barge-in works, silence prompt fires, order confirmation triggers auto-hangup).
+
+## Out of scope (deliberate)
+
+- `CallSession` class refactor — possible follow-up issue.
+- `TelephonyProvider` ABC — wait for vendor #2.
+- Splitting `session.py` into finer modules (`turn.py`, `events.py`, `hangup.py`, etc.) — rejected as decorative during brainstorming. Revisit if `session.py` becomes hard to navigate after this lands.
+- Typed wrappers around incoming Twilio WS events (`StartFrame`, `MediaFrame`, etc.) — speculative; defer.
+- Moving SMS Twilio code (`app/sms/client.py`) into `app/twilio/`. Unrelated to the router refactor; do separately if at all.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ anthropic>=0.98.1,<1.0
 google-cloud-firestore>=2.0,<3.0
 google-cloud-logging>=3.0,<4.0
 firebase-admin>=7.4.0,<8.0
-deepgram-sdk>=3.0,<4.0
+deepgram-sdk>=7.1,<8.0
 httpx>=0.27,<1.0
 tzdata>=2024.1

--- a/tests/fakes/stt.py
+++ b/tests/fakes/stt.py
@@ -1,0 +1,76 @@
+"""FakeSTT — test double for app.stt.base.STTProvider.
+
+Tests script events and assert on calls. The fake is intentionally
+minimal: just enough plumbing to support the scenarios the real plugin
+needs to handle (open, send, multi-event streams, close, error).
+
+Usage:
+
+    fake = FakeSTT(events=[TranscriptEvent("hi", True, 0.95)])
+    await fake.open()
+    async for event in fake.events():
+        ...
+
+    fake.feed(SpeechStartedEvent())             # inject mid-test
+    fake.feed_error(RuntimeError("dropped"))    # surface error in events()
+    await fake.close()
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import AsyncIterator
+
+from app.stt.base import STTEvent
+
+
+_CLOSED = object()
+
+
+@dataclass(frozen=True)
+class _ErrorBox:
+    exc: BaseException
+
+
+class FakeSTT:
+    """Implements STTProvider; lets tests feed scripted events."""
+
+    def __init__(self, *, events: "list[STTEvent] | None" = None) -> None:
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.opened = False
+        self.closed = False
+        self.sent: list[bytes] = []
+        for ev in events or []:
+            self._queue.put_nowait(ev)
+
+    async def open(self) -> None:
+        self.opened = True
+
+    async def send(self, audio: bytes) -> None:
+        self.sent.append(audio)
+
+    def events(self) -> AsyncIterator[STTEvent]:
+        return self._events_impl()
+
+    async def _events_impl(self) -> AsyncIterator[STTEvent]:
+        while True:
+            item = await self._queue.get()
+            if item is _CLOSED:
+                return
+            if isinstance(item, _ErrorBox):
+                raise item.exc
+            yield item
+
+    async def close(self) -> None:
+        self.closed = True
+        self._queue.put_nowait(_CLOSED)
+
+    # Test-side helpers ----------------------------------------------------
+    def feed(self, event: STTEvent) -> None:
+        """Inject one event into the live stream."""
+        self._queue.put_nowait(event)
+
+    def feed_error(self, exc: BaseException) -> None:
+        """Cause the next ``events()`` pull to raise ``exc``."""
+        self._queue.put_nowait(_ErrorBox(exc))

--- a/tests/fakes/stt.py
+++ b/tests/fakes/stt.py
@@ -14,6 +14,10 @@ Usage:
     fake.feed(SpeechStartedEvent())             # inject mid-test
     fake.feed_error(RuntimeError("dropped"))    # surface error in events()
     await fake.close()
+
+Note: events seeded via the constructor are visible from ``events()``
+regardless of whether ``open()`` was called — chosen for test ergonomics.
+Real STTProviders gate event emission on ``open()``.
 """
 
 from __future__ import annotations
@@ -23,7 +27,6 @@ from dataclasses import dataclass
 from typing import AsyncIterator
 
 from app.stt.base import STTEvent
-
 
 _CLOSED = object()
 

--- a/tests/test_barge_in_helper.py
+++ b/tests/test_barge_in_helper.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.telephony.session import _CallState, _barge_in_now
+from app.telephony.session import _barge_in_now, _CallState
 
 
 @pytest.mark.asyncio

--- a/tests/test_barge_in_helper.py
+++ b/tests/test_barge_in_helper.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.telephony.router import _CallState, _barge_in_now
+from app.telephony.session import _CallState, _barge_in_now
 
 
 @pytest.mark.asyncio

--- a/tests/test_barge_in_helper.py
+++ b/tests/test_barge_in_helper.py
@@ -20,8 +20,10 @@ from app.telephony.session import _barge_in_now, _CallState
 async def test_cancels_running_llm_task():
     state = _CallState(websocket=AsyncMock())
     state.stream_sid = "MZ1"
+
     async def long_task():
         await asyncio.sleep(60)
+
     state.llm_task = asyncio.create_task(long_task())
 
     ws = AsyncMock()
@@ -54,8 +56,10 @@ async def test_skips_task_cancel_when_no_llm_task():
 async def test_cancels_silence_task():
     state = _CallState(websocket=AsyncMock())
     state.stream_sid = "MZ1"
+
     async def long_silence():
         await asyncio.sleep(60)
+
     state.silence_task = asyncio.create_task(long_silence())
 
     ws = AsyncMock()
@@ -73,9 +77,7 @@ async def test_sends_twilio_clear_event():
     ws.send_json = AsyncMock()
 
     await _barge_in_now(state, ws, trigger="vad")
-    ws.send_json.assert_awaited_once_with(
-        {"event": "clear", "streamSid": "MZabc"}
-    )
+    ws.send_json.assert_awaited_once_with({"event": "clear", "streamSid": "MZabc"})
 
 
 @pytest.mark.asyncio

--- a/tests/test_barge_in_helper.py
+++ b/tests/test_barge_in_helper.py
@@ -1,0 +1,131 @@
+"""Tests for _barge_in_now() — the helper that stops the bot mid-utterance.
+
+The helper itself does not emit a Firestore event; the event is emitted
+by _run_llm_tts_turn's CancelledError handler when the cancellation we
+trigger here actually propagates. These tests verify the mechanical
+steps (task cancel, watchdog cancel, Twilio clear, trigger field set).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.telephony.router import _CallState, _barge_in_now
+
+
+@pytest.mark.asyncio
+async def test_cancels_running_llm_task():
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    async def long_task():
+        await asyncio.sleep(60)
+    state.llm_task = asyncio.create_task(long_task())
+
+    ws = AsyncMock()
+    await _barge_in_now(state, ws, trigger="vad")
+    await asyncio.sleep(0)  # let cancellation propagate
+
+    assert state.llm_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_skips_task_cancel_when_no_llm_task():
+    """Without a running task, the helper still cancels the silence
+    watchdog and flushes Twilio's buffer — but does NOT set
+    barge_in_trigger (preventing stale trigger from leaking into a
+    later real barge-in's CancelledError handler)."""
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    state.llm_task = None
+    state.barge_in_trigger = None
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await _barge_in_now(state, ws, trigger="vad")
+
+    ws.send_json.assert_awaited_once_with({"event": "clear", "streamSid": "MZ1"})
+    assert state.barge_in_trigger is None  # NOT set — no task to cancel
+
+
+@pytest.mark.asyncio
+async def test_cancels_silence_task():
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    async def long_silence():
+        await asyncio.sleep(60)
+    state.silence_task = asyncio.create_task(long_silence())
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+    await _barge_in_now(state, ws, trigger="vad")
+    await asyncio.sleep(0)
+    assert state.silence_task is None
+
+
+@pytest.mark.asyncio
+async def test_sends_twilio_clear_event():
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZabc"
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await _barge_in_now(state, ws, trigger="vad")
+    ws.send_json.assert_awaited_once_with(
+        {"event": "clear", "streamSid": "MZabc"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_sets_barge_in_trigger_on_state_when_task_running():
+    """Trigger is set when there's actually a task to cancel."""
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+
+    async def long_task():
+        await asyncio.sleep(60)
+
+    state.llm_task = asyncio.create_task(long_task())
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await _barge_in_now(state, ws, trigger="final_transcript")
+    assert state.barge_in_trigger == "final_transcript"
+
+    # Let the cancellation propagate so the task is collected cleanly.
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_does_not_set_trigger_when_no_task_to_cancel():
+    """If _barge_in_now is called repeatedly with no task in flight, the
+    trigger field stays None — preventing stale values from leaking into
+    a future real barge-in's CancelledError handler."""
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    state.llm_task = None
+    state.barge_in_trigger = None
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await _barge_in_now(state, ws, trigger="vad")
+    assert state.barge_in_trigger is None
+
+    await _barge_in_now(state, ws, trigger="final_transcript")
+    assert state.barge_in_trigger is None
+
+
+@pytest.mark.asyncio
+async def test_swallows_websocket_disconnect_during_clear():
+    """If the caller already hung up, sending clear raises but we must
+    not let that exception escape into the call loop."""
+    from starlette.websockets import WebSocketDisconnect
+
+    state = _CallState(websocket=AsyncMock())
+    state.stream_sid = "MZ1"
+    ws = AsyncMock()
+    ws.send_json = AsyncMock(side_effect=WebSocketDisconnect())
+    # No exception escapes is the assertion.
+    await _barge_in_now(state, ws, trigger="vad")

--- a/tests/test_deepgram_tts.py
+++ b/tests/test_deepgram_tts.py
@@ -1,4 +1,4 @@
-"""Unit tests for app.tts.client.speak().
+"""Unit tests for app.deepgram.tts.speak().
 
 All tests mock httpx and WebSocket — no real API calls made.
 """
@@ -9,8 +9,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from starlette.websockets import WebSocketDisconnect
 
-import app.tts.client as tts_module
-from app.tts.client import speak
+import app.deepgram.tts as tts_module
+from app.config import settings
+from app.deepgram.tts import speak
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -56,11 +57,24 @@ def make_mock_websocket() -> AsyncMock:
 
 @pytest.fixture(autouse=True)
 def _patch_settings():
-    """Default settings for every test — keeps the suite independent of local .env."""
-    with patch("app.tts.client.settings") as mock_settings:
-        mock_settings.deepgram_api_key = "test-key"
-        mock_settings.deepgram_tts_model = "aura-2-thalia-en"
-        yield mock_settings
+    """Default settings for every test — keeps the suite independent of local .env.
+
+    Both ``app.deepgram`` (where _api_key reads the key) and
+    ``app.deepgram.tts`` (where the model is read) use their own import of
+    ``settings``, so we patch both module-level names. We yield the
+    ``app.deepgram`` mock because _api_key() reads from there; tests that
+    want to test missing-key behaviour set deepgram_api_key = None on the
+    yielded object and it propagates correctly.
+    """
+    with patch("app.deepgram.settings") as mock_dg, patch(
+        "app.deepgram.tts.settings"
+    ) as mock_tts:
+        mock_dg.deepgram_api_key = "test-key"
+        mock_tts.deepgram_api_key = "test-key"
+        mock_tts.deepgram_tts_model = "aura-2-thalia-en"
+        # Keep the two mocks in sync when the test sets deepgram_api_key = None
+        # on the yielded object. We yield mock_dg so _api_key() sees the change.
+        yield mock_dg
 
 
 # ---------------------------------------------------------------------------
@@ -165,59 +179,39 @@ async def test_speak_uses_configured_model_and_mulaw_format():
 
 
 @pytest.mark.asyncio
-async def test_speak_feeds_recording_session_each_chunk(monkeypatch):
-    """When ``recording_session`` is passed, each TTS chunk is also fed
-    into the recording's outbound side via ``append_chunks``. This is
-    how the agent's voice gets into the recording — Twilio's
-    ``<Connect><Stream>`` only sends us inbound audio, so we capture
-    the bytes we generate ourselves."""
+async def test_speak_on_chunk_receives_each_audio_chunk():
+    """When ``on_chunk`` is passed, each TTS chunk is forwarded to it.
+    This is how the router captures outbound audio for the recording
+    session — the callback is constructed by _make_recording_chunk_handler."""
     chunks = [b"\xab\xcd", b"\xef\x01\x02", b"\x03"]
     client = make_mock_client(chunks)
     ws = make_mock_websocket()
-    fake_session = MagicMock(broken=False)
 
-    captured: list[tuple] = []
-
-    def fake_append(session, inbound, outbound):
-        captured.append((session, inbound, outbound))
-
-    monkeypatch.setattr("app.storage.recordings.append_chunks", fake_append)
+    captured: list[bytes] = []
 
     await speak(
         "Hello",
         ws,
         stream_sid="MZ123",
         client=client,
-        recording_session=fake_session,
+        on_chunk=captured.append,
     )
 
-    # One append_chunks call per TTS chunk. inbound side is always
-    # empty (caller side is captured separately by the WS handler).
-    assert len(captured) == 3
-    for (session, inbound, outbound), expected_chunk in zip(captured, chunks):
-        assert session is fake_session
-        assert inbound == b""
-        assert outbound == expected_chunk
+    assert captured == chunks
 
 
 @pytest.mark.asyncio
-async def test_speak_without_recording_session_skips_append(monkeypatch):
-    """If no recording session is passed, append_chunks is never called.
-    Defensive: the storage module's import should not be required when
-    recording is disabled or unavailable."""
+async def test_speak_without_on_chunk_skips_callback():
+    """If no on_chunk is passed, the call still completes normally
+    and no callback-related error is raised."""
     chunks = [b"\xab", b"\xcd"]
     client = make_mock_client(chunks)
     ws = make_mock_websocket()
 
-    called: list = []
-    monkeypatch.setattr(
-        "app.storage.recordings.append_chunks",
-        lambda *a, **kw: called.append(a),
-    )
-
+    # Should not raise; two media events sent
     await speak("Hello", ws, stream_sid="MZ123", client=client)
 
-    assert called == []
+    assert ws.send_json.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -363,3 +357,68 @@ async def test_speak_without_on_first_byte_works(monkeypatch):
     # No on_first_byte kwarg
     await speak("Hello", ws, stream_sid="MZ123", client=mock_client)
     ws.send_json.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# on_chunk callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_chunk_receives_each_audio_chunk(monkeypatch):
+    """Every non-empty body chunk Deepgram returns is forwarded to on_chunk."""
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    chunks_seen: list[bytes] = []
+    fake_chunks = [b"\x01\x02", b"\x03\x04", b"\x05"]
+
+    async def fake_aiter_bytes():
+        for c in fake_chunks:
+            yield c
+
+    response = AsyncMock()
+    response.status_code = 200
+    response.aiter_bytes = fake_aiter_bytes
+
+    stream_cm = AsyncMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=response)
+    stream_cm.__aexit__ = AsyncMock(return_value=None)
+
+    fake_client = AsyncMock()
+    fake_client.stream = MagicMock(return_value=stream_cm)
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    await speak("hello", ws, "MZ123", client=fake_client, on_chunk=chunks_seen.append)
+
+    assert chunks_seen == fake_chunks
+
+
+@pytest.mark.asyncio
+async def test_on_chunk_exceptions_are_swallowed(monkeypatch, caplog):
+    """A buggy on_chunk callback never breaks a call."""
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    async def fake_aiter_bytes():
+        yield b"\x01"
+
+    response = AsyncMock()
+    response.status_code = 200
+    response.aiter_bytes = fake_aiter_bytes
+
+    stream_cm = AsyncMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=response)
+    stream_cm.__aexit__ = AsyncMock(return_value=None)
+
+    fake_client = AsyncMock()
+    fake_client.stream = MagicMock(return_value=stream_cm)
+
+    ws = AsyncMock()
+    ws.send_json = AsyncMock()
+
+    def bad(_chunk: bytes) -> None:
+        raise RuntimeError("boom")
+
+    # No exception escapes; the assertion is that this returns normally.
+    await speak("hi", ws, "MZ123", client=fake_client, on_chunk=bad)

--- a/tests/test_deepgram_tts.py
+++ b/tests/test_deepgram_tts.py
@@ -66,9 +66,7 @@ def _patch_settings():
     want to test missing-key behaviour set deepgram_api_key = None on the
     yielded object and it propagates correctly.
     """
-    with patch("app.deepgram.settings") as mock_dg, patch(
-        "app.deepgram.tts.settings"
-    ) as mock_tts:
+    with patch("app.deepgram.settings") as mock_dg, patch("app.deepgram.tts.settings") as mock_tts:
         mock_dg.deepgram_api_key = "test-key"
         mock_tts.deepgram_api_key = "test-key"
         mock_tts.deepgram_tts_model = "aura-2-thalia-en"

--- a/tests/test_fake_stt.py
+++ b/tests/test_fake_stt.py
@@ -40,6 +40,7 @@ async def test_events_yields_seeded_events_in_order() -> None:
     await fake.open()
 
     received = []
+
     async def consume():
         async for event in fake.events():
             received.append(event)
@@ -58,6 +59,7 @@ async def test_feed_injects_event_into_live_stream() -> None:
     await fake.open()
 
     received = []
+
     async def consume():
         async for event in fake.events():
             received.append(event)

--- a/tests/test_fake_stt.py
+++ b/tests/test_fake_stt.py
@@ -1,0 +1,164 @@
+"""Tests for tests/fakes/stt.py — the FakeSTT test double itself.
+
+We test the fake because every other test in this push relies on it
+behaving exactly like a real STTProvider should. A bug in the fake
+would be a bug in dozens of consumer tests at once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.stt.base import SpeechStartedEvent, TranscriptEvent
+from tests.fakes.stt import FakeSTT
+
+
+@pytest.mark.asyncio
+async def test_open_marks_opened() -> None:
+    fake = FakeSTT()
+    await fake.open()
+    assert fake.opened is True
+
+
+@pytest.mark.asyncio
+async def test_send_records_audio_chunks_in_order() -> None:
+    fake = FakeSTT()
+    await fake.send(b"chunk1")
+    await fake.send(b"chunk2")
+    assert fake.sent == [b"chunk1", b"chunk2"]
+
+
+@pytest.mark.asyncio
+async def test_events_yields_seeded_events_in_order() -> None:
+    seeded = [
+        TranscriptEvent("hi", False, 0.7),
+        TranscriptEvent("hello", True, 0.95),
+    ]
+    fake = FakeSTT(events=seeded)
+    await fake.open()
+
+    received = []
+    async def consume():
+        async for event in fake.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)  # let consumer drain seeded items
+    await fake.close()
+    await task
+
+    assert received == seeded
+
+
+@pytest.mark.asyncio
+async def test_feed_injects_event_into_live_stream() -> None:
+    fake = FakeSTT()
+    await fake.open()
+
+    received = []
+    async def consume():
+        async for event in fake.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    fake.feed(SpeechStartedEvent())
+    fake.feed(TranscriptEvent("ok", True, 0.9))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert isinstance(received[0], SpeechStartedEvent)
+    assert isinstance(received[1], TranscriptEvent)
+    assert received[1].text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_feed_error_raises_from_events() -> None:
+    fake = FakeSTT()
+    await fake.open()
+    fake.feed_error(RuntimeError("dropped"))
+
+    with pytest.raises(RuntimeError, match="dropped"):
+        async for _event in fake.events():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_events_iterator() -> None:
+    fake = FakeSTT()
+    await fake.open()
+    await fake.close()
+
+    received = []
+    async for event in fake.events():
+        received.append(event)
+
+    assert received == []
+    assert fake.closed is True
+
+
+@pytest.mark.asyncio
+async def test_send_before_open_records_chunks() -> None:
+    """The fake doesn't enforce open() ordering — send() always records.
+    Real providers may raise; the fake is permissive so tests can stub
+    a partial flow without ceremony."""
+    fake = FakeSTT()
+    await fake.send(b"first")
+    assert fake.sent == [b"first"]
+
+
+@pytest.mark.asyncio
+async def test_double_close_is_safe() -> None:
+    """Closing twice doesn't raise. The second _CLOSED sits in the queue
+    harmlessly; the iterator has already returned and won't read it."""
+    fake = FakeSTT()
+    await fake.open()
+    await fake.close()
+    await fake.close()  # should not raise
+    assert fake.closed is True
+
+
+@pytest.mark.asyncio
+async def test_events_can_only_be_drained_by_one_consumer() -> None:
+    """The fake's queue is single-consumer. Two concurrent events()
+    consumers will starve each other; this test pins that contract so
+    the design is explicit and a future refactor doesn't quietly change
+    it."""
+    seeded = [
+        TranscriptEvent("a", True, 0.9),
+        TranscriptEvent("b", True, 0.9),
+    ]
+    fake = FakeSTT(events=seeded)
+    await fake.open()
+
+    a_received: list[TranscriptEvent] = []
+    b_received: list[TranscriptEvent] = []
+
+    async def drain_a() -> None:
+        async for event in fake.events():
+            a_received.append(event)
+
+    async def drain_b() -> None:
+        async for event in fake.events():
+            b_received.append(event)
+
+    task_a = asyncio.create_task(drain_a())
+    task_b = asyncio.create_task(drain_b())
+    await asyncio.sleep(0)
+    await fake.close()
+    # close() puts ONE _CLOSED. Whichever consumer dequeues it returns.
+    # The other will hang waiting for the next item — that's the contract.
+    # Cancel the unfinished task so the test exits.
+    await asyncio.sleep(0)
+    if not task_a.done():
+        task_a.cancel()
+    if not task_b.done():
+        task_b.cancel()
+    # Both tasks may have grabbed events before close — what we're
+    # asserting is that the seeded events ended up split between them
+    # (one each), proving they're competing on a single queue.
+    total = len(a_received) + len(b_received)
+    assert total <= 2  # at most the seeded count; depending on scheduling

--- a/tests/test_fake_stt.py
+++ b/tests/test_fake_stt.py
@@ -122,43 +122,36 @@ async def test_double_close_is_safe() -> None:
 
 
 @pytest.mark.asyncio
-async def test_events_can_only_be_drained_by_one_consumer() -> None:
-    """The fake's queue is single-consumer. Two concurrent events()
-    consumers will starve each other; this test pins that contract so
-    the design is explicit and a future refactor doesn't quietly change
-    it."""
-    seeded = [
-        TranscriptEvent("a", True, 0.9),
-        TranscriptEvent("b", True, 0.9),
-    ]
-    fake = FakeSTT(events=seeded)
+async def test_each_event_goes_to_exactly_one_consumer() -> None:
+    """The fake's queue is single-consumer: each enqueued item is
+    handed to exactly one waiting events() iterator. Two consumers
+    blocked on an empty queue, then one event is fed — exactly one
+    receives it."""
+    fake = FakeSTT()
     await fake.open()
 
     a_received: list[TranscriptEvent] = []
     b_received: list[TranscriptEvent] = []
 
-    async def drain_a() -> None:
+    async def drain(into: list[TranscriptEvent]) -> None:
         async for event in fake.events():
-            a_received.append(event)
+            into.append(event)
 
-    async def drain_b() -> None:
-        async for event in fake.events():
-            b_received.append(event)
-
-    task_a = asyncio.create_task(drain_a())
-    task_b = asyncio.create_task(drain_b())
+    task_a = asyncio.create_task(drain(a_received))
+    task_b = asyncio.create_task(drain(b_received))
+    # Let both consumers reach `await queue.get()` with the queue empty.
     await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    fake.feed(TranscriptEvent("only", True, 0.9))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
     await fake.close()
-    # close() puts ONE _CLOSED. Whichever consumer dequeues it returns.
-    # The other will hang waiting for the next item — that's the contract.
-    # Cancel the unfinished task so the test exits.
     await asyncio.sleep(0)
     if not task_a.done():
         task_a.cancel()
     if not task_b.done():
         task_b.cancel()
-    # Both tasks may have grabbed events before close — what we're
-    # asserting is that the seeded events ended up split between them
-    # (one each), proving they're competing on a single queue.
-    total = len(a_received) + len(b_received)
-    assert total <= 2  # at most the seeded count; depending on scheduling
+
+    assert len(a_received) + len(b_received) == 1

--- a/tests/test_provider_selector.py
+++ b/tests/test_provider_selector.py
@@ -1,0 +1,36 @@
+"""Tests for app/tts and app/stt selector functions.
+
+Confirms the configured provider is dispatched to and unknown providers
+raise. STT-side selector tests are added when get_stt() lands.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config import settings
+
+
+@pytest.mark.asyncio
+async def test_speak_dispatches_to_deepgram_when_provider_is_deepgram(monkeypatch):
+    monkeypatch.setattr(settings, "tts_provider", "deepgram")
+    fake_speak = AsyncMock()
+    monkeypatch.setattr("app.deepgram.tts.speak", fake_speak)
+
+    from app.tts import speak
+
+    ws = MagicMock()
+    await speak("hi", ws, "MZ1")
+    fake_speak.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_speak_raises_for_unknown_tts_provider(monkeypatch):
+    monkeypatch.setattr(settings, "tts_provider", "elevenlabs-not-implemented")
+    from app.tts import speak
+
+    ws = MagicMock()
+    with pytest.raises(ValueError, match="Unknown TTS provider"):
+        await speak("hi", ws, "MZ1")

--- a/tests/test_provider_selector.py
+++ b/tests/test_provider_selector.py
@@ -54,3 +54,37 @@ def test_get_stt_raises_for_unknown_provider(monkeypatch):
 
     with pytest.raises(ValueError, match="Unknown STT provider"):
         get_stt(call_sid="CAtest")
+
+
+def test_get_stt_forwards_keyterms_to_deepgram_provider(monkeypatch):
+    """The selector must thread ``keyterms`` into DeepgramSTT so the
+    per-tenant heuristic output reaches Flux on connect. A regression
+    here would silently drop the menu bias on every call."""
+    monkeypatch.setattr(settings, "stt_provider", "deepgram")
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    from app.stt import get_stt
+
+    provider, _name = get_stt(
+        call_sid="CAtest",
+        keyterms=["Twilight Family Restaurant", "Pepper Shrimp"],
+    )
+    # DeepgramSTT exposes the resolved list via its private attribute;
+    # the selector test pins that the constructor argument flowed
+    # through unchanged.
+    assert provider._keyterms_arg == [
+        "Twilight Family Restaurant",
+        "Pepper Shrimp",
+    ]
+
+
+def test_get_stt_default_keyterms_is_none(monkeypatch):
+    """Callers who don't provide keyterms get a clean default — no
+    accidental empty-list shenanigans, no global state."""
+    monkeypatch.setattr(settings, "stt_provider", "deepgram")
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    from app.stt import get_stt
+
+    provider, _name = get_stt(call_sid="CAtest")
+    assert provider._keyterms_arg is None

--- a/tests/test_provider_selector.py
+++ b/tests/test_provider_selector.py
@@ -34,3 +34,23 @@ async def test_speak_raises_for_unknown_tts_provider(monkeypatch):
     ws = MagicMock()
     with pytest.raises(ValueError, match="Unknown TTS provider"):
         await speak("hi", ws, "MZ1")
+
+
+def test_get_stt_returns_deepgram_by_default(monkeypatch):
+    monkeypatch.setattr(settings, "stt_provider", "deepgram")
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+    from app.deepgram.stt import DeepgramSTT
+    from app.stt import get_stt
+
+    provider, name = get_stt(call_sid="CAtest")
+    assert isinstance(provider, DeepgramSTT)
+    assert name == "deepgram"
+
+
+def test_get_stt_raises_for_unknown_provider(monkeypatch):
+    monkeypatch.setattr(settings, "stt_provider", "whisper-not-implemented")
+    from app.stt import get_stt
+
+    with pytest.raises(ValueError, match="Unknown STT provider"):
+        get_stt(call_sid="CAtest")

--- a/tests/test_restaurants_keyterms.py
+++ b/tests/test_restaurants_keyterms.py
@@ -22,9 +22,7 @@ def _estimate_tokens(text: str) -> int:
 
 
 def test_includes_restaurant_name_first_with_empty_menu() -> None:
-    assert compute_keyterms({}, "Twilight Family Restaurant") == [
-        "Twilight Family Restaurant"
-    ]
+    assert compute_keyterms({}, "Twilight Family Restaurant") == ["Twilight Family Restaurant"]
 
 
 def test_walks_menu_in_category_order() -> None:
@@ -116,16 +114,13 @@ def test_token_budget_honored_on_large_menu() -> None:
     """Build a menu wide enough to exceed the budget; verify the
     function returns early and stays under cap."""
     items = [
-        {"name": f"Special Dish Number {i} With Extra Words", "price": 10.0}
-        for i in range(200)
+        {"name": f"Special Dish Number {i} With Extra Words", "price": 10.0} for i in range(200)
     ]
     menu = {"specials": items}
     keyterms = compute_keyterms(menu, "Big Place")
 
     total_tokens = sum(_estimate_tokens(t) for t in keyterms)
-    assert total_tokens <= 450, (
-        f"keyterms exceed token budget: {total_tokens} > 450"
-    )
+    assert total_tokens <= 450, f"keyterms exceed token budget: {total_tokens} > 450"
     # Should have stopped short of all 200 items.
     assert len(keyterms) < 201
     assert keyterms[0] == "Big Place"
@@ -145,11 +140,7 @@ def test_twilight_real_menu_fits_under_budget() -> None:
     """Regression: the live tenant's menu must fit comfortably. If
     this fires, the heuristic needs tightening before the migration
     can ship."""
-    menu_path = (
-        Path(__file__).parent.parent
-        / "restaurants"
-        / "twilight-family-restaurant.json"
-    )
+    menu_path = Path(__file__).parent.parent / "restaurants" / "twilight-family-restaurant.json"
     if not menu_path.exists():
         # Local dev environments may not have the tenant fixture.
         return

--- a/tests/test_restaurants_keyterms.py
+++ b/tests/test_restaurants_keyterms.py
@@ -1,0 +1,170 @@
+"""Tests for compute_keyterms — the per-tenant Flux keyterm builder.
+
+The function is a pure dict-in / list-out transform; tests cover the
+contract from the spec: restaurant name always first, common-safe
+items skipped, duplicates dropped, token budget honored, edge cases
+on malformed input.
+"""
+
+from __future__ import annotations
+
+import json
+from math import ceil
+from pathlib import Path
+
+from app.restaurants.keyterms import compute_keyterms
+
+
+def _estimate_tokens(text: str) -> int:
+    """Mirror of the production heuristic for budget assertions."""
+    words = text.split()
+    return max(1, ceil(len(words) * 1.3)) if words else 0
+
+
+def test_includes_restaurant_name_first_with_empty_menu() -> None:
+    assert compute_keyterms({}, "Twilight Family Restaurant") == [
+        "Twilight Family Restaurant"
+    ]
+
+
+def test_walks_menu_in_category_order() -> None:
+    menu = {
+        "appetizers": [
+            {"name": "Pepper Shrimp", "price": 16.25},
+            {"name": "Sweet Chilli Shrimp", "price": 16.25},
+        ],
+        "soups": [
+            {"name": "Wonton Soup", "price": 8.0},
+        ],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert keyterms[0] == "Twilight"
+    assert "Pepper Shrimp" in keyterms
+    assert "Sweet Chilli Shrimp" in keyterms
+    assert "Wonton Soup" in keyterms
+
+
+def test_skips_common_safe_items() -> None:
+    """French Fries is a model-cold-recognized item — wastes budget."""
+    menu = {
+        "appetizers": [
+            {"name": "French Fries", "price": 7.25},
+            {"name": "Spicy French Fries", "price": 7.50},
+            {"name": "Pepper Shrimp", "price": 16.25},
+        ],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert "French Fries" not in keyterms
+    assert "Spicy French Fries" not in keyterms
+    assert "Pepper Shrimp" in keyterms
+
+
+def test_skips_underscore_reserved_keys() -> None:
+    """_category_order is a list of strings, not a category. Don't
+    crash on it; don't include its strings as 'menu items'."""
+    menu = {
+        "_category_order": ["appetizers", "soups"],
+        "appetizers": [{"name": "Pepper Shrimp", "price": 16.25}],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert "Pepper Shrimp" in keyterms
+    assert "appetizers" not in keyterms
+    assert "soups" not in keyterms
+
+
+def test_drops_duplicates_case_insensitive() -> None:
+    """Same item appears in two categories or two casings — include once."""
+    menu = {
+        "category_a": [{"name": "Pepper Shrimp", "price": 16.25}],
+        "category_b": [{"name": "pepper shrimp", "price": 16.25}],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    pepper_count = sum(1 for k in keyterms if k.lower() == "pepper shrimp")
+    assert pepper_count == 1
+
+
+def test_skips_items_without_a_name() -> None:
+    menu = {
+        "appetizers": [
+            {"price": 5.0},  # no name
+            {"name": "", "price": 5.0},  # empty name
+            {"name": "   ", "price": 5.0},  # whitespace name
+            {"name": "Pepper Shrimp", "price": 16.25},
+        ],
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert keyterms == ["Twilight", "Pepper Shrimp"]
+
+
+def test_skips_non_dict_menu_items_and_non_list_categories() -> None:
+    """Defensive: Firestore can return surprising shapes. Don't crash."""
+    menu = {
+        "appetizers": [
+            "this is not a dict",
+            {"name": "Pepper Shrimp", "price": 16.25},
+            42,
+        ],
+        "garbage_category": "this is not a list",
+        "another_garbage": 123,
+    }
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert "Pepper Shrimp" in keyterms
+    # Non-dict items contribute nothing; the function does not crash.
+
+
+def test_token_budget_honored_on_large_menu() -> None:
+    """Build a menu wide enough to exceed the budget; verify the
+    function returns early and stays under cap."""
+    items = [
+        {"name": f"Special Dish Number {i} With Extra Words", "price": 10.0}
+        for i in range(200)
+    ]
+    menu = {"specials": items}
+    keyterms = compute_keyterms(menu, "Big Place")
+
+    total_tokens = sum(_estimate_tokens(t) for t in keyterms)
+    assert total_tokens <= 450, (
+        f"keyterms exceed token budget: {total_tokens} > 450"
+    )
+    # Should have stopped short of all 200 items.
+    assert len(keyterms) < 201
+    assert keyterms[0] == "Big Place"
+
+
+def test_pathological_long_restaurant_name_returns_name_only() -> None:
+    """If the restaurant name alone exceeds the budget, the menu items
+    are skipped. Returning an empty list would silently drop biasing
+    for the caller-spoken name."""
+    long_name = " ".join(["Very"] * 400)
+    menu = {"appetizers": [{"name": "Pepper Shrimp", "price": 16.25}]}
+    keyterms = compute_keyterms(menu, long_name)
+    assert keyterms == [long_name]
+
+
+def test_twilight_real_menu_fits_under_budget() -> None:
+    """Regression: the live tenant's menu must fit comfortably. If
+    this fires, the heuristic needs tightening before the migration
+    can ship."""
+    menu_path = (
+        Path(__file__).parent.parent
+        / "restaurants"
+        / "twilight-family-restaurant.json"
+    )
+    if not menu_path.exists():
+        # Local dev environments may not have the tenant fixture.
+        return
+    with menu_path.open(encoding="utf-8") as f:
+        menu = json.load(f)
+    keyterms = compute_keyterms(menu, "Twilight Family Restaurant")
+    total_tokens = sum(_estimate_tokens(t) for t in keyterms)
+    assert keyterms[0] == "Twilight Family Restaurant"
+    assert total_tokens <= 450
+    # Sanity: we should be biasing dozens of items, not just the name.
+    assert len(keyterms) > 5
+
+
+def test_output_preserves_original_casing() -> None:
+    """Don't lowercase or title-case names — they go on the wire as-is."""
+    menu = {"appetizers": [{"name": "PePPer Shrimp"}]}
+    keyterms = compute_keyterms(menu, "Twilight")
+    assert "PePPer Shrimp" in keyterms

--- a/tests/test_stt_base_events.py
+++ b/tests/test_stt_base_events.py
@@ -1,0 +1,62 @@
+"""Tests for the vendor-neutral event dataclasses in app.stt.base.
+
+These events are the contract between STT providers and consumers.
+Pinning their shape protects both Flux's translation and any future
+provider (Whisper) that needs to emit them.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import get_args
+
+import pytest
+
+from app.stt.base import (
+    EarlyTurnEndEvent,
+    SpeechStartedEvent,
+    STTEvent,
+    TranscriptEvent,
+    TurnResumedEvent,
+)
+
+
+def test_early_turn_end_event_is_frozen() -> None:
+    e = EarlyTurnEndEvent()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.some_attr = "x"  # type: ignore[attr-defined]
+
+
+def test_turn_resumed_event_is_frozen() -> None:
+    e = TurnResumedEvent()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        e.some_attr = "x"  # type: ignore[attr-defined]
+
+
+def test_stt_event_union_includes_all_four_types() -> None:
+    members = set(get_args(STTEvent))
+    assert members == {
+        TranscriptEvent,
+        SpeechStartedEvent,
+        EarlyTurnEndEvent,
+        TurnResumedEvent,
+    }
+
+
+def test_early_and_resumed_events_have_no_payload_fields() -> None:
+    """These events are pure signals — they carry no payload. Pinning
+    that here so a future-PR field addition is a deliberate, reviewed
+    change rather than an accidental drift."""
+    assert dataclasses.fields(EarlyTurnEndEvent) == ()
+    assert dataclasses.fields(TurnResumedEvent) == ()
+
+
+def test_existing_event_shapes_unchanged() -> None:
+    """Regression guard. The migration must not silently change the
+    field set on the two pre-existing event types."""
+    assert {f.name for f in dataclasses.fields(SpeechStartedEvent)} == {"at"}
+    assert {f.name for f in dataclasses.fields(TranscriptEvent)} == {
+        "text",
+        "is_final",
+        "confidence",
+    }

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -1,104 +1,166 @@
-"""Tests for app/deepgram/stt.py — DeepgramSTT plugin.
+"""Tests for app/deepgram/stt.py — DeepgramSTT plugin (Flux v2).
 
 The Deepgram SDK is the only thing mocked; everything else exercises
-real plugin code (queue plumbing, callback wiring, options building).
+real plugin code (queue plumbing, event translation, lifecycle).
+Tests stub the v2 connect path so we never hit a network — translation
+correctness is the contract this file pins.
 """
 
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.stt.base import TranscriptEvent
+from app.stt.base import (
+    EarlyTurnEndEvent,
+    SpeechStartedEvent,
+    TranscriptEvent,
+    TurnResumedEvent,
+)
 
 
 @pytest.fixture(autouse=True)
 def _set_api_key(monkeypatch):
     """Every test needs the api key set so _api_key() doesn't raise."""
     from app.config import settings
+
     monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
 
 
+def _make_turn_info(*, event: str, transcript: str = "", confidence: float = 0.95):
+    """Build a real ListenV2TurnInfo. Constructing the SDK's pydantic
+    model rather than ducking it with a MagicMock makes isinstance
+    checks inside the translator behave like production."""
+    from deepgram.listen.v2.types import (
+        ListenV2TurnInfo,
+        ListenV2TurnInfoWordsItem,
+    )
+
+    words = (
+        [
+            ListenV2TurnInfoWordsItem(word=w, confidence=confidence)
+            for w in transcript.split()
+        ]
+        if transcript
+        else []
+    )
+    return ListenV2TurnInfo(
+        request_id="req-test",
+        sequence_id=0,
+        event=event,
+        turn_index=0,
+        audio_window_start=0.0,
+        audio_window_end=1.0,
+        transcript=transcript,
+        words=words,
+        end_of_turn_confidence=confidence,
+    )
+
+
 @pytest.fixture
-def fake_deepgram_client(monkeypatch):
-    """Replace DeepgramClient inside app.deepgram.stt with a fake."""
+def fake_v2_connection(monkeypatch):
+    """Replace AsyncDeepgramClient inside app.deepgram.stt with a fake
+    whose listen.v2.connect(...) returns an async-context-manager that
+    yields a connection mock with controllable recv()/send_media()."""
     fake_conn = AsyncMock()
-    fake_conn.send = AsyncMock()
-    fake_conn.finish = AsyncMock()
-    fake_conn.start = AsyncMock(return_value=True)
-    fake_conn._handlers = {}
+    fake_conn.send_media = AsyncMock()
+    fake_conn.send_close_stream = AsyncMock()
+    fake_conn._recv_queue: asyncio.Queue = asyncio.Queue()
 
-    def fake_on(event, handler):
-        fake_conn._handlers[event] = handler
+    async def fake_recv():
+        return await fake_conn._recv_queue.get()
 
-    fake_conn.on = MagicMock(side_effect=fake_on)
+    fake_conn.recv = fake_recv
 
+    fake_cm = AsyncMock()
+    fake_cm.__aenter__ = AsyncMock(return_value=fake_conn)
+    fake_cm.__aexit__ = AsyncMock(return_value=None)
+
+    fake_v2 = MagicMock()
+    fake_v2.connect = MagicMock(return_value=fake_cm)
     fake_listen = MagicMock()
-    fake_listen.asynclive.v = MagicMock(return_value=fake_conn)
+    fake_listen.v2 = fake_v2
     fake_client = MagicMock()
     fake_client.listen = fake_listen
 
     monkeypatch.setattr(
-        "app.deepgram.stt.DeepgramClient",
+        "app.deepgram.stt.AsyncDeepgramClient",
         MagicMock(return_value=fake_client),
     )
+    # Expose the connect mock so tests can introspect call args.
+    fake_conn._connect_mock = fake_v2.connect
     return fake_conn
 
 
 @pytest.mark.asyncio
-async def test_open_starts_connection_with_configured_options(
-    fake_deepgram_client, monkeypatch,
+async def test_open_calls_v2_connect_with_configured_options(
+    fake_v2_connection, monkeypatch
 ):
     from app.config import settings
     from app.deepgram.stt import DeepgramSTT
 
-    monkeypatch.setattr(settings, "stt_model", "nova-3")
-    monkeypatch.setattr(settings, "stt_endpointing_ms", 600)
-    monkeypatch.setattr(settings, "stt_utterance_end_ms", 1200)
-    monkeypatch.setattr(settings, "stt_keyterms", "tikka,naan")
+    monkeypatch.setattr(settings, "stt_model", "flux-general-en")
+    monkeypatch.setattr(settings, "stt_keyterms", "")  # no env override
 
-    stt = DeepgramSTT(call_sid="CAtest")
+    stt = DeepgramSTT(
+        call_sid="CAtest",
+        keyterms=["Twilight Family Restaurant", "Pepper Shrimp"],
+    )
     await stt.open()
-
-    fake_deepgram_client.start.assert_awaited_once()
-    options = fake_deepgram_client.start.await_args.args[0]
-    assert options.model == "nova-3"
-    assert options.endpointing == 600
-    assert options.utterance_end_ms == 1200
-    assert options.keyterm == ["tikka", "naan"]
-    assert options.encoding == "mulaw"
-    assert options.sample_rate == 8000
+    try:
+        connect_call = fake_v2_connection._connect_mock.call_args
+        assert connect_call.kwargs["model"] == "flux-general-en"
+        assert connect_call.kwargs["encoding"] == "mulaw"
+        assert connect_call.kwargs["sample_rate"] == 8000
+        assert connect_call.kwargs["keyterm"] == [
+            "Twilight Family Restaurant",
+            "Pepper Shrimp",
+        ]
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_keyterms_empty_string_yields_none(fake_deepgram_client, monkeypatch):
+async def test_env_keyterms_override_replaces_constructor_list(
+    fake_v2_connection, monkeypatch
+):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "stt_keyterms", "alpha, beta , gamma")
+
+    stt = DeepgramSTT(
+        call_sid="CAtest", keyterms=["Twilight", "Pepper Shrimp"]
+    )
+    await stt.open()
+    try:
+        kwargs = fake_v2_connection._connect_mock.call_args.kwargs
+        assert kwargs["keyterm"] == ["alpha", "beta", "gamma"]
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_no_keyterms_passes_none(fake_v2_connection, monkeypatch):
     from app.config import settings
     from app.deepgram.stt import DeepgramSTT
 
     monkeypatch.setattr(settings, "stt_keyterms", "")
 
-    stt = DeepgramSTT(call_sid="CAtest")
+    stt = DeepgramSTT(call_sid="CAtest")  # no keyterms arg
     await stt.open()
-
-    options = fake_deepgram_client.start.await_args.args[0]
-    assert options.keyterm is None
-
-
-@pytest.mark.asyncio
-async def test_open_raises_when_start_returns_false(fake_deepgram_client):
-    from app.deepgram.stt import DeepgramSTT
-
-    fake_deepgram_client.start = AsyncMock(return_value=False)
-    stt = DeepgramSTT(call_sid="CAtest")
-    with pytest.raises(RuntimeError, match="failed to start"):
-        await stt.open()
+    try:
+        kwargs = fake_v2_connection._connect_mock.call_args.kwargs
+        assert kwargs["keyterm"] is None
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_open_raises_when_api_key_missing(monkeypatch, fake_deepgram_client):
+async def test_open_raises_when_api_key_missing(monkeypatch, fake_v2_connection):
     from app.config import settings
     from app.deepgram.stt import DeepgramSTT
 
@@ -109,145 +171,184 @@ async def test_open_raises_when_api_key_missing(monkeypatch, fake_deepgram_clien
 
 
 @pytest.mark.asyncio
-async def test_send_forwards_audio_to_sdk(fake_deepgram_client):
+async def test_send_forwards_audio_to_send_media(fake_v2_connection):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
-    await stt.send(b"\x01\x02\x03")
-
-    fake_deepgram_client.send.assert_awaited_once_with(b"\x01\x02\x03")
+    try:
+        await stt.send(b"\x01\x02\x03")
+        fake_v2_connection.send_media.assert_awaited_once_with(b"\x01\x02\x03")
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_send_swallows_sdk_exceptions(fake_deepgram_client, caplog):
+async def test_send_swallows_sdk_exceptions(fake_v2_connection, caplog):
     import logging
+
     from app.deepgram.stt import DeepgramSTT
 
-    fake_deepgram_client.send = AsyncMock(side_effect=RuntimeError("dropped"))
-    stt = DeepgramSTT(call_sid="CAtest")
-    await stt.open()
-
-    with caplog.at_level(logging.ERROR, logger="app.deepgram.stt"):
-        await stt.send(b"x")
-
-    assert any(
-        "deepgram send failed" in rec.message for rec in caplog.records
-    ), "expected the swallowed-error log line"
-
-
-@pytest.mark.asyncio
-async def test_transcript_callback_emits_events_in_order(fake_deepgram_client):
-    from deepgram import LiveTranscriptionEvents
-    from app.deepgram.stt import DeepgramSTT
-
-    stt = DeepgramSTT(call_sid="CAtest")
-    await stt.open()
-
-    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
-
-    def make_result(text: str, is_final: bool, confidence: float):
-        alt = SimpleNamespace(transcript=text, confidence=confidence)
-        channel = SimpleNamespace(alternatives=[alt])
-        return SimpleNamespace(channel=channel, is_final=is_final)
-
-    await handler(stt, make_result("hi", False, 0.7))
-    await handler(stt, make_result("hello", True, 0.95))
-
-    received = []
-    async def consume():
-        async for event in stt.events():
-            received.append(event)
-
-    task = asyncio.create_task(consume())
-    await asyncio.sleep(0)
-    await stt.close()
-    await task
-
-    assert received == [
-        TranscriptEvent("hi", False, 0.7),
-        TranscriptEvent("hello", True, 0.95),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_transcript_callback_skips_empty_text(fake_deepgram_client):
-    from deepgram import LiveTranscriptionEvents
-    from app.deepgram.stt import DeepgramSTT
-
-    stt = DeepgramSTT(call_sid="CAtest")
-    await stt.open()
-    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
-
-    alt = SimpleNamespace(transcript="   ", confidence=0.9)
-    result = SimpleNamespace(
-        channel=SimpleNamespace(alternatives=[alt]),
-        is_final=True,
+    fake_v2_connection.send_media = AsyncMock(
+        side_effect=RuntimeError("dropped")
     )
-    await handler(stt, result)
-
-    received = []
-    async def consume():
-        async for event in stt.events():
-            received.append(event)
-
-    task = asyncio.create_task(consume())
-    await asyncio.sleep(0)
-    await stt.close()
-    await task
-
-    assert received == []
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        with caplog.at_level(logging.ERROR, logger="app.deepgram.stt"):
+            await stt.send(b"x")
+        assert any(
+            "deepgram send failed" in rec.message for rec in caplog.records
+        ), "expected the swallowed-error log line"
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_transcript_callback_normalizes_none_confidence(fake_deepgram_client):
-    """Deepgram occasionally returns confidence=None; we replace with 1.0
-    rather than 0.0 (which would mask worst-case misheard turns)."""
-    from deepgram import LiveTranscriptionEvents
+async def test_translates_start_of_turn_to_speech_started(
+    fake_v2_connection
+):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
-    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
-
-    alt = SimpleNamespace(transcript="ok", confidence=None)
-    result = SimpleNamespace(
-        channel=SimpleNamespace(alternatives=[alt]),
-        is_final=True,
-    )
-    await handler(stt, result)
-
-    received = []
-    async def consume():
-        async for event in stt.events():
-            received.append(event)
-
-    task = asyncio.create_task(consume())
-    await asyncio.sleep(0)
-    await stt.close()
-    await task
-
-    assert len(received) == 1
-    assert received[0].confidence == 1.0
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="StartOfTurn")
+        )
+        # Drain one event then close.
+        ev = await _next_event(stt)
+        assert isinstance(ev, SpeechStartedEvent)
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_error_callback_surfaces_as_exception_from_events(fake_deepgram_client):
-    from deepgram import LiveTranscriptionEvents
+async def test_translates_update_to_interim_transcript(
+    fake_v2_connection
+):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
-    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Error]
-    await handler(stt, "ws closed unexpectedly")
-
-    with pytest.raises(RuntimeError, match="deepgram error"):
-        async for _event in stt.events():
-            pass
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="Update", transcript="hi there", confidence=0.8)
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, TranscriptEvent)
+        assert ev.text == "hi there"
+        assert ev.is_final is False
+        assert ev.confidence == pytest.approx(0.8)
+    finally:
+        await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_close_terminates_events_iterator(fake_deepgram_client):
+async def test_translates_eager_end_of_turn(fake_v2_connection):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="EagerEndOfTurn")
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, EarlyTurnEndEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_translates_turn_resumed(fake_v2_connection):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="TurnResumed")
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, TurnResumedEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_translates_end_of_turn_to_final_transcript(
+    fake_v2_connection
+):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(
+                event="EndOfTurn", transcript="hello world", confidence=0.92
+            )
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, TranscriptEvent)
+        assert ev.text == "hello world"
+        assert ev.is_final is True
+        assert ev.confidence == pytest.approx(0.92)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_update_with_empty_transcript_is_dropped(
+    fake_v2_connection
+):
+    """Flux occasionally sends 'Update' with an empty transcript on
+    barge-in or noise — translator drops them so downstream interim
+    handling doesn't see phantom ''."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="Update", transcript="")
+        )
+        # Followed by something we DO expect, so the consumer wakes up.
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="StartOfTurn")
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, SpeechStartedEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_turn_info_event_is_ignored(
+    fake_v2_connection
+):
+    """A future Flux release adding a new event type must not crash
+    a live call. Translator drops unknowns and continues."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="SomeFutureEvent")
+        )
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="StartOfTurn")
+        )
+        ev = await _next_event(stt)
+        assert isinstance(ev, SpeechStartedEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_events_iterator(fake_v2_connection):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
@@ -258,42 +359,199 @@ async def test_close_terminates_events_iterator(fake_deepgram_client):
     async for event in stt.events():
         received.append(event)
     assert received == []
-    fake_deepgram_client.finish.assert_awaited_once()
+    fake_v2_connection.send_close_stream.assert_awaited()
 
 
 @pytest.mark.asyncio
-async def test_speech_started_callback_emits_event(fake_deepgram_client):
-    """Deepgram's SpeechStarted event becomes a SpeechStartedEvent on
-    the queue.
+async def test_translates_dict_form_messages(fake_v2_connection):
+    """Production path: deepgram-sdk 7.1's ``recv()`` returns plain
+    dicts because ``construct_type`` on a Union doesn't pick a
+    discriminator and falls through to the raw JSON. The translator
+    must route by the dict's ``type`` field directly.
 
-    The live Deepgram SDK invokes the SpeechStarted callback with just
-    the connection handle — NO second positional argument — unlike the
-    Transcript and Error callbacks which both receive a payload. We
-    invoke the handler the same way here (single positional arg) so a
-    regression that removes the `= None` default on _event is caught
-    by tests instead of by a real call (call CA061e6bf3 on 2026-05-06
-    crashed for exactly this reason)."""
-    from deepgram import LiveTranscriptionEvents
+    Without this path the live call sees recv messages, drops every
+    one in ``_translate``, and the silence watchdog fires after 10s
+    despite the caller speaking — that's the bug a 2026-05-06 live
+    call surfaced before this test pinned the dict shape."""
     from app.deepgram.stt import DeepgramSTT
-    from app.stt.base import SpeechStartedEvent
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
-    handler = fake_deepgram_client._handlers[
-        LiveTranscriptionEvents.SpeechStarted
-    ]
-    # Mirror the live SDK: single positional arg (the connection handle).
-    await handler(stt)
+    try:
+        # Connected (lifecycle, no consumer event).
+        fake_v2_connection._recv_queue.put_nowait(
+            {"type": "Connected", "request_id": "abc", "sequence_id": 0}
+        )
+        # StartOfTurn — should produce SpeechStartedEvent.
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "StartOfTurn",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 0.24,
+                "transcript": "",
+                "words": [],
+                "end_of_turn_confidence": 0.05,
+                "sequence_id": 1,
+            }
+        )
+        # Update with text — should produce interim TranscriptEvent.
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "Update",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.0,
+                "transcript": "and a coke",
+                "words": [
+                    {"word": "and", "confidence": 0.9},
+                    {"word": "a", "confidence": 0.85},
+                    {"word": "coke", "confidence": 0.95},
+                ],
+                "end_of_turn_confidence": 0.4,
+                "sequence_id": 2,
+            }
+        )
+        # EndOfTurn — final TranscriptEvent.
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "EndOfTurn",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.5,
+                "transcript": "and a Coke.",
+                "words": [
+                    {"word": "and", "confidence": 0.93},
+                    {"word": "a", "confidence": 0.88},
+                    {"word": "Coke.", "confidence": 0.97},
+                ],
+                "end_of_turn_confidence": 0.92,
+                "sequence_id": 3,
+            }
+        )
 
-    received = []
+        first = await _next_event(stt)
+        assert isinstance(first, SpeechStartedEvent)
 
-    async def consume():
-        async for event in stt.events():
-            received.append(event)
+        second = await _next_event(stt)
+        assert isinstance(second, TranscriptEvent)
+        assert second.is_final is False
+        assert second.text == "and a coke"
+        assert second.confidence == pytest.approx((0.9 + 0.85 + 0.95) / 3)
 
-    task = asyncio.create_task(consume())
-    await asyncio.sleep(0)
-    await stt.close()
-    await task
+        third = await _next_event(stt)
+        assert isinstance(third, TranscriptEvent)
+        assert third.is_final is True
+        assert third.text == "and a Coke."
+    finally:
+        await stt.close()
 
-    assert received == [SpeechStartedEvent()]
+
+@pytest.mark.asyncio
+async def test_translates_dict_form_speculation_events(fake_v2_connection):
+    """EagerEndOfTurn and TurnResumed must also route via the dict
+    path. The session consumer drops them in this PR, but the
+    provider still has to translate them so the speculation-aware
+    follow-up PR doesn't have to revisit the wire-format question."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "EagerEndOfTurn",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.0,
+                "transcript": "",
+                "words": [],
+                "end_of_turn_confidence": 0.7,
+                "sequence_id": 1,
+            }
+        )
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "TurnInfo",
+                "request_id": "abc",
+                "event": "TurnResumed",
+                "turn_index": 0,
+                "audio_window_start": 0.0,
+                "audio_window_end": 1.2,
+                "transcript": "",
+                "words": [],
+                "end_of_turn_confidence": 0.3,
+                "sequence_id": 2,
+            }
+        )
+
+        first = await _next_event(stt)
+        assert isinstance(first, EarlyTurnEndEvent)
+        second = await _next_event(stt)
+        assert isinstance(second, TurnResumedEvent)
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_dict_form_configure_failure_surfaces_error(fake_v2_connection):
+    """A ConfigureFailure dict from Flux should raise out of events()
+    so the call-flow can react (today: end the call cleanly)."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            {
+                "type": "ConfigureFailure",
+                "request_id": "abc",
+                "sequence_id": 1,
+                "description": "bad model",
+            }
+        )
+        with pytest.raises(RuntimeError, match="deepgram error"):
+            async for _ev in stt.events():
+                pass
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_recv_exception_surfaces_as_runtime_error(fake_v2_connection):
+    """If the SDK's recv() raises (e.g. WS dropped mid-call), the
+    error should surface from events() so the consumer can react.
+    Errors aren't silently swallowed — that would feel like dead air
+    to whoever's debugging the call."""
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    fake_v2_connection.recv = AsyncMock(side_effect=RuntimeError("ws dropped"))
+
+    await stt.open()
+    try:
+        with pytest.raises(RuntimeError, match="deepgram error"):
+            async for _ev in stt.events():
+                pass
+    finally:
+        await stt.close()
+
+
+# Helpers ----------------------------------------------------------------
+
+
+async def _next_event(stt: Any):
+    """Drain a single event from stt.events() without leaving the
+    iterator open. Tests use this to assert one-event-per-input."""
+    event_iter = stt.events()
+    # asyncio.wait_for guards against the consumer hanging when a test
+    # has misconfigured the recv queue.
+    return await asyncio.wait_for(event_iter.__anext__(), timeout=1.0)

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -40,10 +40,7 @@ def _make_turn_info(*, event: str, transcript: str = "", confidence: float = 0.9
     )
 
     words = (
-        [
-            ListenV2TurnInfoWordsItem(word=w, confidence=confidence)
-            for w in transcript.split()
-        ]
+        [ListenV2TurnInfoWordsItem(word=w, confidence=confidence) for w in transcript.split()]
         if transcript
         else []
     )
@@ -96,9 +93,7 @@ def fake_v2_connection(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_open_calls_v2_connect_with_configured_options(
-    fake_v2_connection, monkeypatch
-):
+async def test_open_calls_v2_connect_with_configured_options(fake_v2_connection, monkeypatch):
     from app.config import settings
     from app.deepgram.stt import DeepgramSTT
 
@@ -132,9 +127,7 @@ async def test_env_keyterms_override_replaces_constructor_list(
 
     monkeypatch.setattr(settings, "stt_keyterms", "alpha, beta , gamma")
 
-    stt = DeepgramSTT(
-        call_sid="CAtest", keyterms=["Twilight", "Pepper Shrimp"]
-    )
+    stt = DeepgramSTT(call_sid="CAtest", keyterms=["Twilight", "Pepper Shrimp"])
     with caplog.at_level("WARNING", logger="app.deepgram.stt"):
         await stt.open()
     try:
@@ -143,7 +136,8 @@ async def test_env_keyterms_override_replaces_constructor_list(
         # Override is process-wide and silently kills per-tenant biasing,
         # so it must log loudly with the call_sid for traceability.
         override_warnings = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelname == "WARNING" and "STT_KEYTERMS env override" in r.message
         ]
         assert len(override_warnings) == 1
@@ -198,33 +192,27 @@ async def test_send_swallows_sdk_exceptions(fake_v2_connection, caplog):
 
     from app.deepgram.stt import DeepgramSTT
 
-    fake_v2_connection.send_media = AsyncMock(
-        side_effect=RuntimeError("dropped")
-    )
+    fake_v2_connection.send_media = AsyncMock(side_effect=RuntimeError("dropped"))
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
     try:
         with caplog.at_level(logging.ERROR, logger="app.deepgram.stt"):
             await stt.send(b"x")
-        assert any(
-            "deepgram send failed" in rec.message for rec in caplog.records
-        ), "expected the swallowed-error log line"
+        assert any("deepgram send failed" in rec.message for rec in caplog.records), (
+            "expected the swallowed-error log line"
+        )
     finally:
         await stt.close()
 
 
 @pytest.mark.asyncio
-async def test_translates_start_of_turn_to_speech_started(
-    fake_v2_connection
-):
+async def test_translates_start_of_turn_to_speech_started(fake_v2_connection):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
     try:
-        fake_v2_connection._recv_queue.put_nowait(
-            _make_turn_info(event="StartOfTurn")
-        )
+        fake_v2_connection._recv_queue.put_nowait(_make_turn_info(event="StartOfTurn"))
         # Drain one event then close.
         ev = await _next_event(stt)
         assert isinstance(ev, SpeechStartedEvent)
@@ -233,9 +221,7 @@ async def test_translates_start_of_turn_to_speech_started(
 
 
 @pytest.mark.asyncio
-async def test_translates_update_to_interim_transcript(
-    fake_v2_connection
-):
+async def test_translates_update_to_interim_transcript(fake_v2_connection):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
@@ -260,9 +246,7 @@ async def test_translates_eager_end_of_turn(fake_v2_connection):
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
     try:
-        fake_v2_connection._recv_queue.put_nowait(
-            _make_turn_info(event="EagerEndOfTurn")
-        )
+        fake_v2_connection._recv_queue.put_nowait(_make_turn_info(event="EagerEndOfTurn"))
         ev = await _next_event(stt)
         assert isinstance(ev, EarlyTurnEndEvent)
     finally:
@@ -276,9 +260,7 @@ async def test_translates_turn_resumed(fake_v2_connection):
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
     try:
-        fake_v2_connection._recv_queue.put_nowait(
-            _make_turn_info(event="TurnResumed")
-        )
+        fake_v2_connection._recv_queue.put_nowait(_make_turn_info(event="TurnResumed"))
         ev = await _next_event(stt)
         assert isinstance(ev, TurnResumedEvent)
     finally:
@@ -286,18 +268,14 @@ async def test_translates_turn_resumed(fake_v2_connection):
 
 
 @pytest.mark.asyncio
-async def test_translates_end_of_turn_to_final_transcript(
-    fake_v2_connection
-):
+async def test_translates_end_of_turn_to_final_transcript(fake_v2_connection):
     from app.deepgram.stt import DeepgramSTT
 
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
     try:
         fake_v2_connection._recv_queue.put_nowait(
-            _make_turn_info(
-                event="EndOfTurn", transcript="hello world", confidence=0.92
-            )
+            _make_turn_info(event="EndOfTurn", transcript="hello world", confidence=0.92)
         )
         ev = await _next_event(stt)
         assert isinstance(ev, TranscriptEvent)
@@ -309,9 +287,7 @@ async def test_translates_end_of_turn_to_final_transcript(
 
 
 @pytest.mark.asyncio
-async def test_update_with_empty_transcript_is_dropped(
-    fake_v2_connection
-):
+async def test_update_with_empty_transcript_is_dropped(fake_v2_connection):
     """Flux occasionally sends 'Update' with an empty transcript on
     barge-in or noise — translator drops them so downstream interim
     handling doesn't see phantom ''."""
@@ -320,13 +296,9 @@ async def test_update_with_empty_transcript_is_dropped(
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
     try:
-        fake_v2_connection._recv_queue.put_nowait(
-            _make_turn_info(event="Update", transcript="")
-        )
+        fake_v2_connection._recv_queue.put_nowait(_make_turn_info(event="Update", transcript=""))
         # Followed by something we DO expect, so the consumer wakes up.
-        fake_v2_connection._recv_queue.put_nowait(
-            _make_turn_info(event="StartOfTurn")
-        )
+        fake_v2_connection._recv_queue.put_nowait(_make_turn_info(event="StartOfTurn"))
         ev = await _next_event(stt)
         assert isinstance(ev, SpeechStartedEvent)
     finally:
@@ -334,9 +306,7 @@ async def test_update_with_empty_transcript_is_dropped(
 
 
 @pytest.mark.asyncio
-async def test_unknown_turn_info_event_is_ignored(
-    fake_v2_connection
-):
+async def test_unknown_turn_info_event_is_ignored(fake_v2_connection):
     """A future Flux release adding a new event type must not crash
     a live call. Translator drops unknowns and continues."""
     from app.deepgram.stt import DeepgramSTT
@@ -344,12 +314,8 @@ async def test_unknown_turn_info_event_is_ignored(
     stt = DeepgramSTT(call_sid="CAtest")
     await stt.open()
     try:
-        fake_v2_connection._recv_queue.put_nowait(
-            _make_turn_info(event="SomeFutureEvent")
-        )
-        fake_v2_connection._recv_queue.put_nowait(
-            _make_turn_info(event="StartOfTurn")
-        )
+        fake_v2_connection._recv_queue.put_nowait(_make_turn_info(event="SomeFutureEvent"))
+        fake_v2_connection._recv_queue.put_nowait(_make_turn_info(event="StartOfTurn"))
         ev = await _next_event(stt)
         assert isinstance(ev, SpeechStartedEvent)
     finally:

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -125,7 +125,7 @@ async def test_open_calls_v2_connect_with_configured_options(
 
 @pytest.mark.asyncio
 async def test_env_keyterms_override_replaces_constructor_list(
-    fake_v2_connection, monkeypatch
+    fake_v2_connection, monkeypatch, caplog
 ):
     from app.config import settings
     from app.deepgram.stt import DeepgramSTT
@@ -135,10 +135,19 @@ async def test_env_keyterms_override_replaces_constructor_list(
     stt = DeepgramSTT(
         call_sid="CAtest", keyterms=["Twilight", "Pepper Shrimp"]
     )
-    await stt.open()
+    with caplog.at_level("WARNING", logger="app.deepgram.stt"):
+        await stt.open()
     try:
         kwargs = fake_v2_connection._connect_mock.call_args.kwargs
         assert kwargs["keyterm"] == ["alpha", "beta", "gamma"]
+        # Override is process-wide and silently kills per-tenant biasing,
+        # so it must log loudly with the call_sid for traceability.
+        override_warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and "STT_KEYTERMS env override" in r.message
+        ]
+        assert len(override_warnings) == 1
+        assert "CAtest" in override_warnings[0].message
     finally:
         await stt.close()
 

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -1,0 +1,261 @@
+"""Tests for app/deepgram/stt.py — DeepgramSTT plugin.
+
+The Deepgram SDK is the only thing mocked; everything else exercises
+real plugin code (queue plumbing, callback wiring, options building).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.stt.base import TranscriptEvent
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch):
+    """Every test needs the api key set so _api_key() doesn't raise."""
+    from app.config import settings
+    monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
+
+
+@pytest.fixture
+def fake_deepgram_client(monkeypatch):
+    """Replace DeepgramClient inside app.deepgram.stt with a fake."""
+    fake_conn = AsyncMock()
+    fake_conn.send = AsyncMock()
+    fake_conn.finish = AsyncMock()
+    fake_conn.start = AsyncMock(return_value=True)
+    fake_conn._handlers = {}
+
+    def fake_on(event, handler):
+        fake_conn._handlers[event] = handler
+
+    fake_conn.on = MagicMock(side_effect=fake_on)
+
+    fake_listen = MagicMock()
+    fake_listen.asynclive.v = MagicMock(return_value=fake_conn)
+    fake_client = MagicMock()
+    fake_client.listen = fake_listen
+
+    monkeypatch.setattr(
+        "app.deepgram.stt.DeepgramClient",
+        MagicMock(return_value=fake_client),
+    )
+    return fake_conn
+
+
+@pytest.mark.asyncio
+async def test_open_starts_connection_with_configured_options(
+    fake_deepgram_client, monkeypatch,
+):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "stt_model", "nova-3")
+    monkeypatch.setattr(settings, "stt_endpointing_ms", 600)
+    monkeypatch.setattr(settings, "stt_utterance_end_ms", 1200)
+    monkeypatch.setattr(settings, "stt_keyterms", "tikka,naan")
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+
+    fake_deepgram_client.start.assert_awaited_once()
+    options = fake_deepgram_client.start.await_args.args[0]
+    assert options.model == "nova-3"
+    assert options.endpointing == 600
+    assert options.utterance_end_ms == 1200
+    assert options.keyterm == ["tikka", "naan"]
+    assert options.encoding == "mulaw"
+    assert options.sample_rate == 8000
+
+
+@pytest.mark.asyncio
+async def test_keyterms_empty_string_yields_none(fake_deepgram_client, monkeypatch):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "stt_keyterms", "")
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+
+    options = fake_deepgram_client.start.await_args.args[0]
+    assert options.keyterm is None
+
+
+@pytest.mark.asyncio
+async def test_open_raises_when_start_returns_false(fake_deepgram_client):
+    from app.deepgram.stt import DeepgramSTT
+
+    fake_deepgram_client.start = AsyncMock(return_value=False)
+    stt = DeepgramSTT(call_sid="CAtest")
+    with pytest.raises(RuntimeError, match="failed to start"):
+        await stt.open()
+
+
+@pytest.mark.asyncio
+async def test_open_raises_when_api_key_missing(monkeypatch, fake_deepgram_client):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "deepgram_api_key", None)
+    stt = DeepgramSTT(call_sid="CAtest")
+    with pytest.raises(RuntimeError, match="DEEPGRAM_API_KEY not set"):
+        await stt.open()
+
+
+@pytest.mark.asyncio
+async def test_send_forwards_audio_to_sdk(fake_deepgram_client):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    await stt.send(b"\x01\x02\x03")
+
+    fake_deepgram_client.send.assert_awaited_once_with(b"\x01\x02\x03")
+
+
+@pytest.mark.asyncio
+async def test_send_swallows_sdk_exceptions(fake_deepgram_client, caplog):
+    import logging
+    from app.deepgram.stt import DeepgramSTT
+
+    fake_deepgram_client.send = AsyncMock(side_effect=RuntimeError("dropped"))
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+
+    with caplog.at_level(logging.ERROR, logger="app.deepgram.stt"):
+        await stt.send(b"x")
+
+    assert any(
+        "deepgram send failed" in rec.message for rec in caplog.records
+    ), "expected the swallowed-error log line"
+
+
+@pytest.mark.asyncio
+async def test_transcript_callback_emits_events_in_order(fake_deepgram_client):
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
+
+    def make_result(text: str, is_final: bool, confidence: float):
+        alt = SimpleNamespace(transcript=text, confidence=confidence)
+        channel = SimpleNamespace(alternatives=[alt])
+        return SimpleNamespace(channel=channel, is_final=is_final)
+
+    await handler(stt, make_result("hi", False, 0.7))
+    await handler(stt, make_result("hello", True, 0.95))
+
+    received = []
+    async def consume():
+        async for event in stt.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    await stt.close()
+    await task
+
+    assert received == [
+        TranscriptEvent("hi", False, 0.7),
+        TranscriptEvent("hello", True, 0.95),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcript_callback_skips_empty_text(fake_deepgram_client):
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
+
+    alt = SimpleNamespace(transcript="   ", confidence=0.9)
+    result = SimpleNamespace(
+        channel=SimpleNamespace(alternatives=[alt]),
+        is_final=True,
+    )
+    await handler(stt, result)
+
+    received = []
+    async def consume():
+        async for event in stt.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    await stt.close()
+    await task
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_transcript_callback_normalizes_none_confidence(fake_deepgram_client):
+    """Deepgram occasionally returns confidence=None; we replace with 1.0
+    rather than 0.0 (which would mask worst-case misheard turns)."""
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Transcript]
+
+    alt = SimpleNamespace(transcript="ok", confidence=None)
+    result = SimpleNamespace(
+        channel=SimpleNamespace(alternatives=[alt]),
+        is_final=True,
+    )
+    await handler(stt, result)
+
+    received = []
+    async def consume():
+        async for event in stt.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    await stt.close()
+    await task
+
+    assert len(received) == 1
+    assert received[0].confidence == 1.0
+
+
+@pytest.mark.asyncio
+async def test_error_callback_surfaces_as_exception_from_events(fake_deepgram_client):
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    handler = fake_deepgram_client._handlers[LiveTranscriptionEvents.Error]
+    await handler(stt, "ws closed unexpectedly")
+
+    with pytest.raises(RuntimeError, match="deepgram error"):
+        async for _event in stt.events():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_close_terminates_events_iterator(fake_deepgram_client):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    await stt.close()
+
+    received = []
+    async for event in stt.events():
+        received.append(event)
+    assert received == []
+    fake_deepgram_client.finish.assert_awaited_once()

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -259,3 +259,32 @@ async def test_close_terminates_events_iterator(fake_deepgram_client):
         received.append(event)
     assert received == []
     fake_deepgram_client.finish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_speech_started_callback_emits_event(fake_deepgram_client):
+    """Deepgram's SpeechStarted event becomes a SpeechStartedEvent on
+    the queue."""
+    from deepgram import LiveTranscriptionEvents
+    from app.deepgram.stt import DeepgramSTT
+    from app.stt.base import SpeechStartedEvent
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    handler = fake_deepgram_client._handlers[
+        LiveTranscriptionEvents.SpeechStarted
+    ]
+    await handler(stt, None)
+
+    received = []
+
+    async def consume():
+        async for event in stt.events():
+            received.append(event)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0)
+    await stt.close()
+    await task
+
+    assert received == [SpeechStartedEvent()]

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -264,7 +264,15 @@ async def test_close_terminates_events_iterator(fake_deepgram_client):
 @pytest.mark.asyncio
 async def test_speech_started_callback_emits_event(fake_deepgram_client):
     """Deepgram's SpeechStarted event becomes a SpeechStartedEvent on
-    the queue."""
+    the queue.
+
+    The live Deepgram SDK invokes the SpeechStarted callback with just
+    the connection handle — NO second positional argument — unlike the
+    Transcript and Error callbacks which both receive a payload. We
+    invoke the handler the same way here (single positional arg) so a
+    regression that removes the `= None` default on _event is caught
+    by tests instead of by a real call (call CA061e6bf3 on 2026-05-06
+    crashed for exactly this reason)."""
     from deepgram import LiveTranscriptionEvents
     from app.deepgram.stt import DeepgramSTT
     from app.stt.base import SpeechStartedEvent
@@ -274,7 +282,8 @@ async def test_speech_started_callback_emits_event(fake_deepgram_client):
     handler = fake_deepgram_client._handlers[
         LiveTranscriptionEvents.SpeechStarted
     ]
-    await handler(stt, None)
+    # Mirror the live SDK: single positional arg (the connection handle).
+    await handler(stt)
 
     received = []
 

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -94,9 +94,7 @@ def mock_pipeline(monkeypatch):
     )
     monkeypatch.setattr("app.telephony.router.speak", fake_speak)
     monkeypatch.setattr("app.telephony.session.speak", fake_speak)
-    monkeypatch.setattr(
-        "app.telephony.session.stream_reply", _make_fake_stream_reply()
-    )
+    monkeypatch.setattr("app.telephony.session.stream_reply", _make_fake_stream_reply())
     monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
@@ -756,9 +754,7 @@ async def test_media_stream_swallows_runtimeerror_after_server_close(monkeypatch
 
     ws = AsyncMock()
     ws.receive_text = AsyncMock(
-        side_effect=RuntimeError(
-            'WebSocket is not connected. Need to call "accept" first.'
-        )
+        side_effect=RuntimeError('WebSocket is not connected. Need to call "accept" first.')
     )
 
     # Must NOT raise — the handler should swallow the RuntimeError.
@@ -773,9 +769,7 @@ async def test_media_stream_propagates_runtimeerror_when_no_pending_hangup(monke
     from app.telephony import router as router_mod
 
     ws = AsyncMock()
-    ws.receive_text = AsyncMock(
-        side_effect=RuntimeError("something genuinely unexpected")
-    )
+    ws.receive_text = AsyncMock(side_effect=RuntimeError("something genuinely unexpected"))
 
     with pytest.raises(RuntimeError, match="something genuinely unexpected"):
         await router_mod.media_stream(ws)

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -732,6 +732,55 @@ async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
     assert not state.should_hangup.is_set()
 
 
+@pytest.mark.asyncio
+async def test_media_stream_swallows_runtimeerror_after_server_close(monkeypatch):
+    """Server-initiated close (auto-hangup #78) flips Starlette's
+    application_state to DISCONNECTED before the close frame is sent.
+    The next receive_text() iteration then raises RuntimeError instead
+    of WebSocketDisconnect — the handler must treat this as a clean
+    disconnect when should_hangup is set, so the error doesn't surface
+    as 'Exception in ASGI application'."""
+    from app.telephony import router as router_mod
+    from app.telephony.session import _CallState
+
+    # Pre-arm should_hangup so the RuntimeError handler treats the
+    # error as the expected post-close path. Mirrors what
+    # _hang_up_after_grace does in production right before close().
+    original_init = _CallState.__init__
+
+    def patched_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        self.should_hangup.set()
+
+    monkeypatch.setattr(_CallState, "__init__", patched_init)
+
+    ws = AsyncMock()
+    ws.receive_text = AsyncMock(
+        side_effect=RuntimeError(
+            'WebSocket is not connected. Need to call "accept" first.'
+        )
+    )
+
+    # Must NOT raise — the handler should swallow the RuntimeError.
+    await router_mod.media_stream(ws)
+
+
+@pytest.mark.asyncio
+async def test_media_stream_propagates_runtimeerror_when_no_pending_hangup(monkeypatch):
+    """If the loop hits a RuntimeError without should_hangup set, that's
+    a real bug — must propagate, not be silently swallowed by the
+    auto-hangup-tolerant handler."""
+    from app.telephony import router as router_mod
+
+    ws = AsyncMock()
+    ws.receive_text = AsyncMock(
+        side_effect=RuntimeError("something genuinely unexpected")
+    )
+
+    with pytest.raises(RuntimeError, match="something genuinely unexpected"):
+        await router_mod.media_stream(ws)
+
+
 def test_looks_like_goodbye_excludes_coming_right_up():
     """'coming right up' is mid-order, not a wrap-up — must NOT trigger fallback."""
     from app.telephony.session import _looks_like_goodbye

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -21,7 +21,7 @@ from app.llm.client import LLMResponse, StreamEvent
 from app.main import app
 from app.orders.models import Order
 from app.storage import restaurants as restaurants_storage
-from app.telephony.router import _MIN_CHUNK_CHARS, _should_flush_chunk
+from app.telephony.session import _MIN_CHUNK_CHARS, _should_flush_chunk
 
 client = TestClient(app)
 
@@ -93,8 +93,9 @@ def mock_pipeline(monkeypatch):
         lambda **kw: (fake_stt, "deepgram"),
     )
     monkeypatch.setattr("app.telephony.router.speak", fake_speak)
+    monkeypatch.setattr("app.telephony.session.speak", fake_speak)
     monkeypatch.setattr(
-        "app.telephony.router.stream_reply", _make_fake_stream_reply()
+        "app.telephony.session.stream_reply", _make_fake_stream_reply()
     )
     monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
@@ -388,7 +389,7 @@ def test_media_stream_finalizes_recording_on_stop(mock_pipeline, monkeypatch):
 
 def test_ai_greeting_spawned_on_start(mock_pipeline, monkeypatch):
     """On start event, stream_reply is called with GREETING_TRANSCRIPT."""
-    from app.telephony.router import GREETING_TRANSCRIPT
+    from app.telephony.session import GREETING_TRANSCRIPT
 
     calls: list[str] = []
 
@@ -397,7 +398,7 @@ def test_ai_greeting_spawned_on_start(mock_pipeline, monkeypatch):
         yield StreamEvent(text_delta="Hello!")
         yield StreamEvent(final=LLMResponse(reply_text="Hello!", order=order, history=history))
 
-    monkeypatch.setattr("app.telephony.router.stream_reply", recording_stream_reply)
+    monkeypatch.setattr("app.telephony.session.stream_reply", recording_stream_reply)
 
     with client.websocket_connect("/media-stream") as ws:
         ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
@@ -442,7 +443,7 @@ def test_stop_event_persists_ready_order(mock_pipeline, monkeypatch):
         persisted.append(order)
         return order
 
-    monkeypatch.setattr("app.telephony.router.stream_reply", fake_stream_reply)
+    monkeypatch.setattr("app.telephony.session.stream_reply", fake_stream_reply)
     monkeypatch.setattr("app.telephony.router.persist_on_confirm", fake_persist)
 
     with client.websocket_connect("/media-stream") as ws:
@@ -490,8 +491,8 @@ async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
     first_audio Firestore event detail because it arrives before speak()
     fires for the first time."""
     from app.storage import call_sessions
-    from app.telephony import router as router_mod
-    from app.telephony.router import _CallState, _run_llm_tts_turn
+    from app.telephony import session as session_mod
+    from app.telephony.session import _CallState, _run_llm_tts_turn
 
     first_timing = {
         "ttft_seconds": 0.8,
@@ -536,10 +537,10 @@ async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
     def fake_bg_call_event(call_sid, rid, **kwargs):
         recorded_events.append({"call_sid": call_sid, "rid": rid, **kwargs})
 
-    monkeypatch.setattr(router_mod, "stream_reply", fake_stream_reply_tool_only_then_text)
-    monkeypatch.setattr(router_mod, "speak", fake_speak)
-    monkeypatch.setattr(router_mod, "_bg_call_event", fake_bg_call_event)
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "stream_reply", fake_stream_reply_tool_only_then_text)
+    monkeypatch.setattr(session_mod, "speak", fake_speak)
+    monkeypatch.setattr(session_mod, "_bg_call_event", fake_bg_call_event)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
 
     state = _CallState(
@@ -598,7 +599,7 @@ async def test_send_clear_skips_when_stream_sid_missing():
 
 
 def test_looks_like_goodbye_matches_terminal_phrases():
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert _looks_like_goodbye("Great, your order is in — we'll have it ready for you soon!")
     assert _looks_like_goodbye("Perfect, see you soon!")
@@ -608,7 +609,7 @@ def test_looks_like_goodbye_matches_terminal_phrases():
 
 def test_looks_like_goodbye_rejects_questions():
     """A reply that ends with '?' is still asking the caller something."""
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert not _looks_like_goodbye("Got that. Anything else, or are you all set?")
     # Even with goodbye-shaped phrasing earlier, trailing '?' = still asking.
@@ -618,7 +619,7 @@ def test_looks_like_goodbye_rejects_questions():
 def test_looks_like_goodbye_rejects_simple_acknowledgements():
     """Bot acknowledging an item mid-conversation must NOT trigger the
     auto-hangup fallback."""
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert not _looks_like_goodbye("One large margarita, got it.")
     assert not _looks_like_goodbye("Sure, what size would you like?")
@@ -628,7 +629,7 @@ def test_looks_like_goodbye_rejects_simple_acknowledgements():
 
 @pytest.mark.asyncio
 async def test_send_mark_emits_mark_payload():
-    from app.telephony.router import END_OF_CALL_MARK
+    from app.telephony.session import END_OF_CALL_MARK
     from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
@@ -648,7 +649,7 @@ async def test_send_mark_emits_mark_payload():
 
 @pytest.mark.asyncio
 async def test_send_mark_returns_false_when_stream_sid_missing():
-    from app.telephony.router import END_OF_CALL_MARK
+    from app.telephony.session import END_OF_CALL_MARK
     from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
@@ -663,13 +664,13 @@ async def test_hang_up_after_grace_sets_should_hangup_event(monkeypatch):
     should_hangup event so the loop exits and the WebSocket closes —
     Twilio's <Connect> ends and the call hangs up. The REST update path
     is gone (it 404'd on <Connect>-state calls)."""
-    from app.telephony.router import (
+    from app.telephony.session import (
         HANGUP_GRACE_SECONDS,
         _CallState,
         _hang_up_after_grace,
     )
 
-    monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr("app.telephony.session.HANGUP_GRACE_SECONDS", 0.01)
 
     state = _CallState(call_sid="CAtest", pending_hangup=True)
     assert not state.should_hangup.is_set()
@@ -684,9 +685,9 @@ async def test_hang_up_after_grace_sets_should_hangup_event(monkeypatch):
 async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
     """If pending_hangup gets cleared during the grace window (caller
     spoke), the should_hangup event MUST NOT fire."""
-    from app.telephony.router import _CallState, _hang_up_after_grace
+    from app.telephony.session import _CallState, _hang_up_after_grace
 
-    monkeypatch.setattr("app.telephony.router.HANGUP_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr("app.telephony.session.HANGUP_GRACE_SECONDS", 0.01)
 
     state = _CallState(call_sid="CAtest", pending_hangup=True)
     # Simulate: caller spoke during the grace window — _handle_final_transcript
@@ -700,7 +701,7 @@ async def test_hang_up_after_grace_aborts_when_caller_speaks(monkeypatch):
 
 def test_looks_like_goodbye_excludes_coming_right_up():
     """'coming right up' is mid-order, not a wrap-up — must NOT trigger fallback."""
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert _looks_like_goodbye("One large Margherita coming right up.") is False
     assert _looks_like_goodbye("Two Cokes coming right up!") is False
@@ -708,7 +709,7 @@ def test_looks_like_goodbye_excludes_coming_right_up():
 
 def test_looks_like_goodbye_remaining_patterns_still_match():
     """Positive coverage so a drive-by removal of a pattern is caught."""
-    from app.telephony.router import _looks_like_goodbye
+    from app.telephony.session import _looks_like_goodbye
 
     assert _looks_like_goodbye("Thanks for ordering, see you soon!")
     assert _looks_like_goodbye("Your order is in — we'll have it ready shortly.")
@@ -719,7 +720,7 @@ def test_looks_like_goodbye_remaining_patterns_still_match():
 
 def test_hangup_grace_seconds_is_five():
     """Grace window must be 5s so callers can add late items."""
-    from app.telephony.router import HANGUP_GRACE_SECONDS
+    from app.telephony.session import HANGUP_GRACE_SECONDS
 
     assert HANGUP_GRACE_SECONDS == 5.0
 
@@ -730,13 +731,13 @@ async def test_mark_echo_timeout_fires_grace_window(monkeypatch):
     the grace window anyway so the call terminates."""
     import asyncio
 
-    from app.telephony import router as router_mod
-    from app.telephony.router import (
+    from app.telephony import session as session_mod
+    from app.telephony.session import (
         _CallState,
         _hang_up_after_mark_timeout,
     )
 
-    monkeypatch.setattr(router_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(session_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
 
     state = _CallState()
     state.call_sid = "CA_timeout_test"
@@ -747,7 +748,7 @@ async def test_mark_echo_timeout_fires_grace_window(monkeypatch):
     async def fake_grace(s):
         grace_started["flag"] = True
 
-    monkeypatch.setattr(router_mod, "_hang_up_after_grace", fake_grace)
+    monkeypatch.setattr(session_mod, "_hang_up_after_grace", fake_grace)
 
     await _hang_up_after_mark_timeout(state)
 
@@ -762,10 +763,10 @@ async def test_mark_echo_timeout_skips_grace_when_pending_hangup_cleared(monkeyp
     _abort_pending_hangup raced), the timeout must NOT fire the grace window."""
     import asyncio
 
-    from app.telephony import router as router_mod
-    from app.telephony.router import _CallState, _hang_up_after_mark_timeout
+    from app.telephony import session as session_mod
+    from app.telephony.session import _CallState, _hang_up_after_mark_timeout
 
-    monkeypatch.setattr(router_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(session_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.05)
 
     state = _CallState()
     state.call_sid = "CA_abort_race"
@@ -776,7 +777,7 @@ async def test_mark_echo_timeout_skips_grace_when_pending_hangup_cleared(monkeyp
     async def fake_grace(s):
         grace_started["flag"] = True
 
-    monkeypatch.setattr(router_mod, "_hang_up_after_grace", fake_grace)
+    monkeypatch.setattr(session_mod, "_hang_up_after_grace", fake_grace)
 
     await _hang_up_after_mark_timeout(state)
 
@@ -791,7 +792,7 @@ async def test_abort_pending_hangup_cancels_mark_timeout_task():
     timer doesn't fire after the caller speaks during the grace window."""
     import asyncio
 
-    from app.telephony.router import _abort_pending_hangup, _CallState
+    from app.telephony.session import _abort_pending_hangup, _CallState
 
     state = _CallState(call_sid="CAtest", pending_hangup=True)
 
@@ -894,9 +895,9 @@ def test_run_llm_tts_turn_flushes_at_long_comma_clause(monkeypatch, mock_pipelin
     async def capture_speak(text, websocket, stream_sid, **kw):
         chunks_spoken.append(text)
 
-    monkeypatch.setattr("app.telephony.router.speak", capture_speak)
+    monkeypatch.setattr("app.telephony.session.speak", capture_speak)
     monkeypatch.setattr(
-        "app.telephony.router.stream_reply",
+        "app.telephony.session.stream_reply",
         _make_fake_stream_reply_deltas(
             "One Chicken Fried Rice coming up,",
             " what size would you like?",
@@ -922,9 +923,9 @@ def test_run_llm_tts_turn_does_not_flush_at_short_comma(monkeypatch, mock_pipeli
     async def capture_speak(text, websocket, stream_sid, **kw):
         chunks_spoken.append(text)
 
-    monkeypatch.setattr("app.telephony.router.speak", capture_speak)
+    monkeypatch.setattr("app.telephony.session.speak", capture_speak)
     monkeypatch.setattr(
-        "app.telephony.router.stream_reply",
+        "app.telephony.session.stream_reply",
         _make_fake_stream_reply_deltas("Got it,", " moving on."),
     )
 
@@ -962,8 +963,8 @@ def test_first_tts_byte_event_emitted_on_turn(mock_pipeline, monkeypatch):
     def capture_bg_event(call_sid, restaurant_id, **kwargs):
         recorded_events.append({"call_sid": call_sid, "rid": restaurant_id, **kwargs})
 
-    monkeypatch.setattr("app.telephony.router.speak", speak_with_callback)
-    monkeypatch.setattr("app.telephony.router._bg_call_event", capture_bg_event)
+    monkeypatch.setattr("app.telephony.session.speak", speak_with_callback)
+    monkeypatch.setattr("app.telephony.session._bg_call_event", capture_bg_event)
 
     with client.websocket_connect("/media-stream") as ws:
         ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
@@ -994,7 +995,7 @@ def test_first_tts_byte_event_emitted_on_turn(mock_pipeline, monkeypatch):
 
 def test_call_state_has_transfer_trigger_fields():
     """The new fields on _CallState are needed by the trigger detector."""
-    from app.telephony.router import _CallState
+    from app.telephony.session import _CallState
 
     state = _CallState()
     assert state.consecutive_low_confidence_turns == 0
@@ -1678,7 +1679,7 @@ def test_voice_after_hours_without_call_sid_bails_with_hangup(monkeypatch):
 def test_call_state_has_in_flight_transcript_field():
     """#170 — _CallState carries the cancelled-turn transcript forward
     so the next turn can prepend it to the new utterance."""
-    from app.telephony.router import _CallState
+    from app.telephony.session import _CallState
 
     state = _CallState()
     assert state.in_flight_transcript == ""
@@ -1694,8 +1695,8 @@ async def test_cancelled_turn_transcript_carried_forward(monkeypatch):
     chicken fried rice because turn 1 was cancelled by turn 2 1s later
     and only "and a coke" reached the model.
     """
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _handle_final_transcript
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
 
     captured: list[str] = []
 
@@ -1704,10 +1705,10 @@ async def test_cancelled_turn_transcript_carried_forward(monkeypatch):
         # Stay in flight long enough to be cancelled by the next call.
         await asyncio.sleep(10.0)
 
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
     # Suppress the silence watchdog — its done_callback would otherwise
     # arm a real watchdog that tries to call the real speak() later.
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     ws = AsyncMock()
@@ -1739,8 +1740,8 @@ async def test_cancelled_turn_transcript_carried_forward(monkeypatch):
 async def test_chained_cancels_accumulate_transcripts(monkeypatch):
     """#170 — a rapid burst of three finals should accumulate. Turn 3
     must see all three concatenated as one combined caller intent."""
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _handle_final_transcript
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
 
     captured: list[str] = []
 
@@ -1748,8 +1749,8 @@ async def test_chained_cancels_accumulate_transcripts(monkeypatch):
         captured.append(transcript)
         await asyncio.sleep(10.0)
 
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     ws = AsyncMock()
@@ -1780,8 +1781,8 @@ async def test_run_llm_tts_turn_clears_in_flight_transcript_on_final(monkeypatch
     """#170 — once a turn completes successfully (yields event.final),
     the carry-forward field must be cleared. The user message is now in
     state.history, so prepending it to the next turn would duplicate it."""
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _run_llm_tts_turn
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _run_llm_tts_turn
 
     async def fake_stream_reply(*, transcript, history, order, **kw):
         yield StreamEvent(final=LLMResponse(reply_text="ok", order=order, history=history))
@@ -1789,9 +1790,9 @@ async def test_run_llm_tts_turn_clears_in_flight_transcript_on_final(monkeypatch
     async def fake_speak(*a, **kw):
         pass
 
-    monkeypatch.setattr(router_mod, "stream_reply", fake_stream_reply)
-    monkeypatch.setattr(router_mod, "speak", fake_speak)
-    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "stream_reply", fake_stream_reply)
+    monkeypatch.setattr(session_mod, "speak", fake_speak)
+    monkeypatch.setattr(session_mod, "_bg_call_event", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     state.in_flight_transcript = "chicken fried rice and a coke"
@@ -1808,8 +1809,8 @@ async def test_errored_turn_carries_transcript_forward(monkeypatch):
     user's words also never reach history. The next final transcript
     must still pick up the carry-forward — same class of bug as cancel,
     different code path."""
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _handle_final_transcript
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
 
     captured: list[str] = []
 
@@ -1823,13 +1824,13 @@ async def test_errored_turn_carries_transcript_forward(monkeypatch):
         captured.append(transcript)
         await asyncio.sleep(10.0)
 
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     ws = AsyncMock()
 
     # Turn 1 errors. in_flight_transcript should remain set.
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", erroring_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", erroring_run_llm_tts_turn)
     await _handle_final_transcript("i'll get one chicken fried rice", state, ws)
     # Wait for the error to propagate.
     if state.llm_task is not None:
@@ -1841,7 +1842,7 @@ async def test_errored_turn_carries_transcript_forward(monkeypatch):
 
     # Turn 2 with a fresh transcript — must still carry forward despite
     # state.llm_task.done() == True (errored, not running).
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", normal_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", normal_run_llm_tts_turn)
     await _handle_final_transcript("and a coke", state, ws)
     await asyncio.sleep(0)
 
@@ -1865,8 +1866,8 @@ async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch
     in the next turn's text. Today the trailing ``.strip()`` would clean
     it up regardless, but if a future refactor moves or removes that
     strip we want this test to catch the leak."""
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _handle_final_transcript
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
 
     captured: list[str] = []
 
@@ -1874,8 +1875,8 @@ async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch
         captured.append(transcript)
         await asyncio.sleep(10.0)
 
-    monkeypatch.setattr(router_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
-    monkeypatch.setattr(router_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
 
     state = _CallState(call_sid="CAtest", stream_sid="MZtest")
     state.in_flight_transcript = "   \t\n  "

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -226,6 +226,39 @@ def test_media_stream_handles_full_call_lifecycle(mock_pipeline):
     assert mock_pipeline.closed is True
 
 
+def test_start_event_records_after_init_call_session(mock_pipeline, monkeypatch):
+    """init_call_session creates the parent doc; record_event(kind='start')
+    update()s it. The start event must run AFTER init (the doc exists);
+    otherwise update() hits a not-yet-created doc and Firestore 404s.
+
+    Pre-fix the two were dispatched as parallel fire-and-forget
+    asyncio.to_thread tasks, so the start event raced init's
+    parent-doc set() and lost on slow Firestore writes.
+    """
+    from app.storage import call_sessions
+
+    call_order: list[str] = []
+
+    def track_init(*_a, **_kw) -> None:
+        call_order.append("init")
+
+    def track_record(*_a, **kw) -> None:
+        if kw.get("kind") == "start":
+            call_order.append("record_start")
+
+    monkeypatch.setattr(call_sessions, "init_call_session", track_init)
+    monkeypatch.setattr(call_sessions, "record_event", track_record)
+
+    with client.websocket_connect("/media-stream") as ws:
+        ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
+        ws.send_text(json.dumps(_START_MSG))
+        ws.send_text(json.dumps(_STOP_MSG))
+
+    assert call_order == ["init", "record_start"], (
+        f"init must run before record_event(kind='start'); got {call_order!r}"
+    )
+
+
 def test_media_stream_begins_recording_on_start(mock_pipeline, monkeypatch):
     """On WS start, after tenant resolution, begin_recording is called
     with the resolved restaurant id and the tenant's retention setting."""

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -572,7 +572,7 @@ async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
+async def test_send_clear_emits_clear_event_with_stream_sid():
     """The helper emits the documented Twilio clear payload."""
     from app.twilio.media_stream import send_clear
 
@@ -585,7 +585,7 @@ async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
 
 
 @pytest.mark.asyncio
-async def test_clear_twilio_audio_skips_when_stream_sid_missing():
+async def test_send_clear_skips_when_stream_sid_missing():
     """No stream means we never opened the start frame — nothing to clear."""
     from app.twilio.media_stream import send_clear
 
@@ -627,7 +627,7 @@ def test_looks_like_goodbye_rejects_simple_acknowledgements():
 
 
 @pytest.mark.asyncio
-async def test_send_end_of_call_mark_emits_mark_payload():
+async def test_send_mark_emits_mark_payload():
     from app.telephony.router import END_OF_CALL_MARK
     from app.twilio.media_stream import send_mark
 
@@ -647,11 +647,12 @@ async def test_send_end_of_call_mark_emits_mark_payload():
 
 
 @pytest.mark.asyncio
-async def test_send_end_of_call_mark_returns_false_when_stream_sid_missing():
+async def test_send_mark_returns_false_when_stream_sid_missing():
+    from app.telephony.router import END_OF_CALL_MARK
     from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
-    sent = await send_mark(ws, None, name="end_of_call")
+    sent = await send_mark(ws, None, name=END_OF_CALL_MARK)
     assert sent is False
     ws.send_json.assert_not_called()
 
@@ -806,7 +807,7 @@ async def test_abort_pending_hangup_cancels_mark_timeout_task():
 
 
 @pytest.mark.asyncio
-async def test_clear_twilio_audio_swallows_websocket_disconnect():
+async def test_send_clear_swallows_websocket_disconnect():
     """If the caller already hung up, the clear send raises — but we
     must not let that exception escape into the call loop."""
     from starlette.websockets import WebSocketDisconnect

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -5,8 +5,8 @@ WS /media-stream (Twilio Media Stream receiver).  Runs fully
 in-process via TestClient — no Twilio, Deepgram, ElevenLabs, or
 Anthropic credentials required.
 
-The mock_pipeline fixture patches all three network-bound callables
-(_open_deepgram_connection, speak, stream_reply) so every test is
+The mock_pipeline fixture patches all four network-bound callables
+(get_stt, speak, stream_reply, call_sessions) so every test is
 offline and deterministic.
 """
 
@@ -77,12 +77,9 @@ def _make_fake_stream_reply(reply="Hi, welcome to Niko's Pizza Kitchen!"):
 @pytest.fixture()
 def mock_pipeline(monkeypatch):
     """Patch all four network-bound callables for offline testing."""
-    fake_dg = AsyncMock()
-    fake_dg.send = AsyncMock()
-    fake_dg.finish = AsyncMock()
+    from tests.fakes.stt import FakeSTT
 
-    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
-        return fake_dg
+    fake_stt = FakeSTT()
 
     async def fake_speak(text, websocket, stream_sid, **kw):
         pass
@@ -91,13 +88,18 @@ def mock_pipeline(monkeypatch):
     # router never tries to auth to GCP from a unit test (#70).
     from app.storage import call_sessions
 
-    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
+    monkeypatch.setattr(
+        "app.telephony.router.get_stt",
+        lambda **kw: (fake_stt, "deepgram"),
+    )
     monkeypatch.setattr("app.telephony.router.speak", fake_speak)
-    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
+    monkeypatch.setattr(
+        "app.telephony.router.stream_reply", _make_fake_stream_reply()
+    )
     monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
-    return fake_dg
+    return fake_stt
 
 
 # ---------------------------------------------------------------------------
@@ -219,8 +221,8 @@ def test_media_stream_handles_full_call_lifecycle(mock_pipeline):
         ws.send_text(json.dumps(_START_MSG))
         ws.send_text(json.dumps(_MEDIA_MSG))
         ws.send_text(json.dumps(_STOP_MSG))
-    # No exception = handler completed cleanly; Deepgram.finish was called
-    mock_pipeline.finish.assert_called_once()
+    # No exception = handler completed cleanly; STT plugin was closed
+    assert mock_pipeline.closed is True
 
 
 def test_media_stream_begins_recording_on_start(mock_pipeline, monkeypatch):
@@ -271,7 +273,7 @@ def test_media_stream_begins_recording_on_start(mock_pipeline, monkeypatch):
     }
 
 
-def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
+def test_media_stream_dispatches_audio_to_append_chunks(mock_pipeline, monkeypatch):
     """Each Twilio media event drives append_chunks with the right
     inbound/outbound payloads."""
     from base64 import b64encode
@@ -298,25 +300,8 @@ def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
         "finalize_recording",
         lambda _s: ("", 0),
     )
-
-    fake_dg = AsyncMock()
-    fake_dg.send = AsyncMock()
-    fake_dg.finish = AsyncMock()
-
-    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
-        return fake_dg
-
-    async def fake_speak(text, websocket, stream_sid, **kw):
-        pass
-
-    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
-    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
-    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
     from app.storage import call_sessions
 
-    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
-    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
-    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
     monkeypatch.setattr(call_sessions, "mark_recording_ready", lambda *a, **kw: None)
 
     inbound_payload = b64encode(b"\xff" * 8).decode()
@@ -357,7 +342,7 @@ def test_media_stream_dispatches_audio_to_append_chunks(monkeypatch):
     assert (b"", b"\x00" * 8) in captured
 
 
-def test_media_stream_finalizes_recording_on_stop(monkeypatch):
+def test_media_stream_finalizes_recording_on_stop(mock_pipeline, monkeypatch):
     """After the call ends, finalize_recording runs and mark_recording_ready
     writes the resulting gs:// URL to Firestore."""
     from app.storage import call_sessions
@@ -375,21 +360,6 @@ def test_media_stream_finalizes_recording_on_stop(monkeypatch):
         "finalize_recording",
         lambda session: ("gs://niko-recordings/niko-pizza-kitchen/CAtest123.mp3", 12),
     )
-
-    fake_dg = AsyncMock()
-    fake_dg.send = AsyncMock()
-    fake_dg.finish = AsyncMock()
-
-    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
-        return fake_dg
-
-    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
-    monkeypatch.setattr("app.telephony.router.speak", AsyncMock())
-    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
-
-    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
-    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
-    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
 
     captured: list[dict] = []
     monkeypatch.setattr(
@@ -416,28 +386,17 @@ def test_media_stream_finalizes_recording_on_stop(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_ai_greeting_spawned_on_start(monkeypatch):
+def test_ai_greeting_spawned_on_start(mock_pipeline, monkeypatch):
     """On start event, stream_reply is called with GREETING_TRANSCRIPT."""
     from app.telephony.router import GREETING_TRANSCRIPT
 
     calls: list[str] = []
-    fake_dg = AsyncMock()
-    fake_dg.send = AsyncMock()
-    fake_dg.finish = AsyncMock()
-
-    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
-        return fake_dg
-
-    async def fake_speak(text, websocket, stream_sid, **kw):
-        pass
 
     async def recording_stream_reply(*, transcript, history, order, **kw):
         calls.append(transcript)
         yield StreamEvent(text_delta="Hello!")
         yield StreamEvent(final=LLMResponse(reply_text="Hello!", order=order, history=history))
 
-    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
-    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
     monkeypatch.setattr("app.telephony.router.stream_reply", recording_stream_reply)
 
     with client.websocket_connect("/media-stream") as ws:
@@ -453,21 +412,11 @@ def test_ai_greeting_spawned_on_start(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_stop_event_persists_ready_order(monkeypatch):
+def test_stop_event_persists_ready_order(mock_pipeline, monkeypatch):
     """persist_on_confirm is called at call end when order is_ready_to_confirm."""
     from app.orders.models import ItemCategory, LineItem, OrderType
 
     persisted: list = []
-
-    fake_dg = AsyncMock()
-    fake_dg.send = AsyncMock()
-    fake_dg.finish = AsyncMock()
-
-    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
-        return fake_dg
-
-    async def fake_speak(text, websocket, stream_sid, **kw):
-        pass
 
     ready_order = Order(
         call_sid="CAtest123",
@@ -493,8 +442,6 @@ def test_stop_event_persists_ready_order(monkeypatch):
         persisted.append(order)
         return order
 
-    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
-    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
     monkeypatch.setattr("app.telephony.router.stream_reply", fake_stream_reply)
     monkeypatch.setattr("app.telephony.router.persist_on_confirm", fake_persist)
 
@@ -507,27 +454,14 @@ def test_stop_event_persists_ready_order(monkeypatch):
     assert persisted[0].call_sid == "CAtest123"
 
 
-def test_stop_event_skips_persist_if_order_not_ready(monkeypatch):
+def test_stop_event_skips_persist_if_order_not_ready(mock_pipeline, monkeypatch):
     """persist_on_confirm is NOT called when order has no items."""
     persisted: list = []
-
-    fake_dg = AsyncMock()
-    fake_dg.send = AsyncMock()
-    fake_dg.finish = AsyncMock()
-
-    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
-        return fake_dg
-
-    async def fake_speak(text, websocket, stream_sid, **kw):
-        pass
 
     def fake_persist(order):
         persisted.append(order)
         return order
 
-    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
-    monkeypatch.setattr("app.telephony.router.speak", fake_speak)
-    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
     monkeypatch.setattr("app.telephony.router.persist_on_confirm", fake_persist)
 
     with client.websocket_connect("/media-stream") as ws:
@@ -1008,18 +942,11 @@ def test_run_llm_tts_turn_does_not_flush_at_short_comma(monkeypatch, mock_pipeli
 # ---------------------------------------------------------------------------
 
 
-def test_first_tts_byte_event_emitted_on_turn(monkeypatch):
+def test_first_tts_byte_event_emitted_on_turn(mock_pipeline, monkeypatch):
     """A first_tts_byte Firestore event with a latency_seconds field is
     emitted on the first speak() call of a turn. The existing first_audio
     event must still be present — we ADD, not replace."""
     from app.storage import call_sessions
-
-    fake_dg = AsyncMock()
-    fake_dg.send = AsyncMock()
-    fake_dg.finish = AsyncMock()
-
-    async def fake_open_dg(call_sid, restaurant_id, on_final, **kwargs):
-        return fake_dg
 
     # A speak() stub that invokes on_first_byte so the callback fires
     # as it would with a real TTS stream delivering its first chunk.
@@ -1033,13 +960,8 @@ def test_first_tts_byte_event_emitted_on_turn(monkeypatch):
     def capture_bg_event(call_sid, restaurant_id, **kwargs):
         recorded_events.append({"call_sid": call_sid, "rid": restaurant_id, **kwargs})
 
-    monkeypatch.setattr("app.telephony.router._open_deepgram_connection", fake_open_dg)
     monkeypatch.setattr("app.telephony.router.speak", speak_with_callback)
-    monkeypatch.setattr("app.telephony.router.stream_reply", _make_fake_stream_reply())
     monkeypatch.setattr("app.telephony.router._bg_call_event", capture_bg_event)
-    monkeypatch.setattr(call_sessions, "init_call_session", lambda *a, **kw: None)
-    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
-    monkeypatch.setattr(call_sessions, "mark_call_ended", lambda *a, **kw: None)
 
     with client.websocket_connect("/media-stream") as ws:
         ws.send_text(json.dumps({"event": "connected", "protocol": "Call", "version": "1.0.0"}))
@@ -1119,86 +1041,9 @@ def test_voice_twiml_includes_stream_ended_action():
 
 
 # ---------------------------------------------------------------------------
-# on_transcript confidence handling (Fix 1 regression guard)
+# on_transcript confidence handling — moved to test_transcript_consumer.py
+# (test_low_confidence_increments_counter, test_high_confidence_resets_counter)
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_on_transcript_increments_misheard_counter_on_low_confidence(monkeypatch):
-    """Driving on_transcript with low-confidence finals must increment
-    state.consecutive_low_confidence_turns. Reset on a clear final."""
-    from unittest.mock import MagicMock
-
-    import app.telephony.router as router_mod
-    from app.telephony.router import _CallState, _open_deepgram_connection
-
-    # Satisfy the API-key guard without a real credential.
-    monkeypatch.setattr(router_mod.settings, "deepgram_api_key", "fake-key-for-test")
-    # Prevent _bg_call_event from spawning background threads that attempt
-    # real Firestore writes (no GCP in the test environment).
-    monkeypatch.setattr(router_mod, "_bg_call_event", lambda *a, **kw: None)
-
-    state = _CallState()
-    captured: dict = {}
-
-    class FakeDeepgramConn:
-        def on(self, event_type, handler):
-            captured.setdefault(str(event_type), handler)
-
-        async def start(self, *_, **__):
-            return True
-
-        async def finish(self):
-            pass
-
-        async def send(self, *_):
-            pass
-
-        def keepalive(self):
-            pass
-
-    class FakeDeepgramClient:
-        def __init__(self, *_):
-            self.listen = MagicMock()
-            self.listen.asynclive.v.return_value = FakeDeepgramConn()
-
-    monkeypatch.setattr(router_mod, "DeepgramClient", FakeDeepgramClient)
-
-    async def on_final(text):
-        pass
-
-    await _open_deepgram_connection(
-        "CAtest",
-        "r1",
-        on_final,
-        state=state,
-    )
-
-    # LiveTranscriptionEvents.Transcript stringifies to "Results" (Deepgram SDK).
-    handler = captured["Results"]
-
-    def fake_result(text, confidence, is_final=True):
-        r = MagicMock()
-        alt = MagicMock()
-        alt.transcript = text
-        alt.confidence = confidence
-        r.channel.alternatives = [alt]
-        r.is_final = is_final
-        return r
-
-    # Three consecutive low-confidence finals.
-    await handler(None, fake_result("um", 0.2))
-    await handler(None, fake_result("uhh", 0.1))
-    # confidence=0.0 is the key regression: without Fix 1, `0.0 or 1.0`
-    # yields 1.0 and the counter would not advance on this third call.
-    await handler(None, fake_result("what", 0.0))
-
-    assert state.consecutive_low_confidence_turns == 3
-
-    # A clear final resets the counter.
-    await handler(None, fake_result("a large pepperoni pizza", 0.95))
-    assert state.consecutive_low_confidence_turns == 0
-    assert state.last_caller_transcript == "a large pepperoni pizza"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -574,12 +574,12 @@ async def test_tool_use_turn_two_timing_events_handled_by_router(monkeypatch):
 @pytest.mark.asyncio
 async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
     """The helper emits the documented Twilio clear payload."""
-    from app.telephony.router import clear_twilio_audio
+    from app.twilio.media_stream import send_clear
 
     ws = AsyncMock()
     ws.send_json = AsyncMock()
 
-    await clear_twilio_audio(ws, "MZtest456")
+    await send_clear(ws, "MZtest456")
 
     ws.send_json.assert_awaited_once_with({"event": "clear", "streamSid": "MZtest456"})
 
@@ -587,12 +587,12 @@ async def test_clear_twilio_audio_sends_clear_event_with_stream_sid():
 @pytest.mark.asyncio
 async def test_clear_twilio_audio_skips_when_stream_sid_missing():
     """No stream means we never opened the start frame — nothing to clear."""
-    from app.telephony.router import clear_twilio_audio
+    from app.twilio.media_stream import send_clear
 
     ws = AsyncMock()
     ws.send_json = AsyncMock()
 
-    await clear_twilio_audio(ws, None)
+    await send_clear(ws, None)
 
     ws.send_json.assert_not_called()
 
@@ -628,12 +628,13 @@ def test_looks_like_goodbye_rejects_simple_acknowledgements():
 
 @pytest.mark.asyncio
 async def test_send_end_of_call_mark_emits_mark_payload():
-    from app.telephony.router import END_OF_CALL_MARK, send_end_of_call_mark
+    from app.telephony.router import END_OF_CALL_MARK
+    from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
     ws.send_json = AsyncMock()
 
-    sent = await send_end_of_call_mark(ws, "MZtest456")
+    sent = await send_mark(ws, "MZtest456", name=END_OF_CALL_MARK)
 
     assert sent is True
     ws.send_json.assert_awaited_once_with(
@@ -647,10 +648,10 @@ async def test_send_end_of_call_mark_emits_mark_payload():
 
 @pytest.mark.asyncio
 async def test_send_end_of_call_mark_returns_false_when_stream_sid_missing():
-    from app.telephony.router import send_end_of_call_mark
+    from app.twilio.media_stream import send_mark
 
     ws = AsyncMock()
-    sent = await send_end_of_call_mark(ws, None)
+    sent = await send_mark(ws, None, name="end_of_call")
     assert sent is False
     ws.send_json.assert_not_called()
 
@@ -810,13 +811,13 @@ async def test_clear_twilio_audio_swallows_websocket_disconnect():
     must not let that exception escape into the call loop."""
     from starlette.websockets import WebSocketDisconnect
 
-    from app.telephony.router import clear_twilio_audio
+    from app.twilio.media_stream import send_clear
 
     ws = AsyncMock()
     ws.send_json = AsyncMock(side_effect=WebSocketDisconnect())
 
     # No exception escaping is the assertion.
-    await clear_twilio_audio(ws, "MZtest456")
+    await send_clear(ws, "MZtest456")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -120,6 +120,13 @@ async def test_high_confidence_resets_counter(monkeypatch):
 async def test_speech_started_triggers_barge_in_when_llm_task_running(monkeypatch):
     """VAD speech-started while a turn is in flight fires _barge_in_now
     with trigger='vad'."""
+    from app.config import settings
+
+    # Pin the kill-switch ON so this test doesn't depend on local .env
+    # state (a developer with STT_INSTANT_BARGE_IN=false set for a real
+    # call would otherwise see this test fail spuriously).
+    monkeypatch.setattr(settings, "stt_instant_barge_in", True)
+
     state = _make_state()
 
     async def long_turn():
@@ -154,7 +161,12 @@ async def test_speech_started_triggers_barge_in_when_llm_task_running(monkeypatc
 @pytest.mark.asyncio
 async def test_speech_started_no_op_when_no_llm_task(monkeypatch):
     """VAD with no in-flight turn does nothing — there's nothing to
-    barge in on."""
+    barge in on. Pinning kill-switch ON ensures the no-op comes from
+    the no-task branch and not from the kill-switch."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "stt_instant_barge_in", True)
+
     state = _make_state()
     state.llm_task = None
 
@@ -269,6 +281,12 @@ async def test_vad_then_final_transcript_creates_one_barge_in_then_new_turn(
     _handle_final_transcript exactly once for the final. Pins that the
     consumer keeps iterating after a VAD event (would catch a future
     refactor that turned `continue` into `return`)."""
+    from app.config import settings
+
+    # Pin the kill-switch ON so this test doesn't depend on local .env
+    # state.
+    monkeypatch.setattr(settings, "stt_instant_barge_in", True)
+
     state = _make_state()
 
     async def long_turn():
@@ -352,3 +370,92 @@ async def test_kill_switch_off_still_processes_final_transcripts(monkeypatch):
     assert barge_in_calls == []  # VAD ignored
     handler.assert_awaited_once()  # but final still flowed through
     assert handler.await_args.args[0] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_early_turn_end_event_is_dropped(monkeypatch):
+    """EarlyTurnEndEvent flows from the Flux provider; this PR does
+    not consume it (speculative drafting is a future PR). The consumer
+    must silently drop it — no barge-in, no Firestore, no LLM dispatch."""
+    from app.stt.base import EarlyTurnEndEvent
+
+    state = _make_state()
+    monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.session._handle_final_transcript", handler
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
+
+    fake = FakeSTT(events=[EarlyTurnEndEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_not_called()
+    bg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_turn_resumed_event_is_dropped(monkeypatch):
+    """TurnResumedEvent is the cancel signal for the speculative
+    draft. Until speculation lands the consumer drops it cleanly."""
+    from app.stt.base import TurnResumedEvent
+
+    state = _make_state()
+    monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.session._handle_final_transcript", handler
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
+
+    fake = FakeSTT(events=[TurnResumedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_not_called()
+    bg.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_speculation_events_interleaved_with_finals_pass_through(
+    monkeypatch,
+):
+    """A real Flux call delivers EarlyTurnEnd and TurnResumed in
+    between the SpeechStarted and final TranscriptEvent. The consumer
+    must drop the speculative ones and still process the final."""
+    from app.stt.base import EarlyTurnEndEvent, TurnResumedEvent
+
+    state = _make_state()
+    monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.session._handle_final_transcript", handler
+    )
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
+
+    fake = FakeSTT(
+        events=[
+            SpeechStartedEvent(),
+            TranscriptEvent("hi the", False, 0.8),
+            EarlyTurnEndEvent(),
+            TurnResumedEvent(),
+            TranscriptEvent("hi there", True, 0.9),
+        ]
+    )
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_awaited_once()
+    assert handler.await_args.args[0] == "hi there"

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -1,0 +1,181 @@
+"""Tests for _consume_transcripts in app/telephony/router.py.
+
+The consumer is the router's bridge between the STT plugin and call
+state. We feed scripted events into a FakeSTT and assert state changes,
+Firestore emissions, and dispatch into _handle_final_transcript.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.stt.base import SpeechStartedEvent, TranscriptEvent
+from app.telephony.router import _CallState, _consume_transcripts
+from tests.fakes.stt import FakeSTT
+
+
+def _make_state() -> _CallState:
+    state = _CallState(websocket=AsyncMock())
+    state.call_sid = "CAtest"
+    state.stream_sid = "MZ1"
+    return state
+
+
+@pytest.mark.asyncio
+async def test_interim_transcripts_ignored(monkeypatch):
+    """Interims arrive on the queue but cause no state mutation, no
+    Firestore call, no _handle_final_transcript dispatch."""
+    state = _make_state()
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", handler
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+
+    fake = FakeSTT(events=[TranscriptEvent("partial", False, 0.7)])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_not_called()
+    bg.assert_not_called()
+    assert state.last_caller_transcript == ""
+
+
+@pytest.mark.asyncio
+async def test_final_transcript_mutates_state_and_dispatches(monkeypatch):
+    state = _make_state()
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", handler
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+
+    ws = AsyncMock()
+    fake = FakeSTT(events=[TranscriptEvent("two pizzas", True, 0.9)])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, ws))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert state.last_caller_transcript == "two pizzas"
+    handler.assert_awaited_once_with("two pizzas", state, ws)
+    bg.assert_called_once()
+    args, kwargs = bg.call_args
+    assert kwargs["kind"] == "transcript_final"
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_increments_counter(monkeypatch):
+    state = _make_state()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", AsyncMock()
+    )
+    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+
+    fake = FakeSTT(events=[
+        TranscriptEvent("muffled", True, 0.3),
+        TranscriptEvent("still muffled", True, 0.4),
+        # 0.0 boundary case — guards against any future "or 1.0" regression
+        # in the confidence-handling path.
+        TranscriptEvent("zero confidence", True, 0.0),
+    ])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert state.consecutive_low_confidence_turns == 3
+
+
+@pytest.mark.asyncio
+async def test_high_confidence_resets_counter(monkeypatch):
+    state = _make_state()
+    state.consecutive_low_confidence_turns = 3
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", AsyncMock()
+    )
+    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+
+    fake = FakeSTT(events=[TranscriptEvent("clear", True, 0.95)])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert state.consecutive_low_confidence_turns == 0
+
+
+@pytest.mark.asyncio
+async def test_speech_started_currently_ignored(monkeypatch):
+    """Until α-7 wires VAD-triggered barge-in, SpeechStartedEvents are
+    silently dropped by the consumer."""
+    state = _make_state()
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", handler
+    )
+
+    fake = FakeSTT(events=[SpeechStartedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
+    import logging
+
+    state = _make_state()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", AsyncMock()
+    )
+    bg = MagicMock()
+    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+
+    fake = FakeSTT()
+    await fake.open()
+    fake.feed_error(RuntimeError("dropped"))
+
+    with caplog.at_level(logging.ERROR, logger="app.telephony.router"):
+        # Consumer catches the exception and exits cleanly.
+        await _consume_transcripts(fake, state, AsyncMock())
+
+    assert any(
+        "transcript consumer crashed" in rec.message for rec in caplog.records
+    ), "expected the consumer's crash log line"
+    # Mid-call STT crash should also surface as a transfer signal and a
+    # dashboard event, so it isn't invisible.
+    assert state.llm_error_occurred is True
+    error_calls = [c for c in bg.call_args_list if c.kwargs.get("kind") == "error"]
+    assert error_calls, "expected an error Firestore event on consumer crash"
+
+
+@pytest.mark.asyncio
+async def test_consumer_propagates_cancellation(monkeypatch):
+    state = _make_state()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", AsyncMock()
+    )
+
+    fake = FakeSTT()
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -1,6 +1,6 @@
-"""Tests for _consume_transcripts in app/telephony/router.py.
+"""Tests for _consume_transcripts in app/telephony/session.py.
 
-The consumer is the router's bridge between the STT plugin and call
+The consumer is the session's bridge between the STT plugin and call
 state. We feed scripted events into a FakeSTT and assert state changes,
 Firestore emissions, and dispatch into _handle_final_transcript.
 """

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -117,14 +117,22 @@ async def test_high_confidence_resets_counter(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_speech_started_currently_ignored(monkeypatch):
-    """Until α-7 wires VAD-triggered barge-in, SpeechStartedEvents are
-    silently dropped by the consumer."""
+async def test_speech_started_triggers_barge_in_when_llm_task_running(monkeypatch):
+    """VAD speech-started while a turn is in flight fires _barge_in_now
+    with trigger='vad'."""
     state = _make_state()
-    handler = AsyncMock()
-    monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
-    )
+
+    async def long_turn():
+        await asyncio.sleep(60)
+
+    state.llm_task = asyncio.create_task(long_turn())
+
+    barge_in_calls: list[str] = []
+
+    async def fake_barge(state_, ws_, *, trigger):
+        barge_in_calls.append(trigger)
+
+    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
 
     fake = FakeSTT(events=[SpeechStartedEvent()])
     await fake.open()
@@ -133,7 +141,77 @@ async def test_speech_started_currently_ignored(monkeypatch):
     await fake.close()
     await task
 
-    handler.assert_not_called()
+    assert barge_in_calls == ["vad"]
+
+    # Cleanup
+    state.llm_task.cancel()
+    try:
+        await state.llm_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_speech_started_no_op_when_no_llm_task(monkeypatch):
+    """VAD with no in-flight turn does nothing — there's nothing to
+    barge in on."""
+    state = _make_state()
+    state.llm_task = None
+
+    barge_in_calls: list[str] = []
+
+    async def fake_barge(state_, ws_, *, trigger):
+        barge_in_calls.append(trigger)
+
+    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+
+    fake = FakeSTT(events=[SpeechStartedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert barge_in_calls == []
+
+
+@pytest.mark.asyncio
+async def test_speech_started_disabled_by_setting(monkeypatch):
+    """When STT_INSTANT_BARGE_IN is False, VAD events are ignored even
+    with a turn in flight — caller falls back to final-transcript-driven
+    barge-in."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "stt_instant_barge_in", False)
+    state = _make_state()
+
+    async def long_turn():
+        await asyncio.sleep(60)
+
+    state.llm_task = asyncio.create_task(long_turn())
+
+    barge_in_calls: list[str] = []
+
+    async def fake_barge(state_, ws_, *, trigger):
+        barge_in_calls.append(trigger)
+
+    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+
+    fake = FakeSTT(events=[SpeechStartedEvent()])
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert barge_in_calls == []
+
+    # Cleanup
+    state.llm_task.cancel()
+    try:
+        await state.llm_task
+    except asyncio.CancelledError:
+        pass
 
 
 @pytest.mark.asyncio
@@ -179,3 +257,98 @@ async def test_consumer_propagates_cancellation(monkeypatch):
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_vad_then_final_transcript_creates_one_barge_in_then_new_turn(
+    monkeypatch,
+):
+    """The realistic production interleaving: VAD fires (instant
+    barge-in), then the caller's final transcript arrives. The consumer
+    should call _barge_in_now exactly once for the VAD event and dispatch
+    _handle_final_transcript exactly once for the final. Pins that the
+    consumer keeps iterating after a VAD event (would catch a future
+    refactor that turned `continue` into `return`)."""
+    state = _make_state()
+
+    async def long_turn():
+        await asyncio.sleep(60)
+
+    state.llm_task = asyncio.create_task(long_turn())
+
+    barge_in_calls: list[str] = []
+
+    async def fake_barge(state_, ws_, *, trigger):
+        barge_in_calls.append(trigger)
+
+    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", handler
+    )
+    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+
+    fake = FakeSTT(
+        events=[
+            SpeechStartedEvent(),
+            TranscriptEvent("two pizzas", True, 0.95),
+        ]
+    )
+    await fake.open()
+    ws = AsyncMock()
+    task = asyncio.create_task(_consume_transcripts(fake, state, ws))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert barge_in_calls == ["vad"]
+    handler.assert_awaited_once_with("two pizzas", state, ws)
+
+    # Cleanup
+    state.llm_task.cancel()
+    try:
+        await state.llm_task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_off_still_processes_final_transcripts(monkeypatch):
+    """When STT_INSTANT_BARGE_IN is False, the consumer skips VAD events
+    but must continue iterating to handle the final transcript that
+    follows. Guards against a future refactor that turned the kill-switch
+    `continue` into a `return`."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "stt_instant_barge_in", False)
+    state = _make_state()
+
+    barge_in_calls: list[str] = []
+
+    async def fake_barge(state_, ws_, *, trigger):
+        barge_in_calls.append(trigger)
+
+    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+
+    handler = AsyncMock()
+    monkeypatch.setattr(
+        "app.telephony.router._handle_final_transcript", handler
+    )
+    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+
+    fake = FakeSTT(
+        events=[
+            SpeechStartedEvent(),
+            TranscriptEvent("hello", True, 0.95),
+        ]
+    )
+    await fake.open()
+    task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
+    await asyncio.sleep(0)
+    await fake.close()
+    await task
+
+    assert barge_in_calls == []  # VAD ignored
+    handler.assert_awaited_once()  # but final still flowed through
+    assert handler.await_args.args[0] == "hello"

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.stt.base import SpeechStartedEvent, TranscriptEvent
-from app.telephony.router import _CallState, _consume_transcripts
+from app.telephony.session import _CallState, _consume_transcripts
 from tests.fakes.stt import FakeSTT
 
 
@@ -31,10 +31,10 @@ async def test_interim_transcripts_ignored(monkeypatch):
     state = _make_state()
     handler = AsyncMock()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
+        "app.telephony.session._handle_final_transcript", handler
     )
     bg = MagicMock()
-    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
     fake = FakeSTT(events=[TranscriptEvent("partial", False, 0.7)])
     await fake.open()
@@ -53,10 +53,10 @@ async def test_final_transcript_mutates_state_and_dispatches(monkeypatch):
     state = _make_state()
     handler = AsyncMock()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
+        "app.telephony.session._handle_final_transcript", handler
     )
     bg = MagicMock()
-    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
     ws = AsyncMock()
     fake = FakeSTT(events=[TranscriptEvent("two pizzas", True, 0.9)])
@@ -77,9 +77,9 @@ async def test_final_transcript_mutates_state_and_dispatches(monkeypatch):
 async def test_low_confidence_increments_counter(monkeypatch):
     state = _make_state()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", AsyncMock()
+        "app.telephony.session._handle_final_transcript", AsyncMock()
     )
-    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(events=[
         TranscriptEvent("muffled", True, 0.3),
@@ -102,9 +102,9 @@ async def test_high_confidence_resets_counter(monkeypatch):
     state = _make_state()
     state.consecutive_low_confidence_turns = 3
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", AsyncMock()
+        "app.telephony.session._handle_final_transcript", AsyncMock()
     )
-    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(events=[TranscriptEvent("clear", True, 0.95)])
     await fake.open()
@@ -132,7 +132,7 @@ async def test_speech_started_triggers_barge_in_when_llm_task_running(monkeypatc
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     fake = FakeSTT(events=[SpeechStartedEvent()])
     await fake.open()
@@ -163,7 +163,7 @@ async def test_speech_started_no_op_when_no_llm_task(monkeypatch):
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     fake = FakeSTT(events=[SpeechStartedEvent()])
     await fake.open()
@@ -195,7 +195,7 @@ async def test_speech_started_disabled_by_setting(monkeypatch):
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     fake = FakeSTT(events=[SpeechStartedEvent()])
     await fake.open()
@@ -220,16 +220,16 @@ async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
 
     state = _make_state()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", AsyncMock()
+        "app.telephony.session._handle_final_transcript", AsyncMock()
     )
     bg = MagicMock()
-    monkeypatch.setattr("app.telephony.router._bg_call_event", bg)
+    monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
     fake = FakeSTT()
     await fake.open()
     fake.feed_error(RuntimeError("dropped"))
 
-    with caplog.at_level(logging.ERROR, logger="app.telephony.router"):
+    with caplog.at_level(logging.ERROR, logger="app.telephony.session"):
         # Consumer catches the exception and exits cleanly.
         await _consume_transcripts(fake, state, AsyncMock())
 
@@ -247,7 +247,7 @@ async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
 async def test_consumer_propagates_cancellation(monkeypatch):
     state = _make_state()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", AsyncMock()
+        "app.telephony.session._handle_final_transcript", AsyncMock()
     )
 
     fake = FakeSTT()
@@ -281,13 +281,13 @@ async def test_vad_then_final_transcript_creates_one_barge_in_then_new_turn(
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     handler = AsyncMock()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
+        "app.telephony.session._handle_final_transcript", handler
     )
-    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(
         events=[
@@ -329,13 +329,13 @@ async def test_kill_switch_off_still_processes_final_transcripts(monkeypatch):
     async def fake_barge(state_, ws_, *, trigger):
         barge_in_calls.append(trigger)
 
-    monkeypatch.setattr("app.telephony.router._barge_in_now", fake_barge)
+    monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     handler = AsyncMock()
     monkeypatch.setattr(
-        "app.telephony.router._handle_final_transcript", handler
+        "app.telephony.session._handle_final_transcript", handler
     )
-    monkeypatch.setattr("app.telephony.router._bg_call_event", MagicMock())
+    monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(
         events=[

--- a/tests/test_transcript_consumer.py
+++ b/tests/test_transcript_consumer.py
@@ -30,9 +30,7 @@ async def test_interim_transcripts_ignored(monkeypatch):
     Firestore call, no _handle_final_transcript dispatch."""
     state = _make_state()
     handler = AsyncMock()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", handler
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", handler)
     bg = MagicMock()
     monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
@@ -52,9 +50,7 @@ async def test_interim_transcripts_ignored(monkeypatch):
 async def test_final_transcript_mutates_state_and_dispatches(monkeypatch):
     state = _make_state()
     handler = AsyncMock()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", handler
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", handler)
     bg = MagicMock()
     monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
@@ -76,18 +72,18 @@ async def test_final_transcript_mutates_state_and_dispatches(monkeypatch):
 @pytest.mark.asyncio
 async def test_low_confidence_increments_counter(monkeypatch):
     state = _make_state()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", AsyncMock()
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", AsyncMock())
     monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
-    fake = FakeSTT(events=[
-        TranscriptEvent("muffled", True, 0.3),
-        TranscriptEvent("still muffled", True, 0.4),
-        # 0.0 boundary case — guards against any future "or 1.0" regression
-        # in the confidence-handling path.
-        TranscriptEvent("zero confidence", True, 0.0),
-    ])
+    fake = FakeSTT(
+        events=[
+            TranscriptEvent("muffled", True, 0.3),
+            TranscriptEvent("still muffled", True, 0.4),
+            # 0.0 boundary case — guards against any future "or 1.0" regression
+            # in the confidence-handling path.
+            TranscriptEvent("zero confidence", True, 0.0),
+        ]
+    )
     await fake.open()
     task = asyncio.create_task(_consume_transcripts(fake, state, AsyncMock()))
     await asyncio.sleep(0)
@@ -101,9 +97,7 @@ async def test_low_confidence_increments_counter(monkeypatch):
 async def test_high_confidence_resets_counter(monkeypatch):
     state = _make_state()
     state.consecutive_low_confidence_turns = 3
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", AsyncMock()
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", AsyncMock())
     monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(events=[TranscriptEvent("clear", True, 0.95)])
@@ -231,9 +225,7 @@ async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
     import logging
 
     state = _make_state()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", AsyncMock()
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", AsyncMock())
     bg = MagicMock()
     monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
@@ -245,9 +237,9 @@ async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
         # Consumer catches the exception and exits cleanly.
         await _consume_transcripts(fake, state, AsyncMock())
 
-    assert any(
-        "transcript consumer crashed" in rec.message for rec in caplog.records
-    ), "expected the consumer's crash log line"
+    assert any("transcript consumer crashed" in rec.message for rec in caplog.records), (
+        "expected the consumer's crash log line"
+    )
     # Mid-call STT crash should also surface as a transfer signal and a
     # dashboard event, so it isn't invisible.
     assert state.llm_error_occurred is True
@@ -258,9 +250,7 @@ async def test_consumer_logs_and_exits_on_stt_error(monkeypatch, caplog):
 @pytest.mark.asyncio
 async def test_consumer_propagates_cancellation(monkeypatch):
     state = _make_state()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", AsyncMock()
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", AsyncMock())
 
     fake = FakeSTT()
     await fake.open()
@@ -302,9 +292,7 @@ async def test_vad_then_final_transcript_creates_one_barge_in_then_new_turn(
     monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     handler = AsyncMock()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", handler
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", handler)
     monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(
@@ -350,9 +338,7 @@ async def test_kill_switch_off_still_processes_final_transcripts(monkeypatch):
     monkeypatch.setattr("app.telephony.session._barge_in_now", fake_barge)
 
     handler = AsyncMock()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", handler
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", handler)
     monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(
@@ -382,9 +368,7 @@ async def test_early_turn_end_event_is_dropped(monkeypatch):
     state = _make_state()
     monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
     handler = AsyncMock()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", handler
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", handler)
     bg = MagicMock()
     monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
@@ -408,9 +392,7 @@ async def test_turn_resumed_event_is_dropped(monkeypatch):
     state = _make_state()
     monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
     handler = AsyncMock()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", handler
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", handler)
     bg = MagicMock()
     monkeypatch.setattr("app.telephony.session._bg_call_event", bg)
 
@@ -437,9 +419,7 @@ async def test_speculation_events_interleaved_with_finals_pass_through(
     state = _make_state()
     monkeypatch.setattr("app.telephony.session._barge_in_now", AsyncMock())
     handler = AsyncMock()
-    monkeypatch.setattr(
-        "app.telephony.session._handle_final_transcript", handler
-    )
+    monkeypatch.setattr("app.telephony.session._handle_final_transcript", handler)
     monkeypatch.setattr("app.telephony.session._bg_call_event", MagicMock())
 
     fake = FakeSTT(

--- a/tests/test_tts_integration.py
+++ b/tests/test_tts_integration.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.config import settings
-from app.tts.client import speak
+from app.deepgram.tts import speak
 
 pytestmark = pytest.mark.skipif(
     not settings.deepgram_api_key,


### PR DESCRIPTION
## Summary

Sprint 2.1 integration trunk — tunes the conversational bot for production use.

- **STT migration**: extracted to a plugin protocol (`app/stt/`), then migrated to Deepgram Flux English mono with per-tenant keyterm prompting (500-token cap). Adds `DeepgramSTT` provider, `FakeSTT` fixture for offline tests, keyterm builder per restaurant.
- **TTS extraction**: pulled Deepgram TTS into `app/deepgram/tts.py` behind a `TTSProvider` protocol.
- **Telephony refactor**: split `router.py` (855 → ~250 LoC) into `app/telephony/session.py` (call state + orchestration), `app/twilio/` (WS protocol primitives, TwiML builders, Twilio REST creds, voicemail upload).
- **Reliability fixes**: instant barge-in via VAD speech-started; chained `init_call_session` with the start event (Firestore 404 fix); swallowed RuntimeError on server-initiated WS close.
- **Lint**: ruff import-sort fixes so CI is green.

## Linked issue

Relates to #83 (Sprint 2.1 — Tuning conversational bot)

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests` — 471 passed locally; 3 failures are local-env only (empty \`RECORDINGS_BUCKET\` in `.env`) and pass in CI with default config
- [ ] CI green (ruff + pytest)
- [ ] Smoke a live call end-to-end after merge — confirm Flux STT + per-tenant keyterms route correctly, barge-in feels instant
- [ ] Verify voicemail / recording upload still works in staging

## Notes

- 28 commits, ~8.3k LoC across 38 files. Big surface area; merging as the integration branch for Sprint 2.1.
- Behavioral change in `app/storage/recordings.py` (`d27bc4f`): `finalize_recording` now early-returns when `RECORDINGS_BUCKET` is unset — intentional, lets local dev run without recordings configured. Production sets the bucket so behavior is unchanged there.
- Test flake to watch: `tests/test_llm_integration.py::test_caller_correction_lands_in_final_order[substitute_item]` — passes in isolation, intermittently fails in full-suite ordering. Pre-existing pattern, not introduced here. Will follow up if it surfaces in CI.