### PR TITLE
feat(dev): local caller-audio dump + offline STT replay tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ docs/07-local-development-setup.md
 # Local runtime logs
 uvicorn.log
 
+# Local-dev caller-audio dumps (NIKO_LOCAL_AUDIO_DUMP_DIR). Suggested
+# default location; the env var owns the actual path.
+dev_recordings/
+
 # Terraform — local state, plan files, provider plugins, lockfile-overrides
 # (.terraform.lock.hcl is intentionally NOT ignored — it pins provider versions
 # for reproducibility and should be committed.)

--- a/app/config.py
+++ b/app/config.py
@@ -92,6 +92,14 @@ class Settings(BaseSettings):
     # dashboard needs seed data before the voice loop is wired up.
     niko_dev_endpoints: bool = False
 
+    # Local-dev only: when set to a directory path, the /media-stream WS
+    # handler dumps each call's inbound (caller-side) mulaw audio to
+    # ``<dir>/<call_sid>_<started_at>.ulaw``. Empty/unset in production —
+    # ``app.dev.audio_dump.open_caller_dump`` returns None and the dump
+    # path becomes a no-op. Designed to feed ``scripts/replay_stt.py``
+    # for offline STT A/B testing without touching the GCS recording path.
+    niko_local_audio_dump_dir: Optional[str] = None
+
     # Set by the deploy pipeline to the git commit SHA. Used to surface
     # the build version in the dashboard and (when testing_mode=True) as
     # a spoken announcement at call start.

--- a/app/dev/audio_dump.py
+++ b/app/dev/audio_dump.py
@@ -1,0 +1,131 @@
+"""Local-dev caller-audio dump.
+
+Writes raw mulaw 8 kHz bytes from the inbound (caller) Twilio media
+track to a flat file on local disk. Used to capture real-call audio
+that we can then re-feed to Deepgram via ``scripts/replay_stt.py`` to
+A/B different STT configurations (Flux vs Nova-2 vs Nova-3, varying
+keyterm sets) without having to make repeated live calls.
+
+This module is intentionally local-dev-only:
+- ``open_caller_dump`` returns ``None`` when ``settings.niko_local_audio_dump_dir``
+  is empty/unset (the production default), so the production code path
+  pays zero cost.
+- All filesystem failures are caught and logged; they never raise into
+  the call loop.
+
+File format: raw mulaw 8 kHz, no header. Same bytes Twilio's media
+events deliver and Deepgram's ``send_media`` consumes — replay is a
+byte-for-byte forward, no encode/decode round-trip.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class CallerAudioDump:
+    """Append-only writer for one call's inbound mulaw stream.
+
+    Constructed by ``open_caller_dump``. The class swallows IOErrors on
+    ``append`` and ``close`` and flips an internal ``broken`` flag so
+    subsequent ``append`` calls become no-ops — a disk-full mid-call
+    must not break the live STT path.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._fh = open(path, "ab")
+        self._broken = False
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    def append(self, mulaw_bytes: bytes) -> None:
+        if self._broken or not mulaw_bytes:
+            return
+        try:
+            self._fh.write(mulaw_bytes)
+        except (OSError, ValueError):
+            # OSError covers disk-full / permission-denied; ValueError
+            # is what Python raises when the underlying file handle is
+            # already closed. Either way the dump is dead — flip the
+            # broken flag and stop writing for the rest of the call.
+            logger.exception("audio_dump: append failed path=%s", self._path)
+            self._broken = True
+            try:
+                self._fh.close()
+            except (OSError, ValueError):
+                pass
+
+    def close(self) -> None:
+        if self._broken:
+            return
+        try:
+            self._fh.flush()
+            self._fh.close()
+        except (OSError, ValueError):
+            logger.exception("audio_dump: close failed path=%s", self._path)
+            self._broken = True
+
+
+def open_caller_dump(call_sid: str) -> Optional[CallerAudioDump]:
+    """Return a writer for this call, or ``None`` when disabled.
+
+    Disabled cases (all return ``None``):
+      - ``settings.niko_local_audio_dump_dir`` is empty or whitespace.
+      - ``call_sid`` is empty (we can't name the file).
+      - The configured path exists but is a regular file, not a dir.
+      - The directory cannot be created (permission denied) or the
+        file cannot be opened (permission denied, disk full).
+
+    All ``OSError`` paths log at WARNING and return ``None`` so the call
+    loop is never disrupted by a misconfigured local env.
+    """
+    dump_dir = (settings.niko_local_audio_dump_dir or "").strip()
+    if not dump_dir:
+        return None
+    if not call_sid:
+        return None
+
+    try:
+        os.makedirs(dump_dir, exist_ok=True)
+    except OSError:
+        logger.warning(
+            "audio_dump: cannot create dump dir=%r — feature disabled for this call",
+            dump_dir,
+            exc_info=True,
+        )
+        return None
+
+    if not os.path.isdir(dump_dir):
+        logger.warning(
+            "audio_dump: niko_local_audio_dump_dir=%r is not a directory — feature disabled",
+            dump_dir,
+        )
+        return None
+
+    started_at = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    safe_sid = "".join(c for c in call_sid if c.isalnum() or c in ("-", "_"))
+    filename = f"{safe_sid}_{started_at}.ulaw"
+    path = os.path.join(dump_dir, filename)
+
+    try:
+        dump = CallerAudioDump(path)
+    except OSError:
+        logger.warning(
+            "audio_dump: cannot open dump file=%r — feature disabled for this call",
+            path,
+            exc_info=True,
+        )
+        return None
+
+    logger.info("audio_dump: caller dump opened path=%s call_sid=%s", path, call_sid)
+    return dump

--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Request, Response, WebSocket, WebSocketDisconnect
 
 import app.twilio as app_twilio
 from app.config import settings
+from app.dev.audio_dump import open_caller_dump
 from app.llm.prompts import build_system_prompt
 from app.orders.lifecycle import OrderNotReadyError, persist_on_confirm
 from app.orders.models import Order
@@ -406,6 +407,11 @@ async def media_stream(websocket: WebSocket) -> None:
                     state.stream_sid,
                     state.restaurant.id,
                 )
+                # Local-dev caller-audio dump. Returns None in production
+                # (env unset) and on any filesystem error — the call loop
+                # never depends on this succeeding.
+                if state.call_sid:
+                    state.caller_dump = open_caller_dump(state.call_sid)
                 if state.call_sid:
                     # init_call_session creates the parent doc; record_event
                     # (kind="start") then update()s it. Chain them in a single
@@ -494,6 +500,8 @@ async def media_stream(websocket: WebSocket) -> None:
                     outbound_chunk = b""
                     if state.stt is not None:
                         await state.stt.send(payload)
+                    if state.caller_dump is not None:
+                        state.caller_dump.append(payload)
                 elif track == "outbound":
                     inbound_chunk = b""
                     outbound_chunk = payload
@@ -567,6 +575,14 @@ async def media_stream(websocket: WebSocket) -> None:
                 await state.stt.close()
             except Exception:
                 logger.exception("stt: close failed call_sid=%s", state.call_sid)
+        if state.caller_dump is not None:
+            try:
+                state.caller_dump.close()
+            except Exception:
+                logger.exception(
+                    "audio_dump: close failed call_sid=%s",
+                    state.call_sid,
+                )
         if state.llm_task and not state.llm_task.done():
             state.llm_task.cancel()
             try:

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -22,6 +22,7 @@ from typing import Any, Callable
 from fastapi import WebSocket
 
 from app.config import settings
+from app.dev.audio_dump import CallerAudioDump  # noqa: F401  (typing only)
 from app.llm.client import stream_reply
 from app.orders.models import Order, OrderStatus
 from app.restaurants.models import Restaurant
@@ -178,6 +179,10 @@ class _CallState:
     # serialising the two writes ensures the start event never races
     # init's parent-doc set() and 404s on Firestore.
     session_init_task: asyncio.Task | None = None
+    # Local-dev caller-audio dump (#TBD). Set on "start" when
+    # NIKO_LOCAL_AUDIO_DUMP_DIR is configured; otherwise stays None and
+    # the media-event branch and finally-block close are no-ops.
+    caller_dump: "CallerAudioDump | None" = None
 
 
 def _make_recording_chunk_handler(state: "_CallState") -> Callable[[bytes], None] | None:

--- a/docs/superpowers/specs/2026-05-08-local-stt-replay-design.md
+++ b/docs/superpowers/specs/2026-05-08-local-stt-replay-design.md
@@ -1,0 +1,163 @@
+# Local Caller-Audio Dump + STT Replay Tool — Design
+
+**Date:** 2026-05-08
+**Author:** Sandeep (with Claude)
+**Status:** Design — pending implementation plan
+**Related:** `docs/superpowers/specs/2026-05-06-deepgram-flux-stt-investigation.md`
+
+---
+
+## Problem
+
+A real call on 2026-05-08 (`CA4fe24cdd06641e1cc0d7e4a81514c60d`) showed Deepgram Flux mis-transcribing the caller's opening utterance:
+
+| Caller said | Flux returned |
+|---|---|
+| "Can I place an order for pickup?" | `"I cannot place an order for pickup."` |
+
+The LLM and downstream pipeline behaved correctly given that bad input — the failure is in STT. A second attempt at the same phrase later in the same call transcribed correctly, suggesting the bug is sensitive to first-turn conditions (cold-start audio, weak language-model prior on common ordering phrasing, possible TTS-tail bleed).
+
+This is the same class of error already documented in the 2026-05-06 Flux investigation ("coke" → "smoke", "pepper shrimp" → "pepper soup"): the open-domain English LM picks a more frequent everyday phrase over the restaurant-context interpretation.
+
+We have one data point. Before changing production STT, we need a way to:
+1. Capture caller audio from real local calls in a format we can re-feed to Deepgram.
+2. Sweep that audio through multiple STT configurations (model + keyterms) and compare outputs side-by-side.
+
+GCS-uploaded recordings exist but are gated by IAM that the local dev box doesn't have. The fastest iteration loop is local capture → local replay.
+
+## Goals
+
+- Capture inbound (caller-side) audio from a live local call to a local file, in a format byte-for-byte compatible with Deepgram's streaming input.
+- Provide a CLI replay tool that streams a captured file through Deepgram with configurable model + keyterms and prints transcripts.
+- Support a sweep mode that runs the same audio through N model+keyterm configurations and prints a comparison table.
+- Stay **local-dev-only**. No production behavior change. No PII surface in shared infra.
+
+## Non-goals
+
+- Production capture, retention, or playback. Existing GCS recording path remains the production answer.
+- Capturing the agent (outbound) audio. The bug is in caller-side recognition.
+- Choosing a fix for the Flux misrecognition. This spec builds the measuring instrument; the fix is decided from data in a separate PR.
+- Reviving the v1 (Nova) STT in production. Replay talks to Deepgram directly without touching the production STT class.
+
+## Architecture
+
+Three pieces:
+
+### 1. `app/dev/audio_dump.py` (new module)
+
+Pure-function module that owns the local-dump file lifecycle.
+
+```python
+def open_caller_dump(call_sid: str) -> Optional["CallerAudioDump"]: ...
+
+class CallerAudioDump:
+    def append(self, mulaw_bytes: bytes) -> None: ...
+    def close(self) -> None: ...
+```
+
+- `open_caller_dump` returns `None` when `settings.niko_local_audio_dump_dir` is empty/unset (production default).
+- When set, it ensures the directory exists and opens an append-mode file at `{dir}/{call_sid}_{started_at_iso}.ulaw`.
+- All filesystem failures (permission, disk full, bad path) are caught and logged at WARNING. The function returns `None` on failure — never raises into the call loop.
+- File format: **raw mulaw 8 kHz, no header**. Same bytes Twilio's media events deliver and Flux's `send_media` consumes. Replay is byte-for-byte forward — no encode/decode in the testing loop.
+
+### 2. Wire-in: `app/telephony/router.py`
+
+Three additions, all gated on `state.caller_dump is not None`:
+
+- On `start` event, after `state.call_sid` is resolved: `state.caller_dump = open_caller_dump(state.call_sid)`.
+- On `media` event with `track == "inbound"`: `state.caller_dump.append(payload)`.
+- In WS finally block, before STT close: `if state.caller_dump: state.caller_dump.close()`.
+
+`_CallState` gets one new field: `caller_dump: Optional["CallerAudioDump"] = None`.
+
+### 3. `scripts/replay_stt.py` (new CLI)
+
+Standalone diagnostic tool. Talks to Deepgram directly via `AsyncDeepgramClient`, **does not import `app.deepgram.stt`**. Production STT path is untouched.
+
+CLI surface:
+
+```
+python scripts/replay_stt.py PATH.ulaw [options]
+
+Options:
+  --model {flux-general-en,nova-2,nova-3-general}   default: flux-general-en
+  --keyterms term1,term2,...                        default: empty (open-domain)
+  --pace {realtime,fast}                            default: realtime
+  --sweep CONFIG.json                               run a config matrix
+```
+
+Single-config mode dispatches based on `--model`:
+- `flux-general-en` → `listen.v2.connect`, translate `TurnInfo` events
+- `nova-2` / `nova-3-general` → `listen.v1.connect`, translate `Results` / `UtteranceEnd` events
+
+Both code paths print interim and final transcripts to stdout as they arrive, then send close-stream and drain the final EOT/utterance-end before exiting.
+
+`--pace realtime` sleeps 20 ms between 160-byte frames (matches a live call, exercises Flux's prosody-aware turn detection accurately). `--pace fast` blasts as fast as the socket accepts (faster iteration when only the final transcript matters).
+
+Sweep mode reads a JSON file with N configurations and runs each against the same audio file:
+
+```json
+[
+  {"model": "flux-general-en", "keyterms": []},
+  {"model": "flux-general-en", "keyterms": ["Niko's Pizza"]},
+  {"model": "flux-general-en", "keyterms": ["Niko's Pizza", "pickup", "delivery", "Can I"]},
+  {"model": "nova-2", "keyterms": []},
+  {"model": "nova-3-general", "keyterms": ["Niko's Pizza", "pickup"]}
+]
+```
+
+Output is a single comparison table: model, keyterms (count), first final transcript, confidence. Full per-utterance transcripts available with `--verbose`.
+
+## Configuration
+
+One new field in `app/config.py:Settings`:
+
+```python
+niko_local_audio_dump_dir: Optional[str] = None
+```
+
+Mirrors the existing `niko_dev_endpoints` dev-only-flag pattern. Empty/unset → feature dormant. Recommended local value: `./dev_recordings`.
+
+`.env` documentation gets one new line. No production env changes.
+
+## Gitignore
+
+Add `dev_recordings/` to `.gitignore`. The env var owns the actual path; this just covers the suggested default.
+
+## Tests
+
+`tests/test_audio_dump.py` (new):
+- `open_caller_dump` returns `None` when env unset.
+- `open_caller_dump` returns a writer when env set; subsequent `append` writes bytes verbatim; `close` closes the file.
+- Non-existent directory is created on first open.
+- Permission denied path (or any IOError) returns `None` and logs — does not raise.
+
+No tests for `scripts/replay_stt.py`. It's a thin imperative wrapper around Deepgram + file I/O; manual exercise on a real recording is the verification.
+
+Existing telephony tests already cover the WS handler. Confirm the new dump branch doesn't break them; add one test case where `caller_dump` is set and verify `append` is called for inbound media events.
+
+## Failure modes and behavior
+
+- Disk full / permission denied during `append`: catch, log at WARNING, set an internal `broken=True` flag, no-op subsequent appends. The call continues normally.
+- `niko_local_audio_dump_dir` points at a path that's a file (not a directory): caught at `open_caller_dump`, returns `None`.
+- WS handler crashes mid-call: the WS finally block calls `caller_dump.close()`; the file is left at whatever bytes were flushed. Partial files are still replayable.
+- Replay script API key missing: fail loud (`SystemExit` with a clear message). It's a dev tool; no fallback behavior.
+
+## What this enables (the iteration loop)
+
+1. Set `NIKO_LOCAL_AUDIO_DUMP_DIR=./dev_recordings` in local `.env`.
+2. Make a local test call. A `.ulaw` file appears in `dev_recordings/`.
+3. Run `scripts/replay_stt.py dev_recordings/<file>.ulaw --sweep configs/stt_first_turn.json`.
+4. Read the comparison table. Whichever (model, keyterms) configuration recovers the correct transcript with the highest confidence is the candidate fix.
+5. The followup PR is *one of*:
+   - Add ordering-phrase keyterms to `app/restaurants/keyterms.py` (cheap, stays on Flux).
+   - Reopen the Flux migration decision and restore Nova in production (bigger, needs a separate spec).
+
+Both are explicitly out of scope for this spec.
+
+## Out of scope / explicit deferrals
+
+- Capturing or replaying outbound (agent) audio. Doable with a parallel `outbound_dump`, but not needed for this bug.
+- Production audio capture path. The GCS recording path is the production answer; we don't replicate it locally.
+- A diff-mode CLI flag (`--expected "..."`) that pass/fails the script for CI. Possible follow-up if we ever want to lock first-turn behavior into CI.
+- A web UI for visualizing sweep results. Stdout table is enough for the immediate diagnostic loop.

--- a/scripts/replay_stt.py
+++ b/scripts/replay_stt.py
@@ -77,9 +77,7 @@ class ReplayResult:
 def _api_key() -> str:
     key = os.getenv("DEEPGRAM_API_KEY", "").strip()
     if not key:
-        sys.exit(
-            "DEEPGRAM_API_KEY not set. Add it to .env or export it before running."
-        )
+        sys.exit("DEEPGRAM_API_KEY not set. Add it to .env or export it before running.")
     return key
 
 
@@ -167,17 +165,29 @@ async def _run_v2(
                 msg_type = msg.get("type") if isinstance(msg, dict) else getattr(msg, "type", None)
                 if msg_type == "Connected":
                     if verbose:
-                        rid = msg.get("request_id") if isinstance(msg, dict) else getattr(msg, "request_id", "?")
+                        rid = (
+                            msg.get("request_id")
+                            if isinstance(msg, dict)
+                            else getattr(msg, "request_id", "?")
+                        )
                         print(f"[connected request_id={rid}]")
                     continue
                 if msg_type == "TurnInfo":
                     event = msg.get("event") if isinstance(msg, dict) else getattr(msg, "event", "")
-                    text = (msg.get("transcript") if isinstance(msg, dict) else getattr(msg, "transcript", "")) or ""
+                    text = (
+                        msg.get("transcript")
+                        if isinstance(msg, dict)
+                        else getattr(msg, "transcript", "")
+                    ) or ""
                     text = text.strip()
                     if event == "Update" and verbose and text:
                         print(f"[interim] {text}")
                     elif event == "EndOfTurn" and text:
-                        words = msg.get("words", []) if isinstance(msg, dict) else getattr(msg, "words", [])
+                        words = (
+                            msg.get("words", [])
+                            if isinstance(msg, dict)
+                            else getattr(msg, "words", [])
+                        )
                         conf = _avg_word_conf(words)
                         result.finals.append((text, conf))
                         print(f"[final  ] {text}   conf={conf:.2f}")
@@ -242,15 +252,29 @@ async def _run_v1(
                 msg = await conn.recv()
                 msg_type = msg.get("type") if isinstance(msg, dict) else getattr(msg, "type", None)
                 if msg_type == "Results":
-                    is_final = msg.get("is_final") if isinstance(msg, dict) else getattr(msg, "is_final", False)
-                    channel = msg.get("channel", {}) if isinstance(msg, dict) else getattr(msg, "channel", None)
+                    is_final = (
+                        msg.get("is_final")
+                        if isinstance(msg, dict)
+                        else getattr(msg, "is_final", False)
+                    )
+                    channel = (
+                        msg.get("channel", {})
+                        if isinstance(msg, dict)
+                        else getattr(msg, "channel", None)
+                    )
                     alts = (
-                        channel.get("alternatives", []) if isinstance(channel, dict) else getattr(channel, "alternatives", [])
+                        channel.get("alternatives", [])
+                        if isinstance(channel, dict)
+                        else getattr(channel, "alternatives", [])
                     ) or []
                     if not alts:
                         continue
                     alt = alts[0]
-                    text = (alt.get("transcript") if isinstance(alt, dict) else getattr(alt, "transcript", "")) or ""
+                    text = (
+                        alt.get("transcript")
+                        if isinstance(alt, dict)
+                        else getattr(alt, "transcript", "")
+                    ) or ""
                     text = text.strip()
                     if not text:
                         continue
@@ -270,7 +294,11 @@ async def _run_v1(
                         print(f"[interim] {text}")
                     continue
                 if msg_type == "Metadata" and verbose:
-                    rid = msg.get("request_id") if isinstance(msg, dict) else getattr(msg, "request_id", "?")
+                    rid = (
+                        msg.get("request_id")
+                        if isinstance(msg, dict)
+                        else getattr(msg, "request_id", "?")
+                    )
                     print(f"[connected request_id={rid}]")
                     continue
                 if msg_type == "UtteranceEnd" and verbose:
@@ -379,7 +407,9 @@ def _print_sweep_table(results: list[ReplayResult]) -> None:
     print("-" * len(header))
     for i, r in enumerate(results, start=1):
         if r.error:
-            row = f"{i:>2}  {r.model:<20}  {len(r.keyterms):>3}  ERROR: {r.error[:40]:<40}  {'-':>5}"
+            row = (
+                f"{i:>2}  {r.model:<20}  {len(r.keyterms):>3}  ERROR: {r.error[:40]:<40}  {'-':>5}"
+            )
         elif r.first_final:
             text, conf = r.first_final
             display = text if len(text) <= 40 else text[:37] + "..."

--- a/scripts/replay_stt.py
+++ b/scripts/replay_stt.py
@@ -1,0 +1,457 @@
+"""Local STT replay tool — feed a captured caller-audio file through
+Deepgram and print transcripts.
+
+Usage::
+
+    python scripts/replay_stt.py PATH.ulaw [options]
+
+The audio file must be raw mulaw 8 kHz mono with no header — the same
+bytes Twilio's media stream delivers and Deepgram's ``send_media``
+consumes. Files written by ``app.dev.audio_dump.CallerAudioDump`` are
+in this format directly; no conversion needed.
+
+This script talks to Deepgram via the ``deepgram-sdk`` package and is
+deliberately **standalone** — it does NOT import ``app.deepgram.stt``.
+That keeps production STT untouched and lets the script swap between
+v1 (Nova) and v2 (Flux) endpoints freely for offline A/B testing.
+
+Single-config mode::
+
+    python scripts/replay_stt.py call.ulaw --model flux-general-en \\
+        --keyterms "Niko's Pizza,pickup,Can I" --pace realtime
+
+Sweep mode (run N configs against the same file, print a comparison
+table)::
+
+    python scripts/replay_stt.py call.ulaw --sweep configs.json
+
+The sweep file is a JSON list of objects, each with ``model`` and
+``keyterms`` (a list of strings). See the docstring on ``run_sweep``
+for the exact shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional, Sequence
+
+# Ensure ``app`` is importable when running from the repo root.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+from deepgram import AsyncDeepgramClient
+
+# Mulaw 8 kHz: 1 byte = 1 sample, 20 ms = 160 samples = 160 bytes.
+FRAME_SIZE_BYTES = 160
+FRAME_DURATION_S = 0.020
+
+V2_MODELS = {"flux-general-en", "flux-general-multi"}
+
+
+@dataclass
+class ReplayResult:
+    """Outcome of one replay run."""
+
+    model: str
+    keyterms: list[str]
+    finals: list[tuple[str, float]] = field(default_factory=list)
+    error: Optional[str] = None
+
+    @property
+    def first_final(self) -> tuple[str, float] | None:
+        return self.finals[0] if self.finals else None
+
+
+def _api_key() -> str:
+    key = os.getenv("DEEPGRAM_API_KEY", "").strip()
+    if not key:
+        sys.exit(
+            "DEEPGRAM_API_KEY not set. Add it to .env or export it before running."
+        )
+    return key
+
+
+def _read_frames(path: str) -> list[bytes]:
+    """Read the entire file and split into 20 ms mulaw frames.
+
+    For audio short enough to fit in memory (typical call: a few MB)
+    this is simpler than streaming I/O. Trailing partial frames are
+    padded with mulaw silence (0xFF) so Flux's frame-aligned pipeline
+    doesn't see a short final frame.
+    """
+    with open(path, "rb") as f:
+        data = f.read()
+    if not data:
+        sys.exit(f"replay: input file is empty: {path}")
+    frames: list[bytes] = []
+    for i in range(0, len(data), FRAME_SIZE_BYTES):
+        chunk = data[i : i + FRAME_SIZE_BYTES]
+        if len(chunk) < FRAME_SIZE_BYTES:
+            chunk = chunk + b"\xff" * (FRAME_SIZE_BYTES - len(chunk))
+        frames.append(chunk)
+    return frames
+
+
+def _avg_word_conf(words: Any) -> float:
+    """Average word-level confidence; 1.0 fallback when missing."""
+    if not words:
+        return 1.0
+    confs: list[float] = []
+    for w in words:
+        if isinstance(w, dict):
+            c = w.get("confidence")
+        else:
+            c = getattr(w, "confidence", None)
+        if c is None:
+            continue
+        try:
+            confs.append(float(c))
+        except (TypeError, ValueError):
+            pass
+    if confs:
+        return sum(confs) / len(confs)
+    return 1.0
+
+
+async def _pump_frames(conn: Any, frames: Sequence[bytes], pace: str) -> None:
+    """Send all frames to Deepgram, then close-stream."""
+    if pace == "realtime":
+        start = time.monotonic()
+        for i, frame in enumerate(frames):
+            target = start + (i + 1) * FRAME_DURATION_S
+            await conn.send_media(frame)
+            now = time.monotonic()
+            if now < target:
+                await asyncio.sleep(target - now)
+    else:
+        for frame in frames:
+            await conn.send_media(frame)
+    await conn.send_close_stream()
+
+
+async def _run_v2(
+    *,
+    api_key: str,
+    model: str,
+    keyterms: list[str],
+    frames: Sequence[bytes],
+    pace: str,
+    verbose: bool,
+) -> ReplayResult:
+    """Replay through Flux (v2) endpoint."""
+    result = ReplayResult(model=model, keyterms=list(keyterms))
+    client = AsyncDeepgramClient(api_key=api_key)
+    cm = client.listen.v2.connect(
+        model=model,
+        encoding="mulaw",
+        sample_rate=8000,
+        keyterm=keyterms or None,
+    )
+    async with cm as conn:
+        pump = asyncio.create_task(_pump_frames(conn, frames, pace))
+        try:
+            while True:
+                msg = await conn.recv()
+                msg_type = msg.get("type") if isinstance(msg, dict) else getattr(msg, "type", None)
+                if msg_type == "Connected":
+                    if verbose:
+                        rid = msg.get("request_id") if isinstance(msg, dict) else getattr(msg, "request_id", "?")
+                        print(f"[connected request_id={rid}]")
+                    continue
+                if msg_type == "TurnInfo":
+                    event = msg.get("event") if isinstance(msg, dict) else getattr(msg, "event", "")
+                    text = (msg.get("transcript") if isinstance(msg, dict) else getattr(msg, "transcript", "")) or ""
+                    text = text.strip()
+                    if event == "Update" and verbose and text:
+                        print(f"[interim] {text}")
+                    elif event == "EndOfTurn" and text:
+                        words = msg.get("words", []) if isinstance(msg, dict) else getattr(msg, "words", [])
+                        conf = _avg_word_conf(words)
+                        result.finals.append((text, conf))
+                        print(f"[final  ] {text}   conf={conf:.2f}")
+                    continue
+                if msg_type in ("ConfigureFailure", "FatalError"):
+                    err = f"{msg_type}: {msg}"
+                    result.error = err
+                    print(f"[error] {err}", file=sys.stderr)
+                    break
+        except Exception as exc:
+            # Connection closed after close-stream — normal exit path.
+            if not pump.done() or not result.finals:
+                result.error = f"recv error: {exc!r}"
+        finally:
+            if not pump.done():
+                pump.cancel()
+                try:
+                    await pump
+                except (asyncio.CancelledError, Exception):
+                    pass
+    return result
+
+
+async def _run_v1(
+    *,
+    api_key: str,
+    model: str,
+    keyterms: list[str],
+    frames: Sequence[bytes],
+    pace: str,
+    verbose: bool,
+) -> ReplayResult:
+    """Replay through Nova (v1) endpoint."""
+    result = ReplayResult(model=model, keyterms=list(keyterms))
+    client = AsyncDeepgramClient(api_key=api_key)
+    # v1 supports keyterm only on Nova-3; Nova-2 silently ignores it
+    # (which is what we want for the "Nova-2 baseline" config).
+    #
+    # Boolean-shaped params on v1 must be the *strings* ``"true"`` /
+    # ``"false"`` — the SDK doesn't coerce Python ``bool`` and the
+    # server returns 400 if it gets an int/bool. Numeric params accept
+    # ``int``. (Confirmed empirically against deepgram-sdk 7.0.1.)
+    kwargs: dict[str, Any] = dict(
+        model=model,
+        encoding="mulaw",
+        sample_rate=8000,
+        interim_results="true",
+        utterance_end_ms=1000,
+        endpointing=800,
+        vad_events="true",
+        smart_format="false",
+        punctuate="true",
+    )
+    if keyterms:
+        kwargs["keyterm"] = keyterms
+
+    cm = client.listen.v1.connect(**kwargs)
+    async with cm as conn:
+        pump = asyncio.create_task(_pump_frames(conn, frames, pace))
+        try:
+            while True:
+                msg = await conn.recv()
+                msg_type = msg.get("type") if isinstance(msg, dict) else getattr(msg, "type", None)
+                if msg_type == "Results":
+                    is_final = msg.get("is_final") if isinstance(msg, dict) else getattr(msg, "is_final", False)
+                    channel = msg.get("channel", {}) if isinstance(msg, dict) else getattr(msg, "channel", None)
+                    alts = (
+                        channel.get("alternatives", []) if isinstance(channel, dict) else getattr(channel, "alternatives", [])
+                    ) or []
+                    if not alts:
+                        continue
+                    alt = alts[0]
+                    text = (alt.get("transcript") if isinstance(alt, dict) else getattr(alt, "transcript", "")) or ""
+                    text = text.strip()
+                    if not text:
+                        continue
+                    if is_final:
+                        conf = (
+                            alt.get("confidence")
+                            if isinstance(alt, dict)
+                            else getattr(alt, "confidence", None)
+                        )
+                        try:
+                            conf_f = float(conf) if conf is not None else 1.0
+                        except (TypeError, ValueError):
+                            conf_f = 1.0
+                        result.finals.append((text, conf_f))
+                        print(f"[final  ] {text}   conf={conf_f:.2f}")
+                    elif verbose:
+                        print(f"[interim] {text}")
+                    continue
+                if msg_type == "Metadata" and verbose:
+                    rid = msg.get("request_id") if isinstance(msg, dict) else getattr(msg, "request_id", "?")
+                    print(f"[connected request_id={rid}]")
+                    continue
+                if msg_type == "UtteranceEnd" and verbose:
+                    print("[utterance_end]")
+                    continue
+        except Exception as exc:
+            if not pump.done() or not result.finals:
+                result.error = f"recv error: {exc!r}"
+        finally:
+            if not pump.done():
+                pump.cancel()
+                try:
+                    await pump
+                except (asyncio.CancelledError, Exception):
+                    pass
+    return result
+
+
+async def run_one(
+    *,
+    path: str,
+    model: str,
+    keyterms: list[str],
+    pace: str,
+    verbose: bool,
+) -> ReplayResult:
+    api_key = _api_key()
+    frames = _read_frames(path)
+    if verbose:
+        print(
+            f"[opening {model}: {len(frames)} frames "
+            f"({len(frames) * FRAME_DURATION_S:.1f}s), keyterms={len(keyterms)}]"
+        )
+    if model in V2_MODELS:
+        return await _run_v2(
+            api_key=api_key,
+            model=model,
+            keyterms=keyterms,
+            frames=frames,
+            pace=pace,
+            verbose=verbose,
+        )
+    return await _run_v1(
+        api_key=api_key,
+        model=model,
+        keyterms=keyterms,
+        frames=frames,
+        pace=pace,
+        verbose=verbose,
+    )
+
+
+async def run_sweep(
+    *,
+    path: str,
+    sweep_file: str,
+    pace: str,
+    verbose: bool,
+) -> list[ReplayResult]:
+    """Run multiple configs against the same audio file.
+
+    Sweep file format::
+
+        [
+          {"model": "flux-general-en", "keyterms": []},
+          {"model": "flux-general-en", "keyterms": ["Niko's Pizza", "pickup"]},
+          {"model": "nova-2", "keyterms": []},
+          {"model": "nova-3-general", "keyterms": ["pickup", "Can I"]}
+        ]
+    """
+    with open(sweep_file, "r", encoding="utf-8") as f:
+        configs = json.load(f)
+    if not isinstance(configs, list):
+        sys.exit("sweep: top-level JSON must be a list of {model, keyterms} objects")
+
+    results: list[ReplayResult] = []
+    for i, cfg in enumerate(configs, start=1):
+        model = cfg.get("model")
+        keyterms = cfg.get("keyterms", [])
+        if not model:
+            print(f"[skip config #{i}: missing 'model']", file=sys.stderr)
+            continue
+        if not isinstance(keyterms, list):
+            print(f"[skip config #{i}: 'keyterms' must be a list]", file=sys.stderr)
+            continue
+        print(f"\n=== config {i}/{len(configs)}: model={model}, keyterms={len(keyterms)} ===")
+        result = await run_one(
+            path=path,
+            model=model,
+            keyterms=list(keyterms),
+            pace=pace,
+            verbose=verbose,
+        )
+        results.append(result)
+    return results
+
+
+def _print_sweep_table(results: list[ReplayResult]) -> None:
+    if not results:
+        return
+    print("\n" + "=" * 80)
+    print("SWEEP COMPARISON")
+    print("=" * 80)
+    header = f"{'#':>2}  {'model':<20}  {'kt':>3}  {'first_final_transcript':<40}  {'conf':>5}"
+    print(header)
+    print("-" * len(header))
+    for i, r in enumerate(results, start=1):
+        if r.error:
+            row = f"{i:>2}  {r.model:<20}  {len(r.keyterms):>3}  ERROR: {r.error[:40]:<40}  {'-':>5}"
+        elif r.first_final:
+            text, conf = r.first_final
+            display = text if len(text) <= 40 else text[:37] + "..."
+            row = f"{i:>2}  {r.model:<20}  {len(r.keyterms):>3}  {display:<40}  {conf:>5.2f}"
+        else:
+            row = f"{i:>2}  {r.model:<20}  {len(r.keyterms):>3}  {'(no final transcript)':<40}  {'-':>5}"
+        print(row)
+    print("=" * 80)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Replay a captured caller-audio file through Deepgram.",
+    )
+    p.add_argument("path", help="Path to a raw mulaw 8 kHz file (.ulaw).")
+    p.add_argument(
+        "--model",
+        default="flux-general-en",
+        help="Deepgram model. Flux: flux-general-en. Nova: nova-2, nova-3-general. (default: %(default)s)",
+    )
+    p.add_argument(
+        "--keyterms",
+        default="",
+        help="Comma-separated keyterms to bias recognition (single-config mode).",
+    )
+    p.add_argument(
+        "--pace",
+        choices=("realtime", "fast"),
+        default="realtime",
+        help="realtime = 20ms between frames (matches a live call); fast = no pacing. (default: %(default)s)",
+    )
+    p.add_argument(
+        "--sweep",
+        default=None,
+        help="Path to a JSON file with N configs; runs each and prints a comparison table.",
+    )
+    p.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print interim transcripts and connection metadata.",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if not os.path.isfile(args.path):
+        sys.exit(f"replay: input file not found: {args.path}")
+
+    if args.sweep:
+        results = asyncio.run(
+            run_sweep(
+                path=args.path,
+                sweep_file=args.sweep,
+                pace=args.pace,
+                verbose=args.verbose,
+            )
+        )
+        _print_sweep_table(results)
+        return
+
+    keyterms = [t.strip() for t in args.keyterms.split(",") if t.strip()]
+    asyncio.run(
+        run_one(
+            path=args.path,
+            model=args.model,
+            keyterms=keyterms,
+            pace=args.pace,
+            verbose=args.verbose,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ulaw_to_mp3.py
+++ b/scripts/ulaw_to_mp3.py
@@ -52,9 +52,7 @@ def convert_one(ulaw_path: str) -> str:
 def collect_targets(arg: str) -> list[str]:
     if os.path.isdir(arg):
         return sorted(
-            os.path.join(arg, name)
-            for name in os.listdir(arg)
-            if name.lower().endswith(".ulaw")
+            os.path.join(arg, name) for name in os.listdir(arg) if name.lower().endswith(".ulaw")
         )
     if os.path.isfile(arg):
         return [arg]

--- a/scripts/ulaw_to_mp3.py
+++ b/scripts/ulaw_to_mp3.py
@@ -1,0 +1,78 @@
+"""Convert raw mulaw 8 kHz files (the format ``app.dev.audio_dump``
+writes) to MP3 so the audio can be uploaded to tools that don't accept
+raw mulaw — e.g. Deepgram's web console, generic audio players, support
+attachments.
+
+Reuses the production helpers from ``app.storage.recordings``:
+``_ulaw2lin_16`` for the mulaw→PCM decode and ``_make_encoder`` for the
+lameenc MP3 encoder. No new dependencies.
+
+Usage::
+
+    python scripts/ulaw_to_mp3.py PATH.ulaw            # one file
+    python scripts/ulaw_to_mp3.py dev_recordings/      # every .ulaw in dir
+
+Output is written next to each input as ``<basename>.mp3``. Existing
+``.mp3`` files are overwritten.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.storage.recordings import _make_encoder, _ulaw2lin_16
+
+
+def convert_one(ulaw_path: str) -> str:
+    """Convert one ``.ulaw`` file to ``.mp3``. Returns the output path."""
+    with open(ulaw_path, "rb") as f:
+        mulaw_bytes = f.read()
+    if not mulaw_bytes:
+        raise ValueError(f"input file is empty: {ulaw_path}")
+
+    pcm = _ulaw2lin_16(mulaw_bytes)
+    encoder = _make_encoder()
+    mp3 = bytes(encoder.encode(pcm) + encoder.flush())
+
+    out_path = os.path.splitext(ulaw_path)[0] + ".mp3"
+    with open(out_path, "wb") as f:
+        f.write(mp3)
+
+    duration_s = (len(pcm) // 2) / 8000.0
+    print(
+        f"{ulaw_path}  ->  {out_path}  "
+        f"({len(mulaw_bytes):,}B mulaw, {len(mp3):,}B mp3, {duration_s:.1f}s)"
+    )
+    return out_path
+
+
+def collect_targets(arg: str) -> list[str]:
+    if os.path.isdir(arg):
+        return sorted(
+            os.path.join(arg, name)
+            for name in os.listdir(arg)
+            if name.lower().endswith(".ulaw")
+        )
+    if os.path.isfile(arg):
+        return [arg]
+    sys.exit(f"input not found: {arg}")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("usage: ulaw_to_mp3.py <file.ulaw | dir>")
+    targets = collect_targets(sys.argv[1])
+    if not targets:
+        sys.exit("no .ulaw files found")
+    for path in targets:
+        try:
+            convert_one(path)
+        except Exception as exc:
+            print(f"FAIL: {path}: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_audio_dump.py
+++ b/tests/test_audio_dump.py
@@ -1,0 +1,139 @@
+"""Tests for app/dev/audio_dump.py.
+
+This module owns local-dev caller-audio capture. The contract that
+matters for production safety: when ``niko_local_audio_dump_dir`` is
+unset (production default), ``open_caller_dump`` returns ``None`` and
+no filesystem I/O happens. Every other test verifies the local-dev
+behavior we depend on for offline STT replay.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.dev import audio_dump
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_dump_dir():
+    """Snapshot/restore the dump-dir setting around each test."""
+    original = audio_dump.settings.niko_local_audio_dump_dir
+    yield
+    audio_dump.settings.niko_local_audio_dump_dir = original
+
+
+def test_returns_none_when_setting_unset() -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = None
+    assert audio_dump.open_caller_dump("CA123") is None
+
+
+def test_returns_none_when_setting_blank() -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = "   "
+    assert audio_dump.open_caller_dump("CA123") is None
+
+
+def test_returns_none_when_call_sid_blank(tmp_path: Path) -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = str(tmp_path)
+    assert audio_dump.open_caller_dump("") is None
+
+
+def test_writes_bytes_to_disk(tmp_path: Path) -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = str(tmp_path)
+    dump = audio_dump.open_caller_dump("CA123")
+    assert dump is not None
+    dump.append(b"\xff\x80\x7f")
+    dump.append(b"\x00\x01\x02")
+    dump.close()
+
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    assert files[0].name.startswith("CA123_")
+    assert files[0].name.endswith(".ulaw")
+    assert files[0].read_bytes() == b"\xff\x80\x7f\x00\x01\x02"
+
+
+def test_creates_missing_directory(tmp_path: Path) -> None:
+    nested = tmp_path / "does" / "not" / "exist"
+    audio_dump.settings.niko_local_audio_dump_dir = str(nested)
+    dump = audio_dump.open_caller_dump("CA123")
+    assert dump is not None
+    dump.append(b"hello")
+    dump.close()
+    assert nested.is_dir()
+    assert any(nested.iterdir())
+
+
+def test_returns_none_when_dir_path_is_a_file(tmp_path: Path) -> None:
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir")
+    audio_dump.settings.niko_local_audio_dump_dir = str(blocker)
+    assert audio_dump.open_caller_dump("CA123") is None
+
+
+def test_returns_none_when_makedirs_fails(tmp_path: Path) -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = str(tmp_path / "x")
+    with patch("app.dev.audio_dump.os.makedirs", side_effect=PermissionError("denied")):
+        assert audio_dump.open_caller_dump("CA123") is None
+
+
+def test_returns_none_when_open_fails(tmp_path: Path) -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = str(tmp_path)
+    with patch(
+        "app.dev.audio_dump.open",
+        side_effect=PermissionError("denied"),
+        create=True,
+    ):
+        assert audio_dump.open_caller_dump("CA123") is None
+
+
+def test_append_after_ioerror_becomes_noop(tmp_path: Path) -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = str(tmp_path)
+    dump = audio_dump.open_caller_dump("CA123")
+    assert dump is not None
+    dump.append(b"first")
+
+    # Force an error on the next write by closing the underlying fh.
+    dump._fh.close()  # type: ignore[attr-defined]
+
+    # This should be caught, log, and flip _broken — not raise.
+    dump.append(b"second")
+
+    # Subsequent writes are no-ops; close is also safe.
+    dump.append(b"third")
+    dump.close()
+
+
+def test_call_sid_with_special_chars_is_sanitized(tmp_path: Path) -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = str(tmp_path)
+    dump = audio_dump.open_caller_dump("CA/123\\..\\..\\evil")
+    assert dump is not None
+    dump.close()
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    # No path separators should survive sanitization.
+    assert "/" not in files[0].name
+    assert "\\" not in files[0].name
+
+
+def test_empty_append_is_noop(tmp_path: Path) -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = str(tmp_path)
+    dump = audio_dump.open_caller_dump("CA123")
+    assert dump is not None
+    dump.append(b"")  # should not crash, should not write
+    dump.close()
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    assert files[0].read_bytes() == b""
+
+
+def test_dump_path_is_recorded(tmp_path: Path) -> None:
+    audio_dump.settings.niko_local_audio_dump_dir = str(tmp_path)
+    dump = audio_dump.open_caller_dump("CA123")
+    assert dump is not None
+    assert os.path.dirname(dump.path) == str(tmp_path)
+    assert dump.path.endswith(".ulaw")
+    dump.close()


### PR DESCRIPTION
## Summary

- **`app/dev/audio_dump.py` + wire-in** — when `NIKO_LOCAL_AUDIO_DUMP_DIR` is set, /media-stream writes inbound (caller-side) mulaw audio to `<dir>/<call_sid>_<iso>.ulaw`. Production-default unset → returns `None`, no behavior change.
- **`scripts/replay_stt.py`** — standalone CLI to replay a `.ulaw` through Deepgram. Single-config mode or `--sweep CONFIG.json` matrix mode; dispatches to v1 (Nova) or v2 (Flux) directly. Does NOT import production STT — keeps the production path untouched.
- **`scripts/ulaw_to_mp3.py`** — converts raw mulaw dumps to MP3 (reuses `app.storage.recordings._ulaw2lin_16` + `lameenc`) for upload to tools that don't accept raw mulaw (Deepgram web console, support attachments).
- **Tests** — 12 unit tests for `audio_dump` covering env-gating, write behavior, missing-dir creation, IOError tolerance.

Closes #263

## Why

Real calls have hit STT misrecognitions ("Can I" → "I cannot", "I will get" → "I've been getting"). The GCS recording path requires IAM the local dev box doesn't have, and re-dialing per experiment is expensive. This gives us a local-dev capture → offline replay loop that turns a 5-iteration manual call cycle into one command.

Used today to:
- Capture three real calls' caller audio.
- Confirm the misrecognition reproduces deterministically on offline replay.
- Sweep Flux + Nova-2 + Nova-3 with varying keyterm sets on the same audio.
- Discover that Flux v2 silently ignores `term:boost` keyterm syntax.
- Decide internally to stay on Flux (Nova-3 makes the same crucial errors on natural ordering audio).

## Test plan

- [x] `pytest tests/test_audio_dump.py` — 12 / 12 pass
- [x] `pytest tests/test_telephony.py` — 69 / 69 pass (no regressions to the WS handler)
- [x] Live call with `NIKO_LOCAL_AUDIO_DUMP_DIR=./dev_recordings` writes a `.ulaw` of the expected size (~8000 bytes/sec)
- [x] `python scripts/replay_stt.py <file>.ulaw --model flux-general-en --keyterms "..."` returns transcripts
- [x] `python scripts/replay_stt.py <file>.ulaw --sweep configs.json` runs N configs and prints comparison
- [x] `python scripts/ulaw_to_mp3.py dev_recordings/` converts all `.ulaw` to playable MP3
- [x] With env unset, no dump file is created and call behavior is identical

## Notes

- All filesystem failures (disk full, permission denied, dir conflict) in `audio_dump` are caught and logged at WARNING — they never raise into the call loop.
- `dev_recordings/` is added to `.gitignore` as the suggested default dump dir; the env var owns the actual path.
- Spec doc at `docs/superpowers/specs/2026-05-08-local-stt-replay-design.md` is included for traceability.
- One unrelated untracked file in the working tree (`docs/superpowers/specs/2026-05-01-menu-driven-prompts-design.md`) was deliberately **not** included in this PR — belongs to separate work.
- Replay script doesn't have its own tests — it's a thin imperative wrapper around Deepgram + file I/O; manual exercise on real recordings is the verification path.
- v1 (Nova) endpoint requires string `"true"` / `"false"` for boolean params (not Python `bool`); the SDK doesn't coerce. Discovered empirically — comment in `_run_v1` notes it.