### PR TITLE
fix(llm): warm prompt cache across tool follow-ups + rolling breakpoint on history

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -250,6 +250,52 @@ def _system_cache_block(system_prompt: str) -> list[dict[str, Any]]:
     ]
 
 
+def _with_rolling_cache_breakpoint(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Mark the last block of ``messages[-1]`` with ``cache_control: ephemeral``.
+
+    Together with the system-prompt breakpoint, this gives a 2-breakpoint
+    rolling cache (#176): each turn's request is cached up through the
+    new last message, and the next turn reads that as its cached prefix
+    so only the new content (previous assistant reply + new user turn)
+    is uncached prefill.
+
+    Caveat: Haiku 4.5 has a 4096-token minimum cacheable prefix. Short
+    calls won't engage the rolling breakpoint; longer calls (turn 3+ of
+    a typical order) will.
+
+    Returns a NEW messages list with a NEW last message — the input is
+    not mutated. This matters because callers thread the original
+    history forward into ``LLMResponse.history``; a stale cache_control
+    marker in threaded history would accumulate every turn and quickly
+    blow past Anthropic's 4-breakpoint cap.
+    """
+    if not messages:
+        return messages
+    last = messages[-1]
+    content = last["content"]
+    if isinstance(content, str):
+        # Plain-string user transcript. Convert to a one-block list so we
+        # can attach cache_control — strings have nowhere to attach it.
+        new_content: list[dict[str, Any]] = [
+            {
+                "type": "text",
+                "text": content,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+    else:
+        if not content:
+            return messages  # defensive: nothing to mark
+        new_content = [dict(block) for block in content]
+        new_content[-1] = {
+            **new_content[-1],
+            "cache_control": {"type": "ephemeral"},
+        }
+    return [*messages[:-1], {**last, "content": new_content}]
+
+
 def _append_user_transcript(history: list[dict[str, Any]], transcript: str) -> list[dict[str, Any]]:
     """Append the caller's transcript to history with valid alternation.
 
@@ -362,7 +408,7 @@ def generate_reply(
         max_tokens=MAX_TOKENS,
         system=_system_cache_block(system_prompt),
         tools=[UPDATE_ORDER_TOOL],
-        messages=new_history,
+        messages=_with_rolling_cache_breakpoint(new_history),
     )
 
     reply_text_parts: list[str] = []
@@ -408,7 +454,7 @@ def generate_reply(
             system=_system_cache_block(system_prompt),
             tools=[UPDATE_ORDER_TOOL],
             tool_choice={"type": "none"},
-            messages=new_history,
+            messages=_with_rolling_cache_breakpoint(new_history),
         )
         for block in followup.content:
             if block.type == "text":
@@ -504,7 +550,7 @@ async def stream_reply(
         max_tokens=MAX_TOKENS,
         system=_system_cache_block(system_prompt),
         tools=[UPDATE_ORDER_TOOL],
-        messages=new_history,
+        messages=_with_rolling_cache_breakpoint(new_history),
     ) as stream:
         async for event in stream:
             if t_first_event is None:
@@ -599,7 +645,7 @@ async def stream_reply(
             system=_system_cache_block(system_prompt),
             tools=[UPDATE_ORDER_TOOL],
             tool_choice={"type": "none"},
-            messages=new_history,
+            messages=_with_rolling_cache_breakpoint(new_history),
         ) as followup_stream:
             async for event in followup_stream:
                 if fu_t_first_event is None:

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -396,12 +396,18 @@ def generate_reply(
         ]
 
     if tool_uses:
-        # tools=[] is intentional — purely verbal continuation, see #173.
+        # Verbal continuation only — no further tool calls (#173). We keep the
+        # tool schema in ``tools`` and use ``tool_choice="none"`` to suppress
+        # tool use, rather than passing ``tools=[]``: tools sit before system
+        # in Anthropic's cached prefix order, so changing them across the two
+        # calls of one turn invalidates the entire cached prefix on the
+        # follow-up (system + menu + history). See #176.
         followup = api.messages.create(
             model=MODEL,
             max_tokens=MAX_TOKENS,
             system=_system_cache_block(system_prompt),
-            tools=[],
+            tools=[UPDATE_ORDER_TOOL],
+            tool_choice={"type": "none"},
             messages=new_history,
         )
         for block in followup.content:
@@ -571,7 +577,12 @@ async def stream_reply(
         )
 
     if tool_uses:
-        # tools=[] is intentional — purely verbal continuation, see #173.
+        # Verbal continuation only — no further tool calls (#173). We keep the
+        # tool schema in ``tools`` and use ``tool_choice="none"`` to suppress
+        # tool use, rather than passing ``tools=[]``: tools sit before system
+        # in Anthropic's cached prefix order, so changing them across the two
+        # calls of one turn invalidates the entire cached prefix on the
+        # follow-up (system + menu + history). See #176.
         # Each follow-up call gets its own scoped timing variables so the second
         # timing event reports that call's numbers, not the first call's (#175).
         fu_t_request_start = time.monotonic()
@@ -586,7 +597,8 @@ async def stream_reply(
             model=MODEL,
             max_tokens=MAX_TOKENS,
             system=_system_cache_block(system_prompt),
-            tools=[],
+            tools=[UPDATE_ORDER_TOOL],
+            tool_choice={"type": "none"},
             messages=new_history,
         ) as followup_stream:
             async for event in followup_stream:

--- a/dashboard/lib/formatters/call-timeline.ts
+++ b/dashboard/lib/formatters/call-timeline.ts
@@ -75,10 +75,16 @@ export function formatFirstAudioBreakdown(detail: Record<string, unknown>): stri
   if (typeof firstText === 'number')
     parts.push(`text=${Math.round(firstText * 1000)}ms`);
   if (typeof cacheRead === 'number' || typeof cacheCreation === 'number') {
-    const hit = (cacheRead ?? 0) > 0 && (cacheCreation ?? 0) === 0;
     const r = cacheRead ?? 0;
     const w = cacheCreation ?? 0;
-    parts.push(`cache=${hit ? 'hit' : 'miss'} r=${r} w=${w}`);
+    // r>0 w=0 = pure cache hit; r>0 w>0 = hit on the bulk prefix plus a
+    // small extension write on the new tail (the multi-turn rolling-cache
+    // pattern); r=0 = cold cache, full rewrite.
+    let label: 'hit' | 'hit+ext' | 'miss';
+    if (r > 0 && w === 0) label = 'hit';
+    else if (r > 0 && w > 0) label = 'hit+ext';
+    else label = 'miss';
+    parts.push(`cache=${label} r=${r} w=${w}`);
   }
 
   return parts.length ? `[${parts.join(' ')}]` : '';

--- a/dashboard/tests/call-timeline-formatter.test.ts
+++ b/dashboard/tests/call-timeline-formatter.test.ts
@@ -259,4 +259,18 @@ describe('formatFirstAudioBreakdown — #183 raw cache token counts', () => {
     });
     expect(result).toContain('cache=miss r=0 w=4096');
   });
+
+  it('marks cache=hit+ext when read tokens hit AND creation tokens extend the cache', () => {
+    // r>0 + w>0 means the cached prefix matched (cache hit) and a small
+    // new tail was added on top of the existing cache (incremental
+    // extension on a multi-turn call). Previously this was labelled
+    // "miss", which was misleading: most of the prompt hit the cache.
+    const result = formatFirstAudioBreakdown({
+      ttft_seconds: 0.5,
+      cache_read_tokens: 5085,
+      cache_creation_tokens: 329,
+    });
+    expect(result).toContain('cache=hit+ext r=5085 w=329');
+    expect(result).not.toContain('cache=miss');
+  });
 });

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -14,7 +14,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.llm import client as client_module
-from app.llm.client import _apply_update, _summarize_order, generate_reply, stream_reply
+from app.llm.client import (
+    UPDATE_ORDER_TOOL,
+    _apply_update,
+    _summarize_order,
+    generate_reply,
+    stream_reply,
+)
 from app.orders.models import Order, OrderStatus, OrderType
 
 _TEST_SYSTEM_PROMPT = "you are a test agent"
@@ -121,9 +127,11 @@ def test_tool_use_updates_order_in_single_turn():
     assert result.order.order_type is OrderType.PICKUP
     assert result.order.call_sid == "CAtest"
     assert fake_client.messages.create.call_count == 2
-    # Follow-up must pass tools=[] — purely verbal continuation, see #173.
+    # Follow-up keeps the tool schema in tools so the cache prefix matches
+    # the main call (#176); tool_choice="none" suppresses further tool use.
     followup_call_kwargs = fake_client.messages.create.call_args_list[1][1]
-    assert followup_call_kwargs["tools"] == []
+    assert followup_call_kwargs["tools"] == [UPDATE_ORDER_TOOL]
+    assert followup_call_kwargs["tool_choice"] == {"type": "none"}
 
 
 def test_tool_only_response_triggers_followup_call():
@@ -161,9 +169,11 @@ def test_tool_only_response_triggers_followup_call():
     assert result.reply_text == "Okay, order cancelled. Have a good day."
     assert result.order.status is OrderStatus.CANCELLED
     assert fake_client.messages.create.call_count == 2
-    # Follow-up must pass tools=[] — purely verbal continuation, see #173.
+    # Follow-up keeps the tool schema in tools so the cache prefix matches
+    # the main call (#176); tool_choice="none" suppresses further tool use.
     followup_call_kwargs = fake_client.messages.create.call_args_list[1][1]
-    assert followup_call_kwargs["tools"] == []
+    assert followup_call_kwargs["tools"] == [UPDATE_ORDER_TOOL]
+    assert followup_call_kwargs["tool_choice"] == {"type": "none"}
 
 
 def test_history_threads_user_and_assistant_turns():
@@ -871,9 +881,11 @@ async def test_stream_reply_runs_followup_when_first_turn_is_tool_only():
     assert deltas == ["Okay, ", "order cancelled."]
     assert final.reply_text == "Okay, order cancelled."
     assert final.order.status is OrderStatus.CANCELLED
-    # Follow-up must pass tools=[] — purely verbal continuation, see #173.
+    # Follow-up keeps the tool schema in tools so the cache prefix matches
+    # the main call (#176); tool_choice="none" suppresses further tool use.
     assert len(captured_calls) == 2
-    assert captured_calls[1]["tools"] == []
+    assert captured_calls[1]["tools"] == [UPDATE_ORDER_TOOL]
+    assert captured_calls[1]["tool_choice"] == {"type": "none"}
 
 
 async def test_stream_reply_text_deltas_arrive_before_final():
@@ -1619,9 +1631,11 @@ def test_followup_after_text_plus_tool_produces_readback_in_same_turn():
     assert "Got it, one Chicken Fried Rice coming up." in result.reply_text
     assert "So that's one Chicken Fried Rice" in result.reply_text
     assert fake_client.messages.create.call_count == 2
-    # Follow-up must pass tools=[] — purely verbal continuation, see #173.
+    # Follow-up keeps the tool schema in tools so the cache prefix matches
+    # the main call (#176); tool_choice="none" suppresses further tool use.
     followup_call_kwargs = fake_client.messages.create.call_args_list[1][1]
-    assert followup_call_kwargs["tools"] == []
+    assert followup_call_kwargs["tools"] == [UPDATE_ORDER_TOOL]
+    assert followup_call_kwargs["tool_choice"] == {"type": "none"}
 
 
 async def test_stream_reply_followup_after_text_plus_tool_yields_both_deltas():
@@ -1699,9 +1713,11 @@ async def test_stream_reply_followup_after_text_plus_tool_yields_both_deltas():
     assert "So that's" in final.reply_text
     # final.reply_text concatenates ack + read-back in that order.
     assert final.reply_text.index("Got it") < final.reply_text.index("So that's")
-    # Follow-up must pass tools=[] — purely verbal continuation, see #173.
+    # Follow-up keeps the tool schema in tools so the cache prefix matches
+    # the main call (#176); tool_choice="none" suppresses further tool use.
     assert len(captured_calls) == 2
-    assert captured_calls[1]["tools"] == []
+    assert captured_calls[1]["tools"] == [UPDATE_ORDER_TOOL]
+    assert captured_calls[1]["tool_choice"] == {"type": "none"}
 
 
 async def _collect_all_events(stream_iter) -> list:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1997,3 +1997,214 @@ async def test_stream_reply_persistent_client_used_when_no_injection(monkeypatch
     assert client_module._default_async_client is fake_api, (
         "stream_reply must reuse the singleton, not replace it"
     )
+
+
+# ---------------------------------------------------------------------------
+# #176 — rolling cache_control breakpoint on messages[-1]
+# ---------------------------------------------------------------------------
+
+
+def _last_user_blocks(messages: list[dict]) -> list[dict]:
+    """Return the content blocks of the last message, normalising the
+    plain-string case into a single-block list so tests can index uniformly."""
+    last = messages[-1]
+    content = last["content"]
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    return content
+
+
+def test_main_call_marks_plain_user_transcript_with_rolling_cache_breakpoint():
+    """When messages[-1] is a plain-string user transcript, the wrapper
+    converts it into a list with one text block carrying
+    ``cache_control: ephemeral``. Together with the system breakpoint,
+    this gives a 2-breakpoint rolling cache (#176)."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [FakeBlock(type="text", text="Sure, what size?")]
+    )
+
+    generate_reply(
+        transcript="one pepperoni please",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    )
+
+    main_kwargs = fake_client.messages.create.call_args_list[0][1]
+    blocks = _last_user_blocks(main_kwargs["messages"])
+    assert blocks[-1]["cache_control"] == {"type": "ephemeral"}
+    assert blocks[-1]["text"] == "one pepperoni please"
+
+
+def test_main_call_marks_only_last_block_when_tool_result_merged_with_user():
+    """When _append_user_transcript merges the new transcript with a
+    pending tool_result list, only the LAST block (the new text) carries
+    cache_control. Earlier tool_result blocks are not marked — Anthropic
+    only allows up to 4 cache breakpoints per request and we want them
+    on the rolling tail, not in the middle."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [FakeBlock(type="text", text="Got it.")]
+    )
+
+    history_with_pending_tool_result = [
+        {"role": "user", "content": "i'd like a pepperoni"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "got it"},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "update_order",
+                    "input": {},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": "Order updated.",
+                }
+            ],
+        },
+    ]
+
+    generate_reply(
+        transcript="and one coke",
+        history=history_with_pending_tool_result,
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    )
+
+    main_kwargs = fake_client.messages.create.call_args_list[0][1]
+    last_msg = main_kwargs["messages"][-1]
+    assert last_msg["role"] == "user"
+    blocks = last_msg["content"]
+    assert blocks[0]["type"] == "tool_result"
+    assert "cache_control" not in blocks[0]
+    assert blocks[-1]["type"] == "text"
+    assert blocks[-1]["text"] == "and one coke"
+    assert blocks[-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_followup_call_marks_tool_result_with_rolling_cache_breakpoint():
+    """The follow-up call sends history ending in a user message of
+    pure tool_result blocks. The last tool_result carries cache_control."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = [
+        _fake_response(
+            [
+                FakeBlock(type="text", text="Got it."),
+                FakeBlock(
+                    type="tool_use",
+                    id="toolu_x",
+                    name="update_order",
+                    input={
+                        "items": [
+                            {
+                                "name": "Pepperoni",
+                                "category": "pizza",
+                                "size": "medium",
+                                "quantity": 1,
+                                "unit_price": 17.99,
+                            }
+                        ],
+                        "order_type": "pickup",
+                        "status": "in_progress",
+                    },
+                ),
+            ]
+        ),
+        _fake_response([FakeBlock(type="text", text="Anything else?")]),
+    ]
+
+    generate_reply(
+        transcript="one medium pepperoni",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    )
+
+    followup_kwargs = fake_client.messages.create.call_args_list[1][1]
+    last_msg = followup_kwargs["messages"][-1]
+    assert last_msg["role"] == "user"
+    blocks = last_msg["content"]
+    assert blocks[-1]["type"] == "tool_result"
+    assert blocks[-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_threaded_history_does_not_carry_cache_control_marker():
+    """The cache_control marker is applied at the API call boundary only.
+    ``result.history`` (which the orchestrator threads into the next
+    turn) must stay clean — otherwise stale breakpoints accumulate as
+    the call grows and we'd blow past Anthropic's 4-breakpoint cap."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [FakeBlock(type="text", text="Hi.")]
+    )
+
+    result = generate_reply(
+        transcript="hello",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    )
+
+    def _walk(obj):
+        if isinstance(obj, dict):
+            assert "cache_control" not in obj, (
+                f"threaded history must not carry cache_control: {obj}"
+            )
+            for v in obj.values():
+                _walk(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                _walk(v)
+
+    _walk(result.history)
+
+
+async def test_stream_reply_marks_messages_last_block_with_rolling_breakpoint():
+    """Streaming path mirrors the sync path — the messages array sent to
+    ``messages.stream`` carries cache_control on the last block of the
+    last message."""
+    order = Order(call_sid="CAtest")
+    captured_calls: list[dict] = []
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory_capturing(
+        [
+            _FakeAsyncStream(
+                deltas=["Hi!"],
+                blocks=[FakeBlock(type="text", text="Hi!")],
+            ),
+        ],
+        captured_calls,
+    )
+
+    await _collect(
+        stream_reply(
+            transcript="hello",
+            history=[],
+            order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
+            client=fake_client,
+        )
+    )
+
+    assert len(captured_calls) == 1
+    blocks = _last_user_blocks(captured_calls[0]["messages"])
+    assert blocks[-1]["cache_control"] == {"type": "ephemeral"}
+    assert blocks[-1]["text"] == "hello"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -2151,9 +2151,7 @@ def test_threaded_history_does_not_carry_cache_control_marker():
     the call grows and we'd blow past Anthropic's 4-breakpoint cap."""
     order = Order(call_sid="CAtest")
     fake_client = MagicMock()
-    fake_client.messages.create.return_value = _fake_response(
-        [FakeBlock(type="text", text="Hi.")]
-    )
+    fake_client.messages.create.return_value = _fake_response([FakeBlock(type="text", text="Hi.")])
 
     result = generate_reply(
         transcript="hello",


### PR DESCRIPTION
Closes #176.

Two cache leaks fixed in `app/llm/client.py`, plus the dashboard
formatter that mislabelled the result.

## Why this matters

End-of-call goodbye on baseline call CA2408cfaf3f250c0bcf7cc2da2f9e19a5
took **3473ms** (over budget) with `cache=miss r=0 w=4477` — the bot
went silent for ~3.5 seconds between the caller's "yes" and the
spoken "thanks for calling." That's the LLM rebuilding the entire
~5000-token cached prefix from scratch on the post-tool-use follow-up
call.

After this PR (call CA01864c6bb49b3703bcb26e0d071fc5e8): same goodbye
shape **1109ms** with `cache=hit r=5634 w=16`. ~2.4 seconds saved on
the most caller-visible latency surface in the call.

## Part 1 — keep tool schema on follow-up call

`stream_reply` and `generate_reply` were passing `tools=[]` to the
post-tool-use follow-up call. Anthropic's cached prefix order is
`tools → system → messages`, so changing tools across the two calls
of one turn invalidated the entire cached prefix on the follow-up,
forcing a full rebuild of the system prompt + menu (~5000 tokens).

Fix: keep `tools=[UPDATE_ORDER_TOOL]` on the follow-up and use
`tool_choice={"type": "none"}` to suppress further tool use without
dropping the schema. This restores #173's original prediction that
the follow-up "is a cache hit (~500ms TTFT)."

## Part 2a — rolling cache_control breakpoint on `messages[-1]`

#113 added `cache_control: ephemeral` on the system prompt block. That
covers `tools + system`, but the growing `messages` array was
reprocessed fresh on every turn. Anthropic supports up to 4 cache
breakpoints per request; we were using 1.

Added `_with_rolling_cache_breakpoint` helper that marks the last
block of `messages[-1]` with `cache_control: ephemeral` on every API
call. Three message shapes handled (plain string, tool_result-merged
user, pure tool_result follow-up). Returns a NEW list so threaded
history stays clean — stale breakpoints would otherwise accumulate
every turn and blow past the 4-breakpoint cap.

Verified on call CA1fdf536a7206273a6a5a66fe9701106a (11 turns):
`cache_read_tokens` grow steadily turn-by-turn (5486 → 5519 → 5559 →
5595 → 5623 → 5669 → 5701 → 5730 → 5756 → 5817) instead of staying
flat at the system-prompt baseline.

**Caveat:** Haiku 4.5 has a 4096-token minimum cacheable prefix.
Short calls won't engage the rolling breakpoint; longer calls (turn
3+ of a typical order) will.

## Part 2b — dashboard cache label fix

`formatFirstAudioBreakdown` defined `hit = read>0 && creation===0`,
which labelled every turn that read the bulk prefix and wrote a small
extension on the new tail as `cache=miss`. With the rolling breakpoint
that's now most turns of a multi-turn call, so the dashboard would
have been noisy with false "miss" reports.

New labels:
- `r>0 w=0` → `cache=hit` (pure read)
- `r>0 w>0` → `cache=hit+ext` (hit + small extension write)
- `r=0` → `cache=miss` (cold)

Compounds nicely with #183 which exposed the raw r/w numbers.

## Test plan

- [x] `pytest tests/test_llm_client.py -v` — 43/43 pass (5 new tests: tool-schema-preservation on follow-up across both sync and async paths, rolling-breakpoint placement across all three message shapes, threaded-history cleanliness, streaming variant)
- [x] `pytest tests/` minus live-API integration — 461/461 deterministic backend tests pass
- [x] `vitest run` in `dashboard/` — 110/110 pass (1 new test for the `hit+ext` case)
- [x] `tsc --noEmit` in `dashboard/` — clean
- [x] Live multi-turn call CA01864c6bb49b3703bcb26e0d071fc5e8 — goodbye 3473ms → 1109ms (Part 1 effect)
- [x] Live multi-turn call CA1fdf536a7206273a6a5a66fe9701106a — `r` grows 5486→5817 across the call (Part 2 effect); dashboard renders `cache=hit+ext` accurately