### PR TITLE
fix(llm): skip follow-up LLM call on terminal-status turns when main already spoke

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -359,6 +359,29 @@ def _apply_validation(patch: dict[str, Any]) -> tuple[dict[str, Any], list[str]]
     return cleaned, notes
 
 
+_TERMINAL_STATUSES = frozenset({"confirmed", "cancelled"})
+
+
+def _should_skip_followup(tool_uses: list[dict[str, Any]], main_emitted_text: bool) -> bool:
+    """Decide whether to skip the post-tool-use follow-up LLM call (#270).
+
+    The follow-up exists to give the model a chance to speak after seeing
+    ``tool_result`` feedback (#173). On terminal-status turns (confirmed
+    or cancelled) the call is ending — there is no next caller turn for
+    the model to react to — and if the main call already emitted text the
+    caller has already heard the goodbye. In that case the follow-up is
+    pure latency.
+
+    The follow-up still runs when the main call was tool-only on a
+    terminal turn (caller hasn't heard anything yet), or on any
+    non-terminal turn (mid-order item adds need the server-verified
+    subtotal in tool_result before the next "anything else?").
+    """
+    if not main_emitted_text:
+        return False
+    return any(tu["input"].get("status") in _TERMINAL_STATUSES for tu in tool_uses)
+
+
 def _apply_update(order: Order, patch: dict[str, Any]) -> Order:
     """Merge a tool-call payload into the current Order.
 
@@ -441,7 +464,7 @@ def generate_reply(
             {"role": "user", "content": tool_results},
         ]
 
-    if tool_uses:
+    if tool_uses and not _should_skip_followup(tool_uses, bool(reply_text_parts)):
         # Verbal continuation only — no further tool calls (#173). We keep the
         # tool schema in ``tools`` and use ``tool_choice="none"`` to suppress
         # tool use, rather than passing ``tools=[]``: tools sit before system
@@ -622,7 +645,7 @@ async def stream_reply(
             cache_creation_tokens,
         )
 
-    if tool_uses:
+    if tool_uses and not _should_skip_followup(tool_uses, bool(text_parts)):
         # Verbal continuation only — no further tool calls (#173). We keep the
         # tool schema in ``tools`` and use ``tool_choice="none"`` to suppress
         # tool use, rather than passing ``tools=[]``: tools sit before system

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -2206,3 +2206,178 @@ async def test_stream_reply_marks_messages_last_block_with_rolling_breakpoint():
     blocks = _last_user_blocks(captured_calls[0]["messages"])
     assert blocks[-1]["cache_control"] == {"type": "ephemeral"}
     assert blocks[-1]["text"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# #270 — skip the post-tool-use follow-up call on confirm/cancelled turns
+# when the main call already emitted text. The follow-up exists to give
+# the model a chance to react to tool_result feedback (#173); on terminal-
+# status turns there's no useful feedback and the call is ending, so the
+# follow-up is pure latency. Mid-order turns and tool-only confirm turns
+# still run the follow-up.
+# ---------------------------------------------------------------------------
+
+
+def test_generate_reply_skips_followup_on_confirm_turn_when_main_already_spoke():
+    """Caller said 'yes' → main emits goodbye text + status=confirmed
+    tool_use. No follow-up call is needed; the caller already heard
+    everything and the call is ending."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.return_value = _fake_response(
+        [
+            FakeBlock(
+                type="text",
+                text="Thanks for your order. We'll have it ready for you soon.",
+            ),
+            FakeBlock(
+                type="tool_use",
+                id="toolu_confirm",
+                name="update_order",
+                input={"status": "confirmed"},
+            ),
+        ]
+    )
+
+    result = generate_reply(
+        transcript="yes",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    )
+
+    # Only one network call — the main call. No follow-up.
+    assert fake_client.messages.create.call_count == 1
+    assert result.order.status is OrderStatus.CONFIRMED
+    assert "Thanks for your order" in result.reply_text
+
+    # History must still thread cleanly: user transcript, assistant turn
+    # (text + tool_use), then the synthetic user-tool_result so subsequent
+    # turns don't 400 on dangling tool_use (#66 invariant).
+    assert result.history[-1]["role"] == "user"
+    assert isinstance(result.history[-1]["content"], list)
+    assert result.history[-1]["content"][0]["type"] == "tool_result"
+
+
+def test_generate_reply_runs_followup_on_confirm_turn_when_main_was_tool_only():
+    """Edge case: the model emitted update_order(status=confirmed) but
+    no text. The caller hasn't heard anything yet, so the follow-up must
+    still run to produce a goodbye. Preserves #173's invariant for the
+    silent-confirm path."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = [
+        _fake_response(
+            [
+                FakeBlock(
+                    type="tool_use",
+                    id="toolu_confirm",
+                    name="update_order",
+                    input={"status": "confirmed"},
+                )
+            ]
+        ),
+        _fake_response([FakeBlock(type="text", text="Thanks. We'll have it ready soon.")]),
+    ]
+
+    result = generate_reply(
+        transcript="yes",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    )
+
+    assert fake_client.messages.create.call_count == 2  # follow-up still runs
+    assert "Thanks. We'll have it ready soon." in result.reply_text
+
+
+def test_generate_reply_runs_followup_on_mid_order_tool_use_with_text():
+    """Regression guard against accidentally widening the skip. Mid-order
+    item-add turns emit text + tool_use(status=in_progress); the follow-up
+    must still run so the model can react to the server-verified subtotal
+    in tool_result and produce the next prompt ('anything else?')."""
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.create.side_effect = [
+        _fake_response(
+            [
+                FakeBlock(type="text", text="Got it."),
+                FakeBlock(
+                    type="tool_use",
+                    id="toolu_add",
+                    name="update_order",
+                    input={
+                        "items": [
+                            {
+                                "name": "Pepperoni",
+                                "category": "pizza",
+                                "size": "medium",
+                                "quantity": 1,
+                                "unit_price": 17.99,
+                            }
+                        ],
+                        "order_type": "pickup",
+                        "status": "in_progress",
+                    },
+                ),
+            ]
+        ),
+        _fake_response([FakeBlock(type="text", text="Anything else?")]),
+    ]
+
+    result = generate_reply(
+        transcript="one medium pepperoni",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+        client=fake_client,
+    )
+
+    # Two calls — main (got it + tool) AND follow-up (anything else?).
+    assert fake_client.messages.create.call_count == 2
+    assert "Anything else?" in result.reply_text
+
+
+async def test_stream_reply_skips_followup_on_confirm_turn_when_main_already_spoke():
+    """Streaming variant of the confirm-turn skip. No second stream is
+    started; the final event lands directly after the main stream."""
+    order = Order(call_sid="CAtest")
+    captured_calls: list[dict] = []
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory_capturing(
+        [
+            _FakeAsyncStream(
+                deltas=["Thanks for your order. We'll have it ready for you soon."],
+                blocks=[
+                    FakeBlock(
+                        type="text",
+                        text="Thanks for your order. We'll have it ready for you soon.",
+                    ),
+                    FakeBlock(
+                        type="tool_use",
+                        id="toolu_confirm",
+                        name="update_order",
+                        input={"status": "confirmed"},
+                    ),
+                ],
+            ),
+        ],
+        captured_calls,
+    )
+
+    deltas, final = await _collect(
+        stream_reply(
+            transcript="yes",
+            history=[],
+            order=order,
+            system_prompt=_TEST_SYSTEM_PROMPT,
+            client=fake_client,
+        )
+    )
+
+    assert len(captured_calls) == 1  # no follow-up stream started
+    assert final is not None
+    assert final.order.status is OrderStatus.CONFIRMED
+    assert "Thanks for your order" in final.reply_text


### PR DESCRIPTION
Closes #270.

Replaces #272 (auto-closed when its base branch `176-warm-cache-followup`
was deleted on merge of #269).

## Why

After #269's cache fixes (#176), goodbye latency is bimodal depending
on what the model emits in its main call:

| Main call shape | Goodbye TTFA |
|---|---|
| text + tool_use | ~1100ms |
| tool_use only | ~2700ms (follow-up did all the speaking) |

The post-tool-use follow-up call (#173) does nothing useful on a
terminal-status turn (`status=confirmed` or `cancelled`):
1. The call is ending — there is no next caller turn to react to.
2. If the main call already emitted text, the caller already heard
   the goodbye; the follow-up's text is redundant.

The follow-up exists so the model can react to `tool_result` feedback
(server-verified subtotal) on mid-order turns. That value is zero on
confirm.

## What this PR does

New helper `_should_skip_followup` returns `True` when:
- any tool_use has `status` in `{confirmed, cancelled}`, AND
- the main call emitted ≥1 text block

Both `generate_reply` and `stream_reply` check it before running the
follow-up. The synthetic `tool_result` user message is still appended
to history so any defensive next-turn doesn't 400 on a dangling
`tool_use` (#66 invariant preserved).

## Cases preserved

| Scenario | Behavior | Why |
|---|---|---|
| confirm/cancel + main spoke | **Skip** (new fast path) | Caller heard goodbye, call ending |
| confirm/cancel + main tool-only | Follow-up runs | Caller hasn't heard anything yet |
| mid-order tool_use (in_progress) | Follow-up runs | Model needs `tool_result` subtotal feedback |

## Measured effect

Live call CA671b0dc4ee626e9830f8114dd69ca9e7 (4-item order, confirm flow):

```
03:52:58  CALLER      Yes.
03:52:59  FIRST_AUDIO 754ms [ttft=540ms text=544ms cache=hit+ext r=6154 w=42]
03:53:00  AGENT       Thanks for calling. We'll have it ready for you soon.
```

`text=544ms` (not ~2500ms) and `ttft≈text` (no extra round-trip)
confirm the follow-up was skipped. Compare to prior runs:

| Stage | Goodbye TTFA |
|---|---|
| Baseline (no fixes) | 3473ms |
| #176 part 1 alone | 1109ms |
| #176 parts 1+2 (fast case) | 1109ms |
| #176 parts 1+2 (slow case) | 2736ms |
| **+ this PR (#270)** | **754ms** |

The bimodal distribution from #176 alone collapses into the fast
path almost always — the prompt's "speak ack first" rule keeps the
model emitting text on confirm turns, so the skip almost always
triggers.

The remaining slow path (silent-confirm) is left as a separate
optimization (prompt nudge or pre-rendered tenant goodbye audio
à la #192). Out of scope here.

## Test plan

- [x] `pytest tests/test_llm_client.py -v` — 47/47 pass
- [x] `pytest tests/` minus live-API integration — 465/465 deterministic backend tests pass
- [x] Live multi-turn call CA671b0dc4ee626e9830f8114dd69ca9e7 — goodbye TTFA 754ms, no regression on mid-order turns

New tests added:
- `test_generate_reply_skips_followup_on_confirm_turn_when_main_already_spoke` — fast path
- `test_generate_reply_runs_followup_on_confirm_turn_when_main_was_tool_only` — silent-confirm fallback
- `test_generate_reply_runs_followup_on_mid_order_tool_use_with_text` — mid-order regression guard
- `test_stream_reply_skips_followup_on_confirm_turn_when_main_already_spoke` — async variant