### PR TITLE
feat(stt): expose Flux turn-detection knobs + log end_of_turn_confidence

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -47,10 +47,17 @@ class Settings(BaseSettings):
 
     # Deepgram live STT options. Migrated to Flux English mono in #257.
     # Flux owns turn detection natively (prosody-aware, ~260ms confirmed
-    # end-of-turn) so the Nova-2 endpointing knobs were removed; if Flux
-    # turn-detection ever needs tuning, expose `eager_eot_threshold` /
-    # `eot_threshold` / `eot_timeout_ms` here, all per the v2 connect API.
+    # end-of-turn); the knobs below override Flux's own defaults.
     stt_model: str = "flux-general-en"
+    # Confidence threshold to confirm end-of-turn. Flux default is 0.7;
+    # 0.8 reduces false cut-offs on mid-sentence pauses.
+    stt_eot_threshold: float = 0.8
+    # Max silence (ms) before Flux forces end-of-turn. Flux default is 5000;
+    # 4000 keeps latency tighter without clipping normal speech.
+    stt_eot_timeout_ms: int = 4000
+    # Optional early end-of-turn confidence gate. None = let Flux decide;
+    # set e.g. 0.95 to cut off turn aggressively on high-confidence pauses.
+    stt_eager_eot_threshold: Optional[float] = None
     # Comma-separated debug-override keyterms. When non-empty, REPLACES
     # the per-tenant heuristic output entirely (used to A/B test what
     # Flux does with a specific term list). Empty in production —

--- a/app/deepgram/stt.py
+++ b/app/deepgram/stt.py
@@ -35,6 +35,9 @@ background reader task that drains ``recv()`` into an internal queue.
 ``events()`` is an async generator yielding STTEvents until
 ``close()``. ``close()`` cancels the reader, sends close-stream, and
 exits the context manager.
+
+Turn-detection knobs (``stt_eot_threshold``, ``stt_eot_timeout_ms``,
+``stt_eager_eot_threshold``) are configurable via ``Settings``.
 """
 
 from __future__ import annotations
@@ -168,12 +171,17 @@ class DeepgramSTT:
         keyterms = _resolve_keyterms(self._keyterms_arg, call_sid=self._call_sid)
 
         self._client = AsyncDeepgramClient(api_key=api_key)
-        self._cm = self._client.listen.v2.connect(
-            model=settings.stt_model,
-            encoding="mulaw",
-            sample_rate=8000,
-            keyterm=keyterms,
-        )
+        connect_kwargs: dict = {
+            "model": settings.stt_model,
+            "encoding": "mulaw",
+            "sample_rate": 8000,
+            "keyterm": keyterms,
+            "eot_threshold": settings.stt_eot_threshold,
+            "eot_timeout_ms": settings.stt_eot_timeout_ms,
+        }
+        if settings.stt_eager_eot_threshold is not None:
+            connect_kwargs["eager_eot_threshold"] = settings.stt_eager_eot_threshold
+        self._cm = self._client.listen.v2.connect(**connect_kwargs)
         try:
             self._conn = await self._cm.__aenter__()
         except Exception:
@@ -288,17 +296,28 @@ class DeepgramSTT:
                     text,
                 )
                 self._queue.put_nowait(
-                    TranscriptEvent(text=text, is_final=False, confidence=confidence)
+                    TranscriptEvent(
+                        text=text,
+                        is_final=False,
+                        confidence=confidence,
+                        turn_index=int(getter("turn_index", 0) or 0),
+                    )
                 )
                 return
 
             if event == "EagerEndOfTurn":
+                eager_turn_idx = int(getter("turn_index", 0) or 0)
                 logger.info(
                     "eager_eot call_sid=%s turn=%s",
                     self._call_sid,
-                    getter("turn_index", "?"),
+                    eager_turn_idx,
                 )
-                self._queue.put_nowait(EarlyTurnEndEvent())
+                self._queue.put_nowait(
+                    EarlyTurnEndEvent(
+                        text=(getter("transcript", "") or "").strip(),
+                        turn_index=eager_turn_idx,
+                    )
+                )
                 return
 
             if event == "TurnResumed":
@@ -317,13 +336,20 @@ class DeepgramSTT:
                     # has nothing to act on.
                     return
                 confidence = _confidence_from_words_payload(getter("words", []))
+                eot_conf = getter("end_of_turn_confidence", None)
                 logger.info(
-                    "transcript [final] call_sid=%s text=%r",
+                    "transcript [final] call_sid=%s text=%r eot_conf=%s",
                     self._call_sid,
                     text,
+                    eot_conf,
                 )
                 self._queue.put_nowait(
-                    TranscriptEvent(text=text, is_final=True, confidence=confidence)
+                    TranscriptEvent(
+                        text=text,
+                        is_final=True,
+                        confidence=confidence,
+                        turn_index=int(getter("turn_index", 0) or 0),
+                    )
                 )
                 return
 

--- a/app/stt/base.py
+++ b/app/stt/base.py
@@ -30,6 +30,7 @@ class TranscriptEvent:
     text: str
     is_final: bool
     confidence: float
+    turn_index: int = 0
 
 
 @dataclass(frozen=True)
@@ -39,7 +40,15 @@ class EarlyTurnEndEvent:
     speculatively; a ``TurnResumedEvent`` will follow if the caller
     keeps talking. Providers without prosody-aware turn detection (e.g.
     Whisper) never emit this event — consumers must treat it as
-    advisory and tolerate its absence."""
+    advisory and tolerate its absence.
+
+    ``text`` carries the speculated transcript (Deepgram guarantees it
+    matches the eventual ``EndOfTurn.transcript``). ``turn_index``
+    matches the corresponding ``StartOfTurn`` for correlation.
+    """
+
+    text: str = ""
+    turn_index: int = 0
 
 
 @dataclass(frozen=True)

--- a/tests/test_stt_base_events.py
+++ b/tests/test_stt_base_events.py
@@ -43,20 +43,24 @@ def test_stt_event_union_includes_all_four_types() -> None:
     }
 
 
-def test_early_and_resumed_events_have_no_payload_fields() -> None:
-    """These events are pure signals — they carry no payload. Pinning
-    that here so a future-PR field addition is a deliberate, reviewed
-    change rather than an accidental drift."""
-    assert dataclasses.fields(EarlyTurnEndEvent) == ()
+def test_turn_resumed_event_has_no_payload_fields() -> None:
+    """``TurnResumedEvent`` is a pure signal — pinned so a future
+    field addition is deliberate, not accidental drift."""
     assert dataclasses.fields(TurnResumedEvent) == ()
 
 
-def test_existing_event_shapes_unchanged() -> None:
-    """Regression guard. The migration must not silently change the
-    field set on the two pre-existing event types."""
+def test_event_shapes() -> None:
+    """Regression guard for the field set on each event dataclass.
+    Field additions are fine; this test forces them to be a deliberate
+    line edit here rather than silent drift."""
     assert {f.name for f in dataclasses.fields(SpeechStartedEvent)} == {"at"}
     assert {f.name for f in dataclasses.fields(TranscriptEvent)} == {
         "text",
         "is_final",
         "confidence",
+        "turn_index",
+    }
+    assert {f.name for f in dataclasses.fields(EarlyTurnEndEvent)} == {
+        "text",
+        "turn_index",
     }

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -573,9 +573,7 @@ async def test_final_transcript_log_includes_eot_confidence(fake_v2_connection, 
         matching = [
             r
             for r in caplog.records
-            if r.name == "app.deepgram.stt"
-            and "want a burger" in r.message
-            and "0.92" in r.message
+            if r.name == "app.deepgram.stt" and "want a burger" in r.message and "0.92" in r.message
         ]
         assert len(matching) >= 1, "expected INFO log with transcript text and eot_conf=0.92"
     finally:

--- a/tests/test_stt_deepgram.py
+++ b/tests/test_stt_deepgram.py
@@ -30,7 +30,9 @@ def _set_api_key(monkeypatch):
     monkeypatch.setattr(settings, "deepgram_api_key", "test-key")
 
 
-def _make_turn_info(*, event: str, transcript: str = "", confidence: float = 0.95):
+def _make_turn_info(
+    *, event: str, transcript: str = "", confidence: float = 0.95, turn_index: int = 0
+):
     """Build a real ListenV2TurnInfo. Constructing the SDK's pydantic
     model rather than ducking it with a MagicMock makes isinstance
     checks inside the translator behave like production."""
@@ -48,7 +50,7 @@ def _make_turn_info(*, event: str, transcript: str = "", confidence: float = 0.9
         request_id="req-test",
         sequence_id=0,
         event=event,
-        turn_index=0,
+        turn_index=turn_index,
         audio_window_start=0.0,
         audio_window_end=1.0,
         transcript=transcript,
@@ -516,6 +518,108 @@ async def test_recv_exception_surfaces_as_runtime_error(fake_v2_connection):
         with pytest.raises(RuntimeError, match="deepgram error"):
             async for _ev in stt.events():
                 pass
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_open_passes_eot_knobs_to_v2_connect(fake_v2_connection, monkeypatch):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "stt_eot_threshold", 0.85)
+    monkeypatch.setattr(settings, "stt_eot_timeout_ms", 3500)
+    monkeypatch.setattr(settings, "stt_eager_eot_threshold", None)
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        connect_call = fake_v2_connection._connect_mock.call_args
+        assert connect_call.kwargs["eot_threshold"] == 0.85
+        assert connect_call.kwargs["eot_timeout_ms"] == 3500
+        assert "eager_eot_threshold" not in connect_call.kwargs
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_open_passes_eager_threshold_when_configured(fake_v2_connection, monkeypatch):
+    from app.config import settings
+    from app.deepgram.stt import DeepgramSTT
+
+    monkeypatch.setattr(settings, "stt_eager_eot_threshold", 0.6)
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        connect_call = fake_v2_connection._connect_mock.call_args
+        assert connect_call.kwargs["eager_eot_threshold"] == 0.6
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_final_transcript_log_includes_eot_confidence(fake_v2_connection, caplog):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="EndOfTurn", transcript="want a burger", confidence=0.92)
+        )
+        with caplog.at_level("INFO", logger="app.deepgram.stt"):
+            await _next_event(stt)
+        matching = [
+            r
+            for r in caplog.records
+            if r.name == "app.deepgram.stt"
+            and "want a burger" in r.message
+            and "0.92" in r.message
+        ]
+        assert len(matching) >= 1, "expected INFO log with transcript text and eot_conf=0.92"
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_early_turn_end_event_carries_text_and_turn_index(fake_v2_connection):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="EagerEndOfTurn", transcript="i'd like a coke", turn_index=3)
+        )
+        evt = await _next_event(stt)
+        assert isinstance(evt, EarlyTurnEndEvent)
+        assert evt.text == "i'd like a coke"
+        assert evt.turn_index == 3
+    finally:
+        await stt.close()
+
+
+@pytest.mark.asyncio
+async def test_transcript_event_carries_turn_index(fake_v2_connection):
+    from app.deepgram.stt import DeepgramSTT
+
+    stt = DeepgramSTT(call_sid="CAtest")
+    await stt.open()
+    try:
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="Update", transcript="hello", turn_index=7)
+        )
+        interim = await _next_event(stt)
+        assert interim.turn_index == 7
+        assert interim.is_final is False
+
+        fake_v2_connection._recv_queue.put_nowait(
+            _make_turn_info(event="EndOfTurn", transcript="hello", turn_index=7)
+        )
+        final = await _next_event(stt)
+        assert final.turn_index == 7
+        assert final.is_final is True
     finally:
         await stt.close()
 


### PR DESCRIPTION
## Summary

- Settings: `stt_eot_threshold=0.8` (Flux default 0.7), `stt_eot_timeout_ms=4000` (Flux default 5000), `stt_eager_eot_threshold=None` (eager mode stays off — same as today). Tunable via env without code changes.
- `DeepgramSTT.open` plumbs `eot_threshold` + `eot_timeout_ms` always; passes `eager_eot_threshold` only when non-None so we don't override Flux's "eager off" default with an explicit None.
- Translator logs `end_of_turn_confidence` on final transcripts via `%s` formatter (None-safe). Interim `Update` path is unchanged — one confidence reading per finalized turn, not per ~250ms heartbeat.
- Protocol prep for the future eager-mode consumer-wiring PR: `TranscriptEvent` gains `turn_index`, `EarlyTurnEndEvent` gains `text` + `turn_index`. All defaulted, so `app/telephony/session.py` keeps working unchanged.

## Linked issue
Closes #267

## Test plan

- [x] `pytest tests/test_stt_deepgram.py -x -q` — 23/23 pass (5 new cases pin the new contracts: kwarg presence/absence, eot_conf log line, additive event fields).
- [x] Live call against `twilight-family-restaurant` over the dev tunnel: 7 turns, all final transcripts log `eot_conf=` (range 0.81–0.96 on this call), no premature turn-cuts, 354 wire messages cleanly drained.
- [ ] Reviewer eyes on the final diff before merge.

## Notes

- Out of scope for this PR (separate issues): #268 (LLM mishear defense), #271 (universal modifier keyterms), #177 (silence watchdog on interims), #178 (silence watchdog timing). Live-call mishears like "No. Operator" → "No. Advertiser" are #268/#271 territory and were not addressed here.
- The new `eager_eot_threshold` knob is wired but unused — eager mode requires consumer-side changes in `app/telephony/session.py` (cancel speculative LLM/TTS on `TurnResumed`, deliver cached audio when `EagerEndOfTurn.text == EndOfTurn.text`). That's the follow-up PR; this one just makes the protocol additive so it doesn't break.
- Defaults of 0.8 / 4000 chosen for phone-order accuracy vs latency — see issue body for rationale.

🤖 Built by team `niko-267-flux-knobs` (niko-developer + niko-tester + niko-reviewer)