### PR TITLE
feat(stt): seed Flux keyterms with universal restaurant modifiers

### DIFF
--- a/app/restaurants/keyterms.py
+++ b/app/restaurants/keyterms.py
@@ -11,6 +11,12 @@ it with ``ceil(word_count * 1.3)`` because the tokenizer is not
 public. The 50-token safety margin under the 500 cap absorbs the
 heuristic's slop.
 
+The keyterm list emitted by this module includes three layers: the
+restaurant name (always first), universal order-modifiers that every
+restaurant needs but no menu enumerates (e.g. "spicy", "no", "extra"),
+and per-tenant menu item names. All three share the same token budget
+and dedup set.
+
 This module is intentionally a pure function over a menu dict. No
 Firestore reads, no settings reads, no logging — the caller owns
 all of that. Keeps the heuristic deterministic and trivially testable.
@@ -38,6 +44,39 @@ _COMMON_SAFE_TERMS = frozenset(
         "vegetable spring roll",
         "fried rice",
     }
+)
+
+# Modifier vocabulary every restaurant uses but no menu lists. Without
+# bias these single-word words lose to acoustically-similar menu items
+# ("spicy" → "Iced [Tea]" was the live failure that prompted #271).
+# Order roughly mirrors call frequency; the budget gate further down
+# stops emission if a pathological menu has already eaten the budget.
+_UNIVERSAL_MODIFIERS = (
+    # Negation / removal
+    "no",
+    "without",
+    "hold the",
+    # Addition / intensification
+    "extra",
+    "add",
+    "with",
+    # Reduction
+    "less",
+    "light",
+    # Spice / heat
+    "spicy",
+    "mild",
+    "hot",
+    # Sides / placement
+    "side of",
+    "on the side",
+    # Substitution
+    "instead of",
+    # Order context
+    "pickup",
+    "takeout",
+    "delivery",
+    "to go",
 )
 
 # Conservative token estimate. Deepgram's tokenizer isn't public; a
@@ -71,11 +110,12 @@ def compute_keyterms(menu: dict[str, Any], restaurant_name: str) -> list[str]:
     """Build a Flux keyterm list for one restaurant.
 
     Returns ``restaurant_name`` first (always — the caller may say it
-    when greeting), then menu item names in menu order, skipping items
-    in the common-safe set and items that duplicate something already
-    included (case-insensitive). Stops at the first item whose addition
-    would push the running token estimate over the budget — remaining
-    items get no bias on this call.
+    when greeting), then the universal restaurant modifiers in
+    ``_UNIVERSAL_MODIFIERS`` (every tenant gets these), then menu item
+    names in menu order, skipping items in the common-safe set and
+    items that duplicate something already included (case-insensitive).
+    Stops at the first item whose addition would push the running token
+    estimate over the budget — remaining items get no bias on this call.
 
     Pathological input where ``restaurant_name`` alone exceeds budget:
     return only ``[restaurant_name]`` — the caller is responsible for
@@ -92,6 +132,17 @@ def compute_keyterms(menu: dict[str, Any], restaurant_name: str) -> list[str]:
     terms: list[str] = [restaurant_name]
     used_tokens = name_tokens
     seen: set[str] = {restaurant_name.lower()}
+
+    for modifier in _UNIVERSAL_MODIFIERS:
+        modifier_lower = modifier.lower()
+        if modifier_lower in seen:
+            continue
+        cost = _estimate_tokens(modifier)
+        if used_tokens + cost > _TOKEN_BUDGET:
+            break
+        terms.append(modifier)
+        used_tokens += cost
+        seen.add(modifier_lower)
 
     for category_key, items in menu.items():
         if isinstance(category_key, str) and category_key.startswith("_"):

--- a/tests/test_restaurants_keyterms.py
+++ b/tests/test_restaurants_keyterms.py
@@ -12,7 +12,7 @@ import json
 from math import ceil
 from pathlib import Path
 
-from app.restaurants.keyterms import compute_keyterms
+from app.restaurants.keyterms import _UNIVERSAL_MODIFIERS, compute_keyterms
 
 
 def _estimate_tokens(text: str) -> int:
@@ -22,7 +22,12 @@ def _estimate_tokens(text: str) -> int:
 
 
 def test_includes_restaurant_name_first_with_empty_menu() -> None:
-    assert compute_keyterms({}, "Twilight Family Restaurant") == ["Twilight Family Restaurant"]
+    keyterms = compute_keyterms({}, "Twilight Family Restaurant")
+    assert keyterms[0] == "Twilight Family Restaurant"
+    # Universal modifiers are emitted even with an empty menu.
+    assert "no" in keyterms
+    assert "spicy" in keyterms
+    assert "to go" in keyterms
 
 
 def test_walks_menu_in_category_order() -> None:
@@ -91,7 +96,12 @@ def test_skips_items_without_a_name() -> None:
         ],
     }
     keyterms = compute_keyterms(menu, "Twilight")
-    assert keyterms == ["Twilight", "Pepper Shrimp"]
+    assert keyterms[0] == "Twilight"
+    assert "Pepper Shrimp" in keyterms
+    # Universal modifiers appear between the restaurant name and menu items.
+    assert "no" in keyterms
+    pepper_idx = keyterms.index("Pepper Shrimp")
+    assert pepper_idx > keyterms.index("no")
 
 
 def test_skips_non_dict_menu_items_and_non_list_categories() -> None:
@@ -159,3 +169,88 @@ def test_output_preserves_original_casing() -> None:
     menu = {"appetizers": [{"name": "PePPer Shrimp"}]}
     keyterms = compute_keyterms(menu, "Twilight")
     assert "PePPer Shrimp" in keyterms
+
+
+def test_universal_modifiers_emitted_after_restaurant_name() -> None:
+    """With an empty menu the output is [restaurant_name] + modifiers in order."""
+    keyterms = compute_keyterms({}, "Twilight")
+    assert keyterms[0] == "Twilight"
+    assert keyterms[1:] == list(_UNIVERSAL_MODIFIERS)
+
+
+def test_universal_modifiers_emitted_before_menu_items() -> None:
+    """Every modifier appears before any menu item in the result list."""
+    menu = {"appetizers": [{"name": "Pepper Shrimp"}]}
+    keyterms = compute_keyterms(menu, "Test")
+    pepper_idx = keyterms.index("Pepper Shrimp")
+    for modifier in _UNIVERSAL_MODIFIERS:
+        if modifier in keyterms:
+            assert keyterms.index(modifier) < pepper_idx, (
+                f"modifier '{modifier}' appears after menu item 'Pepper Shrimp'"
+            )
+
+
+def test_modifier_dedups_against_menu_item() -> None:
+    """A menu item named like a modifier is not emitted a second time."""
+    menu = {"appetizers": [{"name": "spicy"}]}
+    keyterms = compute_keyterms(menu, "Test")
+    count = sum(1 for k in keyterms if k.lower() == "spicy")
+    assert count == 1, f"'spicy' appeared {count} times; expected exactly 1"
+    assert keyterms.index("spicy") < keyterms.index("Test") + len(keyterms)
+
+
+def test_modifier_dedups_against_restaurant_name() -> None:
+    """Restaurant name 'No' means the 'no' modifier must not appear again."""
+    keyterms = compute_keyterms({}, "No")
+    assert keyterms[0] == "No"
+    count = sum(1 for k in keyterms if k.lower() == "no")
+    assert count == 1, f"'no' appeared {count} times; expected exactly 1"
+
+
+def test_token_budget_still_includes_full_menu_for_realistic_input() -> None:
+    """A realistic ~30-item menu fits under budget alongside all modifiers."""
+    short_items = [
+        "Jerk Chicken",
+        "Oxtail Stew",
+        "Curry Goat",
+        "Brown Stew Fish",
+        "Ackee Saltfish",
+        "Callaloo",
+        "Bammy",
+        "Festival",
+        "Rice Peas",
+        "Plantain",
+        "Escovitch Fish",
+        "Steamed Cabbage",
+        "Breadfruit",
+        "Roast Yam",
+        "Peas Soup",
+        "Beef Patty",
+        "Coco Bread",
+        "Mannish Water",
+        "Tripe Beans",
+        "Cow Foot",
+        "Pelau",
+        "Roti",
+        "Doubles",
+        "Bake Shark",
+        "Sorrel Drink",
+        "Ginger Beer",
+        "Sea Moss",
+        "Rum Punch",
+        "Mango Juice",
+        "Soursop",
+    ]
+    menu = {"entrees": [{"name": name} for name in short_items]}
+    keyterms = compute_keyterms(menu, "Island Kitchen")
+
+    # All modifiers must be present.
+    for modifier in _UNIVERSAL_MODIFIERS:
+        assert modifier in keyterms, f"modifier '{modifier}' missing from keyterms"
+
+    # All menu items must be present (none dropped due to modifier-tax).
+    for item in short_items:
+        assert item in keyterms, f"menu item '{item}' was dropped from keyterms"
+
+    total_tokens = sum(_estimate_tokens(t) for t in keyterms)
+    assert total_tokens <= 450, f"keyterms exceed token budget: {total_tokens} > 450"


### PR DESCRIPTION
## Summary

- New `_UNIVERSAL_MODIFIERS` tuple in `app/restaurants/keyterms.py` — 18 terms covering negation, addition, reduction, heat, sides/placement, substitution, and order context. Every tenant gets these on every call.
- Emitted between `restaurant_name` and the menu loop, reusing the existing `seen` set + `used_tokens` accumulator so dedup against menu items and the 450-token budget cap behave identically to before.
- ~42-token modifier list out of 450 — no menu items pushed out for any realistic tenant.

## Linked issue
Closes #271

## Test plan

- [x] 16/16 keyterm tests pass — 5 new cases pin the contract: modifiers emitted after the name, before menu items, dedup'd against both, and a realistic 30-item menu still fully fits with modifiers added.
- [x] `ruff format --check` clean on touched files.
- [ ] Live call to verify the `spicy → iced` failure mode is fixed (manual, post-merge).

## Notes

The seeded modifiers (in emission order):

```
no, without, hold the,
extra, add, with,
less, light,
spicy, mild, hot,
side of, on the side,
instead of,
pickup, takeout, delivery, to go
```

Excluded on purpose: generic English order verbs ("I'd like", "can I get") — too common to need biasing, would just eat budget. Also excluded: payment-adjacent words ("cash", "card") — out of scope until a payment-collection feature exists.

🤖 Built by team `niko-271-universal-modifiers` (niko-developer + niko-tester + niko-reviewer)