### PR TITLE
Sprint 2.4 settings — deferred follow-ups (#7)

### DIFF
--- a/dashboard/components/settings/hours-editor.tsx
+++ b/dashboard/components/settings/hours-editor.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 
 import { updateRestaurantAction } from '@/app/actions/update-restaurant';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import type {
@@ -106,13 +107,13 @@ export function HoursEditor({ restaurant }: { restaurant: Restaurant }) {
                 htmlFor={`closed-${key}`}
                 className="ml-auto inline-flex cursor-pointer items-center gap-2 text-sm text-foreground-muted"
               >
-                <input
+                <Checkbox
                   id={`closed-${key}`}
-                  type="checkbox"
                   checked={day.closed}
-                  onChange={(e) => update(key, { closed: e.target.checked })}
+                  onCheckedChange={(checked) =>
+                    update(key, { closed: checked === true })
+                  }
                   aria-label={`${label} closed`}
-                  className="size-4 accent-brand"
                 />
                 Closed
               </label>

--- a/dashboard/components/settings/restaurant-info-form.tsx
+++ b/dashboard/components/settings/restaurant-info-form.tsx
@@ -22,8 +22,19 @@ export function RestaurantInfoForm({ restaurant }: { restaurant: Restaurant }) {
   const [offersDelivery, setOffersDelivery] = useState(
     restaurant.offers_delivery,
   );
+  const [fallbackError, setFallbackError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+
+  function handleFallbackChange(val: string) {
+    setFallbackPhone(val);
+    const trimmed = val.trim();
+    setFallbackError(
+      trimmed !== '' && !E164.test(trimmed)
+        ? 'Must be E.164 format (e.g. +15551234567)'
+        : null,
+    );
+  }
 
   function buildPatch() {
     const patch: Record<string, unknown> = {};
@@ -48,7 +59,7 @@ export function RestaurantInfoForm({ restaurant }: { restaurant: Restaurant }) {
 
     const trimmedFallback = fallbackPhone.trim();
     if (trimmedFallback !== '' && !E164.test(trimmedFallback)) {
-      setError('Fallback number must be in E.164 format (e.g. +15551234567).');
+      // fallbackError already shown inline via handleFallbackChange; just block submit.
       return;
     }
 
@@ -107,9 +118,10 @@ export function RestaurantInfoForm({ restaurant }: { restaurant: Restaurant }) {
           id="fallback-phone"
           label="Fallback number"
           value={fallbackPhone}
-          onChange={setFallbackPhone}
+          onChange={handleFallbackChange}
           placeholder="+15551234567"
           helper="Niko transfers callers here when the AI hits a snag or the caller asks for a human. Leave blank to skip the transfer attempt and go straight to voicemail."
+          inlineError={fallbackError}
         />
 
         <div className="flex items-center gap-2">
@@ -146,6 +158,7 @@ function Field({
   onChange,
   placeholder,
   helper,
+  inlineError,
   readOnly,
 }: {
   id: string;
@@ -154,6 +167,7 @@ function Field({
   onChange?: (next: string) => void;
   placeholder?: string;
   helper?: string;
+  inlineError?: string | null;
   readOnly?: boolean;
 }) {
   return (
@@ -173,7 +187,11 @@ function Field({
             : undefined
         }
       />
-      {helper ? (
+      {inlineError ? (
+        <p className="text-sm text-status-cancelled" role="alert">
+          {inlineError}
+        </p>
+      ) : helper ? (
         <p className="text-sm text-foreground-subtle">{helper}</p>
       ) : null}
     </div>

--- a/dashboard/components/settings/restaurant-info-form.tsx
+++ b/dashboard/components/settings/restaurant-info-form.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 
 import { updateRestaurantAction } from '@/app/actions/update-restaurant';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import type { Restaurant } from '@/lib/schemas/restaurant';
@@ -17,6 +18,9 @@ export function RestaurantInfoForm({ restaurant }: { restaurant: Restaurant }) {
   const [displayPhone, setDisplayPhone] = useState(restaurant.display_phone);
   const [fallbackPhone, setFallbackPhone] = useState(
     restaurant.fallback_phone ?? '',
+  );
+  const [offersDelivery, setOffersDelivery] = useState(
+    restaurant.offers_delivery,
   );
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
@@ -31,6 +35,9 @@ export function RestaurantInfoForm({ restaurant }: { restaurant: Restaurant }) {
     const restaurantFallback = restaurant.fallback_phone ?? '';
     if (trimmedFallback !== restaurantFallback) {
       patch.fallback_phone = trimmedFallback === '' ? null : trimmedFallback;
+    }
+    if (offersDelivery !== restaurant.offers_delivery) {
+      patch.offers_delivery = offersDelivery;
     }
     return patch;
   }
@@ -104,6 +111,17 @@ export function RestaurantInfoForm({ restaurant }: { restaurant: Restaurant }) {
           placeholder="+15551234567"
           helper="Niko transfers callers here when the AI hits a snag or the caller asks for a human. Leave blank to skip the transfer attempt and go straight to voicemail."
         />
+
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="offers-delivery"
+            checked={offersDelivery}
+            onCheckedChange={(checked) => setOffersDelivery(checked === true)}
+          />
+          <Label htmlFor="offers-delivery" className="text-sm text-foreground-muted cursor-pointer">
+            Accept delivery orders
+          </Label>
+        </div>
 
         {error ? (
           <p className="text-sm text-status-cancelled" role="alert">

--- a/dashboard/components/ui/checkbox.tsx
+++ b/dashboard/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/dashboard/tests/restaurant-info-form.test.tsx
+++ b/dashboard/tests/restaurant-info-form.test.tsx
@@ -67,6 +67,25 @@ describe('RestaurantInfoForm', () => {
     expect(updateRestaurantAction).not.toHaveBeenCalled();
   });
 
+  it('shows inline E.164 error while typing an invalid fallback number', async () => {
+    render(<RestaurantInfoForm restaurant={BASE} />);
+    const fallback = screen.getByLabelText(/fallback number/i);
+    fireEvent.change(fallback, { target: { value: 'bad' } });
+    await screen.findByText(/Must be E\.164 format/i);
+    expect(updateRestaurantAction).not.toHaveBeenCalled();
+  });
+
+  it('clears inline E.164 error when input becomes valid', async () => {
+    render(<RestaurantInfoForm restaurant={BASE} />);
+    const fallback = screen.getByLabelText(/fallback number/i);
+    fireEvent.change(fallback, { target: { value: 'bad' } });
+    await screen.findByText(/Must be E\.164 format/i);
+    fireEvent.change(fallback, { target: { value: '+15551234567' } });
+    await waitFor(() =>
+      expect(screen.queryByText(/Must be E\.164 format/i)).toBeNull(),
+    );
+  });
+
   it('includes offers_delivery: false in patch when toggled off', async () => {
     // BASE has offers_delivery: true — toggling the checkbox once → false
     render(<RestaurantInfoForm restaurant={BASE} />);

--- a/dashboard/tests/restaurant-info-form.test.tsx
+++ b/dashboard/tests/restaurant-info-form.test.tsx
@@ -66,4 +66,18 @@ describe('RestaurantInfoForm', () => {
     await screen.findByText(/E\.164/i);
     expect(updateRestaurantAction).not.toHaveBeenCalled();
   });
+
+  it('includes offers_delivery: false in patch when toggled off', async () => {
+    // BASE has offers_delivery: true — toggling the checkbox once → false
+    render(<RestaurantInfoForm restaurant={BASE} />);
+    const checkbox = screen.getByRole('checkbox', { name: /accept delivery orders/i });
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() =>
+      expect(updateRestaurantAction).toHaveBeenCalledWith(
+        expect.objectContaining({ offers_delivery: false }),
+      ),
+    );
+  });
 });

--- a/dashboard/tests/setup.ts
+++ b/dashboard/tests/setup.ts
@@ -2,6 +2,14 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
 import { afterEach } from 'vitest';
 
+// Radix UI primitives (Checkbox, etc.) use ResizeObserver internally.
+// jsdom doesn't ship it, so stub it out.
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 afterEach(() => {
   cleanup();
 });

--- a/tests/test_restaurants_api.py
+++ b/tests/test_restaurants_api.py
@@ -126,8 +126,7 @@ def test_patch_restaurant_404_when_doc_missing(client: TestClient):
 def test_patch_restaurant_validates_fallback_phone_format(client: TestClient):
     _wire_storage(_existing_doc())
 
-    # Loose validation: any non-empty E.164-like string is fine; "abc"
-    # rejected.
+    # E.164 format is enforced — non-conforming strings 422.
     resp = client.patch("/restaurants/me", json={"fallback_phone": "abc"})
     assert resp.status_code == 422
 
@@ -154,3 +153,41 @@ def test_patch_restaurant_rejects_empty_strings(client: TestClient):
     for field in ("name", "address", "display_phone"):
         resp = client.patch("/restaurants/me", json={field: ""})
         assert resp.status_code == 422, f"{field} empty should 422"
+
+
+def test_patch_restaurant_scoped_to_tenant_restaurant_id():
+    """PATCH /restaurants/me reads and writes only the authenticated tenant's
+    restaurant document — never another tenant's doc."""
+    tenant_a = Tenant(
+        uid="user-a",
+        email="owner@tenant-a.test",
+        restaurant_id="tenant-A",
+        role="owner",
+    )
+    app.dependency_overrides[current_tenant] = lambda: tenant_a
+
+    existing = {
+        "id": "tenant-A",
+        "name": "Tenant A Restaurant",
+        "display_phone": "+15550000001",
+        "twilio_phone": "+15550000002",
+        "address": "1 Tenant Ave",
+        "hours": "Mon-Sun 10-21",
+        "menu": {},
+    }
+    fs = _wire_storage(existing)
+
+    try:
+        resp = TestClient(app).patch("/restaurants/me", json={"name": "Updated"})
+    finally:
+        app.dependency_overrides.pop(current_tenant, None)
+        r_storage.set_client(None)
+        r_storage.clear_cache()
+
+    assert resp.status_code == 200
+
+    # Every document() call must reference "tenant-A" — never any other rid.
+    for call_args in fs.collection.return_value.document.call_args_list:
+        assert call_args.args[0] == "tenant-A", (
+            f"document() called with unexpected id: {call_args.args[0]!r}"
+        )


### PR DESCRIPTION
## Summary

Addresses all five items explicitly deferred from PR #153 ("Follow-ups deliberately deferred" section). No items were already addressed on master since 2026-05-01.

### Items addressed (4 commits)

**`tests:` fix misleading comment + cross-tenant scoping test**
- Rewords the `"Loose validation"` comment on `test_patch_restaurant_validates_fallback_phone_format` (line 129 in #153) to `"E.164 format is enforced — non-conforming strings 422."`.
- Adds `test_patch_restaurant_scoped_to_tenant_restaurant_id`: wires a `tenant-A` tenant via `_wire_storage`, calls PATCH, then asserts every `collection().document()` call used `"tenant-A"` — never any other rid.

**`dashboard:` swap bare `<input type="checkbox">` for ShadCN `<Checkbox>` in `HoursEditor`**
- Installed `components/ui/checkbox.tsx` via `pnpm dlx shadcn@latest add checkbox`.
- Replaced `<input type="checkbox" ... onChange={e => ... e.target.checked}>` with `<Checkbox checked={...} onCheckedChange={checked => ... checked === true}>`.
- All 5 existing `hours-editor` vitest cases pass unchanged with `fireEvent.click()`.
- Added `ResizeObserver` stub to `tests/setup.ts` — Radix primitives call it in effects; jsdom doesn't ship it.

**`dashboard:` wire `offers_delivery` toggle into `RestaurantInfoForm`**
- Adds a `<Checkbox id="offers-delivery">` with label "Accept delivery orders" below the fallback_phone field.
- Reads initial value from `restaurant.offers_delivery`; included in `buildPatch()` only when it differs from the server value.
- New vitest case: asserts patch includes `offers_delivery: false` when the checkbox is toggled from its initial `true`.

**`dashboard:` inline E.164 feedback while typing fallback_phone**
- Adds `fallbackError` state updated synchronously via `handleFallbackChange` (the `onChange` handler). Empty or valid E.164 → clears error; anything else → `"Must be E.164 format (e.g. +15551234567)"` shown inline below the input via the `Field` component's new `inlineError` prop.
- Removed the duplicate bottom-level `setError` for fallback phone in `handleSubmit` — inline feedback covers it; submit still blocks early on invalid input.
- Two new vitest cases: inline error appears on invalid input; clears when input becomes valid.

### Items skipped

None — all five deferred items are addressed in this PR.

## Test plan

- [x] `pytest tests/ -x` — 495 passed, 15 skipped
- [x] `cd dashboard && pnpm typecheck` — clean (0 errors)
- [x] `cd dashboard && pnpm vitest run` — 113/113 passed across 15 files
- [ ] **Manual smoke:** Open `/settings`, type a non-E.164 string in Fallback number — inline error appears while typing. Toggle "Accept delivery orders" off and save — verify patch sent. Check Monday Closed checkbox uses the new ShadCN style. Confirm staff role still gets 403 (unchanged endpoint).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYAzyJQuG96rvLU7LuCpQ3)_