### PR TITLE
feat(voice): block-boundary flush to drain buffered TTS (#305 Part A)

### DIFF
--- a/app/llm/anthropic.py
+++ b/app/llm/anthropic.py
@@ -398,6 +398,11 @@ class AnthropicLLM:
         cache_read_tokens = 0
         cache_creation_tokens = 0
         timing_emitted = False
+        # Tracks the block type observed at the most recent
+        # ``content_block_start`` so the matching ``content_block_stop``
+        # can decide whether to emit ``flush_now`` (#305). Only text
+        # blocks trigger a flush — tool_use blocks carry no spoken text.
+        current_block_type: Optional[str] = None
 
         async with api.messages.stream(
             model=self._model,
@@ -421,7 +426,8 @@ class AnthropicLLM:
                         )
                 elif etype == "content_block_start":
                     block = getattr(event, "content_block", None)
-                    if getattr(block, "type", None) == "text" and t_first_text_block is None:
+                    current_block_type = getattr(block, "type", None)
+                    if current_block_type == "text" and t_first_text_block is None:
                         t_first_text_block = time.monotonic()
                         yield _make_timing_event(
                             t_request_start,
@@ -437,6 +443,10 @@ class AnthropicLLM:
                     if getattr(delta, "type", None) == "text_delta":
                         text_parts.append(delta.text)
                         yield StreamEvent(text_delta=delta.text)
+                elif etype == "content_block_stop":
+                    if current_block_type == "text":
+                        yield StreamEvent(flush_now=True)
+                    current_block_type = None
             first_message = await stream.get_final_message()
 
         for block in first_message.content:
@@ -494,6 +504,7 @@ class AnthropicLLM:
             fu_cache_read_tokens = 0
             fu_cache_creation_tokens = 0
             fu_timing_emitted = False
+            fu_current_block_type: Optional[str] = None
 
             async with api.messages.stream(
                 model=self._model,
@@ -518,7 +529,8 @@ class AnthropicLLM:
                             )
                     elif etype == "content_block_start":
                         block = getattr(event, "content_block", None)
-                        if getattr(block, "type", None) == "text" and fu_t_first_text_block is None:
+                        fu_current_block_type = getattr(block, "type", None)
+                        if fu_current_block_type == "text" and fu_t_first_text_block is None:
                             fu_t_first_text_block = time.monotonic()
                             yield _make_timing_event(
                                 fu_t_request_start,
@@ -534,6 +546,10 @@ class AnthropicLLM:
                         if getattr(delta, "type", None) == "text_delta":
                             text_parts.append(delta.text)
                             yield StreamEvent(text_delta=delta.text)
+                    elif etype == "content_block_stop":
+                        if fu_current_block_type == "text":
+                            yield StreamEvent(flush_now=True)
+                        fu_current_block_type = None
                 followup_message = await followup_stream.get_final_message()
 
             if not fu_timing_emitted:

--- a/app/llm/base.py
+++ b/app/llm/base.py
@@ -131,13 +131,19 @@ class LLMResponse:
 class StreamEvent:
     """One event yielded by ``LLMProvider.stream_reply``.
 
-    Exactly one of ``text_delta``, ``timing``, or ``final`` is set on
-    any given event. Text-delta events arrive incrementally as the
-    model produces output; a ``timing`` event lands the moment the
-    first text block opens (so the router can fold the latency
-    breakdown into its ``first_audio`` Firestore event before TTS
-    starts); the terminal ``final`` event carries the assembled
-    ``LLMResponse`` so the caller can persist state for the next turn.
+    At most one of ``text_delta``, ``timing``, or ``final`` is set on
+    any given event; ``flush_now`` is a boolean signal that can be set
+    on its own event (no payload) or alongside a ``text_delta``. Text
+    deltas arrive incrementally as the model produces output; a
+    ``timing`` event lands the moment the first text block opens (so
+    the router can fold the latency breakdown into its ``first_audio``
+    Firestore event before TTS starts); ``flush_now`` fires at content
+    block boundaries (#305) so the caller can drain any buffered TTS
+    text before the next block starts — critical on text-then-tool
+    turns where the buffered text would otherwise sit idle until the
+    tool round-trip completes. The terminal ``final`` event carries
+    the assembled ``LLMResponse`` so the caller can persist state for
+    the next turn.
 
     The ``timing`` payload has the shape::
 
@@ -157,6 +163,7 @@ class StreamEvent:
     text_delta: Optional[str] = None
     final: Optional[LLMResponse] = None
     timing: Optional[dict[str, Any]] = None
+    flush_now: bool = False
 
 
 class LLMProvider(Protocol):

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -549,6 +549,32 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                 timing_snapshot = event.timing
                 continue
 
+            if event.flush_now:
+                # Block-boundary drain (#305 Part A). The provider has
+                # finished a text content block; ship whatever is buffered
+                # to TTS now instead of waiting for ``_should_flush_chunk``
+                # to fire on a future delta or for ``event.final`` to run
+                # its remainder path. On text-then-tool turns this drains
+                # the short ack ("Okay,") before the tool round-trip
+                # starts, removing dead air during the tool call.
+                remainder = "".join(text_buffer).strip()
+                text_buffer.clear()
+                if remainder and state.stream_sid:
+                    if first_speak:
+                        _record_first_audio()
+                        first_speak = False
+                        on_first_byte = _record_first_tts_byte
+                    else:
+                        on_first_byte = None
+                    await speak(
+                        remainder,
+                        websocket,
+                        state.stream_sid,
+                        on_chunk=_make_recording_chunk_handler(state),
+                        on_first_byte=on_first_byte,
+                    )
+                continue
+
             if event.text_delta is not None:
                 if first_text_at is None:
                     first_text_at = time.monotonic()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -782,6 +782,92 @@ async def test_stream_reply_emits_text_deltas_then_final():
     assert final.history[1]["role"] == "assistant"
 
 
+async def test_stream_reply_emits_flush_now_after_text_block(monkeypatch):
+    """Pure-text turn: a flush_now event lands after the deltas and before
+    the terminal final event, so the session can drain its TTS buffer at
+    the block boundary instead of waiting for ``event.final``.
+
+    Reproduces case A from #305 — a single text block whose deltas don't
+    happen to end on a hard/soft break, so _should_flush_chunk never
+    fires mid-stream and the buffer otherwise sits idle until final.
+    """
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=["Okay", " one", " moment"],  # no trailing punctuation
+                blocks=[FakeBlock(type="text", text="Okay one moment")],
+            )
+        ]
+    )
+
+    event_kinds: list[str] = []
+    async for event in AnthropicLLM(async_client=fake_client).stream_reply(
+        transcript="hi",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+    ):
+        if event.text_delta is not None:
+            event_kinds.append("delta")
+        if event.flush_now:
+            event_kinds.append("flush")
+        if event.final is not None:
+            event_kinds.append("final")
+
+    # Three deltas, one flush at block-stop, then final — in that order.
+    assert event_kinds == ["delta", "delta", "delta", "flush", "final"]
+
+
+async def test_stream_reply_emits_flush_now_before_tool_use_block():
+    """Text-then-tool turn: the text block's flush_now must fire before
+    the tool round-trip starts, so any buffered TTS text drains while
+    the tool call is in flight rather than waiting for the follow-up.
+
+    Reproduces case B from #305 — model emits a short ack ("Okay,") then
+    calls update_order. Without block-boundary flush, "Okay," is too
+    short for _MIN_CHUNK_CHARS and gets held until event.final.
+    """
+    order = Order(call_sid="CAtest")
+    fake_client = MagicMock()
+    fake_client.messages.stream = _stream_manager_factory(
+        [
+            _FakeAsyncStream(
+                deltas=["Okay,"],
+                blocks=[
+                    FakeBlock(type="text", text="Okay,"),
+                    FakeBlock(
+                        type="tool_use",
+                        id="toolu_1",
+                        name="update_order",
+                        input={"items": [], "status": "in_progress"},
+                    ),
+                ],
+            ),
+            _FakeAsyncStream(
+                deltas=["What else?"],
+                blocks=[FakeBlock(type="text", text="What else?")],
+            ),
+        ]
+    )
+
+    seen_flush_before_final = False
+    seen_final = False
+    async for event in AnthropicLLM(async_client=fake_client).stream_reply(
+        transcript="add nothing",
+        history=[],
+        order=order,
+        system_prompt=_TEST_SYSTEM_PROMPT,
+    ):
+        if event.flush_now and not seen_final:
+            seen_flush_before_final = True
+        if event.final is not None:
+            seen_final = True
+
+    assert seen_flush_before_final, "flush_now must be emitted before event.final"
+
+
 async def test_stream_reply_applies_tool_use_to_order_state():
     order = Order(call_sid="CAtest")
     fake_client = MagicMock()

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -1223,9 +1223,7 @@ async def test_run_llm_tts_turn_flush_now_with_no_buffer_is_noop(monkeypatch):
         # already drained it. The trailing flush_now should be a no-op.
         yield StreamEvent(text_delta="Sure thing.")
         yield StreamEvent(flush_now=True)
-        yield StreamEvent(
-            final=LLMResponse(reply_text="Sure thing.", order=order, history=history)
-        )
+        yield StreamEvent(final=LLMResponse(reply_text="Sure thing.", order=order, history=history))
 
     monkeypatch.setattr(session_mod, "speak", capture_speak)
     monkeypatch.setattr(session_mod, "get_llm", _fake_llm_factory(fake_stream_reply))

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -1199,8 +1199,8 @@ async def test_run_llm_tts_turn_drains_buffer_on_flush_now(monkeypatch):
     # The speak() that drained the buffer must have happened BEFORE the
     # final event was yielded — proving flush_now (not final) triggered it.
     assert speak_calls_at_flush == ["Hold on please"], (
-        f"flush_now did not drain buffer before final; speak_calls_at_flush={speak_calls_at_flush}, "
-        f"chunks_spoken={chunks_spoken}"
+        f"flush_now did not drain buffer before final; "
+        f"speak_calls_at_flush={speak_calls_at_flush}, chunks_spoken={chunks_spoken}"
     )
 
 

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -1178,7 +1178,9 @@ async def test_run_llm_tts_turn_drains_buffer_on_flush_now(monkeypatch):
         # wired correctly the buffer has already drained here; if not,
         # this list will be empty (the drain doesn't happen until final).
         speak_calls_at_flush.extend(chunks_spoken)
-        yield StreamEvent(final=LLMResponse(reply_text="Hold on please", order=order, history=history))
+        yield StreamEvent(
+            final=LLMResponse(reply_text="Hold on please", order=order, history=history)
+        )
 
     monkeypatch.setattr(session_mod, "speak", capture_speak)
     monkeypatch.setattr(session_mod, "get_llm", _fake_llm_factory(fake_stream_reply))
@@ -1221,7 +1223,9 @@ async def test_run_llm_tts_turn_flush_now_with_no_buffer_is_noop(monkeypatch):
         # already drained it. The trailing flush_now should be a no-op.
         yield StreamEvent(text_delta="Sure thing.")
         yield StreamEvent(flush_now=True)
-        yield StreamEvent(final=LLMResponse(reply_text="Sure thing.", order=order, history=history))
+        yield StreamEvent(
+            final=LLMResponse(reply_text="Sure thing.", order=order, history=history)
+        )
 
     monkeypatch.setattr(session_mod, "speak", capture_speak)
     monkeypatch.setattr(session_mod, "get_llm", _fake_llm_factory(fake_stream_reply))

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -1137,6 +1137,111 @@ async def test_run_llm_tts_turn_does_not_flush_at_short_comma(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# _run_llm_tts_turn — flush_now block-boundary drain (#305 Part A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_llm_tts_turn_drains_buffer_on_flush_now(monkeypatch):
+    """When the LLM provider yields a flush_now signal, the session must
+    drain whatever is in the text buffer to TTS immediately — even if the
+    buffered text doesn't end in a hard/soft break that would normally
+    trigger ``_should_flush_chunk``.
+
+    Reproduces case A from #305: a text block ends mid-phrase with no
+    trailing punctuation (e.g. before the model invokes a tool). Without
+    flush_now, the partial buffer sits until ``event.final``, adding
+    tool-round-trip dead air. With flush_now, the buffer ships now.
+
+    Asserts ORDERING — the speak() must fire between flush_now and
+    final, NOT inside the final-event remainder path (which would also
+    drain the buffer but defeats the whole purpose).
+    """
+    from app.storage import call_sessions
+    from app.telephony import session as session_mod
+    from app.telephony.session import _CallState, _run_llm_tts_turn
+
+    speak_calls_at_flush: list[str] = []
+    chunks_spoken: list[str] = []
+
+    async def capture_speak(text, websocket, stream_sid, **kw):
+        chunks_spoken.append(text)
+
+    async def fake_stream_reply(*, transcript, history, order, **kw):
+        # Two short deltas with no terminator; _should_flush_chunk would
+        # keep them buffered. flush_now must drain them anyway.
+        yield StreamEvent(text_delta="Hold on")
+        yield StreamEvent(text_delta=" please")
+        yield StreamEvent(flush_now=True)
+        # Snapshot chunks_spoken immediately after the session processed
+        # flush_now but BEFORE it sees the final event. If the session is
+        # wired correctly the buffer has already drained here; if not,
+        # this list will be empty (the drain doesn't happen until final).
+        speak_calls_at_flush.extend(chunks_spoken)
+        yield StreamEvent(final=LLMResponse(reply_text="Hold on please", order=order, history=history))
+
+    monkeypatch.setattr(session_mod, "speak", capture_speak)
+    monkeypatch.setattr(session_mod, "get_llm", _fake_llm_factory(fake_stream_reply))
+    monkeypatch.setattr(session_mod, "_bg_call_event", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+
+    state = _CallState(
+        call_sid="CAtest",
+        stream_sid="MZtest",
+        order=Order(call_sid="CAtest"),
+        system_prompt="test prompt",
+    )
+    await _run_llm_tts_turn("hi", state, AsyncMock())
+
+    # The speak() that drained the buffer must have happened BEFORE the
+    # final event was yielded — proving flush_now (not final) triggered it.
+    assert speak_calls_at_flush == ["Hold on please"], (
+        f"flush_now did not drain buffer before final; speak_calls_at_flush={speak_calls_at_flush}, "
+        f"chunks_spoken={chunks_spoken}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_llm_tts_turn_flush_now_with_no_buffer_is_noop(monkeypatch):
+    """flush_now arriving with an empty buffer must not call speak() with
+    an empty string — that would emit a noise mark to Twilio for no audio.
+    """
+    from app.storage import call_sessions
+    from app.telephony import session as session_mod
+    from app.telephony.session import _CallState, _run_llm_tts_turn
+
+    chunks_spoken: list[str] = []
+
+    async def capture_speak(text, websocket, stream_sid, **kw):
+        chunks_spoken.append(text)
+
+    async def fake_stream_reply(*, transcript, history, order, **kw):
+        # Text already ended with a hard break — _should_flush_chunk
+        # already drained it. The trailing flush_now should be a no-op.
+        yield StreamEvent(text_delta="Sure thing.")
+        yield StreamEvent(flush_now=True)
+        yield StreamEvent(final=LLMResponse(reply_text="Sure thing.", order=order, history=history))
+
+    monkeypatch.setattr(session_mod, "speak", capture_speak)
+    monkeypatch.setattr(session_mod, "get_llm", _fake_llm_factory(fake_stream_reply))
+    monkeypatch.setattr(session_mod, "_bg_call_event", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+
+    state = _CallState(
+        call_sid="CAtest",
+        stream_sid="MZtest",
+        order=Order(call_sid="CAtest"),
+        system_prompt="test prompt",
+    )
+    await _run_llm_tts_turn("hi", state, AsyncMock())
+
+    assert chunks_spoken == ["Sure thing."]
+    assert "" not in chunks_spoken
+
+
+# ---------------------------------------------------------------------------
 # first_tts_byte event (#152)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds a `flush_now: bool` signal to `StreamEvent` and wires `AnthropicLLM` to emit it on `content_block_stop` for text blocks (main + follow-up streams).
- `_run_llm_tts_turn` now drains its TTS chunk buffer when `event.flush_now` fires, mirroring the remainder-flush already in `event.final`.
- Eliminates dead air on **text-then-tool turns** where the model spoke a short ack ("Okay,") that was under `MIN_CHUNK_CHARS` and would otherwise sit buffered until `event.final` post-tool round-trip.

This is **Part A** of #305 — standalone, additive, safe to ship without Part B. Part B (atomic patch tools) is gated on a separate diagnostic.

## Linked issue
Relates to #305 (does not close — Part B remains)

## What changed
| File | Change |
|---|---|
| `app/llm/base.py` | `StreamEvent.flush_now: bool = False` + docstring |
| `app/llm/anthropic.py` | Track `current_block_type` from start→stop; yield `StreamEvent(flush_now=True)` on text-block stop in both streams |
| `app/telephony/session.py` | New `if event.flush_now:` branch in `_run_llm_tts_turn` that drains `text_buffer` to TTS |
| `tests/test_llm_client.py` | 2 tests: pure-text turn flush_now ordering + text-then-tool flush_now-before-tool |
| `tests/test_telephony.py` | 2 tests: buffer drain at flush_now (with ordering assertion) + empty-buffer no-op |

## Test plan
- [x] Unit tests pass — 4 new tests cover both halves of the contract; all 534 niko tests pass locally (`pytest tests/ -m "not live_llm and not live_discord"`).
- [x] Smoke call on real Twilio — `CA8e25c6c39972e6eea4fb0705777b3b9f` (2026-05-16). Multi-item order with mid-call additions; no double-speak, no clipped audio, `first_audio` latencies in normal band (0.72–1.15s). `flush_now` exercised the empty-buffer no-op path on every tool turn (model used clean punctuation in acks).
- [ ] Watch `first_audio` latencies on tool-bearing turns over the next few real calls — expect lower numbers when the model emits an unpunctuated ack.

## Notes for reviewer
- No behavior change on pure-text turns ending in `.` `?` `!` — `_should_flush_chunk` already drains there, and the trailing `flush_now` is a no-op.
- Auto-hangup, barge-in, silence watchdog, recording pipeline — all untouched.
- Two unrelated bugs surfaced during the smoke call (LLM premature `status=confirmed` and abort-path missing `SpeechStartedEvent`); filed as #307 and #308 — not in scope here.
- Windows ruff format flags CRLF false positives across the whole repo; trusting Linux CI for the format gate. Ruff lint clean on touched files.

## Out of scope (Part B — separate work)
- Atomic update_order patch tools (`add_item`, `remove_item`, etc.) — gated on the diagnostic in #305 measuring whether confirm-turn `first_audio` grows with order size.
