### PR TITLE
feat(llm): atomic order tools replace snapshot update_order (#305 Part B)

### DIFF
--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -11,7 +11,7 @@ matching the ``LLMProvider`` Protocol from ``app/llm/base.py``.
 from __future__ import annotations
 
 from app.llm.base import (
-    UPDATE_ORDER_TOOL_SPEC,
+    ATOMIC_TOOL_SPECS,
     LLMProvider,
     LLMResponse,
     StreamEvent,
@@ -19,11 +19,11 @@ from app.llm.base import (
 )
 
 __all__ = [
+    "ATOMIC_TOOL_SPECS",
     "LLMProvider",
     "LLMResponse",
     "StreamEvent",
     "ToolSpec",
-    "UPDATE_ORDER_TOOL_SPEC",
     "get_llm",
 ]
 

--- a/app/llm/anthropic.py
+++ b/app/llm/anthropic.py
@@ -310,9 +310,7 @@ class AnthropicLLM:
         updated_order = order
         tool_results: list[dict[str, Any]] = []
         for tu in tool_uses:
-            updated_order, rejection_notes = apply_tool_call(
-                updated_order, tu["name"], tu["input"]
-            )
+            updated_order, rejection_notes = apply_tool_call(updated_order, tu["name"], tu["input"])
             summary = summarize_order_for_tool_result(updated_order)
             if rejection_notes:
                 summary = summary + " " + " ".join(rejection_notes)
@@ -459,9 +457,7 @@ class AnthropicLLM:
         updated_order = order
         tool_results: list[dict[str, Any]] = []
         for tu in tool_uses:
-            updated_order, rejection_notes = apply_tool_call(
-                updated_order, tu["name"], tu["input"]
-            )
+            updated_order, rejection_notes = apply_tool_call(updated_order, tu["name"], tu["input"])
             summary = summarize_order_for_tool_result(updated_order)
             if rejection_notes:
                 summary = summary + " " + " ".join(rejection_notes)

--- a/app/llm/anthropic.py
+++ b/app/llm/anthropic.py
@@ -29,27 +29,29 @@ from anthropic import Anthropic, AsyncAnthropic
 
 from app.config import settings
 from app.llm.base import (
-    UPDATE_ORDER_TOOL_SPEC,
+    ATOMIC_TOOL_SPECS,
     LLMResponse,
     StreamEvent,
 )
 from app.llm.orchestration import (
-    apply_order_patch,
+    apply_tool_call,
     should_skip_followup,
     summarize_order_for_tool_result,
-    validate_order_patch,
 )
 from app.orders.models import Order
 
 # Anthropic accepts the JSON Schema directly under ``input_schema``.
-# Build the wire-shape dict once at import so the cached ``tools=[...]``
-# list stays a constant across calls (matters for prompt caching: tools
-# sit before system in Anthropic's cached prefix order).
-UPDATE_ORDER_TOOL: dict[str, Any] = {
-    "name": UPDATE_ORDER_TOOL_SPEC.name,
-    "description": UPDATE_ORDER_TOOL_SPEC.description,
-    "input_schema": UPDATE_ORDER_TOOL_SPEC.parameters,
-}
+# Build the wire-shape list once at import so the cached ``tools=[...]``
+# stays a constant across calls (matters for prompt caching: tools sit
+# before system in Anthropic's cached prefix order).
+ATOMIC_TOOLS: list[dict[str, Any]] = [
+    {
+        "name": spec.name,
+        "description": spec.description,
+        "input_schema": spec.parameters,
+    }
+    for spec in ATOMIC_TOOL_SPECS
+]
 
 
 def _missing_key_error() -> RuntimeError:
@@ -293,7 +295,7 @@ class AnthropicLLM:
             model=self._model,
             max_tokens=self._max_tokens,
             system=_system_cache_block(system_prompt),
-            tools=[UPDATE_ORDER_TOOL],
+            tools=ATOMIC_TOOLS,
             messages=_with_rolling_cache_breakpoint(new_history),
         )
 
@@ -302,14 +304,15 @@ class AnthropicLLM:
         for block in response.content:
             if block.type == "text":
                 reply_text_parts.append(block.text)
-            elif block.type == "tool_use" and block.name == "update_order":
-                tool_uses.append({"id": block.id, "input": block.input})
+            elif block.type == "tool_use":
+                tool_uses.append({"id": block.id, "name": block.name, "input": block.input})
 
         updated_order = order
         tool_results: list[dict[str, Any]] = []
         for tu in tool_uses:
-            cleaned_input, rejection_notes = validate_order_patch(tu["input"])
-            updated_order = apply_order_patch(updated_order, cleaned_input)
+            updated_order, rejection_notes = apply_tool_call(
+                updated_order, tu["name"], tu["input"]
+            )
             summary = summarize_order_for_tool_result(updated_order)
             if rejection_notes:
                 summary = summary + " " + " ".join(rejection_notes)
@@ -338,7 +341,7 @@ class AnthropicLLM:
                 model=self._model,
                 max_tokens=self._max_tokens,
                 system=_system_cache_block(system_prompt),
-                tools=[UPDATE_ORDER_TOOL],
+                tools=ATOMIC_TOOLS,
                 tool_choice={"type": "none"},
                 messages=_with_rolling_cache_breakpoint(new_history),
             )
@@ -408,7 +411,7 @@ class AnthropicLLM:
             model=self._model,
             max_tokens=self._max_tokens,
             system=_system_cache_block(system_prompt),
-            tools=[UPDATE_ORDER_TOOL],
+            tools=ATOMIC_TOOLS,
             messages=_with_rolling_cache_breakpoint(new_history),
         ) as stream:
             async for event in stream:
@@ -450,14 +453,15 @@ class AnthropicLLM:
             first_message = await stream.get_final_message()
 
         for block in first_message.content:
-            if block.type == "tool_use" and block.name == "update_order":
-                tool_uses.append({"id": block.id, "input": block.input})
+            if block.type == "tool_use":
+                tool_uses.append({"id": block.id, "name": block.name, "input": block.input})
 
         updated_order = order
         tool_results: list[dict[str, Any]] = []
         for tu in tool_uses:
-            cleaned_input, rejection_notes = validate_order_patch(tu["input"])
-            updated_order = apply_order_patch(updated_order, cleaned_input)
+            updated_order, rejection_notes = apply_tool_call(
+                updated_order, tu["name"], tu["input"]
+            )
             summary = summarize_order_for_tool_result(updated_order)
             if rejection_notes:
                 summary = summary + " " + " ".join(rejection_notes)
@@ -510,7 +514,7 @@ class AnthropicLLM:
                 model=self._model,
                 max_tokens=self._max_tokens,
                 system=_system_cache_block(system_prompt),
-                tools=[UPDATE_ORDER_TOOL],
+                tools=ATOMIC_TOOLS,
                 tool_choice={"type": "none"},
                 messages=_with_rolling_cache_breakpoint(new_history),
             ) as followup_stream:
@@ -591,6 +595,6 @@ class AnthropicLLM:
 
 
 __all__ = [
+    "ATOMIC_TOOLS",
     "AnthropicLLM",
-    "UPDATE_ORDER_TOOL",
 ]

--- a/app/llm/base.py
+++ b/app/llm/base.py
@@ -161,8 +161,7 @@ _UPDATE_ITEM_SPEC: ToolSpec = ToolSpec(
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Full new list of modifications — replaces the "
-                    "existing list, does not append."
+                    "Full new list of modifications — replaces the existing list, does not append."
                 ),
             },
         },

--- a/app/llm/base.py
+++ b/app/llm/base.py
@@ -47,70 +47,205 @@ class ToolSpec:
     parameters: dict[str, Any]
 
 
-UPDATE_ORDER_TOOL_SPEC: ToolSpec = ToolSpec(
-    name="update_order",
+# ---------------------------------------------------------------------------
+# Atomic tool specs (#305 Part B)
+# ---------------------------------------------------------------------------
+#
+# Six narrow operations replacing the single snapshot ``update_order``
+# tool. Discrimination between tools depends on the descriptions below —
+# the model picks a tool by matching caller intent against
+# ``name`` + ``description``, so each description has to be intent-keyed
+# and non-overlapping. The provider's atomic dispatch
+# (``orchestration.apply_tool_call``) keys off ``name``.
+
+
+_ADD_ITEM_SPEC: ToolSpec = ToolSpec(
+    name="add_item",
     description=(
-        "Record the caller's current order state. Call this whenever "
-        "the order changes — items added, removed, or modified; order "
-        "type decided; delivery address given; or the caller confirms "
-        "or cancels. Emit the FULL current order state each time, not "
-        "a diff."
+        "Add a new line item to the order. Call this when the caller "
+        "asks for something not already in the order, or asks for a "
+        "different size or variant of an existing item — different "
+        "sizes are SEPARATE line items, not in-place size changes. "
+        "For changing the size or quantity of an item already in the "
+        "order, use update_item instead."
     ),
     parameters={
         "type": "object",
         "properties": {
-            "items": {
-                "type": "array",
-                "description": "Full list of line items currently in the order.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string"},
-                        "category": {
-                            "type": "string",
-                            "description": (
-                                "Free-form category from the menu (e.g. "
-                                "appetizer, main, soup, drink, dessert). "
-                                "Used for grouping in the dashboard — not "
-                                "validated against a fixed enum, since "
-                                "tenants pick their own category names."
-                            ),
-                        },
-                        "size": {
-                            "type": ["string", "null"],
-                            "description": (
-                                "Required when the menu item is multi-size "
-                                "(small/medium/large, half/whole, etc.) — "
-                                "use whichever size keys the menu shows. "
-                                "Null for single-priced items."
-                            ),
-                        },
-                        "quantity": {"type": "integer", "minimum": 1},
-                        "unit_price": {
-                            "type": "number",
-                            "description": "Per-unit price from the menu.",
-                        },
-                        "modifications": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": ("Customizations like 'extra cheese' or 'no onions'."),
-                        },
-                    },
-                    "required": ["name", "category", "quantity", "unit_price"],
-                },
-            },
-            "order_type": {
-                "type": ["string", "null"],
-                "enum": ["pickup", "delivery", None],
-            },
-            "delivery_address": {"type": ["string", "null"]},
-            "status": {
+            "name": {"type": "string", "description": "Menu item name."},
+            "category": {
                 "type": "string",
-                "enum": ["in_progress", "confirmed", "cancelled"],
+                "description": (
+                    "Free-form category from the menu (appetizer, main, "
+                    "soup, drink, dessert, etc.). Use whatever category "
+                    "key the menu lists — not validated against a fixed enum."
+                ),
+            },
+            "size": {
+                "type": ["string", "null"],
+                "description": (
+                    "Required when the menu item is multi-size "
+                    "(small/medium/large, half/whole, etc.) — use the "
+                    "size key the menu shows. Null for single-priced items."
+                ),
+            },
+            "quantity": {"type": "integer", "minimum": 1},
+            "unit_price": {
+                "type": "number",
+                "description": "Per-unit price from the menu.",
+            },
+            "modifications": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Customizations like 'extra cheese' or 'no onions'.",
             },
         },
+        "required": ["name", "category", "quantity", "unit_price"],
     },
 )
+
+
+_REMOVE_ITEM_SPEC: ToolSpec = ToolSpec(
+    name="remove_item",
+    description=(
+        "Remove a line item from the order, identified by item_id. The "
+        "item_id was surfaced in the tool_result when the item was "
+        "added — read it from your prior tool_result blocks rather than "
+        "inventing one. Call this when the caller takes something back "
+        "('scratch the wings', 'no actually skip the coke')."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "item_id": {
+                "type": "string",
+                "description": (
+                    "The 'i_xxxxxx' ID surfaced in a prior tool_result "
+                    "for the item you want to remove."
+                ),
+            },
+        },
+        "required": ["item_id"],
+    },
+)
+
+
+_UPDATE_ITEM_SPEC: ToolSpec = ToolSpec(
+    name="update_item",
+    description=(
+        "Modify an existing line item identified by item_id. Use for: "
+        "quantity changes ('make that two'), size changes on the same "
+        "line ('change to large' — also update unit_price to match the "
+        "menu's price for the new size), and modification edits ('add "
+        "no onions', 'remove extra cheese'). The item_id was surfaced "
+        "in a prior tool_result — read it from there rather than "
+        "inventing one. If the caller is adding a DIFFERENT size or "
+        "variant alongside the existing item, use add_item instead."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "item_id": {
+                "type": "string",
+                "description": (
+                    "The 'i_xxxxxx' ID surfaced in a prior tool_result "
+                    "for the item you want to modify."
+                ),
+            },
+            "name": {"type": "string"},
+            "category": {"type": "string"},
+            "size": {"type": ["string", "null"]},
+            "quantity": {"type": "integer", "minimum": 1},
+            "unit_price": {"type": "number"},
+            "modifications": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Full new list of modifications — replaces the "
+                    "existing list, does not append."
+                ),
+            },
+        },
+        "required": ["item_id"],
+    },
+)
+
+
+_SET_ORDER_TYPE_SPEC: ToolSpec = ToolSpec(
+    name="set_order_type",
+    description=(
+        "Set the order as pickup or delivery. Call when the caller "
+        "decides. Switching to pickup automatically clears any "
+        "previously captured delivery address — no need to call "
+        "set_delivery_address(null) afterward."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "order_type": {
+                "type": "string",
+                "enum": ["pickup", "delivery"],
+            },
+        },
+        "required": ["order_type"],
+    },
+)
+
+
+_SET_DELIVERY_ADDRESS_SPEC: ToolSpec = ToolSpec(
+    name="set_delivery_address",
+    description=(
+        "Capture the caller's delivery address. Only meaningful when "
+        "order_type is delivery. Pass null or an empty string to clear "
+        "an existing address (e.g., the caller wants to change it)."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "delivery_address": {
+                "type": ["string", "null"],
+                "description": (
+                    "Full street address as the caller stated it. "
+                    "Null or empty string clears the field."
+                ),
+            },
+        },
+        "required": ["delivery_address"],
+    },
+)
+
+
+_SET_STATUS_SPEC: ToolSpec = ToolSpec(
+    name="set_status",
+    description=(
+        "Mark the order as confirmed (caller explicitly confirmed "
+        "after the read-back) or cancelled (caller cancelled the "
+        "order). Do NOT call confirmed on a vague 'uh huh' mid-call — "
+        "only on an explicit yes after you've read the full order "
+        "back. Kitchen workflow states (preparing/ready/completed) "
+        "are not available here; the dashboard owns those."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["confirmed", "cancelled"],
+            },
+        },
+        "required": ["status"],
+    },
+)
+
+
+ATOMIC_TOOL_SPECS: list[ToolSpec] = [
+    _ADD_ITEM_SPEC,
+    _REMOVE_ITEM_SPEC,
+    _UPDATE_ITEM_SPEC,
+    _SET_ORDER_TYPE_SPEC,
+    _SET_DELIVERY_ADDRESS_SPEC,
+    _SET_STATUS_SPEC,
+]
 
 
 @dataclass
@@ -202,9 +337,9 @@ class LLMProvider(Protocol):
 
 
 __all__ = [
+    "ATOMIC_TOOL_SPECS",
     "LLMProvider",
     "LLMResponse",
     "StreamEvent",
     "ToolSpec",
-    "UPDATE_ORDER_TOOL_SPEC",
 ]

--- a/app/llm/orchestration.py
+++ b/app/llm/orchestration.py
@@ -1,20 +1,20 @@
 """Provider-neutral order-update domain logic.
 
-Helpers shared across every LLM provider for the ``update_order`` tool
-flow:
+Helpers shared across every LLM provider for the atomic order tools
+(#305 Part B):
 
-- ``apply_order_patch`` — merge a tool-call payload into the current
-  ``Order``, preserving server-owned identifiers.
-- ``validate_order_patch`` — filter a patch through server-side
-  validators (today: delivery address). Returns the cleaned patch plus
-  rejection notes the provider should append to its tool_result so the
-  model knows to re-ask the caller.
+- ``apply_tool_call`` — dispatch one atomic tool_use block to the right
+  per-operation handler; returns the mutated ``Order`` plus rejection
+  notes the provider should append to its tool_result so the model knows
+  to re-ask the caller.
 - ``summarize_order_for_tool_result`` — render a server-verified
-  subtotal + item list as the string body of a tool_result, closing
-  the accuracy hole where the model otherwise fabricates totals.
+  subtotal + item_id-prefixed item list as the string body of a
+  tool_result, closing the accuracy hole where the model otherwise
+  fabricates totals and surfacing item_ids the model uses for
+  subsequent remove_item / update_item calls.
 - ``should_skip_followup`` — decide whether the post-tool-use
-  follow-up call can be skipped (terminal-status turn where the main
-  call already spoke).
+  follow-up call can be skipped (terminal set_status turn where the
+  main call already spoke).
 
 These functions take and return plain dicts / domain objects so any
 provider can call them without leaking wire-format concerns.
@@ -22,9 +22,9 @@ provider can call them without leaking wire-format concerns.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
-from app.orders.models import Order
+from app.orders.models import LineItem, Order, OrderStatus, OrderType
 from app.orders.validation import validate_delivery_address
 
 INVALID_ADDRESS_NOTE = (
@@ -43,47 +43,21 @@ def summarize_order_for_tool_result(order: Order) -> str:
     $49.25 — without a server-verified number in the tool_result, the
     model fabricates totals from its memory of unit prices. Now it
     has a ground-truth subtotal to read back instead.
+
+    Each line is prefixed with its ``item_id`` (e.g. ``[i_a3f4c1]``)
+    so the model can reference it in subsequent ``remove_item`` /
+    ``update_item`` calls (#305 Part B). The IDs live in the model's
+    message history as plain tool_result text — that's where the model
+    reads them from when constructing later tool calls.
     """
     if not order.items:
         return "Order updated. Subtotal: $0.00. (no items yet)"
     items_summary = ", ".join(
-        f"{item.quantity}× {item.name}"
+        f"[{item.item_id}] {item.quantity}× {item.name}"
         + (f" ({', '.join(item.modifications)})" if item.modifications else "")
         for item in order.items
     )
     return f"Order updated. Subtotal: ${order.subtotal:.2f}. Items: {items_summary}."
-
-
-def validate_order_patch(patch: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
-    """Filter an update_order patch through server-side validators.
-
-    Returns a (cleaned_patch, rejection_notes) tuple:
-    - cleaned_patch is a copy of patch with any field that failed
-      validation removed (so the previous Order value stays put when
-      the patch is applied).
-    - rejection_notes is a list of human-readable strings to append to
-      the tool_result so the model knows to re-ask the caller. Empty
-      when every field passed validation.
-
-    Today only delivery_address has a validator (Sprint 2.2 #105). New
-    field validators slot in here so ``apply_order_patch`` stays a dumb
-    dict-merger and orchestration stays in one place.
-
-    Note on explicit-clear intents: when the model ships
-    ``delivery_address=None`` or ``""`` (e.g. swapping order_type from
-    delivery to pickup), that's a legitimate clear, not a rejection.
-    The validator returns False for both, so we only invoke it when
-    there's actual non-empty content to validate.
-    """
-    cleaned = dict(patch)
-    notes: list[str] = []
-    if "delivery_address" in cleaned:
-        value = cleaned["delivery_address"]
-        if value is not None and isinstance(value, str) and value.strip():
-            if not validate_delivery_address(value):
-                del cleaned["delivery_address"]
-                notes.append(INVALID_ADDRESS_NOTE)
-    return cleaned, notes
 
 
 def should_skip_followup(tool_uses: list[dict[str, Any]], main_emitted_text: bool) -> bool:
@@ -101,38 +75,173 @@ def should_skip_followup(tool_uses: list[dict[str, Any]], main_emitted_text: boo
     non-terminal turn (mid-order item adds need the server-verified
     subtotal in tool_result before the next "anything else?").
 
-    ``tool_uses`` items must have an ``input`` dict; the function only
-    reads ``input.status`` so any provider can map its native tool-use
-    representation onto this shape.
+    ``tool_uses`` items must have ``name`` and ``input`` fields. The
+    function recognizes ``set_status`` (atomic-tool path, #305 Part B)
+    as the terminal signal.
     """
     if not main_emitted_text:
         return False
-    return any(tu["input"].get("status") in TERMINAL_STATUSES for tu in tool_uses)
+    return any(
+        tu.get("name") == "set_status"
+        and tu.get("input", {}).get("status") in TERMINAL_STATUSES
+        for tu in tool_uses
+    )
 
 
-def apply_order_patch(order: Order, patch: dict[str, Any]) -> Order:
-    """Merge a tool-call payload into the current ``Order``.
+# ---------------------------------------------------------------------------
+# Atomic tool dispatch (#305 Part B)
+# ---------------------------------------------------------------------------
+#
+# Replaces the single snapshot ``update_order`` tool with six narrow
+# operations dispatched by ``apply_tool_call``. The model picks an
+# operation per turn and the provider routes the tool_use block here.
+# Each handler returns ``(new_order, rejection_notes)`` so the provider
+# can append notes to the tool_result alongside the order summary.
+#
+# Item identity: ``add_item`` mints a new ``item_id`` on the resulting
+# LineItem (default factory on the model). The provider surfaces that
+# ID via the tool_result summary; the model uses it in subsequent
+# ``remove_item`` / ``update_item`` calls.
 
-    Preserves call_sid, caller_phone, restaurant_id, and created_at
-    from the existing order so the LLM cannot overwrite them. Every
-    other field the LLM provided is accepted as the new authoritative
-    value.
+
+_ADD_ITEM_REQUIRED = ("name", "category", "quantity", "unit_price")
+_UPDATE_ITEM_FIELDS = ("name", "category", "size", "quantity", "unit_price", "modifications")
+_VALID_ORDER_TYPES = ("pickup", "delivery")
+_VALID_LLM_STATUSES = ("confirmed", "cancelled")
+
+
+def _apply_add_item(order: Order, payload: dict[str, Any]) -> tuple[Order, list[str]]:
+    missing = [k for k in _ADD_ITEM_REQUIRED if k not in payload]
+    if missing:
+        return order, [
+            f"add_item rejected: missing required field(s) {missing}. "
+            "Re-ask the caller for the missing info."
+        ]
+    try:
+        new_item = LineItem(
+            name=payload["name"],
+            category=payload["category"],
+            size=payload.get("size"),
+            quantity=payload["quantity"],
+            unit_price=payload["unit_price"],
+            modifications=payload.get("modifications", []),
+        )
+    except (ValueError, TypeError) as exc:
+        return order, [f"add_item rejected: {exc}"]
+    return order.model_copy(update={"items": [*order.items, new_item]}), []
+
+
+def _apply_remove_item(order: Order, payload: dict[str, Any]) -> tuple[Order, list[str]]:
+    item_id = payload.get("item_id")
+    if not item_id:
+        return order, ["remove_item rejected: missing item_id."]
+    remaining = [i for i in order.items if i.item_id != item_id]
+    if len(remaining) == len(order.items):
+        return order, [
+            f"remove_item rejected: no item with item_id {item_id!r} in the order."
+        ]
+    return order.model_copy(update={"items": remaining}), []
+
+
+def _apply_update_item(order: Order, payload: dict[str, Any]) -> tuple[Order, list[str]]:
+    item_id = payload.get("item_id")
+    if not item_id:
+        return order, ["update_item rejected: missing item_id."]
+    updates = {k: payload[k] for k in _UPDATE_ITEM_FIELDS if k in payload}
+    if not updates:
+        return order, ["update_item rejected: no fields to update."]
+    new_items: list[LineItem] = []
+    found = False
+    for item in order.items:
+        if item.item_id == item_id:
+            found = True
+            try:
+                new_items.append(item.model_copy(update=updates))
+            except (ValueError, TypeError) as exc:
+                return order, [f"update_item rejected: {exc}"]
+        else:
+            new_items.append(item)
+    if not found:
+        return order, [
+            f"update_item rejected: no item with item_id {item_id!r} in the order."
+        ]
+    # Re-validate to catch constraint violations not caught by model_copy
+    # (Pydantic's model_copy(update=...) is a shallow assignment that
+    # bypasses field validators — round-trip through model_validate to
+    # actually enforce ge=1 quantity, ge=0 unit_price, etc.).
+    try:
+        validated = [LineItem.model_validate(i.model_dump()) for i in new_items]
+    except (ValueError, TypeError) as exc:
+        return order, [f"update_item rejected: {exc}"]
+    return order.model_copy(update={"items": validated}), []
+
+
+def _apply_set_order_type(order: Order, payload: dict[str, Any]) -> tuple[Order, list[str]]:
+    value = payload.get("order_type")
+    if value not in _VALID_ORDER_TYPES:
+        return order, [
+            f"set_order_type rejected: {value!r} is not one of {list(_VALID_ORDER_TYPES)}."
+        ]
+    updates: dict[str, Any] = {"order_type": OrderType(value)}
+    if value == "pickup":
+        updates["delivery_address"] = None  # see _CORRECTIONS prompt
+    return order.model_copy(update=updates), []
+
+
+def _apply_set_delivery_address(
+    order: Order, payload: dict[str, Any]
+) -> tuple[Order, list[str]]:
+    value = payload.get("delivery_address")
+    if value is None or (isinstance(value, str) and not value.strip()):
+        return order.model_copy(update={"delivery_address": None}), []
+    if not validate_delivery_address(value):
+        return order, [INVALID_ADDRESS_NOTE]
+    return order.model_copy(update={"delivery_address": value}), []
+
+
+def _apply_set_status(order: Order, payload: dict[str, Any]) -> tuple[Order, list[str]]:
+    value = payload.get("status")
+    if value not in _VALID_LLM_STATUSES:
+        return order, [
+            f"set_status rejected: {value!r} is not one of {list(_VALID_LLM_STATUSES)}. "
+            "Kitchen states are set by the dashboard, not the model."
+        ]
+    return order.model_copy(update={"status": OrderStatus(value)}), []
+
+
+_TOOL_DISPATCH: dict[str, Callable[[Order, dict[str, Any]], tuple[Order, list[str]]]] = {
+    "add_item": _apply_add_item,
+    "remove_item": _apply_remove_item,
+    "update_item": _apply_update_item,
+    "set_order_type": _apply_set_order_type,
+    "set_delivery_address": _apply_set_delivery_address,
+    "set_status": _apply_set_status,
+}
+
+
+def apply_tool_call(
+    order: Order, tool_name: str, payload: dict[str, Any]
+) -> tuple[Order, list[str]]:
+    """Dispatch one atomic tool_use call. Returns ``(new_order, notes)``.
+
+    ``notes`` are human-readable strings the provider appends to the
+    tool_result so the model knows what went wrong and can recover by
+    re-asking the caller. Empty list on success.
+
+    Unknown tool names return the order unchanged with a one-line note
+    — defensive against model output drift (e.g. Haiku hallucinating a
+    tool that doesn't exist).
     """
-    preserved = {
-        "call_sid": order.call_sid,
-        "caller_phone": order.caller_phone,
-        "restaurant_id": order.restaurant_id,
-        "created_at": order.created_at,
-    }
-    merged = {**order.model_dump(), **patch, **preserved}
-    return Order.model_validate(merged)
+    handler = _TOOL_DISPATCH.get(tool_name)
+    if handler is None:
+        return order, [f"unknown tool: {tool_name!r}"]
+    return handler(order, payload)
 
 
 __all__ = [
     "INVALID_ADDRESS_NOTE",
     "TERMINAL_STATUSES",
-    "apply_order_patch",
+    "apply_tool_call",
     "should_skip_followup",
     "summarize_order_for_tool_result",
-    "validate_order_patch",
 ]

--- a/app/llm/orchestration.py
+++ b/app/llm/orchestration.py
@@ -82,8 +82,7 @@ def should_skip_followup(tool_uses: list[dict[str, Any]], main_emitted_text: boo
     if not main_emitted_text:
         return False
     return any(
-        tu.get("name") == "set_status"
-        and tu.get("input", {}).get("status") in TERMINAL_STATUSES
+        tu.get("name") == "set_status" and tu.get("input", {}).get("status") in TERMINAL_STATUSES
         for tu in tool_uses
     )
 
@@ -137,9 +136,7 @@ def _apply_remove_item(order: Order, payload: dict[str, Any]) -> tuple[Order, li
         return order, ["remove_item rejected: missing item_id."]
     remaining = [i for i in order.items if i.item_id != item_id]
     if len(remaining) == len(order.items):
-        return order, [
-            f"remove_item rejected: no item with item_id {item_id!r} in the order."
-        ]
+        return order, [f"remove_item rejected: no item with item_id {item_id!r} in the order."]
     return order.model_copy(update={"items": remaining}), []
 
 
@@ -162,9 +159,7 @@ def _apply_update_item(order: Order, payload: dict[str, Any]) -> tuple[Order, li
         else:
             new_items.append(item)
     if not found:
-        return order, [
-            f"update_item rejected: no item with item_id {item_id!r} in the order."
-        ]
+        return order, [f"update_item rejected: no item with item_id {item_id!r} in the order."]
     # Re-validate to catch constraint violations not caught by model_copy
     # (Pydantic's model_copy(update=...) is a shallow assignment that
     # bypasses field validators — round-trip through model_validate to
@@ -188,9 +183,7 @@ def _apply_set_order_type(order: Order, payload: dict[str, Any]) -> tuple[Order,
     return order.model_copy(update=updates), []
 
 
-def _apply_set_delivery_address(
-    order: Order, payload: dict[str, Any]
-) -> tuple[Order, list[str]]:
+def _apply_set_delivery_address(order: Order, payload: dict[str, Any]) -> tuple[Order, list[str]]:
     value = payload.get("delivery_address")
     if value is None or (isinstance(value, str) and not value.strip()):
         return order.model_copy(update={"delivery_address": None}), []

--- a/app/llm/prompts.py
+++ b/app/llm/prompts.py
@@ -83,19 +83,24 @@ _CUSTOMIZATIONS = dedent("""\
 
 _CORRECTIONS = dedent("""\
     Caller corrections:
-    - When the caller corrects something already in the order, emit ONE
-      update_order with the FULL corrected state. Replace the wrong item —
-      never leave it alongside the new one.
-    - Removals ("take off the Coke", "remove the second pizza"): emit
-      update_order without that item.
+    - Removals ("take off the Coke", "remove the second pizza"): call
+      remove_item with the item_id from the prior tool_result for the line
+      the caller wants gone.
     - Substitutions ("change the Margherita to a calzone", "I meant
-      pepperoni, not Margherita"): swap the item, carry the quantity through
-      unless the caller restated it.
-    - Quantity or size changes ("make that 2", "I said large"): same item
-      line with the new value — never duplicate the line. Use the menu's
-      unit_price for the new size.
+      pepperoni, not Margherita"): call remove_item for the old line, then
+      add_item for the new one. Carry the quantity through unless the
+      caller restated it.
+    - Quantity changes ("make that 2"): call update_item with the new
+      quantity. Same line — never duplicate it.
+    - Size changes ("I said large, not medium"): call update_item with the
+      new size AND new unit_price (the menu's price for the new size).
+      Different size of the SAME item is still ONE line — do not add_item.
+    - Modification edits ("add no onions", "remove extra cheese"): call
+      update_item with the full new modifications list — the list replaces
+      the existing one, it does not append.
     {order_type_swap_rule}
-    - Delivery-address fix: send the full corrected address, not a partial.
+    - Delivery-address fix: call set_delivery_address with the full
+      corrected address, not a partial.
     - After a correction, briefly acknowledge what changed in one short
       phrase — do NOT re-read the whole order; that happens at the
       read-back step.""")
@@ -130,23 +135,23 @@ _READ_BACK = dedent("""\
     - After the closer, give the caller a beat. They will either
       confirm explicitly ("yes", "yep", "go ahead", "send it",
       "sounds good"), ask to change something, or hesitate. If they
-      confirm, proceed to the goodbye. If they want a change, update
-      via update_order and read the corrected order back. If they
-      hesitate for a moment, do NOT re-prompt — wait for them.
-    - Use the subtotal returned by the update_order tool — never compute
+      confirm, proceed to the goodbye. If they want a change, call the
+      right correction tool (see the corrections section) and read the
+      corrected order back. If they hesitate for a moment, do NOT
+      re-prompt — wait for them.
+    - Use the subtotal returned by the latest tool_result — never compute
       it yourself from unit prices.
     - If an item has no modifications, omit the modifier clause entirely —
       do not say "no modifications."
-    - Only flip status="confirmed" after explicit confirmation, not on a
-      vague "uh huh" mid-conversation.""")
+    - Only call set_status(confirmed) after explicit confirmation, not on
+      a vague "uh huh" mid-conversation.""")
 
 
 _CLOSING = dedent("""\
     Closing the call:
-    - Once the caller has confirmed the order, set status="confirmed" via
-      update_order and say a brief, terminal goodbye. Keep it short and
-      natural — let the wording vary call to call rather than repeating
-      the same phrase.
+    - Once the caller has confirmed the order, call set_status(confirmed)
+      and say a brief, terminal goodbye. Keep it short and natural — let
+      the wording vary call to call rather than repeating the same phrase.
     - Lead the goodbye, the read-back, and any acknowledgement-then-tool
       turn with a short word or short phrase ending in a period — not a
       comma. Periods let TTS start speaking sooner; commas hold the audio
@@ -155,8 +160,8 @@ _CLOSING = dedent("""\
       terminates in a period.
     - CRITICAL: any time you say a wrap-up phrase like "your order is in",
       "we'll have it ready", "see you soon", or "thanks for calling", you
-      MUST call update_order in the same turn with status="confirmed".
-      Saying the goodbye without flipping status leaves the call hanging.
+      MUST call set_status(confirmed) in the same turn. Saying the goodbye
+      without flipping status leaves the call hanging.
     - Do NOT ask another follow-up question after confirming. The call
       ends shortly after your goodbye.""")
 
@@ -171,21 +176,47 @@ _ADDRESS_HANDLING = dedent("""\
 
 
 _TOOL_ORDERING = dedent("""\
-    When you call the update_order tool — ORDERING IS CRITICAL:
-    1. ALWAYS speak a short acknowledgement first, THEN call update_order.
+    Order tools — there are six:
+    - add_item: caller asks for something new, or asks for a DIFFERENT
+      size or variant of an existing item (different sizes are SEPARATE
+      lines, not in-place size changes on the same line).
+    - remove_item(item_id): caller takes something off. The item_id was
+      surfaced in a prior tool_result when the item was added — read it
+      from there. Never invent an item_id.
+    - update_item(item_id, ...): caller changes quantity, size, or
+      modifications of a line that's already in the order. Same line —
+      never duplicate it. See the corrections section for size + price
+      handling.
+    - set_order_type(pickup|delivery): caller picks pickup or delivery.
+      Switching to pickup automatically clears any captured delivery
+      address — no follow-up tool call needed.
+    - set_delivery_address: caller gives a delivery address. Pass null or
+      empty to clear.
+    - set_status(confirmed|cancelled): caller explicitly confirms after
+      the read-back, or cancels. Kitchen states (preparing/ready/...) are
+      set by the dashboard, not this tool.
+
+    Per-turn rule: call the relevant tool the moment the order changes,
+    in the SAME turn the change is acknowledged. Do not batch tool calls
+    to the end of the conversation — that defeats the dashboard live view
+    and concentrates all the call's latency on the confirm turn.
+
+    When you call any of these tools — ORDERING IS CRITICAL:
+    1. ALWAYS speak a short acknowledgement first, THEN call the tool.
        This is non-negotiable: the caller hears nothing while you stream
        the tool's JSON, so a tool-first turn produces 1-2 seconds of dead
        air that callers experience as "the bot froze".
-    2. The spoken acknowledgement must come first in your output, then the
-       tool call. Shape: "<short ack ending in a period>" → update_order(...).
-    3. Wrong (DO NOT DO THIS): update_order(...) → spoken text. The spoken
+    2. The spoken acknowledgement must come first in your output, then
+       the tool call. Shape: "<short ack ending in a period>" → <tool>.
+    3. Wrong (DO NOT DO THIS): <tool call> → spoken text. The spoken
        words must precede the tool call in your output.
     4. Brevity is fine; silence is not. A few words ending in a period is
        enough. Pick wording that fits the moment rather than repeating
        the same phrase across turns.
-    5. After your spoken ack and update_order call, the system feeds you
-       back a tool_result with the new subtotal. What you say next
-       depends on whether the caller has signaled they're done:
+    5. After your spoken ack and tool call, the system feeds you back a
+       tool_result with the new subtotal and the current item_ids. What
+       you say next depends on whether the caller has signaled they're
+       done:
        - Mid-order (caller has NOT signaled done): ask "anything else?"
          and stop. Do NOT recite what they just ordered, do NOT announce
          the running subtotal, do NOT re-read previous items. The full
@@ -218,8 +249,8 @@ _OFF_MENU_AND_HESITATION = dedent("""\
 
 _SUBTOTAL_TRUST = dedent("""\
     When you tell the caller their total, use the subtotal returned by the
-    most recent update_order tool_result — never compute totals yourself from
-    unit prices. The tool_result's "Subtotal: $X.XX" is the server-verified
+    most recent tool_result — never compute totals yourself from unit
+    prices. The tool_result's "Subtotal: $X.XX" is the server-verified
     number; your math from memory will drift.""")
 
 
@@ -372,8 +403,10 @@ def build_system_prompt(restaurant: Restaurant) -> str:
         intro_line = "Place a pickup or delivery order from the menu below."
         delivery_handling = "- If delivery, collect the caller's delivery address."
         order_type_swap_rule = (
-            "- Order-type swap to delivery: ask for the address before the next\n"
-            "  read-back. Swap to pickup: clear delivery_address."
+            "- Order-type swap to delivery: call set_order_type(delivery), then\n"
+            "  ask for the address before the next read-back. Swap to pickup:\n"
+            "  call set_order_type(pickup) — it clears the delivery address\n"
+            "  automatically, no follow-up tool call needed."
         )
     else:
         intro_line = "Place a pickup order from the menu below."
@@ -381,7 +414,7 @@ def build_system_prompt(restaurant: Restaurant) -> str:
             "- If the caller asks for delivery, say something like\n"
             '  "We\'re actually pickup-only — would pickup work for you?"\n'
             "  and continue from there. Do not capture a delivery address;\n"
-            "  do not set order_type to delivery."
+            "  do not call set_order_type(delivery)."
         )
         order_type_swap_rule = (
             "- Order-type stays pickup. If the caller tries to switch to delivery,\n"

--- a/app/llm/warmup.py
+++ b/app/llm/warmup.py
@@ -22,7 +22,7 @@ import time
 
 from app.config import settings
 from app.llm.anthropic import (
-    UPDATE_ORDER_TOOL,
+    ATOMIC_TOOLS,
     _get_async_client,
     _system_cache_block,
 )
@@ -47,7 +47,7 @@ async def prime_tenant_cache(restaurant: Restaurant) -> None:
             model=settings.anthropic_model,
             max_tokens=1,
             system=_system_cache_block(system_prompt),
-            tools=[UPDATE_ORDER_TOOL],
+            tools=ATOMIC_TOOLS,
             messages=[{"role": "user", "content": "ping"}],
         )
     except Exception as exc:

--- a/app/orders/models.py
+++ b/app/orders/models.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
+from uuid import uuid4
 
 from pydantic import BaseModel, Field, computed_field
 
@@ -60,7 +61,16 @@ def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _new_item_id() -> str:
+    """Server-assigned short ID for a LineItem. The LLM references items
+    in ``remove_item`` / ``update_item`` calls by this ID, which it reads
+    out of prior ``tool_result`` summaries (#305 Part B). Stable for the
+    lifetime of one call; the 6-hex space (~16M) is more than enough."""
+    return f"i_{uuid4().hex[:6]}"
+
+
 class LineItem(BaseModel):
+    item_id: str = Field(default_factory=_new_item_id)
     name: str
     # Free-form per-tenant category (matches the menu key, e.g.
     # ``appetizers``, ``mains``, ``soups``). Was a fixed ItemCategory

--- a/tests/fixtures/correction_transcripts.py
+++ b/tests/fixtures/correction_transcripts.py
@@ -12,8 +12,9 @@ Each entry is a multi-turn scenario:
   fields per pattern.
 
 Add a row whenever a real correction bug is found in production. Pair
-the row with a backstop in ``tests/test_llm_client.py`` that exercises
-the same shape against ``_apply_update`` deterministically.
+the row with a unit-test backstop in
+``tests/test_atomic_order_tools.py`` that exercises the same shape
+against ``apply_tool_call`` deterministically.
 """
 
 from __future__ import annotations

--- a/tests/test_atomic_order_tools.py
+++ b/tests/test_atomic_order_tools.py
@@ -170,9 +170,7 @@ def test_update_item_changes_quantity_only():
     a = LineItem(name="Pepperoni", category="pizza", quantity=1, unit_price=10.0)
     order = _order([a])
 
-    new_order, notes = apply_tool_call(
-        order, "update_item", {"item_id": a.item_id, "quantity": 3}
-    )
+    new_order, notes = apply_tool_call(order, "update_item", {"item_id": a.item_id, "quantity": 3})
 
     assert notes == []
     item = new_order.items[0]
@@ -220,9 +218,7 @@ def test_update_item_replaces_modifications():
 def test_update_item_unknown_id_returns_rejection_note():
     order = _order([LineItem(name="X", category="y", quantity=1, unit_price=1.0)])
 
-    new_order, notes = apply_tool_call(
-        order, "update_item", {"item_id": "i_nope", "quantity": 5}
-    )
+    new_order, notes = apply_tool_call(order, "update_item", {"item_id": "i_nope", "quantity": 5})
 
     assert new_order == order
     assert notes and "i_nope" in notes[0]
@@ -301,9 +297,7 @@ def test_set_delivery_address_invalid_returns_rejection_note():
 def test_set_delivery_address_none_clears():
     order = Order(call_sid="CAtest", delivery_address="14 Main St")
 
-    new_order, notes = apply_tool_call(
-        order, "set_delivery_address", {"delivery_address": None}
-    )
+    new_order, notes = apply_tool_call(order, "set_delivery_address", {"delivery_address": None})
 
     assert notes == []
     assert new_order.delivery_address is None

--- a/tests/test_atomic_order_tools.py
+++ b/tests/test_atomic_order_tools.py
@@ -1,0 +1,429 @@
+"""Tests for the atomic order-update tools (Issue #305 Part B).
+
+Replaces the snapshot ``update_order`` tool with 6 atomic operations:
+``add_item``, ``remove_item``, ``update_item``, ``set_order_type``,
+``set_delivery_address``, ``set_status``. Each operation has a single
+dispatch entry point ``apply_tool_call`` in ``app.llm.orchestration``.
+
+Item identity uses server-assigned IDs (``i_<6hex>``) returned in
+``tool_result`` summaries so the model can reference items in subsequent
+``remove_item`` / ``update_item`` calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.llm.orchestration import apply_tool_call, summarize_order_for_tool_result
+from app.orders.models import LineItem, Order
+
+
+def _order(items: list[LineItem] | None = None) -> Order:
+    return Order(call_sid="CAtest", items=items or [])
+
+
+def test_line_item_has_auto_generated_item_id():
+    """Every LineItem gets a unique ``item_id`` at construction so the
+    LLM can reference it from later ``remove_item`` / ``update_item``
+    tool calls (the model reads IDs out of prior ``tool_result`` blocks
+    in its message history)."""
+    item_a = LineItem(name="Pepperoni", category="pizza", quantity=1, unit_price=12.99)
+    item_b = LineItem(name="Coke", category="drink", quantity=1, unit_price=2.99)
+
+    assert item_a.item_id.startswith("i_")
+    assert item_b.item_id.startswith("i_")
+    assert item_a.item_id != item_b.item_id
+
+
+# ---------------------------------------------------------------------------
+# Dispatch + add_item
+# ---------------------------------------------------------------------------
+
+
+def test_apply_tool_call_unknown_tool_returns_rejection_note():
+    order = _order()
+    new_order, notes = apply_tool_call(order, "frobnicate", {})
+
+    assert new_order == order  # no mutation
+    assert notes and "unknown" in notes[0].lower()
+
+
+def test_add_item_to_empty_order_appends_with_generated_id():
+    order = _order()
+    new_order, notes = apply_tool_call(
+        order,
+        "add_item",
+        {"name": "Pad Thai", "category": "main", "quantity": 1, "unit_price": 12.0},
+    )
+
+    assert notes == []
+    assert len(new_order.items) == 1
+    assert new_order.items[0].name == "Pad Thai"
+    assert new_order.items[0].item_id.startswith("i_")
+    assert new_order.subtotal == 12.0
+
+
+def test_add_item_appends_to_existing_order_preserving_ids():
+    first = LineItem(name="Pepperoni", category="pizza", quantity=1, unit_price=10.0)
+    order = _order([first])
+
+    new_order, notes = apply_tool_call(
+        order,
+        "add_item",
+        {"name": "Coke", "category": "drink", "quantity": 2, "unit_price": 3.0},
+    )
+
+    assert notes == []
+    assert len(new_order.items) == 2
+    assert new_order.items[0].item_id == first.item_id  # preserved
+    assert new_order.items[1].name == "Coke"
+    assert new_order.items[1].quantity == 2
+    assert new_order.subtotal == pytest.approx(16.0)
+
+
+def test_add_item_captures_size_and_modifications():
+    order = _order()
+    new_order, _ = apply_tool_call(
+        order,
+        "add_item",
+        {
+            "name": "Margherita",
+            "category": "pizza",
+            "size": "large",
+            "quantity": 1,
+            "unit_price": 20.0,
+            "modifications": ["extra cheese", "no basil"],
+        },
+    )
+
+    item = new_order.items[0]
+    assert item.size == "large"
+    assert item.modifications == ["extra cheese", "no basil"]
+
+
+def test_add_item_rejects_missing_required_fields():
+    order = _order()
+    new_order, notes = apply_tool_call(
+        order,
+        "add_item",
+        {"name": "Pad Thai"},  # missing category, quantity, unit_price
+    )
+
+    assert new_order == order
+    assert notes and "add_item" in notes[0]
+
+
+def test_add_item_rejects_zero_quantity():
+    order = _order()
+    new_order, notes = apply_tool_call(
+        order,
+        "add_item",
+        {"name": "Coke", "category": "drink", "quantity": 0, "unit_price": 2.0},
+    )
+
+    assert new_order == order
+    assert notes
+
+
+# ---------------------------------------------------------------------------
+# remove_item
+# ---------------------------------------------------------------------------
+
+
+def test_remove_item_by_id_drops_matching_line():
+    a = LineItem(name="Pepperoni", category="pizza", quantity=1, unit_price=10.0)
+    b = LineItem(name="Coke", category="drink", quantity=2, unit_price=3.0)
+    order = _order([a, b])
+
+    new_order, notes = apply_tool_call(order, "remove_item", {"item_id": a.item_id})
+
+    assert notes == []
+    assert [i.item_id for i in new_order.items] == [b.item_id]
+    assert new_order.subtotal == pytest.approx(6.0)
+
+
+def test_remove_item_unknown_id_returns_rejection_note():
+    a = LineItem(name="Pepperoni", category="pizza", quantity=1, unit_price=10.0)
+    order = _order([a])
+
+    new_order, notes = apply_tool_call(order, "remove_item", {"item_id": "i_nope"})
+
+    assert new_order == order
+    assert notes and "i_nope" in notes[0]
+
+
+def test_remove_item_missing_item_id_returns_rejection_note():
+    order = _order([LineItem(name="X", category="y", quantity=1, unit_price=1.0)])
+
+    new_order, notes = apply_tool_call(order, "remove_item", {})
+
+    assert new_order == order
+    assert notes
+
+
+# ---------------------------------------------------------------------------
+# update_item
+# ---------------------------------------------------------------------------
+
+
+def test_update_item_changes_quantity_only():
+    a = LineItem(name="Pepperoni", category="pizza", quantity=1, unit_price=10.0)
+    order = _order([a])
+
+    new_order, notes = apply_tool_call(
+        order, "update_item", {"item_id": a.item_id, "quantity": 3}
+    )
+
+    assert notes == []
+    item = new_order.items[0]
+    assert item.item_id == a.item_id  # ID preserved
+    assert item.quantity == 3
+    assert item.name == "Pepperoni"  # other fields untouched
+    assert item.unit_price == 10.0
+
+
+def test_update_item_changes_size_and_unit_price():
+    a = LineItem(name="Margherita", category="pizza", size="small", quantity=1, unit_price=12.0)
+    order = _order([a])
+
+    new_order, _ = apply_tool_call(
+        order,
+        "update_item",
+        {"item_id": a.item_id, "size": "large", "unit_price": 20.0},
+    )
+
+    item = new_order.items[0]
+    assert item.size == "large"
+    assert item.unit_price == 20.0
+    assert item.quantity == 1  # not provided -> unchanged
+
+
+def test_update_item_replaces_modifications():
+    a = LineItem(
+        name="Margherita",
+        category="pizza",
+        quantity=1,
+        unit_price=12.0,
+        modifications=["extra cheese"],
+    )
+    order = _order([a])
+
+    new_order, _ = apply_tool_call(
+        order,
+        "update_item",
+        {"item_id": a.item_id, "modifications": ["no basil"]},
+    )
+
+    assert new_order.items[0].modifications == ["no basil"]
+
+
+def test_update_item_unknown_id_returns_rejection_note():
+    order = _order([LineItem(name="X", category="y", quantity=1, unit_price=1.0)])
+
+    new_order, notes = apply_tool_call(
+        order, "update_item", {"item_id": "i_nope", "quantity": 5}
+    )
+
+    assert new_order == order
+    assert notes and "i_nope" in notes[0]
+
+
+# ---------------------------------------------------------------------------
+# set_order_type
+# ---------------------------------------------------------------------------
+
+
+def test_set_order_type_pickup():
+    order = _order()
+    new_order, notes = apply_tool_call(order, "set_order_type", {"order_type": "pickup"})
+
+    assert notes == []
+    assert new_order.order_type.value == "pickup"
+
+
+def test_set_order_type_delivery():
+    order = _order()
+    new_order, notes = apply_tool_call(order, "set_order_type", {"order_type": "delivery"})
+
+    assert notes == []
+    assert new_order.order_type.value == "delivery"
+
+
+def test_set_order_type_pickup_clears_existing_delivery_address():
+    """Switching pickup wipes any address captured during the prior
+    delivery flow — matches the _CORRECTIONS prompt rule from the
+    snapshot era."""
+    order = Order(
+        call_sid="CAtest",
+        order_type="delivery",
+        delivery_address="14 Main St",
+    )
+
+    new_order, _ = apply_tool_call(order, "set_order_type", {"order_type": "pickup"})
+
+    assert new_order.order_type.value == "pickup"
+    assert new_order.delivery_address is None
+
+
+def test_set_order_type_rejects_invalid_value():
+    order = _order()
+    new_order, notes = apply_tool_call(order, "set_order_type", {"order_type": "carrier-pigeon"})
+
+    assert new_order == order
+    assert notes
+
+
+# ---------------------------------------------------------------------------
+# set_delivery_address
+# ---------------------------------------------------------------------------
+
+
+def test_set_delivery_address_valid():
+    order = _order()
+    new_order, notes = apply_tool_call(
+        order, "set_delivery_address", {"delivery_address": "14 Main St"}
+    )
+
+    assert notes == []
+    assert new_order.delivery_address == "14 Main St"
+
+
+def test_set_delivery_address_invalid_returns_rejection_note():
+    order = _order()
+    new_order, notes = apply_tool_call(
+        order, "set_delivery_address", {"delivery_address": "garbled"}
+    )
+
+    assert new_order == order
+    assert notes and "address" in notes[0].lower()
+
+
+def test_set_delivery_address_none_clears():
+    order = Order(call_sid="CAtest", delivery_address="14 Main St")
+
+    new_order, notes = apply_tool_call(
+        order, "set_delivery_address", {"delivery_address": None}
+    )
+
+    assert notes == []
+    assert new_order.delivery_address is None
+
+
+# ---------------------------------------------------------------------------
+# set_status
+# ---------------------------------------------------------------------------
+
+
+def test_set_status_confirmed():
+    order = _order()
+    new_order, notes = apply_tool_call(order, "set_status", {"status": "confirmed"})
+
+    assert notes == []
+    assert new_order.status.value == "confirmed"
+
+
+def test_set_status_cancelled():
+    order = _order()
+    new_order, notes = apply_tool_call(order, "set_status", {"status": "cancelled"})
+
+    assert notes == []
+    assert new_order.status.value == "cancelled"
+
+
+def test_set_status_rejects_other_values():
+    """Only ``confirmed`` and ``cancelled`` are valid for the LLM tool
+    surface — kitchen-workflow states (preparing/ready/completed) are
+    set by the dashboard, not the model."""
+    order = _order()
+    new_order, notes = apply_tool_call(order, "set_status", {"status": "preparing"})
+
+    assert new_order == order
+    assert notes
+
+
+# ---------------------------------------------------------------------------
+# tool_result summary surfaces item_ids
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# ToolSpec declarations in app/llm/base.py (#305 Part B)
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_tool_specs_cover_all_six_operations():
+    """Six atomic tool specs replace the single snapshot ``update_order``
+    spec. Names map 1:1 to the dispatch table in ``orchestration.py``."""
+    from app.llm.base import ATOMIC_TOOL_SPECS
+
+    names = {spec.name for spec in ATOMIC_TOOL_SPECS}
+    assert names == {
+        "add_item",
+        "remove_item",
+        "update_item",
+        "set_order_type",
+        "set_delivery_address",
+        "set_status",
+    }
+
+
+def test_add_item_spec_required_fields_match_handler():
+    """add_item's JSON schema must require exactly the fields the handler
+    enforces — drift here would let the model emit a payload the schema
+    accepts but the handler rejects."""
+    from app.llm.base import ATOMIC_TOOL_SPECS
+
+    spec = next(s for s in ATOMIC_TOOL_SPECS if s.name == "add_item")
+    required = set(spec.parameters["required"])
+    assert required == {"name", "category", "quantity", "unit_price"}
+
+
+def test_add_item_description_calls_out_size_as_separate_line():
+    """Discrimination from update_item depends on the model knowing that
+    ordering a different size = new line, not an in-place size change.
+    Without that signal the model misroutes 'add a large pad thai' to
+    update_item when a small pad thai already exists."""
+    from app.llm.base import ATOMIC_TOOL_SPECS
+
+    spec = next(s for s in ATOMIC_TOOL_SPECS if s.name == "add_item")
+    assert "size" in spec.description.lower()
+    assert "separate" in spec.description.lower() or "new line" in spec.description.lower()
+
+
+def test_remove_and_update_item_specs_reference_item_id():
+    """Both must require ``item_id`` and steer the model toward reading
+    it from prior tool_result blocks (otherwise the model invents IDs
+    that don't exist in the order)."""
+    from app.llm.base import ATOMIC_TOOL_SPECS
+
+    for name in ("remove_item", "update_item"):
+        spec = next(s for s in ATOMIC_TOOL_SPECS if s.name == name)
+        assert "item_id" in spec.parameters["required"]
+        assert "tool_result" in spec.description.lower()
+
+
+def test_set_status_spec_restricts_to_confirmed_or_cancelled():
+    """Kitchen states are dashboard-only — the LLM tool surface must
+    not advertise them."""
+    from app.llm.base import ATOMIC_TOOL_SPECS
+
+    spec = next(s for s in ATOMIC_TOOL_SPECS if s.name == "set_status")
+    enum = spec.parameters["properties"]["status"]["enum"]
+    assert set(enum) == {"confirmed", "cancelled"}
+
+
+def test_summary_includes_item_ids_so_model_can_reference_them():
+    """The tool_result summary must surface each line's item_id so the
+    model can call ``remove_item``/``update_item`` against it on the
+    next turn. Without this, the IDs exist only inside the Order
+    object — invisible to the model."""
+    a = LineItem(name="Pepperoni", category="pizza", quantity=2, unit_price=10.0)
+    b = LineItem(name="Coke", category="drink", quantity=1, unit_price=3.0)
+    order = _order([a, b])
+
+    summary = summarize_order_for_tool_result(order)
+
+    assert a.item_id in summary
+    assert b.item_id in summary
+    assert "Pepperoni" in summary
+    assert "Subtotal: $23.00" in summary

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -15,11 +15,11 @@ import pytest
 
 from app.llm import anthropic as anthropic_module
 from app.llm.anthropic import (
-    UPDATE_ORDER_TOOL,
+    ATOMIC_TOOLS,
     AnthropicLLM,
 )
 from app.llm.orchestration import (
-    apply_order_patch as _apply_update,
+    apply_tool_call as _apply_tool,
 )
 from app.llm.orchestration import (
     summarize_order_for_tool_result as _summarize_order,
@@ -81,6 +81,10 @@ def test_plain_text_response_leaves_order_unchanged():
 
 
 def test_tool_use_updates_order_in_single_turn():
+    """Multi-tool turn: add_item + set_order_type emitted together. The
+    snapshot tool would have done both in one update_order call; with
+    atomic tools the model issues separate tool_use blocks that the
+    provider dispatches in order."""
     order = Order(call_sid="CAtest")
     fake_client = MagicMock()
     fake_client.messages.create.side_effect = [
@@ -88,22 +92,21 @@ def test_tool_use_updates_order_in_single_turn():
             [
                 FakeBlock(
                     type="tool_use",
-                    id="toolu_1",
-                    name="update_order",
+                    id="toolu_add",
+                    name="add_item",
                     input={
-                        "items": [
-                            {
-                                "name": "Pepperoni",
-                                "category": "pizza",
-                                "size": "medium",
-                                "quantity": 1,
-                                "unit_price": 17.99,
-                                "modifications": [],
-                            }
-                        ],
-                        "order_type": "pickup",
-                        "status": "in_progress",
+                        "name": "Pepperoni",
+                        "category": "pizza",
+                        "size": "medium",
+                        "quantity": 1,
+                        "unit_price": 17.99,
                     },
+                ),
+                FakeBlock(
+                    type="tool_use",
+                    id="toolu_type",
+                    name="set_order_type",
+                    input={"order_type": "pickup"},
                 ),
                 FakeBlock(
                     type="text",
@@ -131,7 +134,7 @@ def test_tool_use_updates_order_in_single_turn():
     # Follow-up keeps the tool schema in tools so the cache prefix matches
     # the main call (#176); tool_choice="none" suppresses further tool use.
     followup_call_kwargs = fake_client.messages.create.call_args_list[1][1]
-    assert followup_call_kwargs["tools"] == [UPDATE_ORDER_TOOL]
+    assert followup_call_kwargs["tools"] == ATOMIC_TOOLS
     assert followup_call_kwargs["tool_choice"] == {"type": "none"}
 
 
@@ -144,8 +147,8 @@ def test_tool_only_response_triggers_followup_call():
                 FakeBlock(
                     type="tool_use",
                     id="toolu_1",
-                    name="update_order",
-                    input={"items": [], "status": "cancelled"},
+                    name="set_status",
+                    input={"status": "cancelled"},
                 ),
             ]
         ),
@@ -172,7 +175,7 @@ def test_tool_only_response_triggers_followup_call():
     # Follow-up keeps the tool schema in tools so the cache prefix matches
     # the main call (#176); tool_choice="none" suppresses further tool use.
     followup_call_kwargs = fake_client.messages.create.call_args_list[1][1]
-    assert followup_call_kwargs["tools"] == [UPDATE_ORDER_TOOL]
+    assert followup_call_kwargs["tools"] == ATOMIC_TOOLS
     assert followup_call_kwargs["tool_choice"] == {"type": "none"}
 
 
@@ -219,19 +222,13 @@ def test_text_plus_tool_use_appends_tool_result_to_history():
                 FakeBlock(
                     type="tool_use",
                     id="toolu_committed",
-                    name="update_order",
+                    name="add_item",
                     input={
-                        "items": [
-                            {
-                                "name": "Margarita",
-                                "category": "pizza",
-                                "size": "large",
-                                "quantity": 1,
-                                "unit_price": 19.99,
-                            }
-                        ],
-                        "order_type": "pickup",
-                        "status": "in_progress",
+                        "name": "Margarita",
+                        "category": "pizza",
+                        "size": "large",
+                        "quantity": 1,
+                        "unit_price": 19.99,
                     },
                 ),
             ]
@@ -303,42 +300,23 @@ def test_tool_result_carries_post_apply_subtotal():
                 FakeBlock(
                     type="tool_use",
                     id="toolu_one",
-                    name="update_order",
+                    name="add_item",
                     input={
-                        "items": [
-                            {
-                                "name": "Wings",
-                                "category": "appetizers",
-                                "size": None,
-                                "quantity": 1,
-                                "unit_price": 14.50,
-                            }
-                        ],
-                        "status": "in_progress",
+                        "name": "Wings",
+                        "category": "appetizers",
+                        "quantity": 1,
+                        "unit_price": 14.50,
                     },
                 ),
                 FakeBlock(
                     type="tool_use",
                     id="toolu_two",
-                    name="update_order",
+                    name="add_item",
                     input={
-                        "items": [
-                            {
-                                "name": "Wings",
-                                "category": "appetizers",
-                                "size": None,
-                                "quantity": 1,
-                                "unit_price": 14.50,
-                            },
-                            {
-                                "name": "Fries",
-                                "category": "appetizers",
-                                "size": None,
-                                "quantity": 1,
-                                "unit_price": 7.50,
-                            },
-                        ],
-                        "status": "in_progress",
+                        "name": "Fries",
+                        "category": "appetizers",
+                        "quantity": 1,
+                        "unit_price": 7.50,
                     },
                 ),
             ]
@@ -464,25 +442,19 @@ def test_history_strips_sdk_only_fields_from_assistant_blocks():
 
 
 def test_apply_update_preserves_call_sid_and_created_at():
+    """Atomic operations mutate one slice of the Order via model_copy;
+    every other field stays put. Regression for the snapshot-era hazard
+    where a patch could rewrite call_sid or created_at."""
     original = Order(call_sid="CAoriginal")
     original_created_at = original.created_at
 
-    updated = _apply_update(
+    updated, notes = _apply_tool(
         original,
-        {
-            "call_sid": "CAhacked",
-            "created_at": "1999-01-01T00:00:00Z",
-            "items": [
-                {
-                    "name": "Coke",
-                    "category": "drink",
-                    "quantity": 1,
-                    "unit_price": 2.99,
-                }
-            ],
-        },
+        "add_item",
+        {"name": "Coke", "category": "drink", "quantity": 1, "unit_price": 2.99},
     )
 
+    assert notes == []
     assert updated.call_sid == "CAoriginal"
     assert updated.created_at == original_created_at
     assert len(updated.items) == 1
@@ -550,75 +522,6 @@ def test_unclear_utterance_asks_for_clarification():
     assert "again" in result.reply_text.lower() or "didn't catch" in result.reply_text.lower()
     assert result.order.items == []
     assert fake_client.messages.create.call_count == 1
-
-
-def test_caller_changes_mind_replaces_items():
-    """When the caller switches their order mid-conversation, the model
-    emits the FULL new state via update_order — the previous item is
-    replaced, not appended to."""
-
-    order = Order(call_sid="CAtest")
-    order = _apply_update(
-        order,
-        {
-            "items": [
-                {
-                    "name": "Pepperoni",
-                    "category": "pizza",
-                    "size": "medium",
-                    "quantity": 1,
-                    "unit_price": 17.99,
-                }
-            ],
-            "order_type": "pickup",
-            "status": "in_progress",
-        },
-    )
-    assert order.items[0].name == "Pepperoni"
-
-    fake_client = MagicMock()
-    fake_client.messages.create.side_effect = [
-        _fake_response(
-            [
-                FakeBlock(
-                    type="tool_use",
-                    id="toolu_change",
-                    name="update_order",
-                    input={
-                        "items": [
-                            {
-                                "name": "Veggie Supreme",
-                                "category": "pizza",
-                                "size": "medium",
-                                "quantity": 1,
-                                "unit_price": 18.99,
-                                "modifications": [],
-                            }
-                        ],
-                        "order_type": "pickup",
-                        "status": "in_progress",
-                    },
-                ),
-                FakeBlock(
-                    type="text",
-                    text="Got it — one medium veggie supreme for pickup instead.",
-                ),
-            ]
-        ),
-        _fake_response([FakeBlock(type="text", text="Anything else?")]),
-    ]
-
-    result = AnthropicLLM(sync_client=fake_client).generate_reply(
-        transcript="actually scratch that, make it a veggie supreme",
-        history=[],
-        order=order,
-        system_prompt=_TEST_SYSTEM_PROMPT,
-    )
-
-    assert len(result.order.items) == 1
-    assert result.order.items[0].name == "Veggie Supreme"
-    assert result.order.items[0].unit_price == 18.99
-    assert result.order.order_type is OrderType.PICKUP
 
 
 class _FakeAsyncStream:
@@ -878,22 +781,21 @@ async def test_stream_reply_applies_tool_use_to_order_state():
                 blocks=[
                     FakeBlock(
                         type="tool_use",
-                        id="toolu_1",
-                        name="update_order",
+                        id="toolu_add",
+                        name="add_item",
                         input={
-                            "items": [
-                                {
-                                    "name": "Pepperoni",
-                                    "category": "pizza",
-                                    "size": "medium",
-                                    "quantity": 1,
-                                    "unit_price": 17.99,
-                                    "modifications": [],
-                                }
-                            ],
-                            "order_type": "pickup",
-                            "status": "in_progress",
+                            "name": "Pepperoni",
+                            "category": "pizza",
+                            "size": "medium",
+                            "quantity": 1,
+                            "unit_price": 17.99,
                         },
+                    ),
+                    FakeBlock(
+                        type="tool_use",
+                        id="toolu_type",
+                        name="set_order_type",
+                        input={"order_type": "pickup"},
                     ),
                     FakeBlock(type="text", text="One medium pepperoni for pickup."),
                 ],
@@ -931,8 +833,8 @@ async def test_stream_reply_runs_followup_when_first_turn_is_tool_only():
                     FakeBlock(
                         type="tool_use",
                         id="toolu_1",
-                        name="update_order",
-                        input={"items": [], "status": "cancelled"},
+                        name="set_status",
+                        input={"status": "cancelled"},
                     )
                 ],
             ),
@@ -959,7 +861,7 @@ async def test_stream_reply_runs_followup_when_first_turn_is_tool_only():
     # Follow-up keeps the tool schema in tools so the cache prefix matches
     # the main call (#176); tool_choice="none" suppresses further tool use.
     assert len(captured_calls) == 2
-    assert captured_calls[1]["tools"] == [UPDATE_ORDER_TOOL]
+    assert captured_calls[1]["tools"] == ATOMIC_TOOLS
     assert captured_calls[1]["tool_choice"] == {"type": "none"}
 
 
@@ -1089,8 +991,8 @@ async def test_stream_reply_timing_reflects_tool_use_before_text():
             FakeBlock(
                 type="tool_use",
                 id="toolu_x",
-                name="update_order",
-                input={"items": [], "status": "confirmed"},
+                name="set_status",
+                input={"status": "confirmed"},
             ),
             FakeBlock(type="text", text="Done."),
         ]
@@ -1116,20 +1018,14 @@ def test_modifications_round_trip_into_line_item():
                 FakeBlock(
                     type="tool_use",
                     id="toolu_mods",
-                    name="update_order",
+                    name="add_item",
                     input={
-                        "items": [
-                            {
-                                "name": "Margherita",
-                                "category": "pizza",
-                                "size": "large",
-                                "quantity": 1,
-                                "unit_price": 20.99,
-                                "modifications": ["extra cheese", "no basil"],
-                            }
-                        ],
-                        "order_type": "pickup",
-                        "status": "in_progress",
+                        "name": "Margherita",
+                        "category": "pizza",
+                        "size": "large",
+                        "quantity": 1,
+                        "unit_price": 20.99,
+                        "modifications": ["extra cheese", "no basil"],
                     },
                 ),
                 FakeBlock(
@@ -1155,20 +1051,16 @@ def test_summarize_order_includes_modifications():
     """Sprint 2.2 #2 — _summarize_order must include modification strings in
     the tool_result so the agent can read them back to the caller verbatim."""
     order = Order(call_sid="CAtest")
-    order = _apply_update(
+    order, _ = _apply_tool(
         order,
+        "add_item",
         {
-            "items": [
-                {
-                    "name": "Margherita",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 1,
-                    "unit_price": 20.99,
-                    "modifications": ["extra cheese", "no basil"],
-                }
-            ],
-            "status": "in_progress",
+            "name": "Margherita",
+            "category": "pizza",
+            "size": "large",
+            "quantity": 1,
+            "unit_price": 20.99,
+            "modifications": ["extra cheese", "no basil"],
         },
     )
     result = _summarize_order(order)
@@ -1181,353 +1073,31 @@ def test_summarize_order_omits_parentheses_when_no_modifications():
     emit a parenthesized clause; the agent should omit the modifier phrase
     entirely per the read-back instruction."""
     order = Order(call_sid="CAtest")
-    order = _apply_update(
+    order, _ = _apply_tool(
         order,
+        "add_item",
         {
-            "items": [
-                {
-                    "name": "Margherita",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 1,
-                    "unit_price": 20.99,
-                    "modifications": [],
-                }
-            ],
-            "status": "in_progress",
+            "name": "Margherita",
+            "category": "pizza",
+            "size": "large",
+            "quantity": 1,
+            "unit_price": 20.99,
         },
     )
     result = _summarize_order(order)
+    # No modifications -> no "(...)" clause in the items list. The line
+    # is still bracketed by "[item_id]" though, so check parens specifically.
     assert "(" not in result
 
 
-# ---------------------------------------------------------------------------
-# Caller-correction characterization tests (Sprint 2.2 #103)
-# ---------------------------------------------------------------------------
-# These assert that _apply_update — which already does full-state overwrite —
-# correctly handles every correction shape the new prompt block instructs
-# Haiku to emit. They lock in current behavior; if a future refactor
-# introduces a remove_item / change_item tool, these MUST still pass against
-# the equivalent payload shape.
+# Caller-correction tests for the snapshot tool moved to
+# tests/test_atomic_order_tools.py (#305 Part B). Each atomic operation
+# is now exercised against the dispatch via apply_tool_call directly,
+# replacing the full-state-overwrite assertions that lived here.
 
 
-def _seed_order_with(items: list[dict[str, Any]], **extra: Any) -> Order:
-    """Helper: build an Order with the given items and apply once."""
-    base = Order(call_sid="CAtest")
-    return _apply_update(base, {"items": items, "status": "in_progress", **extra})
-
-
-def test_correction_remove_item_drops_it_from_order():
-    """Caller: 'take off the Coke.' Payload omits the Coke entirely;
-    only the Margherita remains."""
-    order = _seed_order_with(
-        [
-            {
-                "name": "Margherita",
-                "category": "pizza",
-                "size": "large",
-                "quantity": 1,
-                "unit_price": 19.99,
-            },
-            {"name": "Coke", "category": "drinks", "size": None, "quantity": 1, "unit_price": 2.99},
-        ],
-        order_type="pickup",
-    )
-
-    corrected = _apply_update(
-        order,
-        {
-            "items": [
-                {
-                    "name": "Margherita",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 1,
-                    "unit_price": 19.99,
-                },
-            ],
-            "order_type": "pickup",
-            "status": "in_progress",
-        },
-    )
-
-    assert [i.name for i in corrected.items] == ["Margherita"]
-    assert corrected.subtotal == 19.99
-
-
-def test_correction_substitute_item_replaces_not_appends():
-    """Caller: 'change the Margherita to a calzone.' Payload swaps the
-    item; quantity carries through. Crucially the resulting order has
-    ONE item, not two."""
-    order = _seed_order_with(
-        [
-            {
-                "name": "Margherita",
-                "category": "pizza",
-                "size": "large",
-                "quantity": 1,
-                "unit_price": 19.99,
-            },
-        ],
-        order_type="pickup",
-    )
-
-    corrected = _apply_update(
-        order,
-        {
-            "items": [
-                {
-                    "name": "Calzone",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 1,
-                    "unit_price": 16.99,
-                },
-            ],
-            "order_type": "pickup",
-            "status": "in_progress",
-        },
-    )
-
-    assert len(corrected.items) == 1
-    assert corrected.items[0].name == "Calzone"
-    assert corrected.items[0].unit_price == 16.99
-
-
-def test_correction_quantity_change_does_not_duplicate_line():
-    """Caller: 'make that 2 not 1.' Same line item with quantity bumped;
-    never two lines for the same item."""
-    order = _seed_order_with(
-        [
-            {
-                "name": "Margherita",
-                "category": "pizza",
-                "size": "large",
-                "quantity": 1,
-                "unit_price": 19.99,
-            },
-        ],
-        order_type="pickup",
-    )
-
-    corrected = _apply_update(
-        order,
-        {
-            "items": [
-                {
-                    "name": "Margherita",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 2,
-                    "unit_price": 19.99,
-                },
-            ],
-            "order_type": "pickup",
-            "status": "in_progress",
-        },
-    )
-
-    assert len(corrected.items) == 1
-    assert corrected.items[0].quantity == 2
-    assert corrected.subtotal == 39.98
-
-
-def test_correction_size_change_swaps_size_and_unit_price():
-    """Caller: 'I said large not medium.' Same item with new size +
-    new unit_price (the menu's price for the new size)."""
-    order = _seed_order_with(
-        [
-            {
-                "name": "Margherita",
-                "category": "pizza",
-                "size": "medium",
-                "quantity": 1,
-                "unit_price": 14.99,
-            },
-        ],
-        order_type="pickup",
-    )
-
-    corrected = _apply_update(
-        order,
-        {
-            "items": [
-                {
-                    "name": "Margherita",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 1,
-                    "unit_price": 19.99,
-                },
-            ],
-            "order_type": "pickup",
-            "status": "in_progress",
-        },
-    )
-
-    assert len(corrected.items) == 1
-    assert corrected.items[0].size == "large"
-    assert corrected.items[0].unit_price == 19.99
-
-
-def test_correction_order_type_swap_to_pickup_clears_delivery_address():
-    """Caller: 'switch back to pickup.' order_type flips and
-    delivery_address goes back to None — otherwise the dashboard
-    would show a stale address on a pickup order."""
-    order = _seed_order_with(
-        [
-            {
-                "name": "Margherita",
-                "category": "pizza",
-                "size": "large",
-                "quantity": 1,
-                "unit_price": 19.99,
-            },
-        ],
-        order_type="delivery",
-        delivery_address="14 Spadina Ave",
-    )
-    assert order.order_type is OrderType.DELIVERY
-    assert order.delivery_address == "14 Spadina Ave"
-
-    corrected = _apply_update(
-        order,
-        {
-            "items": [
-                {
-                    "name": "Margherita",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 1,
-                    "unit_price": 19.99,
-                },
-            ],
-            "order_type": "pickup",
-            "delivery_address": None,
-            "status": "in_progress",
-        },
-    )
-
-    assert corrected.order_type is OrderType.PICKUP
-    assert corrected.delivery_address is None
-
-
-def test_correction_delivery_address_fix_overwrites_full_value():
-    """Caller: 'no, my address is 14 not 40.' Payload contains the
-    fully-corrected address — not a partial / diff."""
-    order = _seed_order_with(
-        [
-            {
-                "name": "Margherita",
-                "category": "pizza",
-                "size": "large",
-                "quantity": 1,
-                "unit_price": 19.99,
-            },
-        ],
-        order_type="delivery",
-        delivery_address="40 Main St",
-    )
-
-    corrected = _apply_update(
-        order,
-        {
-            "items": [
-                {
-                    "name": "Margherita",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 1,
-                    "unit_price": 19.99,
-                },
-            ],
-            "order_type": "delivery",
-            "delivery_address": "14 Main St",
-            "status": "in_progress",
-        },
-    )
-
-    assert corrected.delivery_address == "14 Main St"
-    assert corrected.order_type is OrderType.DELIVERY
-
-
-def test_correction_invalid_delivery_address_is_rejected_and_signaled():
-    """Sprint 2.2 #105 — when Haiku ships an update_order patch whose
-    delivery_address fails validation (non-empty + has a digit), the
-    address is dropped from the patch (existing value stays) AND the
-    tool_result string carries a rejection note so Haiku re-asks on
-    the next turn."""
-    order = Order(call_sid="CAtest")
-    order = _apply_update(
-        order,
-        {
-            "items": [
-                {
-                    "name": "Margherita",
-                    "category": "pizza",
-                    "size": "large",
-                    "quantity": 1,
-                    "unit_price": 19.99,
-                },
-            ],
-            "order_type": "delivery",
-            "delivery_address": "14 Spadina Ave",
-            "status": "in_progress",
-        },
-    )
-    assert order.delivery_address == "14 Spadina Ave"
-
-    fake_client = MagicMock()
-    fake_client.messages.create.side_effect = [
-        _fake_response(
-            [
-                FakeBlock(type="text", text="Got it, what's your address?"),
-                FakeBlock(
-                    type="tool_use",
-                    id="toolu_bad_addr",
-                    name="update_order",
-                    input={
-                        "items": [
-                            {
-                                "name": "Margherita",
-                                "category": "pizza",
-                                "size": "large",
-                                "quantity": 1,
-                                "unit_price": 19.99,
-                            },
-                        ],
-                        "order_type": "delivery",
-                        "delivery_address": "uhh",
-                        "status": "in_progress",
-                    },
-                ),
-            ]
-        ),
-        _fake_response([FakeBlock(type="text", text="Could you give me the full street address?")]),
-    ]
-
-    result = AnthropicLLM(sync_client=fake_client).generate_reply(
-        transcript="my address is uhh",
-        history=[],
-        order=order,
-        system_prompt=_TEST_SYSTEM_PROMPT,
-    )
-
-    # Bad address was REJECTED — previous good value stays.
-    assert result.order.delivery_address == "14 Spadina Ave"
-    # Find the tool_result user message in history and check it carries the rejection note.
-    tool_result_msg = None
-    for msg in result.history:
-        if (
-            msg["role"] == "user"
-            and isinstance(msg["content"], list)
-            and msg["content"]
-            and msg["content"][0].get("type") == "tool_result"
-        ):
-            tool_result_msg = msg
-            break
-    assert tool_result_msg is not None
-    assert "Delivery address incomplete" in tool_result_msg["content"][0]["content"]
+def _correction_marker_unused():  # pragma: no cover
+    """Sentinel so the next deleted-block edit can target a unique string."""
 
 
 def test_generate_reply_sends_system_as_cache_block():
@@ -1590,61 +1160,6 @@ async def test_stream_reply_sends_system_as_cache_block():
     assert system[0]["cache_control"] == {"type": "ephemeral"}
 
 
-def test_apply_validation_passes_through_explicit_address_clears():
-    """Sprint 2.2 #105 — when Haiku ships delivery_address=None or ""
-    (e.g. swapping from delivery to pickup), that's a legitimate clear,
-    not a rejection. The patch must pass through unchanged with no
-    rejection note. Regression guard for the PD-D4 -> PD-D5 fix."""
-    from app.llm.orchestration import INVALID_ADDRESS_NOTE
-    from app.llm.orchestration import validate_order_patch as _apply_validation
-
-    # Explicit None passes through, no rejection note.
-    cleaned, notes = _apply_validation(
-        {
-            "items": [],
-            "order_type": "pickup",
-            "delivery_address": None,
-            "status": "in_progress",
-        }
-    )
-    assert cleaned == {
-        "items": [],
-        "order_type": "pickup",
-        "delivery_address": None,
-        "status": "in_progress",
-    }
-    assert notes == []
-
-    # Empty string passes through, no rejection note.
-    cleaned, notes = _apply_validation(
-        {
-            "delivery_address": "",
-        }
-    )
-    assert cleaned == {"delivery_address": ""}
-    assert notes == []
-
-    # Whitespace-only passes through, no rejection note.
-    cleaned, notes = _apply_validation(
-        {
-            "delivery_address": "   ",
-        }
-    )
-    assert cleaned == {"delivery_address": "   "}
-    assert notes == []
-
-    # Real garbage with content STILL gets rejected — verifies the
-    # explicit-clear pass-through didn't accidentally weaken the
-    # rejection path.
-    cleaned, notes = _apply_validation(
-        {
-            "delivery_address": "uhh",
-        }
-    )
-    assert "delivery_address" not in cleaned
-    assert notes == [INVALID_ADDRESS_NOTE]
-
-
 def test_followup_after_text_plus_tool_produces_readback_in_same_turn():
     """#173 — when the first response has BOTH text and tool_use, a follow-up
     call always runs so the model can read back the verified subtotal in the
@@ -1662,18 +1177,12 @@ def test_followup_after_text_plus_tool_produces_readback_in_same_turn():
                 FakeBlock(
                     type="tool_use",
                     id="toolu_cfr",
-                    name="update_order",
+                    name="add_item",
                     input={
-                        "items": [
-                            {
-                                "name": "Chicken Fried Rice",
-                                "category": "fried_rice",
-                                "size": None,
-                                "quantity": 1,
-                                "unit_price": 12.25,
-                            }
-                        ],
-                        "status": "in_progress",
+                        "name": "Chicken Fried Rice",
+                        "category": "fried_rice",
+                        "quantity": 1,
+                        "unit_price": 12.25,
                     },
                 ),
             ]
@@ -1702,7 +1211,7 @@ def test_followup_after_text_plus_tool_produces_readback_in_same_turn():
     # Follow-up keeps the tool schema in tools so the cache prefix matches
     # the main call (#176); tool_choice="none" suppresses further tool use.
     followup_call_kwargs = fake_client.messages.create.call_args_list[1][1]
-    assert followup_call_kwargs["tools"] == [UPDATE_ORDER_TOOL]
+    assert followup_call_kwargs["tools"] == ATOMIC_TOOLS
     assert followup_call_kwargs["tool_choice"] == {"type": "none"}
 
 
@@ -1722,18 +1231,12 @@ async def test_stream_reply_followup_after_text_plus_tool_yields_both_deltas():
                     FakeBlock(
                         type="tool_use",
                         id="toolu_cfr",
-                        name="update_order",
+                        name="add_item",
                         input={
-                            "items": [
-                                {
-                                    "name": "Chicken Fried Rice",
-                                    "category": "fried_rice",
-                                    "size": None,
-                                    "quantity": 1,
-                                    "unit_price": 12.25,
-                                }
-                            ],
-                            "status": "in_progress",
+                            "name": "Chicken Fried Rice",
+                            "category": "fried_rice",
+                            "quantity": 1,
+                            "unit_price": 12.25,
                         },
                     ),
                     FakeBlock(
@@ -1783,7 +1286,7 @@ async def test_stream_reply_followup_after_text_plus_tool_yields_both_deltas():
     # Follow-up keeps the tool schema in tools so the cache prefix matches
     # the main call (#176); tool_choice="none" suppresses further tool use.
     assert len(captured_calls) == 2
-    assert captured_calls[1]["tools"] == [UPDATE_ORDER_TOOL]
+    assert captured_calls[1]["tools"] == ATOMIC_TOOLS
     assert captured_calls[1]["tool_choice"] == {"type": "none"}
 
 
@@ -2293,7 +1796,7 @@ def test_generate_reply_skips_followup_on_confirm_turn_when_main_already_spoke()
             FakeBlock(
                 type="tool_use",
                 id="toolu_confirm",
-                name="update_order",
+                name="set_status",
                 input={"status": "confirmed"},
             ),
         ]
@@ -2320,9 +1823,9 @@ def test_generate_reply_skips_followup_on_confirm_turn_when_main_already_spoke()
 
 
 def test_generate_reply_runs_followup_on_confirm_turn_when_main_was_tool_only():
-    """Edge case: the model emitted update_order(status=confirmed) but
-    no text. The caller hasn't heard anything yet, so the follow-up must
-    still run to produce a goodbye. Preserves #173's invariant for the
+    """Edge case: the model emitted set_status(confirmed) but no text.
+    The caller hasn't heard anything yet, so the follow-up must still
+    run to produce a goodbye. Preserves #173's invariant for the
     silent-confirm path."""
     order = Order(call_sid="CAtest")
     fake_client = MagicMock()
@@ -2332,7 +1835,7 @@ def test_generate_reply_runs_followup_on_confirm_turn_when_main_was_tool_only():
                 FakeBlock(
                     type="tool_use",
                     id="toolu_confirm",
-                    name="update_order",
+                    name="set_status",
                     input={"status": "confirmed"},
                 )
             ]
@@ -2353,7 +1856,7 @@ def test_generate_reply_runs_followup_on_confirm_turn_when_main_was_tool_only():
 
 def test_generate_reply_runs_followup_on_mid_order_tool_use_with_text():
     """Regression guard against accidentally widening the skip. Mid-order
-    item-add turns emit text + tool_use(status=in_progress); the follow-up
+    item-add turns emit text + add_item (non-terminal); the follow-up
     must still run so the model can react to the server-verified subtotal
     in tool_result and produce the next prompt ('anything else?')."""
     order = Order(call_sid="CAtest")
@@ -2365,19 +1868,13 @@ def test_generate_reply_runs_followup_on_mid_order_tool_use_with_text():
                 FakeBlock(
                     type="tool_use",
                     id="toolu_add",
-                    name="update_order",
+                    name="add_item",
                     input={
-                        "items": [
-                            {
-                                "name": "Pepperoni",
-                                "category": "pizza",
-                                "size": "medium",
-                                "quantity": 1,
-                                "unit_price": 17.99,
-                            }
-                        ],
-                        "order_type": "pickup",
-                        "status": "in_progress",
+                        "name": "Pepperoni",
+                        "category": "pizza",
+                        "size": "medium",
+                        "quantity": 1,
+                        "unit_price": 17.99,
                     },
                 ),
             ]
@@ -2415,7 +1912,7 @@ async def test_stream_reply_skips_followup_on_confirm_turn_when_main_already_spo
                     FakeBlock(
                         type="tool_use",
                         id="toolu_confirm",
-                        name="update_order",
+                        name="set_status",
                         input={"status": "confirmed"},
                     ),
                 ],

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -14,6 +14,10 @@ The ``-s`` flag keeps ``print()`` output visible so you can read the
 reply transcript and the structured Order state.
 """
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 from app.config import settings
@@ -287,6 +291,157 @@ def _system_prompt_for(scenario_id: str) -> str:
     if scenario_id == "pickup_only_soft_pivot":
         return _DEMO_PICKUP_ONLY_SYSTEM_PROMPT
     return _DEMO_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Atomic-tool live regression suite (#305 Part B)
+# ---------------------------------------------------------------------------
+# Replays the saved transcript at dev_recordings/transcripts/ through the
+# atomic-tool flow against real Haiku, then asserts: (a) the right atomic
+# tools were called by name, and (b) the final order matches what the
+# transcript implies. Catches anything the unit-test mocks can't — schema
+# rejections, model picking the wrong tool, batching to confirm, etc.
+
+
+_ATOMIC_REPLAY_TRANSCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "dev_recordings"
+    / "transcripts"
+    / "CAe52763d5aabb7b126cfdee1db32eace8.json"
+)
+
+
+def _load_replay_transcript(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _restaurant_for_replay(scenario: dict[str, Any]) -> Restaurant:
+    """Build a Restaurant from the menu JSON referenced in the saved
+    transcript. The harness mirrors what scripts/replay_llm.py does —
+    real menu JSON + dummy non-menu fields, since the integration test
+    only exercises the prompt builder + LLM."""
+    menu_path = (
+        Path(__file__).resolve().parent.parent
+        / "restaurants"
+        / f"{scenario['restaurant']}.json"
+    )
+    menu_doc = json.loads(menu_path.read_text(encoding="utf-8"))
+    menu_dict = menu_doc.get("menu", menu_doc)
+    return Restaurant(
+        id=scenario["restaurant"],
+        name=scenario["restaurant_name"],
+        display_phone="+1-000-000-0000",
+        twilio_phone="+10000000000",
+        address="Replay fixture (not a real address)",
+        hours="Replay fixture (not real hours)",
+        offers_delivery=scenario.get("offers_delivery", True),
+        menu=menu_dict,
+    )
+
+
+def _collect_tool_calls(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Walk the threaded history and pull out every tool_use block the
+    assistant emitted, in order. Returns ``[{"name": ..., "input": ...}, ...]``."""
+    out: list[dict[str, Any]] = []
+    for msg in history:
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                out.append({"name": block.get("name"), "input": block.get("input")})
+    return out
+
+
+@pytest.mark.live_llm
+def test_replay_atomic_tool_flow_against_saved_transcript():
+    """Replay the saved Twilight call (CAe52763d5...) end-to-end against
+    real Haiku and assert the model uses the atomic tools correctly.
+
+    The transcript was captured pre-Part-B against the snapshot tool;
+    re-running it now must succeed against the atomic surface without
+    rewriting the caller turns. If Haiku starts hallucinating
+    `update_order` (or any non-atomic name) the test fails on the
+    unknown-tool dispatch path.
+    """
+    scenario = _load_replay_transcript(_ATOMIC_REPLAY_TRANSCRIPT_PATH)
+    restaurant = _restaurant_for_replay(scenario)
+    system_prompt = build_system_prompt(restaurant)
+
+    order = Order(call_sid=f"CAreplay-{_ATOMIC_REPLAY_TRANSCRIPT_PATH.stem}")
+    history: list[dict[str, Any]] = []
+
+    for i, turn in enumerate(scenario["turns"]):
+        caller = turn["caller"]
+        result = _LLM.generate_reply(
+            transcript=caller,
+            history=history,
+            order=order,
+            system_prompt=system_prompt,
+        )
+        order = result.order
+        history = result.history
+        print(
+            f"\n--- Turn {i + 1}/{len(scenario['turns'])} ---\n"
+            f"Caller: {caller}\n"
+            f"Haiku: {result.reply_text}\n"
+            f"Items so far: {[(it.item_id, it.name) for it in order.items]}\n"
+            f"Status: {order.status.value}"
+        )
+
+    tool_calls = _collect_tool_calls(history)
+    tool_names = [tc["name"] for tc in tool_calls]
+    print(f"\n--- Tool calls (in order) ---\n{tool_names}")
+
+    # The atomic tool surface must be exercised. The transcript adds at
+    # least one item ("Chicken Fried Rice"), so at minimum we expect one
+    # add_item call. If we see zero add_item calls, either the model
+    # batched everything to a snapshot tool (regression to update_order)
+    # or it failed to record the order at all.
+    assert any(name == "add_item" for name in tool_names), (
+        f"Expected at least one add_item call; got tool names {tool_names!r}"
+    )
+
+    # Snapshot-tool regression guard. If Haiku reverts to calling the old
+    # update_order name (e.g., someone re-registers UPDATE_ORDER_TOOL_SPEC
+    # in the provider by accident), apply_tool_call returns an
+    # unknown-tool note and the order stays empty. Fail loudly.
+    assert "update_order" not in tool_names, (
+        f"Model called the legacy update_order tool — atomic surface is no "
+        f"longer registered. Tool calls were: {tool_names!r}"
+    )
+
+    # The caller said "I'm all set" / "Sounds right" near the end —
+    # Haiku should have called set_status(confirmed) at some point.
+    assert any(
+        tc["name"] == "set_status" and tc["input"].get("status") == "confirmed"
+        for tc in tool_calls
+    ), (
+        f"Expected set_status(confirmed) somewhere in the call; got tool calls "
+        f"{tool_calls!r}"
+    )
+    assert order.status.value == "confirmed", (
+        f"Expected final order.status == 'confirmed'; got {order.status.value!r}"
+    )
+
+    # Order populates MID-CALL with atomic tools — the #305 Part B win
+    # that unlocks dashboard live view and #314 partial-order recovery.
+    # The transcript adds at least 3 items across separate turns, so the
+    # final order should contain multiple items. We don't pin specific
+    # names: real Haiku is non-deterministic on a transcript with
+    # STT-fuzzy follow-ups ("Do you have steamed fried rice" then
+    # "I want one shrimp fried rice" can plausibly be interpreted as a
+    # substitution rather than an addition), and "Coke" isn't on the
+    # Twilight menu so the model substitutes a close drink. The
+    # invariant that matters is: atomic tools landed structured items
+    # mid-call rather than batching to confirm.
+    final_names = [it.name.lower() for it in order.items]
+    assert len(order.items) >= 2, (
+        f"Expected at least 2 items in final order (caller added >= 3); "
+        f"got {len(order.items)}: {final_names!r}"
+    )
 
 
 @pytest.mark.live_llm

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -321,9 +321,7 @@ def _restaurant_for_replay(scenario: dict[str, Any]) -> Restaurant:
     real menu JSON + dummy non-menu fields, since the integration test
     only exercises the prompt builder + LLM."""
     menu_path = (
-        Path(__file__).resolve().parent.parent
-        / "restaurants"
-        / f"{scenario['restaurant']}.json"
+        Path(__file__).resolve().parent.parent / "restaurants" / f"{scenario['restaurant']}.json"
     )
     menu_doc = json.loads(menu_path.read_text(encoding="utf-8"))
     menu_dict = menu_doc.get("menu", menu_doc)
@@ -416,12 +414,8 @@ def test_replay_atomic_tool_flow_against_saved_transcript():
     # The caller said "I'm all set" / "Sounds right" near the end —
     # Haiku should have called set_status(confirmed) at some point.
     assert any(
-        tc["name"] == "set_status" and tc["input"].get("status") == "confirmed"
-        for tc in tool_calls
-    ), (
-        f"Expected set_status(confirmed) somewhere in the call; got tool calls "
-        f"{tool_calls!r}"
-    )
+        tc["name"] == "set_status" and tc["input"].get("status") == "confirmed" for tc in tool_calls
+    ), f"Expected set_status(confirmed) somewhere in the call; got tool calls {tool_calls!r}"
     assert order.status.value == "confirmed", (
         f"Expected final order.status == 'confirmed'; got {order.status.value!r}"
     )

--- a/tests/test_llm_warmup.py
+++ b/tests/test_llm_warmup.py
@@ -19,7 +19,7 @@ import pytest
 from app.config import settings
 from app.llm import anthropic as anthropic_module
 from app.llm import warmup
-from app.llm.anthropic import UPDATE_ORDER_TOOL
+from app.llm.anthropic import ATOMIC_TOOLS
 from app.restaurants.models import Restaurant
 
 
@@ -79,14 +79,14 @@ async def test_prime_tenant_cache_wraps_system_in_ephemeral_cache_block():
 
 
 @pytest.mark.asyncio
-async def test_prime_tenant_cache_includes_update_order_tool():
+async def test_prime_tenant_cache_includes_atomic_tools():
     """Tools sit before system in Anthropic's cached prefix order
-    (per #176). A primer missing the tool would write a *different*
+    (per #176). A primer missing the tools would write a *different*
     cache key than T2's real call."""
     client = _install_fake_async_client()
     await warmup.prime_tenant_cache(_restaurant())
     kwargs = client.messages.create.await_args.kwargs
-    assert kwargs["tools"] == [UPDATE_ORDER_TOOL]
+    assert kwargs["tools"] == ATOMIC_TOOLS
 
 
 @pytest.mark.asyncio

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -37,6 +37,41 @@ def test_prompt_includes_restaurant_name_and_menu_items():
         assert pizza["name"] in prompt
 
 
+def test_prompt_describes_all_six_atomic_tools():
+    """#305 Part B — the prompt must list each of the six atomic order
+    tools so the model knows the full surface it has to work with.
+    Missing a tool from the prompt would silently push the model to
+    pick the wrong one (e.g., add_item for a quantity change because
+    update_item was never introduced)."""
+    prompt = build_system_prompt(_demo())
+    lower = prompt.lower()
+    for tool_name in (
+        "add_item",
+        "remove_item",
+        "update_item",
+        "set_order_type",
+        "set_delivery_address",
+        "set_status",
+    ):
+        assert tool_name in lower, f"prompt is missing the {tool_name} tool description"
+
+
+def test_prompt_enforces_per_turn_tool_calls_against_batching():
+    """#305 Part B core invariant — the model must call the relevant
+    tool the moment the order changes, in the SAME turn. Pre-Part-B
+    diagnostic showed Haiku batching all update_order calls to the
+    confirm turn (n_items=0 on adds, w=386 cache writes concentrated
+    at confirm). With atomic tools batching defeats both the dashboard
+    live view and the latency win — the prompt must explicitly forbid
+    it."""
+    prompt = build_system_prompt(_demo())
+    flat = _collapse_ws(prompt.lower())
+    # Same-turn rule must be present.
+    assert "in the same turn" in flat
+    # Explicit forbid against batching to confirm.
+    assert "do not batch tool calls to the end" in flat
+
+
 def test_prompt_warns_against_reciting_address_on_pickup_wrapup():
     """Regression for #76 — the placeholder address (or any address) must
     not be volunteered in pickup confirmations."""
@@ -48,13 +83,16 @@ def test_prompt_warns_against_reciting_address_on_pickup_wrapup():
 
 
 def test_prompt_requires_text_before_tool_use():
-    """Regression for #76 and #155 — Haiku must speak first then call update_order,
-    so audio starts streaming within the <1s budget on commit turns. In #155 the
-    rule was strengthened from a soft bullet to a numbered CRITICAL block after
-    Haiku was observed ignoring the soft form (1192ms tool_prefix on 18:33 call)."""
+    """Regression for #76, #155, and #305 Part B — Haiku must speak first
+    then call the tool, so audio starts streaming within the <1s budget on
+    commit turns. In #155 the rule was strengthened from a soft bullet to a
+    numbered CRITICAL block after Haiku was observed ignoring the soft form
+    (1192ms tool_prefix on 18:33 call). #305 Part B replaced the single
+    update_order tool with six atomic tools — the speak-first rule now
+    applies to ALL of them."""
     prompt = build_system_prompt(_demo())
     lower = prompt.lower()
-    assert "when you call the update_order tool" in lower
+    assert "when you call any of these tools" in lower
     assert "first" in lower
     # Updated for #155 — the rule was strengthened to a numbered CRITICAL block.
     # The "do not do this" string is the new equivalent assertion that the
@@ -89,19 +127,21 @@ def test_prompt_makes_confirmation_goodbyes_terminal():
     assert "do not ask another follow-up question after confirming" in lower
     # Spot-check that the directive references the confirmed status flow.
     # #260 simplified the wording from "set the order's status to confirmed"
-    # to the literal tool-call form to keep the rule terse.
-    assert 'status="confirmed"' in lower
+    # to the literal tool-call form to keep the rule terse; #305 Part B
+    # swapped update_order for the atomic set_status(confirmed) call.
+    assert "set_status(confirmed)" in lower
 
 
 def test_prompt_couples_goodbye_phrases_with_status_flip():
     """Regression for #79 — Haiku was saying 'your order is in' without
-    calling update_order(status='confirmed'), which left the auto-hangup
-    inert. The prompt now insists on the status flip in the same turn."""
+    calling the confirm tool, which left the auto-hangup inert. The
+    prompt insists on the status flip in the same turn. #305 Part B
+    swapped the snapshot tool for set_status(confirmed)."""
     prompt = build_system_prompt(_demo())
     lower = prompt.lower()
     assert "critical" in lower
     assert "your order is in" in lower
-    assert 'status="confirmed"' in lower
+    assert "set_status(confirmed)" in lower
 
 
 def test_prompt_closing_uses_period_terminated_openers():
@@ -345,8 +385,8 @@ def test_prompt_includes_customization_guidance():
 
 def test_prompt_includes_readback_instruction():
     """Sprint 2.2 #3 — prompt must direct the agent to read back the full
-    order using the server-verified update_order subtotal, and only
-    confirm on an explicit caller yes.
+    order using the server-verified subtotal returned in tool_result, and
+    only confirm on an explicit caller yes.
 
     #260 (initial) tried statement-form read-backs to dodge price-
     validation framing; that produced a silence-timeout regression on
@@ -355,12 +395,19 @@ def test_prompt_includes_readback_instruction():
     oriented. The "explicit confirmation" requirement still holds —
     the model must wait for a real "yes" before flipping status, not
     infer it from silence.
+
+    #305 Part B replaced the single update_order tool with six atomic
+    tools — the read-back rule now points the model at the latest
+    tool_result for the subtotal (any of the six atomic tools surfaces it)
+    instead of naming a specific tool.
     """
     prompt = build_system_prompt(_demo())
     lower = prompt.lower()
     flat = _collapse_ws(lower)
     assert "read back" in lower
-    assert "update_order" in lower
+    # The subtotal comes from the latest tool_result regardless of which
+    # atomic tool produced it.
+    assert "tool_result" in lower
     # Price-validation framing remains banned (#260).
     assert "does that sound right" not in lower
     # An action-oriented turn-cue closer is required.
@@ -416,33 +463,44 @@ def test_prompt_forbids_per_item_readback_and_running_total():
 
 
 def test_prompt_includes_caller_corrections_block():
-    """Sprint 2.2 #103 — when a caller corrects something already in the
-    order (remove, substitute, quantity, size, order-type swap, delivery
-    address), Haiku must emit a single update_order carrying the FULL
-    corrected state. The prompt must explicitly tell it to replace the
-    wrong item, not add the new one alongside it."""
+    """Sprint 2.2 #103 + #305 Part B — when a caller corrects something
+    already in the order (remove, substitute, quantity, size, order-type
+    swap, delivery address), the prompt must direct the model to the
+    right atomic tool for each correction shape.
+
+    Pre-Part-B this section told Haiku to emit one update_order with the
+    FULL corrected state and explicitly "replace the wrong item" so the
+    snapshot didn't drift into appending. Atomic tools make that
+    impossible by construction (remove_item / update_item operate on
+    specific item_ids), so the section now teaches per-correction tool
+    selection instead."""
     prompt = build_system_prompt(_demo())
     lower = prompt.lower()
     # Section header is present
     assert "caller corrections:" in lower
-    # Core "replace, don't add" rule
-    assert "emit one" in lower
-    assert "update_order with the full corrected state" in lower
-    assert "replace the wrong item" in lower
-    # Coverage of each correction shape (one anchor per pattern)
+    # Each correction shape now maps to a specific atomic tool.
     assert "removals" in lower
+    assert "call remove_item" in lower
     assert "substitutions" in lower
-    assert "quantity or size changes" in lower
+    assert "call remove_item for the old line, then" in lower
+    assert "add_item for the new one" in lower
+    assert "quantity changes" in lower
+    assert "size changes" in lower
+    assert "call update_item" in lower
+    # Size + price coupling is the trickiest discrimination case — the
+    # prompt must explicitly keep it on the same line rather than spawning
+    # a new add_item (which would duplicate the line at the new size).
+    assert "different size of the same item is still one line" in lower
+    # Order-type and delivery-address shapes both still covered.
     assert "order-type swap to delivery" in lower
     assert "delivery-address fix" in lower
+    assert "call set_delivery_address" in lower
     # Post-correction acknowledgement is short, not a full re-read
     assert "do not re-read" in lower
     assert "whole order" in lower
-    # Caps preserve emphasis for Haiku — guard against silent downcasing
-    # (a3e8d5e had to restore these after the initial commit downcased them).
-    assert "emit ONE" in prompt
-    assert "FULL corrected state" in prompt
+    # Caps preserve emphasis for Haiku — guard against silent downcasing.
     assert "do NOT re-read" in prompt
+    assert "ONE line" in prompt
 
 
 def test_prompt_renders_delivery_offered_branch():


### PR DESCRIPTION
## Summary

Replaces the single snapshot `update_order` tool with six narrow atomic operations: `add_item`, `remove_item`, `update_item`, `set_order_type`, `set_delivery_address`, `set_status`. Each tool_use block is dispatched independently via `apply_tool_call` in `app/llm/orchestration.py`. Implements Part B of #305 (Part A — block-boundary flush — shipped in #309).

## Linked issue

Closes #305 (Part B). Unblocks #314 (mid-call partial-order persistence).

## Why this change

Pre-Part-B diagnostic on call `CAd463aac73cba156fb42d873108e14ac4` (see [the #305 comment](https://github.com/tsuki-works/niko/issues/305#issuecomment-4468531534)) showed Haiku 4.5 batching every `update_order` call to the confirm turn:

- `n_items=0` on every mid-order add turn (state.order empty until confirm)
- Cache writes concentrated at confirm (`w=386` only on the confirm turn)
- Confirm-turn TTFT ~3.0s dominated by snapshot decode + dispatch + follow-up
- Mid-call disconnect = total order loss (no structured state ever written)

Atomic tools fix all three. Live smoke (`CA127b7df7bde417016f00b55aadba9916`) confirms:

| Metric | Pre-Part-B | Post-Part-B |
|---|---|---|
| `state.order.items` mid-call | empty until confirm | grows per turn (0→2→3→4→5→6 in the smoke call) |
| Confirm-turn `post_text` dead air | 3.168s | 1.581s |
| Confirm-turn TOTAL | 3.734s (n=5) | 3.008s (n=6) |
| Per-turn add TTFT | ~500ms (already fast) | ~500–700ms (flat across n) |

## Mechanics

- **`LineItem` gains a server-assigned `item_id`** (default factory `f"i_{uuid4().hex[:6]}"`) so the model can reference lines in subsequent `remove_item` / `update_item` calls. `summarize_order_for_tool_result` prefixes each line with its `item_id` so the IDs land in tool_result blocks the model reads on the next turn.
- **`apply_tool_call(order, tool_name, payload) -> (Order, notes)`** is the single dispatch entry point. Six handlers in `app/llm/orchestration.py`, each returns the updated `Order` plus any rejection notes the provider appends to the tool_result.
- **`should_skip_followup`** now keys off `name == "set_status"` instead of `input.status` — same terminal-status semantics, atomic-shaped check.
- **Provider** (`app/llm/anthropic.py`) registers `ATOMIC_TOOLS` in both sync and async paths, captures every tool_use block (no name filtering), dispatches via `apply_tool_call`. Same for the cache primer in `app/llm/warmup.py` so the cached prefix matches the real call.
- **Prompt rewrite** (`app/llm/prompts.py`) teaches the atomic tool catalog, the per-turn rule ("call the relevant tool the moment the order changes, in the SAME turn — do not batch tool calls to the end"), preserves the speak-first ordering rule from #76/#155, and updates the corrections / read-back / closing sections to point at the right per-correction tools.
- **Dead code removed**: `UPDATE_ORDER_TOOL_SPEC`, `apply_order_patch`, `validate_order_patch`, `INVALID_ADDRESS_NOTE` export.

## Test plan

- [x] **Unit suite green**: 540 pass, 10 deselected, 0 fail (`pytest tests/ -m "not live_llm"`).
- [x] **New test file** `tests/test_atomic_order_tools.py` — 30 TDD'd tests covering all 6 handlers, dispatch, rejection paths, item_id generation, tool_result summary format.
- [x] **New prompt invariants** in `tests/test_prompts.py`: `test_prompt_describes_all_six_atomic_tools` + `test_prompt_enforces_per_turn_tool_calls_against_batching`.
- [x] **Mechanics tests** in `tests/test_llm_client.py` rewritten to use atomic-tool fixtures; 8 snapshot-semantic correction tests deleted (covered by atomic unit tests).
- [x] **Live integration test** `test_replay_atomic_tool_flow_against_saved_transcript` — replays `dev_recordings/transcripts/CAe52763d5...json` through real Haiku and asserts atomic dispatch + mid-call state + terminal status flip. Passes (~29s, gated on `ANTHROPIC_API_KEY` + `-m live_llm`).
- [x] **Live smoke** — two clean calls:
  - `CA66a5c34490260b64fec3ed23296a4b76` — pickup, 4 items, set_status(confirmed), auto-hangup. (Hit pre-existing TTS RemoteProtocolError on turn 2 — separate ticket, not Part B regression.)
  - `CA127b7df7bde417016f00b55aadba9916` — pickup, 6 items, `update_item` with modifications ("extra spicy"), `set_status(confirmed)`, auto-hangup. No exceptions.

## Tool variants not exercised by live smoke

These are covered by unit tests (`test_atomic_order_tools.py`) and share the same dispatcher as the validated ones, but weren't hit in the two smoke calls:

- `set_order_type(delivery)` + `set_delivery_address` — both smokes were pickup.
- `remove_item` — caller didn't remove anything.
- `update_item` quantity change — caller only changed modifications, not quantity.
- `set_status(cancelled)` — cancel path not smoked.

## Notes / follow-ups

- **History-drift edge case**: when a TTS error cancels a turn mid-stream, the assistant text already spoken stays in the message history but the tool result is never committed. The model can later read items from history that aren't in `state.order`. Pre-existing (would have happened with snapshot too); worth a separate ticket if it shows up on real calls.
- **No new TTS / STT regressions** observed in smoke calls. The pre-existing TTS `RemoteProtocolError` and STT mishearing tickets are unaffected.
- **#314 is now cheaply implementable**: with structured state every turn, persisting partial orders to Firestore on mid-call disconnect is a small follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
