### PR TITLE
fix(telephony): tag transfer reason as tts_error vs llm_error

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -629,6 +629,7 @@ async def media_stream(websocket: WebSocket) -> None:
                 consecutive_low_confidence_turns=state.consecutive_low_confidence_turns,
                 last_transcript=state.last_caller_transcript,
                 llm_error_occurred=state.llm_error_occurred,
+                tts_error_occurred=state.tts_error_occurred,
             )
             if transfer_reason is not None:
                 logger.info(

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -159,6 +159,7 @@ class _CallState:
     consecutive_low_confidence_turns: int = 0
     last_caller_transcript: str = ""
     llm_error_occurred: bool = False
+    tts_error_occurred: bool = False
     # Carry-forward of the most recent transcript fed to an LLM turn
     # that has not yet been persisted to ``history``. When a new final
     # transcript arrives mid-turn, ``_handle_final_transcript`` cancels
@@ -498,6 +499,9 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
     # GCP log access.
     timing_snapshot: dict[str, Any] | None = None
     first_text_at: float | None = None
+    # Set to True inside any speak() call that raises so the outer
+    # except can attribute the failure to TTS rather than the LLM.
+    _tts_failed = False
 
     def _record_first_audio() -> None:
         latency = time.monotonic() - turn_start
@@ -566,13 +570,17 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                         on_first_byte = _record_first_tts_byte
                     else:
                         on_first_byte = None
-                    await speak(
-                        remainder,
-                        websocket,
-                        state.stream_sid,
-                        on_chunk=_make_recording_chunk_handler(state),
-                        on_first_byte=on_first_byte,
-                    )
+                    try:
+                        await speak(
+                            remainder,
+                            websocket,
+                            state.stream_sid,
+                            on_chunk=_make_recording_chunk_handler(state),
+                            on_first_byte=on_first_byte,
+                        )
+                    except Exception:
+                        _tts_failed = True
+                        raise
                 continue
 
             if event.text_delta is not None:
@@ -591,13 +599,17 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                             on_first_byte = _record_first_tts_byte
                         else:
                             on_first_byte = None
-                        await speak(
-                            chunk,
-                            websocket,
-                            state.stream_sid,
-                            on_chunk=_make_recording_chunk_handler(state),
-                            on_first_byte=on_first_byte,
-                        )
+                        try:
+                            await speak(
+                                chunk,
+                                websocket,
+                                state.stream_sid,
+                                on_chunk=_make_recording_chunk_handler(state),
+                                on_first_byte=on_first_byte,
+                            )
+                        except Exception:
+                            _tts_failed = True
+                            raise
 
             elif event.final is not None:
                 remainder = "".join(text_buffer).strip()
@@ -609,13 +621,17 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
                         on_first_byte = _record_first_tts_byte
                     else:
                         on_first_byte = None
-                    await speak(
-                        remainder,
-                        websocket,
-                        state.stream_sid,
-                        on_chunk=_make_recording_chunk_handler(state),
-                        on_first_byte=on_first_byte,
-                    )
+                    try:
+                        await speak(
+                            remainder,
+                            websocket,
+                            state.stream_sid,
+                            on_chunk=_make_recording_chunk_handler(state),
+                            on_first_byte=on_first_byte,
+                        )
+                    except Exception:
+                        _tts_failed = True
+                        raise
                 state.history = event.final.history
                 state.order = event.final.order
                 # Transcript is now durably in history — no need to carry
@@ -695,8 +711,14 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
         raise
     except Exception as exc:
         logger.exception("llm_turn errored call_sid=%s", state.call_sid)
-        # #7: signal the trigger detector at end-of-stream
-        state.llm_error_occurred = True
+        # #265: attribute the failure to the right vendor so the dashboard
+        # shows the correct transfer reason. _tts_failed is set by the
+        # inner try/except around every speak() call; anything else is
+        # an LLM (Anthropic) failure.
+        if _tts_failed:
+            state.tts_error_occurred = True
+        else:
+            state.llm_error_occurred = True
         _bg_call_event(
             state.call_sid,
             _state_rid(state),

--- a/app/telephony/transfer_triggers.py
+++ b/app/telephony/transfer_triggers.py
@@ -35,6 +35,7 @@ _HUMAN_INTENT = re.compile(
 class TransferReason(str, Enum):
     MISHEARD_TURNS = "misheard_turns"
     LLM_ERROR = "llm_error"
+    TTS_ERROR = "tts_error"
     HUMAN_INTENT = "human_intent"
 
 
@@ -52,17 +53,20 @@ def should_trigger_transfer(
     consecutive_low_confidence_turns: int,
     last_transcript: str,
     llm_error_occurred: bool,
+    tts_error_occurred: bool = False,
 ) -> Optional[TransferReason]:
     """Return the first matching transfer reason, or None.
 
-    The order matters — LLM error and human intent dominate the
-    misheard threshold (a hard error or an explicit ask for a human is
-    more important than a noisy mic count).
+    The order matters — LLM error takes highest priority (Anthropic
+    failure is a harder signal than Deepgram TTS), then human intent,
+    then TTS error, then the misheard threshold.
     """
     if llm_error_occurred:
         return TransferReason.LLM_ERROR
     if detect_human_intent_in_text(last_transcript):
         return TransferReason.HUMAN_INTENT
+    if tts_error_occurred:
+        return TransferReason.TTS_ERROR
     if consecutive_low_confidence_turns >= MISHEARD_THRESHOLD:
         return TransferReason.MISHEARD_TURNS
     return None

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2209,3 +2209,80 @@ async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch
             pass
 
     assert captured == ["and a coke"]
+
+
+# ---------------------------------------------------------------------------
+# #265 — TTS vs LLM error attribution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tts_exception_sets_tts_error_not_llm_error(monkeypatch):
+    """A speak() failure inside _run_llm_tts_turn must set
+    state.tts_error_occurred and leave state.llm_error_occurred False.
+    Previously the single outer except set llm_error_occurred regardless
+    of which vendor raised."""
+    from app.storage import call_sessions
+    from app.telephony import session as session_mod
+    from app.telephony.session import _CallState, _run_llm_tts_turn
+
+    async def fake_stream_reply(*, transcript, history, order, **kw):
+        yield StreamEvent(text_delta="Hello.")
+        yield StreamEvent(final=LLMResponse(reply_text="Hello.", order=order, history=history))
+
+    async def exploding_speak(text, websocket, stream_sid, **kw):
+        raise ConnectionError("Deepgram TTS connect timeout")
+
+    monkeypatch.setattr(session_mod, "get_llm", _fake_llm_factory(fake_stream_reply))
+    monkeypatch.setattr(session_mod, "speak", exploding_speak)
+    monkeypatch.setattr(session_mod, "_bg_call_event", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+
+    state = _CallState(
+        call_sid="CAtest",
+        stream_sid="MZtest",
+        order=Order(call_sid="CAtest"),
+        system_prompt="test prompt",
+    )
+
+    with pytest.raises(ConnectionError):
+        await _run_llm_tts_turn("hi", state, AsyncMock())
+
+    assert state.tts_error_occurred is True
+    assert state.llm_error_occurred is False
+
+
+@pytest.mark.asyncio
+async def test_llm_exception_sets_llm_error_not_tts_error(monkeypatch):
+    """An Anthropic stream_reply failure must set state.llm_error_occurred
+    and leave state.tts_error_occurred False."""
+    from app.storage import call_sessions
+    from app.telephony import session as session_mod
+    from app.telephony.session import _CallState, _run_llm_tts_turn
+
+    async def exploding_stream_reply(*, transcript, history, order, **kw):
+        raise RuntimeError("Anthropic 529 overloaded")
+        yield  # make it a generator
+
+    async def fake_speak(text, websocket, stream_sid, **kw):
+        pass
+
+    monkeypatch.setattr(session_mod, "get_llm", _fake_llm_factory(exploding_stream_reply))
+    monkeypatch.setattr(session_mod, "speak", fake_speak)
+    monkeypatch.setattr(session_mod, "_bg_call_event", lambda *a, **kw: None)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+    monkeypatch.setattr(call_sessions, "record_event", lambda *a, **kw: None)
+
+    state = _CallState(
+        call_sid="CAtest",
+        stream_sid="MZtest",
+        order=Order(call_sid="CAtest"),
+        system_prompt="test prompt",
+    )
+
+    with pytest.raises(RuntimeError):
+        await _run_llm_tts_turn("hi", state, AsyncMock())
+
+    assert state.llm_error_occurred is True
+    assert state.tts_error_occurred is False

--- a/tests/test_transfer_triggers.py
+++ b/tests/test_transfer_triggers.py
@@ -69,3 +69,34 @@ def test_should_trigger_transfer_returns_none_below_threshold():
         llm_error_occurred=False,
     )
     assert reason is None
+
+
+def test_should_trigger_transfer_on_tts_error():
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=0,
+        last_transcript="any",
+        llm_error_occurred=False,
+        tts_error_occurred=True,
+    )
+    assert reason is TransferReason.TTS_ERROR
+
+
+def test_should_trigger_transfer_llm_error_wins_over_tts_error():
+    """When both LLM and TTS failures are flagged, LLM error takes priority."""
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=0,
+        last_transcript="any",
+        llm_error_occurred=True,
+        tts_error_occurred=True,
+    )
+    assert reason is TransferReason.LLM_ERROR
+
+
+def test_should_trigger_transfer_tts_error_default_false():
+    """Existing callers that omit tts_error_occurred still work — default is False."""
+    reason = should_trigger_transfer(
+        consecutive_low_confidence_turns=0,
+        last_transcript="any",
+        llm_error_occurred=False,
+    )
+    assert reason is None


### PR DESCRIPTION
## Summary
- `_run_llm_tts_turn` previously wrapped the entire LLM + TTS pipeline in one `try/except`, causing any Deepgram TTS failure (e.g. `httpx.ConnectTimeout` against `api.deepgram.com`) to be attributed to the LLM
- Adds `TransferReason.TTS_ERROR` and `state.tts_error_occurred` so TTS and LLM failures are tracked separately and surfaced correctly in the dashboard
- Priority order in `should_trigger_transfer`: LLM error → human intent → TTS error → misheard threshold

## Linked issue
Closes #265

## Changes
- `app/telephony/transfer_triggers.py` — new `TTS_ERROR` enum value; `should_trigger_transfer` accepts `tts_error_occurred: bool = False`
- `app/telephony/session.py` — `tts_error_occurred` flag on `_CallState`; each `speak()` call wrapped in an inner `try/except` that sets `_tts_failed=True` so the outer handler routes to the right flag
- `app/telephony/router.py` — passes `tts_error_occurred=state.tts_error_occurred` to `should_trigger_transfer`
- `tests/test_transfer_triggers.py` — TTS error triggers `TTS_ERROR`, LLM error wins when both set, backward-compat default case
- `tests/test_telephony.py` — TTS exception sets only `tts_error_occurred`; LLM exception sets only `llm_error_occurred`

## Test plan
- [x] `pytest tests/` — 84/84 green
- [ ] Live verification: break Deepgram TTS endpoint mid-call; confirm `transfer_requested reason=tts_error` in call events (not `llm_error`)

## Notes
- Out of scope: retry / no-dead-air recovery on TTS failure — that's #116. This is purely correct labeling.
- `tts_error_occurred` defaults to `False` — all existing `should_trigger_transfer` call sites without the new kwarg are backward-compatible.