### PR TITLE
fix: stale ElevenLabs docs + silence dup task-exception log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Key locations:
 
 - **`/current-sprint`** — surfaces the active sprint from the project board. Prefers items with Status = "In progress"; falls back to the earliest incomplete Phase.
 - **`/pr-driven-dev`** — enforces feature-branch + PR workflow; never commit directly to `master`. Includes a rescue flow if edits start on `master` by accident.
-- **`/shared-creds`** — fetches shared third-party credentials (Twilio, Deepgram, Anthropic, ElevenLabs, Square, etc.) from the private Discord `#shared-creds` channel via the Discord MCP. Encodes the don't-commit / don't-memory-save rules.
+- **`/shared-creds`** — fetches shared third-party credentials (Twilio, Deepgram, Anthropic, Square, etc.) from the private Discord `#shared-creds` channel via the Discord MCP. Encodes the don't-commit / don't-memory-save rules.
 - **`/onboard-restaurant`** — admin-assisted onboarding from a restaurant website URL: scrapes name/phone/address/hours/menu, asks for any gaps (image-only menus, missing hours, etc.), writes `restaurants/<rid>.json`, and dry-runs/then-confirms `scripts/provision_restaurant.py`. The Sprint 2.1 path; pre-dates the Sprint 4.2 self-serve wizard.
 
 ## Agent roles (`.claude/agents/`)

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -737,7 +737,15 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
 
     state.in_flight_transcript = text
     state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
-    state.llm_task.add_done_callback(lambda _t: _arm_silence_watchdog(state, websocket))
+
+    def _llm_task_done(task: asyncio.Task) -> None:
+        _arm_silence_watchdog(state, websocket)
+        # Swallow the exception so asyncio doesn't log it a second time
+        # (it was already logged inside _run_llm_tts_turn).
+        if not task.cancelled():
+            task.exception()  # consume without re-raising
+
+    state.llm_task.add_done_callback(_llm_task_done)
 
 
 def _resolve_restaurant_for_voice(

--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -20,7 +20,7 @@ The backend is the source of truth. This dashboard is a reader of Firestore docs
 - **`lib/schemas/order.ts`** is the single source of truth on the dashboard side. Every Firestore read goes through the Zod converter exported from there — no ad-hoc parsing of `doc.data()` anywhere.
 - **Field names stay snake_case** on the dashboard (`call_sid`, `caller_phone`, `unit_price`, `line_total`, `order_type`, `delivery_address`, `created_at`, `confirmed_at`). That's what's in Firestore. Don't rename to camelCase on read.
 - **FastAPI owns order creation and status transitions during a call.** The dashboard writes for staff workflow transitions (Start preparing, Mark ready, Mark completed) and for cancellation.
-- **The voice pipeline (Twilio → Deepgram → Claude Haiku → ElevenLabs → Firestore) is not this codebase's concern.** New capabilities touching the pipeline go in FastAPI.
+- **The voice pipeline (Twilio → Deepgram → Claude Haiku → Deepgram Aura → Firestore) is not this codebase's concern.** New capabilities touching the pipeline go in FastAPI.
 
 ## Domain glossary
 
@@ -40,7 +40,7 @@ Always "order," never "ticket." Always "call," never "session."
 - **Telephony:** Twilio → FastAPI `/voice` on GCP Cloud Run
 - **STT:** Deepgram Nova-2 streaming
 - **LLM:** Claude Haiku 4.5 (`claude-haiku-4-5-20251001`) via Anthropic API
-- **TTS:** ElevenLabs streaming
+- **TTS:** Deepgram Aura streaming
 - **Latency contract:** <1s end-to-end on the voice pipeline
 
 ### This codebase


### PR DESCRIPTION
## Summary
- **#182** — Remove stale ElevenLabs references from `CLAUDE.md` and `dashboard/CLAUDE.md`. ElevenLabs was retired as the TTS provider on 2026-04-25 (#62); Deepgram Aura has been the live provider since then.
- **#312** — The `llm_task` done_callback was a bare lambda that only re-armed the silence watchdog. Because it never called `task.exception()`, asyncio's GC would log the same exception traceback a second time after `_run_llm_tts_turn` already logged it cleanly. Replaced with a named callback that consumes the exception after watchdog re-arm.

## Linked issues
Closes #182
Closes #312

## Changes
| File | Change |
|------|--------|
| `CLAUDE.md` | Removed `ElevenLabs,` from `/shared-creds` blurb |
| `dashboard/CLAUDE.md` | Pipeline diagram + TTS line updated to Deepgram Aura |
| `app/telephony/session.py` | `lambda` done_callback → named `_llm_task_done` that calls `task.exception()` to swallow GC double-log |

## Test plan
- [x] `pytest tests/` — all existing tests green (no logic change, cosmetic fix only for #312)
- [ ] Smoke call: confirm only one traceback appears in logs when a TTS/LLM error occurs (no second `Task exception was never retrieved` line)

## Notes
Both changes are cosmetic / non-functional. No behaviour change for callers.