### PR TITLE
fix(telephony): filter short filler transcripts before LLM

### DIFF
--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -99,6 +99,18 @@ _GOODBYE_PATTERNS = (
     "enjoy your",
 )
 
+# Short filler words Deepgram marks is_final on that aren't complete
+# thoughts — sending them to the LLM produces non-sequitur replies.
+_FILLER_WORDS = frozenset({
+    "uh", "um", "hmm", "hm", "ah", "er",
+    "yeah", "yep", "ok", "okay",
+})
+
+
+def _is_noise_transcript(text: str) -> bool:
+    words = text.lower().split()
+    return len(words) <= 2 and all(w.strip(".,?!") in _FILLER_WORDS for w in words)
+
 
 def _looks_like_goodbye(reply: str) -> bool:
     """True if ``reply`` reads as a terminal wrap-up rather than another
@@ -734,6 +746,11 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
         # task to cancel, no event to emit).
         _cancel_silence_task(state)
         await send_clear(websocket, state.stream_sid)
+
+    if _is_noise_transcript(text):
+        logger.debug("filler transcript filtered call_sid=%s text=%r", state.call_sid, text)
+        _arm_silence_watchdog(state, websocket)
+        return
 
     state.in_flight_transcript = text
     state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -101,10 +101,20 @@ _GOODBYE_PATTERNS = (
 
 # Short filler words Deepgram marks is_final on that aren't complete
 # thoughts — sending them to the LLM produces non-sequitur replies.
-_FILLER_WORDS = frozenset({
-    "uh", "um", "hmm", "hm", "ah", "er",
-    "yeah", "yep", "ok", "okay",
-})
+_FILLER_WORDS = frozenset(
+    {
+        "uh",
+        "um",
+        "hmm",
+        "hm",
+        "ah",
+        "er",
+        "yeah",
+        "yep",
+        "ok",
+        "okay",
+    }
+)
 
 
 def _is_noise_transcript(text: str) -> bool:

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -101,6 +101,9 @@ _GOODBYE_PATTERNS = (
 
 # Short filler words Deepgram marks is_final on that aren't complete
 # thoughts — sending them to the LLM produces non-sequitur replies.
+# Confirmation tokens (yeah/yep/ok/okay) are intentionally NOT in this set —
+# they're real caller intent ("That'll be $14, sound good?" → "yeah") and
+# must reach the LLM.
 _FILLER_WORDS = frozenset(
     {
         "uh",
@@ -109,10 +112,6 @@ _FILLER_WORDS = frozenset(
         "hm",
         "ah",
         "er",
-        "yeah",
-        "yep",
-        "ok",
-        "okay",
     }
 )
 
@@ -730,6 +729,19 @@ async def _run_llm_tts_turn(transcript: str, state: _CallState, websocket: WebSo
 
 
 async def _handle_final_transcript(text: str, state: _CallState, websocket: WebSocket) -> None:
+    # Filler-only transcripts ("uh", "hmm") are not real intent — drop
+    # them before any side-effecting work. In particular, do NOT barge-in
+    # on a turn in progress just because the caller said "uh" while
+    # thinking; that would cancel the bot's TTS and leave them in dead
+    # air. Still abort any pending auto-hangup (caller is on the line)
+    # and re-arm the silence watchdog so prolonged silence eventually
+    # prompts again.
+    if _is_noise_transcript(text):
+        logger.debug("filler transcript filtered call_sid=%s text=%r", state.call_sid, text)
+        _abort_pending_hangup(state)
+        _arm_silence_watchdog(state, websocket)
+        return
+
     interrupted = bool(state.llm_task and not state.llm_task.done())
     # Carry forward — if any prior turn (cancelled or errored) left a
     # transcript on state without persisting it to history, prepend it
@@ -756,11 +768,6 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
         # task to cancel, no event to emit).
         _cancel_silence_task(state)
         await send_clear(websocket, state.stream_sid)
-
-    if _is_noise_transcript(text):
-        logger.debug("filler transcript filtered call_sid=%s text=%r", state.call_sid, text)
-        _arm_silence_watchdog(state, websocket)
-        return
 
     state.in_flight_transcript = text
     state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2186,7 +2186,19 @@ def test_is_noise_transcript_filters_pure_fillers():
     assert _is_noise_transcript("uh") is True
     assert _is_noise_transcript("um") is True
     assert _is_noise_transcript("hmm") is True
-    assert _is_noise_transcript("yeah okay") is True
+    assert _is_noise_transcript("uh um") is True
+
+
+def test_is_noise_transcript_passes_confirmation_tokens():
+    """yeah/yep/ok/okay are real caller intent — confirmation of an order
+    or a prompt — and must reach the LLM, not be silently dropped."""
+    from app.telephony.session import _is_noise_transcript
+
+    assert _is_noise_transcript("yeah") is False
+    assert _is_noise_transcript("yep") is False
+    assert _is_noise_transcript("ok") is False
+    assert _is_noise_transcript("okay") is False
+    assert _is_noise_transcript("yeah okay") is False
 
 
 def test_is_noise_transcript_passes_short_meaningful_strings():
@@ -2203,7 +2215,7 @@ def test_is_noise_transcript_passes_longer_strings_with_filler_words():
     from app.telephony.session import _is_noise_transcript
 
     # Three words — exceeds the ≤2 threshold even though it starts with a filler
-    assert _is_noise_transcript("yeah I want a burger") is False
+    assert _is_noise_transcript("uh I want a burger") is False
 
 
 def test_is_noise_transcript_filters_empty_string():
@@ -2241,6 +2253,48 @@ async def test_handle_final_transcript_skips_llm_for_filler(monkeypatch):
 
     assert spawned == [], "LLM task must not be spawned for a filler transcript"
     assert watchdog_armed, "silence watchdog must be re-armed after a filler is filtered"
+
+
+@pytest.mark.asyncio
+async def test_handle_final_transcript_filler_does_not_cancel_in_progress_turn(monkeypatch):
+    """A filler arriving while a turn is in progress must NOT trigger
+    barge-in. The check sits at the top of _handle_final_transcript so
+    the bot keeps talking and the caller's "uh" is treated as a no-op."""
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
+
+    barge_in_called: list[bool] = []
+
+    async def fake_barge_in_now(state, websocket, trigger):
+        barge_in_called.append(True)
+
+    async def fake_run_llm_tts_turn(transcript, state, websocket):
+        await asyncio.sleep(60.0)
+
+    monkeypatch.setattr(session_mod, "_barge_in_now", fake_barge_in_now)
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    # Simulate a turn already running.
+    state.llm_task = asyncio.create_task(fake_run_llm_tts_turn("prior turn", state, ws))
+    await asyncio.sleep(0)
+
+    await _handle_final_transcript("uh", state, ws)
+    await asyncio.sleep(0)
+
+    assert not barge_in_called, "filler 'uh' arriving mid-turn must not cancel the bot's TTS"
+    assert state.llm_task is not None and not state.llm_task.done(), (
+        "the in-progress LLM task must still be alive after a filtered filler"
+    )
+
+    state.llm_task.cancel()
+    try:
+        await state.llm_task
+    except (asyncio.CancelledError, BaseException):
+        pass
 
 
 @pytest.mark.asyncio

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2175,6 +2175,105 @@ async def test_errored_turn_carries_transcript_forward(monkeypatch):
     ]
 
 
+# ---------------------------------------------------------------------------
+# _is_noise_transcript — filler filter (#121)
+# ---------------------------------------------------------------------------
+
+
+def test_is_noise_transcript_filters_pure_fillers():
+    from app.telephony.session import _is_noise_transcript
+
+    assert _is_noise_transcript("uh") is True
+    assert _is_noise_transcript("um") is True
+    assert _is_noise_transcript("hmm") is True
+    assert _is_noise_transcript("yeah okay") is True
+
+
+def test_is_noise_transcript_passes_short_meaningful_strings():
+    from app.telephony.session import _is_noise_transcript
+
+    assert _is_noise_transcript("large pizza") is False
+    assert _is_noise_transcript("cancel that") is False
+    assert _is_noise_transcript("yes please") is False
+    # "no" is not in the filler set — meaningful negation
+    assert _is_noise_transcript("no") is False
+
+
+def test_is_noise_transcript_passes_longer_strings_with_filler_words():
+    from app.telephony.session import _is_noise_transcript
+
+    # Three words — exceeds the ≤2 threshold even though it starts with a filler
+    assert _is_noise_transcript("yeah I want a burger") is False
+
+
+def test_is_noise_transcript_filters_empty_string():
+    from app.telephony.session import _is_noise_transcript
+
+    # 0 words ≤ 2, vacuously all() is True
+    assert _is_noise_transcript("") is True
+
+
+@pytest.mark.asyncio
+async def test_handle_final_transcript_skips_llm_for_filler(monkeypatch):
+    """Filler transcripts must not spawn an LLM task — the silence watchdog
+    is re-armed instead so the call keeps waiting for a real utterance."""
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
+
+    spawned: list[str] = []
+
+    async def fake_run_llm_tts_turn(transcript, state, websocket):
+        spawned.append(transcript)
+
+    watchdog_armed: list[bool] = []
+
+    def fake_arm_watchdog(state, websocket):
+        watchdog_armed.append(True)
+
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", fake_arm_watchdog)
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    await _handle_final_transcript("uh", state, ws)
+    await asyncio.sleep(0)
+
+    assert spawned == [], "LLM task must not be spawned for a filler transcript"
+    assert watchdog_armed, "silence watchdog must be re-armed after a filler is filtered"
+
+
+@pytest.mark.asyncio
+async def test_handle_final_transcript_does_not_skip_llm_for_real_speech(monkeypatch):
+    """A non-filler transcript must still reach the LLM unchanged."""
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _handle_final_transcript
+
+    spawned: list[str] = []
+
+    async def fake_run_llm_tts_turn(transcript, state, websocket):
+        spawned.append(transcript)
+        await asyncio.sleep(10.0)
+
+    monkeypatch.setattr(session_mod, "_run_llm_tts_turn", fake_run_llm_tts_turn)
+    monkeypatch.setattr(session_mod, "_arm_silence_watchdog", lambda *a, **kw: None)
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    await _handle_final_transcript("large pizza please", state, ws)
+    await asyncio.sleep(0)
+
+    if state.llm_task and not state.llm_task.done():
+        state.llm_task.cancel()
+        try:
+            await state.llm_task
+        except (asyncio.CancelledError, BaseException):
+            pass
+
+    assert spawned == ["large pizza please"]
+
+
 @pytest.mark.asyncio
 async def test_whitespace_only_in_flight_transcript_is_not_prepended(monkeypatch):
     """#170 regression sentinel — locks in the observable behavior that a


### PR DESCRIPTION
## Summary
- Deepgram fires `is_final` on short filler utterances ("uh", "hmm", "yeah") that aren't complete thoughts
- These were being sent to the LLM, producing awkward non-sequitur replies mid-order
- Adds a lightweight `_is_noise_transcript()` guard in `_handle_final_transcript` that skips the LLM turn and re-arms the silence watchdog instead

## Linked issue
Closes #121

## Changes
- `app/telephony/session.py` — `_FILLER_WORDS` frozenset + `_is_noise_transcript()` at module level; guard added in `_handle_final_transcript` before the LLM task is spawned; filtered turns logged at DEBUG
- `tests/test_telephony.py` — 6 new tests: 4 unit tests for `_is_noise_transcript` (fillers, meaningful short strings, longer-with-filler, empty string) + 2 integration tests confirming fillers skip the LLM and meaningful speech still reaches it

## Test plan
- [x] `pytest tests/` — 534 passed, pre-existing SDK/credential failures unchanged
- [ ] Live call: say "uh" or "hmm" mid-order — agent should stay silent and wait, not reply with a non-sequitur
- [ ] Live call: say "large pizza" — should still be picked up and processed normally

## Notes
- Filter is conservative: only ≤2-word strings where every word is in the filler set. "no", "yes", "cancel that", "large pizza" all pass through.
- Empty string (`""`) is also filtered (0 words ≤ 2, vacuously true) — acceptable since an empty transcript is never a meaningful input.