### PR TITLE
fix(llm): trim conversation history at 40 messages to cap latency

### DIFF
--- a/app/llm/anthropic.py
+++ b/app/llm/anthropic.py
@@ -40,6 +40,8 @@ from app.llm.orchestration import (
 )
 from app.orders.models import Order
 
+_MAX_HISTORY_MESSAGES = 40
+
 # Anthropic accepts the JSON Schema directly under ``input_schema``.
 # Build the wire-shape list once at import so the cached ``tools=[...]``
 # stays a constant across calls (matters for prompt caching: tools sit
@@ -190,6 +192,43 @@ def _with_rolling_cache_breakpoint(
     return [*messages[:-1], {**last, "content": new_content}]
 
 
+def _trim_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop oldest turns when history exceeds _MAX_HISTORY_MESSAGES.
+
+    The cut point must always be a user message that starts with text
+    content (not a pure tool_result), because a tool_result requires
+    the preceding tool_use to stay in context. Scanning forward from
+    the oldest end, we find the first user message whose content is
+    either a plain string or starts with a text block, and drop
+    everything before it.
+
+    If no safe cut point exists (entire history is tool pairs), return
+    as-is — better to let the call exceed the limit than corrupt context.
+    """
+    if len(history) <= _MAX_HISTORY_MESSAGES:
+        return history
+
+    # Find the oldest safe cut index: scan forward until the tail fits within
+    # the limit, then pick the first user message with text (not pure tool_result)
+    # at or after that point so the cut lands on a safe boundary.
+    min_drop = len(history) - _MAX_HISTORY_MESSAGES
+    for i, msg in enumerate(history):
+        if i < min_drop:
+            continue
+        if msg["role"] != "user":
+            continue
+        content = msg["content"]
+        # Plain string transcript — always safe to cut here
+        if isinstance(content, str):
+            return history[i:]
+        # List content: safe only if the first block is NOT a tool_result
+        if isinstance(content, list) and content and content[0].get("type") != "tool_result":
+            return history[i:]
+
+    # No safe cut found — return unchanged
+    return history
+
+
 def _append_user_transcript(history: list[dict[str, Any]], transcript: str) -> list[dict[str, Any]]:
     """Append the caller's transcript to history with valid alternation.
 
@@ -290,6 +329,7 @@ class AnthropicLLM:
         api = self._sync_client or _client()
 
         new_history = _append_user_transcript(history, transcript)
+        new_history = _trim_history(new_history)
 
         response = api.messages.create(
             model=self._model,
@@ -383,6 +423,7 @@ class AnthropicLLM:
         api = self._async_client or _get_async_client()
 
         new_history = _append_user_transcript(history, transcript)
+        new_history = _trim_history(new_history)
 
         text_parts: list[str] = []
         tool_uses: list[dict[str, Any]] = []

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1894,6 +1894,83 @@ def test_generate_reply_runs_followup_on_mid_order_tool_use_with_text():
     assert "Anything else?" in result.reply_text
 
 
+# ---------------------------------------------------------------------------
+# #115 — conversation history trimming
+# ---------------------------------------------------------------------------
+
+
+def test_trim_history_noop_under_limit():
+    """History shorter than _MAX_HISTORY_MESSAGES is returned unchanged."""
+    from app.llm.anthropic import _MAX_HISTORY_MESSAGES, _trim_history
+
+    history = [{"role": "user", "content": f"turn {i}"} for i in range(_MAX_HISTORY_MESSAGES - 1)]
+    assert _trim_history(history) is history  # same object, untouched
+
+
+def test_trim_history_drops_oldest_turns_when_over_limit():
+    """When history exceeds _MAX_HISTORY_MESSAGES, oldest turns are dropped
+    and the result starts at the first safe user message."""
+    from app.llm.anthropic import _MAX_HISTORY_MESSAGES, _trim_history
+
+    # Build a history that is 10 turns over the limit, all plain user/assistant pairs
+    history = []
+    for i in range(_MAX_HISTORY_MESSAGES + 10):
+        history.append({"role": "user", "content": f"user turn {i}"})
+        history.append({"role": "assistant", "content": [{"type": "text", "text": f"reply {i}"}]})
+
+    trimmed = _trim_history(history)
+    assert len(trimmed) <= _MAX_HISTORY_MESSAGES + 1  # may be slightly over due to cut alignment
+    # Must start with a user message (safe cut point)
+    assert trimmed[0]["role"] == "user"
+    # The earliest turns should be gone
+    assert trimmed[0]["content"] != "user turn 0"
+
+
+def test_trim_history_never_cuts_at_pure_tool_result():
+    """The trimmer must not cut at a pure tool_result user message — that would
+    leave a dangling tool_use in the preceding assistant message with no matching
+    tool_result, causing Anthropic API 400s."""
+    from app.llm.anthropic import _MAX_HISTORY_MESSAGES, _trim_history
+
+    # Build history over the limit where the oldest user messages are all pure tool_results
+    # followed eventually by a plain text user message
+    history = []
+    # First few turns: user with plain text (these will be the oldest)
+    for i in range(5):
+        history.append({"role": "user", "content": f"early turn {i}"})
+        history.append({"role": "assistant", "content": [{"type": "text", "text": f"reply {i}"}]})
+
+    # Middle section: tool_use + tool_result pairs only (no plain text user turns here)
+    for i in range(20):
+        history.append(
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": f"tu_{i}", "name": "add_item", "input": {}}],
+            }
+        )
+        history.append(
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": f"tu_{i}", "content": "ok"}],
+            }
+        )
+
+    # Pad to go well over limit with normal turns
+    for i in range(_MAX_HISTORY_MESSAGES):
+        history.append({"role": "user", "content": f"later turn {i}"})
+        history.append({"role": "assistant", "content": [{"type": "text", "text": f"resp {i}"}]})
+
+    trimmed = _trim_history(history)
+
+    # The trimmed history must not start with a pure tool_result user message
+    assert trimmed[0]["role"] == "user"
+    content = trimmed[0]["content"]
+    if isinstance(content, list):
+        assert content[0].get("type") != "tool_result", (
+            "trim must not cut at a pure tool_result message"
+        )
+
+
 async def test_stream_reply_skips_followup_on_confirm_turn_when_main_already_spoke():
     """Streaming variant of the confirm-turn skip. No second stream is
     started; the final event lands directly after the main stream."""


### PR DESCRIPTION
## Summary
- History grows unboundedly today — long or stuck calls with many tool_use blocks push per-turn latency as Anthropic processes an ever-growing context, and will eventually hit token limits
- Adds `_trim_history()` that drops oldest turns when history exceeds `_MAX_HISTORY_MESSAGES = 40`
- Cut point is always a safe user message (plain text or list starting with a non-tool_result block) — never cuts at a pure `tool_result` message, which would leave a dangling `tool_use` in the preceding assistant turn and cause a 400 on the next call

## Linked issue
Closes #115

## Changes
| File | Change |
|------|--------|
| `app/llm/anthropic.py` | `_MAX_HISTORY_MESSAGES = 40` constant; `_trim_history()` module-level function; wired into both `generate_reply` and `stream_reply` after `_append_user_transcript` |
| `tests/test_llm_client.py` | 3 new tests: noop under limit, drops oldest turns over limit, never cuts at pure `tool_result` |

## Implementation note
The agent fixed a subtle off-by-one from the spec: scanning from `min_drop = len(history) - _MAX_HISTORY_MESSAGES` (not from index 0) ensures the first eligible candidate already drops enough turns to bring history within the limit. Candidates before `min_drop` are skipped even if they are safe cut points.

## Test plan
- [x] `pytest tests/test_llm_client.py` — all existing + 3 new tests green
- [x] `pytest tests/` — 531 passed, same pre-existing 18 failures/23 errors (SDK/credential-dependent, unrelated)
- [ ] Long smoke call (10+ turns) — confirm no API 400 and latency stays stable across turns