### PR TITLE
fix(telephony): cancel silence watchdog on interim transcripts

### DIFF
--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -458,6 +458,18 @@ async def _consume_transcripts(
 
             if isinstance(event, TranscriptEvent):
                 if not event.is_final:
+                    # #177 — a non-empty interim proves the caller has begun
+                    # speaking, so disarm the silence watchdog now. Interim
+                    # Updates arrive on the wire before the final transcript /
+                    # StartOfTurn, so a caller still mid-utterance at the 10s
+                    # mark would otherwise be reprompted over their own words.
+                    # SpeechStartedEvent only cancels silence indirectly via
+                    # _barge_in_now, which no-ops once the agent's turn is done
+                    # (the exact moment the watchdog is armed). The final path
+                    # still cancels in _handle_final_transcript; this is the
+                    # earlier guard.
+                    if event.text and event.text.strip():
+                        _cancel_silence_task(state)
                     continue  # interim: captured in plugin logs only
 
                 state.last_caller_transcript = event.text

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2573,3 +2573,41 @@ async def test_handler_lock_carry_forward_works_under_serialised_path(monkeypatc
             await state.llm_task
         except (asyncio.CancelledError, BaseException):
             pass
+
+
+@pytest.mark.asyncio
+async def test_consume_transcripts_interim_cancels_silence_watchdog(monkeypatch):
+    """A non-empty interim transcript proves the caller has begun speaking,
+    so the silence watchdog must be disarmed — otherwise a caller still
+    mid-utterance when the 10s timer expires gets reprompted over their own
+    words (#177). Interims are otherwise dropped by the consumer, and
+    SpeechStartedEvent only cancels silence via _barge_in_now, which no-ops
+    once the agent's turn is done (exactly when the watchdog is armed)."""
+    from app.stt import TranscriptEvent
+    from app.telephony.session import (
+        _arm_silence_watchdog,
+        _cancel_silence_task,
+        _CallState,
+        _consume_transcripts,
+    )
+    from tests.fakes.stt import FakeSTT
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    # An empty/blank interim is noise and must NOT disarm the watchdog.
+    _arm_silence_watchdog(state, ws)
+    assert state.silence_task is not None and not state.silence_task.done()
+    blank = FakeSTT(events=[TranscriptEvent("   ", False, 0.9)])
+    await blank.close()  # terminate the consumer loop after the queued event
+    await _consume_transcripts(blank, state, ws)
+    assert state.silence_task is not None and not state.silence_task.done()
+    _cancel_silence_task(state)  # cleanup the still-armed watchdog
+
+    # A real interim — caller is mid-utterance — must disarm it.
+    _arm_silence_watchdog(state, ws)
+    assert state.silence_task is not None and not state.silence_task.done()
+    fake = FakeSTT(events=[TranscriptEvent("i'd like a large", False, 0.9)])
+    await fake.close()
+    await _consume_transcripts(fake, state, ws)
+    assert state.silence_task is None


### PR DESCRIPTION
## Summary
- Disarm the silence watchdog on the first non-empty **interim** transcript in `_consume_transcripts`, so a caller still mid-utterance at the 10s mark is no longer reprompted ("Are you still there?") over their own words.
- Previously interims were dropped outright and only a **final** transcript cancelled the watchdog (`_handle_final_transcript`). `SpeechStartedEvent` only disarms silence indirectly via `_barge_in_now`, which no-ops once the agent's turn is done — exactly when the watchdog is armed. Interim Updates arrive on the wire before the final / StartOfTurn, making them the earliest reliable "caller is speaking" signal. Blank interims still no-op.

## Linked issue
Closes #177

## Test plan
- [x] New regression test `test_consume_transcripts_interim_cancels_silence_watchdog` — written failing first (verified red without the fix), drives `_consume_transcripts` with a blank interim (must NOT disarm) then a real interim (must disarm) against an armed watchdog.
- [x] `tests/test_telephony.py` — full file passes.
- [x] Remaining repo-wide failures (`test_stt_deepgram.py`, `test_provider_selector.py`, two `test_llm_integration.py`) pre-exist on `master` unchanged — broken local STT/Deepgram test env, unrelated to this change.

## Notes
- Rebased onto current `master`: the original fix targeted `on_transcript` in `router.py`, but the #261/#320 refactor relocated transcript handling into `app/telephony/session.py::_consume_transcripts`. Fix re-derived there.
- Scoped to the "watchdog doesn't notice the caller started" half. Sibling #178 (watchdog *starts* too early — times from byte-send vs audio-playback) is intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
