### PR TITLE
fix(telephony): arm silence watchdog on turn-end mark echo, not byte-send

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -32,13 +32,13 @@ from app.storage import call_sessions, recordings
 from app.storage import restaurants as restaurants_storage
 from app.stt import get_stt
 from app.telephony.session import (
-    END_OF_CALL_MARK,
     _abort_pending_hangup,
     _bg_call_event,
     _CallState,
+    _cancel_pending_silence_arm,
     _cancel_silence_task,
     _consume_transcripts,
-    _hang_up_after_grace,
+    _handle_mark_echo,
     _make_recording_chunk_handler,
     _play_greeting,
     _resolve_restaurant_for_voice,
@@ -520,20 +520,12 @@ async def media_stream(websocket: WebSocket) -> None:
 
             elif event == "mark":
                 # Twilio echoes our outgoing marks once the audio queued
-                # before them has finished playing. We use it to drive
-                # auto-hangup after order confirmation (#78).
+                # before them has finished playing. Drives auto-hangup after
+                # order confirmation (#78) and arms the silence watchdog from
+                # audio-end (#178). Dispatch handled in session._handle_mark_echo.
                 mark_name = msg.get("mark", {}).get("name")
-                if mark_name == END_OF_CALL_MARK and state.pending_hangup:
-                    logger.info(
-                        "auto-hangup: end_of_call mark received call_sid=%s",
-                        state.call_sid,
-                    )
-                    if state.mark_timeout_task and not state.mark_timeout_task.done():
-                        state.mark_timeout_task.cancel()
-                    state.mark_timeout_task = None
-                    if state.hangup_task and not state.hangup_task.done():
-                        state.hangup_task.cancel()
-                    state.hangup_task = asyncio.create_task(_hang_up_after_grace(state))
+                if mark_name:
+                    _handle_mark_echo(state, websocket, mark_name)
 
             elif event == "stop":
                 logger.info("media-stream stop call_sid=%s", state.call_sid)
@@ -562,6 +554,9 @@ async def media_stream(websocket: WebSocket) -> None:
         )
     finally:
         _cancel_silence_task(state)
+        # Drop any deferred silence-watchdog arm (#178) so its fallback timer
+        # can't fire after teardown.
+        _cancel_pending_silence_arm(state)
         # Auto-hangup: stop any pending grace-window timer; the call is
         # already ending so we don't need to fire the REST close (#78).
         _abort_pending_hangup(state)

--- a/app/telephony/session.py
+++ b/app/telephony/session.py
@@ -58,6 +58,15 @@ HANGUP_GRACE_SECONDS = 5.0
 # instead of hanging open. Picked > typical mark round-trip (1-3s).
 MARK_ECHO_TIMEOUT_SECONDS = 8.0
 
+# Named mark sent after every non-wrap-up TTS turn (#178). Twilio echoes
+# it back once its audio buffer has drained past it — i.e. once the
+# caller has actually heard the agent's reply. We arm the silence
+# watchdog on that echo, not when the last byte was handed to Twilio, so
+# its countdown starts from audio-end instead of byte-send. Without this,
+# a long (~10s) reply whose bytes flush in <1s would let the watchdog
+# count down and fire "Are you still there?" over the caller's response.
+TURN_END_MARK = "turn_end"
+
 # Chunking thresholds for TTS handoff (#151). Sentence terminators
 # always flush; soft breaks (commas, semicolons, colons, em dashes)
 # only flush once the buffered chunk is ≥ _MIN_CHUNK_CHARS so that
@@ -167,6 +176,12 @@ class _CallState:
     hangup_task: asyncio.Task | None = None  # pending auto-hangup (#78)
     mark_timeout_task: asyncio.Task | None = None  # mark-echo fallback (#114)
     pending_hangup: bool = False  # set when goodbye mark sent (#78)
+    # Silence-watchdog arming deferred until the turn-end mark echoes back
+    # (#178). ``silence_arm_pending`` is True between sending the mark and
+    # receiving its echo; ``silence_arm_task`` is the fallback that arms
+    # anyway if the echo never arrives.
+    silence_arm_pending: bool = False
+    silence_arm_task: asyncio.Task | None = None
     recording_session: "RecordingUploadSession | None" = None
     should_hangup: asyncio.Event = field(default_factory=asyncio.Event)
     # WS reference so _hang_up_after_grace can close the connection
@@ -268,6 +283,93 @@ def _arm_silence_watchdog(state: _CallState, websocket: WebSocket) -> None:
     state.silence_task = asyncio.create_task(_silence_watchdog(state, websocket))
 
 
+def _cancel_pending_silence_arm(state: _CallState) -> None:
+    """Drop any deferred "arm the watchdog once the agent's audio plays out"
+    state (#178). Called whenever the caller speaks or barges in before the
+    turn-end mark echoes, so a stale echo or the fallback timer can't arm a
+    watchdog in the middle of the next turn."""
+    state.silence_arm_pending = False
+    if state.silence_arm_task and not state.silence_arm_task.done():
+        state.silence_arm_task.cancel()
+    state.silence_arm_task = None
+
+
+async def _arm_after_mark_timeout(state: _CallState, websocket: WebSocket) -> None:
+    """Fallback for the deferred silence-watchdog arm (#178). If Twilio never
+    echoes the turn-end mark (WS dropped, mark lost), arm the watchdog anyway
+    after ``MARK_ECHO_TIMEOUT_SECONDS`` so prolonged silence still eventually
+    reprompts. Cancelled by ``_cancel_pending_silence_arm`` once the echo
+    arrives or the caller speaks."""
+    try:
+        await asyncio.sleep(MARK_ECHO_TIMEOUT_SECONDS)
+    except asyncio.CancelledError:
+        return
+    if not state.silence_arm_pending:
+        return  # echo already arrived, or caller spoke — nothing to do
+    logger.info(
+        "silence-arm fallback fired (no turn-end mark echo) call_sid=%s",
+        state.call_sid,
+    )
+    state.silence_arm_pending = False
+    state.silence_arm_task = None
+    _arm_silence_watchdog(state, websocket)
+
+
+async def _schedule_silence_arm(state: _CallState, websocket: WebSocket) -> None:
+    """Arm the silence watchdog only once the agent's audio has actually
+    played out, not when the last byte was handed to Twilio (#178).
+
+    Sends a turn-end mark; Twilio echoes it back over the WebSocket once its
+    buffer drains past it (the caller has heard everything). The echo handler
+    (``_handle_mark_echo``) then arms the watchdog, so its 10s countdown
+    starts from audio-end rather than byte-send. A fallback timer arms anyway
+    if the echo never arrives.
+    """
+    # Wrap-up turns hand the call to the auto-hangup machinery (#78); no
+    # silence watchdog wanted there.
+    if state.pending_hangup:
+        return
+    # Barge-in cancelled the turn — the caller is already speaking.
+    if state.llm_task and state.llm_task.cancelled():
+        return
+    _cancel_pending_silence_arm(state)
+    sent = await send_mark(websocket, state.stream_sid, name=TURN_END_MARK)
+    if not sent:
+        # No stream / WS gone — we can't wait for an echo, so arm immediately.
+        # Degrades to the old byte-send timing rather than never arming.
+        _arm_silence_watchdog(state, websocket)
+        return
+    state.silence_arm_pending = True
+    state.silence_arm_task = asyncio.create_task(_arm_after_mark_timeout(state, websocket))
+
+
+def _handle_mark_echo(state: _CallState, websocket: WebSocket, mark_name: str) -> None:
+    """Dispatch a mark echoed back by Twilio over the media stream.
+
+    Twilio echoes our outgoing marks once the audio queued before them has
+    finished playing. Two marks are in play: ``END_OF_CALL_MARK`` drives
+    auto-hangup after order confirmation (#78), and ``TURN_END_MARK`` arms
+    the silence watchdog from audio-end (#178). Extracted from the WS loop
+    so both echoes are handled in one place and unit-testable without
+    driving the socket.
+    """
+    if mark_name == END_OF_CALL_MARK and state.pending_hangup:
+        logger.info("auto-hangup: end_of_call mark received call_sid=%s", state.call_sid)
+        if state.mark_timeout_task and not state.mark_timeout_task.done():
+            state.mark_timeout_task.cancel()
+        state.mark_timeout_task = None
+        if state.hangup_task and not state.hangup_task.done():
+            state.hangup_task.cancel()
+        state.hangup_task = asyncio.create_task(_hang_up_after_grace(state))
+    elif mark_name == TURN_END_MARK and state.silence_arm_pending:
+        logger.info(
+            "silence watchdog armed on turn-end mark echo call_sid=%s",
+            state.call_sid,
+        )
+        _cancel_pending_silence_arm(state)
+        _arm_silence_watchdog(state, websocket)
+
+
 async def _play_greeting(state: _CallState, websocket: WebSocket) -> None:
     """Speak the call's opening greeting via Aura — no LLM round-trip (#192).
 
@@ -316,7 +418,9 @@ async def _play_greeting(state: _CallState, websocket: WebSocket) -> None:
         {"role": "user", "content": GREETING_TRANSCRIPT},
         {"role": "assistant", "content": [{"type": "text", "text": text}]},
     ]
-    _arm_silence_watchdog(state, websocket)
+    # Defer arming until Twilio reports the greeting audio has played out,
+    # so the watchdog's countdown starts from audio-end, not byte-send (#178).
+    await _schedule_silence_arm(state, websocket)
 
 
 async def _hang_up_after_grace(state: _CallState) -> None:
@@ -419,6 +523,9 @@ async def _barge_in_now(
         state.barge_in_trigger = trigger
         state.llm_task.cancel()
     _cancel_silence_task(state)
+    # Caller is speaking — drop any deferred arm so a late turn-end mark
+    # echo can't re-arm the watchdog mid-utterance (#178).
+    _cancel_pending_silence_arm(state)
     await send_clear(websocket, state.stream_sid)
 
 
@@ -778,6 +885,9 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
         if _is_noise_transcript(text):
             logger.debug("filler transcript filtered call_sid=%s text=%r", state.call_sid, text)
             _abort_pending_hangup(state)
+            # No new agent audio is pending, so arm immediately rather than
+            # waiting on a turn-end mark; clear any deferred arm first (#178).
+            _cancel_pending_silence_arm(state)
             _arm_silence_watchdog(state, websocket)
             return
 
@@ -795,6 +905,10 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
         # spoke during the grace window after a confirmation, we want to
         # keep the call alive and process this transcript.
         _abort_pending_hangup(state)
+        # Caller spoke before the previous turn's audio finished playing out —
+        # drop any deferred silence arm so its mark echo / fallback can't arm
+        # a watchdog during the turn we're about to start (#178).
+        _cancel_pending_silence_arm(state)
 
         if interrupted:
             # True barge-in: a turn is running and we're interrupting it.
@@ -812,11 +926,16 @@ async def _handle_final_transcript(text: str, state: _CallState, websocket: WebS
         state.llm_task = asyncio.create_task(_run_llm_tts_turn(text, state, websocket))
 
         def _llm_task_done(task: asyncio.Task) -> None:
-            _arm_silence_watchdog(state, websocket)
             # Swallow the exception so asyncio doesn't log it a second time
             # (it was already logged inside _run_llm_tts_turn).
-            if not task.cancelled():
-                task.exception()  # consume without re-raising
+            if task.cancelled():
+                # Barge-in / teardown — caller is already speaking, so don't
+                # arm. The next turn (or cleanup) handles the watchdog.
+                return
+            task.exception()  # consume without re-raising
+            # Defer arming until the agent's audio has played out (#178):
+            # schedule the turn-end mark now that the last byte is sent.
+            asyncio.create_task(_schedule_silence_arm(state, websocket))
 
         state.llm_task.add_done_callback(_llm_task_done)
 

--- a/tests/test_play_greeting.py
+++ b/tests/test_play_greeting.py
@@ -3,7 +3,8 @@
 ``_play_greeting`` replaces the cold T1 LLM call. It picks one of the
 restaurant's hand-written greetings (or a hardcoded fallback template),
 streams it via Aura, seeds conversation history so the caller's first
-real turn (T2) has context, and arms the silence watchdog.
+real turn (T2) has context, and arms the silence watchdog once Twilio
+confirms the greeting audio has played out (#178).
 
 These tests stub ``speak`` so the suite stays offline; the audio path
 itself is exercised by ``tests/test_deepgram_tts.py``.
@@ -43,15 +44,17 @@ async def state() -> _CallState:
     s.call_sid = "CAtest"
     s.stream_sid = "MZtest"
     yield s
-    # _play_greeting arms the silence watchdog. Cancel it inside the
-    # event loop so it doesn't dangle into the "Task was destroyed"
-    # warning territory.
-    if s.silence_task is not None and not s.silence_task.done():
-        s.silence_task.cancel()
-        try:
-            await s.silence_task
-        except asyncio.CancelledError:
-            pass
+    # _play_greeting defers arming the silence watchdog behind a turn-end
+    # mark echo (#178); cancel both the deferred-arm fallback and any armed
+    # watchdog inside the event loop so neither dangles into "Task was
+    # destroyed" warning territory.
+    for task in (s.silence_arm_task, s.silence_task):
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
 
 @pytest.mark.asyncio
@@ -99,11 +102,29 @@ async def test_play_greeting_swallows_speak_failure(state, caplog):
 
 
 @pytest.mark.asyncio
-async def test_play_greeting_arms_silence_watchdog(state, fake_speak):
-    """If the caller stays silent after the greeting, we still need the
-    'are you still there?' prompt to fire."""
+async def test_play_greeting_defers_silence_watchdog_to_mark_echo(state, fake_speak):
+    """If the caller stays silent after the greeting, the 'are you still
+    there?' prompt must still fire — but the watchdog is armed only once
+    Twilio echoes the turn-end mark (greeting audio played out), not at
+    byte-send (#178). So right after _play_greeting it is deferred, and the
+    mark echo arms it."""
+    from app.telephony.session import TURN_END_MARK, _handle_mark_echo
+
     state.restaurant = _restaurant_with(["Hi there."])
-    await _play_greeting(state, websocket=AsyncMock())
+    ws = AsyncMock()
+    await _play_greeting(state, websocket=ws)
+
+    # Deferred: not armed yet, but a turn-end mark was sent and we're waiting.
+    assert state.silence_task is None
+    assert state.silence_arm_pending is True
+    sent = [c.args[0] for c in ws.send_json.call_args_list]
+    assert any(
+        m.get("event") == "mark" and m.get("mark", {}).get("name") == TURN_END_MARK
+        for m in sent
+    )
+
+    # Twilio echoes the greeting's turn-end mark → watchdog arms.
+    _handle_mark_echo(state, ws, TURN_END_MARK)
     assert state.silence_task is not None
 
 

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2611,3 +2611,134 @@ async def test_consume_transcripts_interim_cancels_silence_watchdog(monkeypatch)
     await fake.close()
     await _consume_transcripts(fake, state, ws)
     assert state.silence_task is None
+
+
+# ---------------------------------------------------------------------------
+# Silence watchdog arms on turn-end mark echo, not byte-send (#178)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_silence_arm_defers_until_mark_echo(monkeypatch):
+    """After a TTS turn the watchdog must NOT arm immediately — it sends a
+    turn-end mark and waits. Arming only happens when Twilio echoes the mark
+    back (audio has played out), so the 10s countdown starts from audio-end,
+    not byte-send (#178)."""
+    from app.telephony.session import (
+        TURN_END_MARK,
+        _CallState,
+        _handle_mark_echo,
+        _schedule_silence_arm,
+    )
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    await _schedule_silence_arm(state, ws)
+
+    # The acceptance criterion: NOT armed before the echo arrives.
+    assert state.silence_task is None
+    assert state.silence_arm_pending is True
+    assert state.silence_arm_task is not None and not state.silence_arm_task.done()
+    # A turn-end mark was sent to Twilio.
+    sent = [c.args[0] for c in ws.send_json.call_args_list]
+    assert any(
+        m.get("event") == "mark" and m.get("mark", {}).get("name") == TURN_END_MARK
+        for m in sent
+    ), "a turn-end mark must be sent so Twilio can echo it back"
+
+    # Twilio echoes the mark once the audio drained → now the watchdog arms.
+    _handle_mark_echo(state, ws, TURN_END_MARK)
+    assert state.silence_task is not None and not state.silence_task.done()
+    assert state.silence_arm_pending is False
+    assert state.silence_arm_task is None
+
+    if state.silence_task and not state.silence_task.done():
+        state.silence_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_schedule_silence_arm_fallback_arms_without_echo(monkeypatch):
+    """If Twilio never echoes the turn-end mark, the fallback timer must arm
+    the watchdog anyway so prolonged silence still eventually reprompts."""
+    import app.telephony.session as session_mod
+    from app.telephony.session import _CallState, _schedule_silence_arm
+
+    # Make the fallback fire effectively immediately.
+    monkeypatch.setattr(session_mod, "MARK_ECHO_TIMEOUT_SECONDS", 0.0)
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    await _schedule_silence_arm(state, ws)
+    assert state.silence_task is None  # still deferred at this instant
+    assert state.silence_arm_task is not None
+
+    await state.silence_arm_task  # let the fallback run
+
+    assert state.silence_task is not None and not state.silence_task.done()
+    assert state.silence_arm_pending is False
+    if state.silence_task and not state.silence_task.done():
+        state.silence_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_schedule_silence_arm_arms_immediately_when_mark_send_fails():
+    """With no stream_sid (mark can't be sent), arming must fall back to the
+    old byte-send timing rather than never arming."""
+    from app.telephony.session import _CallState, _schedule_silence_arm
+
+    state = _CallState(call_sid="CAtest", stream_sid=None)
+    ws = AsyncMock()
+
+    await _schedule_silence_arm(state, ws)
+
+    assert state.silence_task is not None and not state.silence_task.done()
+    assert state.silence_arm_pending is False
+    if state.silence_task and not state.silence_task.done():
+        state.silence_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_schedule_silence_arm_skips_on_pending_hangup():
+    """A wrap-up turn hands the call to the auto-hangup machinery — no silence
+    watchdog and no turn-end mark should be set up."""
+    from app.telephony.session import _CallState, _schedule_silence_arm
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest", pending_hangup=True)
+    ws = AsyncMock()
+
+    await _schedule_silence_arm(state, ws)
+
+    assert state.silence_task is None
+    assert state.silence_arm_pending is False
+    assert state.silence_arm_task is None
+    ws.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_late_mark_echo_after_caller_speaks_does_not_arm():
+    """If the caller speaks before the echo arrives, the deferred arm is
+    cancelled — a late turn-end mark echo must NOT arm a watchdog mid-turn."""
+    from app.telephony.session import (
+        TURN_END_MARK,
+        _cancel_pending_silence_arm,
+        _CallState,
+        _handle_mark_echo,
+        _schedule_silence_arm,
+    )
+
+    state = _CallState(call_sid="CAtest", stream_sid="MZtest")
+    ws = AsyncMock()
+
+    await _schedule_silence_arm(state, ws)
+    assert state.silence_arm_pending is True
+
+    # Caller spoke → deferred arm dropped (as _handle_final_transcript /
+    # _barge_in_now do).
+    _cancel_pending_silence_arm(state)
+    assert state.silence_arm_pending is False
+
+    # A late echo for the now-stale mark must be a no-op.
+    _handle_mark_echo(state, ws, TURN_END_MARK)
+    assert state.silence_task is None


### PR DESCRIPTION
## Summary
- Arm the silence watchdog when the agent's audio has **played out**, not when the last TTS byte is handed to Twilio. Twilio buffers and plays audio in real time, so for a ~10s reply (bytes flush in <1s) the 10s timer counted down during playback and fired "Are you still there?" over the caller (call `CAb1ccc23c...`).
- Reuses the production mark-echo primitive (#78): send a named **turn-end mark** after each non-wrap-up TTS turn and after the greeting; arm the watchdog when Twilio echoes it back (`_handle_mark_echo`), so the countdown starts from audio-end.
- Fallback timer (`MARK_ECHO_TIMEOUT_SECONDS`) arms anyway if the echo never arrives; immediate arm if the mark can't be sent. Wrap-up (`pending_hangup`) and barge-in/cancelled turns skip arming; caller speech drops any deferred arm so a late echo can't arm mid-utterance.
- Extracts the mark-echo dispatch out of `router.py`'s WS loop into `session._handle_mark_echo` so both the auto-hangup and silence-arm echoes live in one unit-testable place.

## Linked issue
Closes #178 (sub-task of #83). Distinct from #177 (caller-side interim cancel), which is already merged.

## Test plan
- [x] New tests assert the watchdog is **NOT** armed before the mark echo (the issue's acceptance criterion), arms on echo, fallback arms without an echo, immediate-arm when send fails, skips on `pending_hangup`, and a late echo after caller speech is a no-op. Mutation-checked: the deferral test fails if arming is immediate.
- [x] `test_play_greeting` updated for the deferred behavior.
- [x] `tests/test_telephony.py` + `tests/test_play_greeting.py` — 97 passed.
- [x] Full suite — 724 passed, 1 skipped. The 4 remaining failures (`test_provider_selector` ×3, flaky `test_llm_integration`) + 23 `test_stt_deepgram` errors pre-exist on `master` (broken local STT env), unrelated to this change.

## Notes
- Live-call validation from the issue (long reply; caller responds within 2s of audio end; no SILENCE_TIMEOUT) still wants a real-call check before fully closing the loop — see issue "Done when".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
