### PR TITLE
fix(dashboard): pin pnpm 9 in Docker build to unblock Cloud Run deploy

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -13,7 +13,7 @@
 #   - NIKO_API_BASE_URL — the FastAPI Cloud Run service URL
 #   - PORT — Cloud Run sets this; Next.js standalone reads it
 
-ARG NODE_VERSION=20-alpine
+ARG NODE_VERSION=22-alpine
 
 # ---------- deps ----------
 FROM node:${NODE_VERSION} AS deps

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -13,7 +13,7 @@
 #   - NIKO_API_BASE_URL — the FastAPI Cloud Run service URL
 #   - PORT — Cloud Run sets this; Next.js standalone reads it
 
-ARG NODE_VERSION=22-alpine
+ARG NODE_VERSION=20-alpine
 
 # ---------- deps ----------
 FROM node:${NODE_VERSION} AS deps

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -2,6 +2,7 @@
   "name": "dashboard",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Problem

The **Deploy Dashboard to Cloud Run** workflow has failed on every push since 2026-05-09. The live dashboard was stuck on `c73d982` (2026-05-05), so merged dashboard changes (e.g. PR #269's `cache=hit+ext` timeline label) never reached production.

## Root cause

`dashboard/Dockerfile` ran a bare `corepack enable` with **no pinned pnpm version**, so each build floated to corepack's `latest` pnpm. That drifted to **pnpm 11.x**, which:
1. imports `node:sqlite` (a Node ≥22.13 builtin) → crashed `pnpm install` on the Dockerfile's Node 20 with `ERR_UNKNOWN_BUILTIN_MODULE`; and
2. errors with `ERR_PNPM_IGNORED_BUILDS` on un-approved dependency build scripts (`@firebase/util`, `esbuild`, `protobufjs`) under `--frozen-lockfile`.

The deploy passed on 2026-05-05 because corepack's `latest` at the time was still an older pnpm. The green **Dashboard** CI job never broke because it pins pnpm explicitly via `pnpm/action-setup` (`version: 9`) on Node 20 — Docker just didn't match it.

## Fix

Make the Docker build use the same toolchain as the passing CI job:
- Pin `"packageManager": "pnpm@9.15.9"` in `dashboard/package.json` so `corepack enable` resolves pnpm 9 (no `node:sqlite`; runs dependency build scripts by default, with only `sharp`/`unrs-resolver` excluded via `pnpm-workspace.yaml`, exactly as before).
- Keep `dashboard/Dockerfile` on `NODE_VERSION=20-alpine` for parity with CI.

A Node 20 → 22 upgrade is deliberately **out of scope** — Node 20 is near EOL, but that's a separate change that should bump CI too and be tested on its own.

## Verification

Ran the deploy workflow against this branch via `workflow_dispatch`: **green** — Build image → Push image → Deploy to Cloud Run all succeeded ([run](https://github.com/tsuki-works/niko/actions/runs/28477819536)). The fix is now live on Cloud Run.

Remaining manual check from #276 acceptance: open a recent multi-turn call timeline and confirm turn 2+ renders `cache=hit+ext` instead of `cache=miss`.

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)