### PR TITLE
fix(tests): fix ruff lint + format errors breaking Backend CI on master

### DIFF
--- a/tests/test_play_greeting.py
+++ b/tests/test_play_greeting.py
@@ -119,8 +119,7 @@ async def test_play_greeting_defers_silence_watchdog_to_mark_echo(state, fake_sp
     assert state.silence_arm_pending is True
     sent = [c.args[0] for c in ws.send_json.call_args_list]
     assert any(
-        m.get("event") == "mark" and m.get("mark", {}).get("name") == TURN_END_MARK
-        for m in sent
+        m.get("event") == "mark" and m.get("mark", {}).get("name") == TURN_END_MARK for m in sent
     )
 
     # Twilio echoes the greeting's turn-end mark → watchdog arms.

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2643,8 +2643,7 @@ async def test_schedule_silence_arm_defers_until_mark_echo(monkeypatch):
     # A turn-end mark was sent to Twilio.
     sent = [c.args[0] for c in ws.send_json.call_args_list]
     assert any(
-        m.get("event") == "mark" and m.get("mark", {}).get("name") == TURN_END_MARK
-        for m in sent
+        m.get("event") == "mark" and m.get("mark", {}).get("name") == TURN_END_MARK for m in sent
     ), "a turn-end mark must be sent so Twilio can echo it back"
 
     # Twilio echoes the mark once the audio drained → now the watchdog arms.

--- a/tests/test_telephony.py
+++ b/tests/test_telephony.py
@@ -2586,8 +2586,8 @@ async def test_consume_transcripts_interim_cancels_silence_watchdog(monkeypatch)
     from app.stt import TranscriptEvent
     from app.telephony.session import (
         _arm_silence_watchdog,
-        _cancel_silence_task,
         _CallState,
+        _cancel_silence_task,
         _consume_transcripts,
     )
     from tests.fakes.stt import FakeSTT
@@ -2722,8 +2722,8 @@ async def test_late_mark_echo_after_caller_speaks_does_not_arm():
     cancelled — a late turn-end mark echo must NOT arm a watchdog mid-turn."""
     from app.telephony.session import (
         TURN_END_MARK,
-        _cancel_pending_silence_arm,
         _CallState,
+        _cancel_pending_silence_arm,
         _handle_mark_echo,
         _schedule_silence_arm,
     )


### PR DESCRIPTION
The **Backend (ruff + pytest)** CI job is red on `master`. This PR fixes the two **ruff** failures (lint + format). It does **not** fix the separate pytest failure those ruff errors were masking — that's split out into #347 (a real telephony bug), which is stacked on this branch.

### 1. `ruff check` — import sorting (`I001`)
Two un-sorted function-local import blocks in `tests/test_telephony.py` (`_CallState` ordered after lowercase `_cancel_*`). Auto-fixed with `ruff check --fix`.

### 2. `ruff format --check`
`tests/test_play_greeting.py` and `tests/test_telephony.py` had an `assert any(...)` generator expression split across lines that ruff collapses onto one. Auto-fixed with `ruff format`.

### Heads-up on this PR's CI
With ruff now green, the Backend job runs pytest and surfaces a pre-existing failure (`test_start_event_records_after_init_call_session`) — a real bug fixed in **#347**. So the Backend check on *this* PR will be red on that one test until #347 lands. Recommended merge order: **#346 → #347** (#347 auto-retargets to `master` after this merges).

Formatting-only; no behavior change. Separate from the dashboard deploy fix (#345).

🤖 Generated with [Claude Code](https://claude.com/claude-code)