### PR TITLE
fix(telephony): await session_init_task on teardown so start event lands

### DIFF
--- a/app/telephony/router.py
+++ b/app/telephony/router.py
@@ -560,6 +560,20 @@ async def media_stream(websocket: WebSocket) -> None:
         # Auto-hangup: stop any pending grace-window timer; the call is
         # already ending so we don't need to fire the REST close (#78).
         _abort_pending_hangup(state)
+        # Let the chained init_call_session + record_event(kind="start")
+        # finish before teardown completes. A fast hangup (start
+        # immediately followed by stop) must not abandon the task
+        # mid-chain — otherwise init's parent-doc set() lands but the
+        # start event never does, and mark_call_ended below would write
+        # the call end before its start.
+        if state.session_init_task and not state.session_init_task.done():
+            try:
+                await state.session_init_task
+            except (asyncio.CancelledError, Exception):
+                logger.exception(
+                    "call_sessions: session init task failed call_sid=%s",
+                    state.call_sid,
+                )
         # Quiesce the transcript consumer FIRST so it can't spawn a new
         # state.llm_task from a late final transcript while we're cleaning
         # up the in-flight one. Closing the STT connection here also


### PR DESCRIPTION
> **Stacked on #346** (ruff fixes). The failing test lives in `test_telephony.py`, which #346 reformats, so this is based on that branch to show a green Backend job. GitHub will auto-retarget this PR to `master` once #346 merges. **Merge order: #346 first, then this.**

## Real bug: start event silently lost on a fast hangup

`test_start_event_records_after_init_call_session` fails on `master` (`got ['init']`, expected `['init', 'record_start']`). It was hidden behind the red ruff step until #346 made ruff green and pytest finally ran.

**Root cause:** the WS handler's `finally` block in `app/telephony/router.py` never awaited `state.session_init_task` — despite the comment at the task's creation stating it must:

> Tracked on `state.session_init_task` so the WS finally block can await it — otherwise a fast hangup tears the loop down before the chained `record_event` lands.

The `await` was never actually implemented (`git log -S "await state.session_init_task"` is empty). On a fast hangup (Twilio `start` immediately followed by `stop`), the chained task `init_call_session → record_event(kind="start")` completes `init`'s parent-doc `set()` but is abandoned before the start event. In production this means:
- the call-session **start event is silently dropped**, and
- `mark_call_ended` (later in the same `finally`) can write the call end **before** its start.

## Fix

Await `state.session_init_task` (guarded) in `finally`, before `mark_call_ended`, so the chained start event always lands first.

```python
if state.session_init_task and not state.session_init_task.done():
    try:
        await state.session_init_task
    except (asyncio.CancelledError, Exception):
        logger.exception("call_sessions: session init task failed call_sid=%s", state.call_sid)
```

## Verification

`test_start_event_records_after_init_call_session` is the regression test; it passes via CI on this stacked branch (no local Python env to run pytest). Behavioral change is telephony-only — worth a call-flow review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)